### PR TITLE
Issue 372: SegmentAggregator uses a synchronized Queue instead of ConcurrentLinkedList.

### DIFF
--- a/integrationtests/src/main/java/com/emc/pravega/service/selftest/TruncateableArray.java
+++ b/integrationtests/src/main/java/com/emc/pravega/service/selftest/TruncateableArray.java
@@ -29,10 +29,12 @@ import java.io.SequenceInputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * Represents an ArrayView that can append at one end and truncate at the other one.
  */
+@NotThreadSafe
 class TruncateableArray implements ArrayView {
     //region Members
 

--- a/service/server/src/main/java/com/emc/pravega/service/server/writer/SegmentAggregator.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/writer/SegmentAggregator.java
@@ -1217,10 +1217,16 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
             return this.queue.size();
         }
 
+        /**
+         * Returns an iterator. While this method is synchronized, the iterator itself is not.
+         */
         public synchronized Iterator<StorageOperation> iterator() {
             return this.queue.iterator();
         }
 
+        /**
+         * Returns a Stream. While this method is synchronized, the Stream itself is not.
+         */
         synchronized Stream<StorageOperation> stream() {
             return this.queue.stream();
         }


### PR DESCRIPTION
**Change log description**
 1. Changed SegmentAggregator to use an ArrayDeque (wrapped in a synchronized class) instead of ConcurrentLinkedQueue.

2. Reworked TruncateableArray (used by SelfTester for buffering) to be a lot more efficient for reads - this virtually eliminates all the overhead this class was adding to the time measurements

**Purpose of the change**
Performance improvements.

**What the code does**
The same thing as before.

**How to verify it**
Run SelfTester with a lot of 100-byte appends on one segment, with no transactions.

Fixes #372 .