### PR TITLE
Add IntelliJ project files to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.iml
+*.iws
+*.ipr
 .project
 build
 .classpath


### PR DESCRIPTION
These files are generated by `./gradlew idea` and shouldn't be committed.