### PR TITLE
Remove listeningProperties from host config file

### DIFF
--- a/integrationtests/config.properties
+++ b/integrationtests/config.properties
@@ -1,7 +1,6 @@
 pravegaservice.containerCount=1
 pravegaservice.threadPoolSize=50
 pravegaservice.listeningPort=12345
-pravegaservice.listeningIPAddress=127.0.0.1
 pravegaservice.zkHostName=zk1
 pravegaservice.zkPort=2181
 pravegaservice.zkRetrySleepMs=100


### PR DESCRIPTION
This will ensure that the host IP Address is picked up which is unique per Pravega host.

**Change log description**
Remove a line from config.properties.
**Purpose of the change**
To ensure that platform team can use the built docker containers.
**What the code does**
-
**How to verify it**
Unique IP addresses are registered.