### PR TITLE
Issue 422: Fix enable statistics flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ log/
 .metadata/
 .recommenders/
 *.log
-*.iws
-*.ipr


### PR DESCRIPTION
Fix issue with reversed check for `metrics.enableStatistics`. Without this change, we have to set `metrics_enableStatistics=false` in the environment to enable StatsD which seems reverse. 

This change also matches what's in [`MetricsProvider::createStatsLogger`](https://github.com/emccode/pravega/blob/e02cf2db0436d9b71f841c75e22c7e1c7dfaa7d8/common/src/main/java/com/emc/pravega/common/metrics/MetricsProvider.java#L44-L46).