### PR TITLE
Add a gradle task to start controller locally.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,14 +194,12 @@ project('integrationtests') {
         testCompile files(project(':service:server').sourceSets.test.output)
         testCompile files(project(':service:server:host').sourceSets.test.output)
     }
+
     task startServer(type: JavaExec) {
         main = "com.emc.pravega.service.server.host.ServiceStarter"
         classpath = sourceSets.main.runtimeClasspath
         standardInput = System.in
     }
-
-
-
 
     task startServerInteractive(type: JavaExec) {
         main = "com.emc.pravega.service.server.host.InteractiveStreamSegmentStoreTester"
@@ -229,6 +227,12 @@ project('integrationtests') {
 	
     task startConsumer(type: JavaExec) {
         main = "com.emc.pravega.demo.StartConsumer"
+        classpath = sourceSets.main.runtimeClasspath
+        standardInput = System.in
+    }
+
+    task startController(type: JavaExec) {
+        main = "com.emc.pravega.controller.server.Main"
         classpath = sourceSets.main.runtimeClasspath
         standardInput = System.in
     }


### PR DESCRIPTION
This fixes #228 . `gradle startController` starts the controller locally.