### PR TITLE
addressing thrift and other dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,12 @@ project('common') {
     publishing {
         publications {
             maven(MavenPublication) {
+                pom.withXml {
+                    asNode().appendNode('repositories', '').appendNode('repository','').
+                            appendNode('id','jcenter').parent().
+                            appendNode('name','JCenter Repository').parent().
+                            appendNode('url','http://jcenter.bintray.com')
+                }
                 groupId 'pravega'
                 artifactId 'common'
                 version = pravegaVersion


### PR DESCRIPTION
**Change log description**
1.There are some dependencies that are not properly resolved, while using published artifacts. Ex : clients:streaming has dependency on both `common`  and `controller:contract`(thrift). 
2.There is one dependency of `common`, namely `com.readytalk:metrics3-statsd`, which is available in jcenter, but not in maven central. When compiling with gradle, this dependency  is correctly resolved, however, when using the published `common.pom`, this dependency is not resolved. We solve this by making direct changes to `common.pom`.

**Purpose of the change**
 dependencies not resolved while using published artifacts

**What the code does**
Resolves all dependencies

**How to verify it**
do a ./gradlew publish, verify the individual pom generated.