### PR TITLE
Replacing exception with getMessage()

### DIFF
--- a/service/server/src/main/java/com/emc/pravega/service/server/writer/StorageWriter.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/writer/StorageWriter.java
@@ -491,7 +491,7 @@ class StorageWriter extends AbstractService implements Writer {
 
     private void logErrorHandled(Throwable ex) {
         ex = ExceptionHelpers.getRealException(ex);
-        log.warn("{}: Iteration[{}].HandledError {}", this.traceObjectId, this.state.getIterationId(), ex.getMessage());
+        log.warn("{}: Iteration[{}].HandledError {}", this.traceObjectId, this.state.getIterationId(), ex.toString());
         //        System.out.println(String.format("%s: Iteration[%s].Warn. %s", this.traceObjectId, this.state.getIterationId(), ex));
     }
 


### PR DESCRIPTION
Replacing exception with getMessage() to avoid unnecessary stack traces in the log.