### PR TITLE
Issue 239: Using pravega cluster namespace in zookeeper for controller metadata

### DIFF
--- a/controller/server/src/main/java/com/emc/pravega/controller/util/ZKUtils.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/util/ZKUtils.java
@@ -41,8 +41,11 @@ public final class ZKUtils {
 
         CuratorSingleton() {
             //Create and initialize the curator client framework.
-            zkClient = CuratorFrameworkFactory.newClient(Config.zKURL, new ExponentialBackoffRetry(
-                        Config.ZK_RETRY_SLEEP_MS, Config.ZK_MAX_RETRIES));
+            zkClient = CuratorFrameworkFactory.builder()
+                    .connectString(Config.zKURL)
+                    .namespace("pravega/" + Config.CLUSTER_NAME)
+                    .retryPolicy(new ExponentialBackoffRetry(Config.ZK_RETRY_SLEEP_MS, Config.ZK_MAX_RETRIES))
+                    .build();
             zkClient.start();
         }
 

--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
@@ -184,8 +184,11 @@ public final class ServiceStarter {
     }
 
     private CuratorFramework createZKClient() {
-        CuratorFramework zkClient = CuratorFrameworkFactory.newClient(this.serviceConfig.getZkHostName() + ":" + this.serviceConfig.getZkPort(),
-                new ExponentialBackoffRetry(this.serviceConfig.getZkRetrySleepMs(), this.serviceConfig.getZkRetryCount()));
+        CuratorFramework zkClient = CuratorFrameworkFactory.builder()
+                .connectString(this.serviceConfig.getZkHostName() + ":" + this.serviceConfig.getZkPort())
+                .namespace("pravega/" + this.serviceConfig.getClusterName())
+                .retryPolicy(new ExponentialBackoffRetry(this.serviceConfig.getZkRetrySleepMs(), this.serviceConfig.getZkRetryCount()))
+                .build();
         zkClient.start();
         return zkClient;
     }


### PR DESCRIPTION
**Change log description**
Using pravega cluster namespace in zookeeper for storing all controller's metadata.

**Purpose of the change**
Create all zookeeper data in its own cluster namespace will allow multiple pravega cluster use the same zookeeper deployment.

**What the code does**
Set the zookeeper root directory using the configured cluster name.

**How to verify it**
Check the metadata paths created in zookeeper. They all should be under the root path which is of the form /pravega/<cluster name>
