### PR TITLE
enable Checkstyle back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,11 @@ allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'maven'
     apply plugin: 'signing'
-    //apply plugin: 'checkstyle'
+    apply plugin: 'checkstyle'
 
-    //checkstyle {
-    //    toolVersion = "7.1"
-    //}
+    checkstyle {
+        toolVersion = "7.1"
+    }
 
     repositories {
         // Use 'jcenter' for resolving your dependencies.
@@ -33,10 +33,10 @@ allprojects {
         }
     }
 
-    //checkstyle {
-    //    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    //    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-    //}
+    checkstyle {
+        configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
+    }
 
     dependencies {
         // The production code uses the SLF4J logging API at compile time


### PR DESCRIPTION
Checkstyle was commented out in my previous checkin to feature-controller, enabling it.
The checkstyle gradle tasks are faster when executed in offline mode.
