### PR TITLE
Issue #341: Sporadic unit test failures in Travis

### DIFF
--- a/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentContainerTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentContainerTests.java
@@ -109,7 +109,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                        .with(WriterConfig.PROPERTY_MAX_READ_TIMEOUT_MILLIS, 250));
     @Override
     protected int getThreadPoolSize() {
-        return 10;
+        return 20;
     }
 
     /**

--- a/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentMapperTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentMapperTests.java
@@ -66,7 +66,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
 
     @Override
     protected int getThreadPoolSize() {
-        return 3;
+        return 5;
     }
 
     /**

--- a/service/server/src/test/java/com/emc/pravega/service/server/reading/ContainerReadIndexTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/reading/ContainerReadIndexTests.java
@@ -77,7 +77,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     @Override
     protected int getThreadPoolSize() {
-        return 10;
+        return 20;
     }
 
     /**

--- a/service/server/src/test/java/com/emc/pravega/service/server/writer/StorageWriterTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/writer/StorageWriterTests.java
@@ -90,7 +90,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
 
     @Override
     protected int getThreadPoolSize() {
-        return 2 * SEGMENT_COUNT;
+        return 100; // Need a larger TP since this test has a large number of Segments and ops (thus many concurrent ops).
     }
 
     /**


### PR DESCRIPTION
Rolling back some changes in #329 that downsized some unit test threadpools too much. Since that change was merged, various sporadic build failures were observed.

This change aims to increase those ThreadPools to some sizes that are adequate for the amount of testing done in those unit tests.

Tracked in #341.