### PR TITLE
Issue 507: Added segment-level metrics for bytes in/out and latency in/out.

### DIFF
--- a/common/src/main/java/com/emc/pravega/common/SegmentStoreMetricsNames.java
+++ b/common/src/main/java/com/emc/pravega/common/SegmentStoreMetricsNames.java
@@ -18,22 +18,27 @@
 
 package com.emc.pravega.common;
 
-public interface SegmentStoreMetricsNames {
+public final class SegmentStoreMetricsNames {
     // Stream Segment request Operations
-    public final static String CREATE_SEGMENT = "CREATE_SEGMENT";
-    public final static String DELETE_SEGMENT = "DELETE_SEGMENT";
-    public final static String READ_SEGMENT = "READ_SEGMENT";
+    public static final String CREATE_SEGMENT = "CreateSegment";
+
     // Bytes read by READ_SEGMENT operation, for read throughput
-    public final static String SEGMENT_READ_BYTES = "SEGMENT_READ_BYTES";
-    // Counter for all read bytes.
-    public final static String ALL_READ_BYTES = "ALL_READ_BYTES";
+    public static final String SEGMENT_READ_BYTES = "SegmentReadBytes";
+    public static final String SEGMENT_READ_LATENCY = "SegmentReadLatencyMillis";
+
+    public static final String SEGMENT_WRITE_BYTES = "SegmentWriteBytes";
+    public static final String SEGMENT_WRITE_LATENCY = "SegmentWriteLatencyMillis";
+
     // Gauge for pending append bytes
-    public final static String PENDING_APPEND_BYTES = "PENDING_APPEND_BYTES";
+    public static final String PENDING_APPEND_BYTES = "PendingAppendBytes";
 
     //HDFS stats
-    public final static String HDFS_READ_LATENCY = "HDFSReadLatencyMillis";
+    public static final String HDFS_READ_LATENCY = "HDFSReadLatencyMillis";
     public static final String HDFS_WRITE_LATENCY = "HDFSWriteLatencyMillis";
     public static final String HDFS_READ_BYTES = "HDFSReadBytes";
-    public static final String HDFS_WRITTEN_BYTES = "HDFSWriteBytes";
+    public static final String HDFS_WRITE_BYTES = "HDFSWriteBytes";
 
+    public static String nameFromSegment(String metric, String segmentName) {
+        return metric + "." + segmentName.replace('/', '_');
+    }
 }

--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessor.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessor.java
@@ -18,9 +18,9 @@
 
 package com.emc.pravega.service.server.host.handler;
 
+import com.emc.pravega.common.SegmentStoreMetricsNames;
 import com.emc.pravega.common.Timer;
 import com.emc.pravega.common.io.StreamHelpers;
-import com.emc.pravega.common.metrics.Counter;
 import com.emc.pravega.common.metrics.DynamicLogger;
 import com.emc.pravega.common.metrics.MetricsProvider;
 import com.emc.pravega.common.metrics.OpStatsLogger;
@@ -70,15 +70,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import lombok.extern.slf4j.Slf4j;
 
-
+import static com.emc.pravega.common.SegmentStoreMetricsNames.SEGMENT_READ_BYTES;
+import static com.emc.pravega.common.SegmentStoreMetricsNames.SEGMENT_READ_LATENCY;
+import static com.emc.pravega.common.SegmentStoreMetricsNames.nameFromSegment;
 import static com.emc.pravega.common.netty.WireCommands.TYPE_PLUS_LENGTH_SIZE;
 import static com.emc.pravega.service.contracts.ReadResultEntryType.Cache;
 import static com.emc.pravega.service.contracts.ReadResultEntryType.EndOfStreamSegment;
 import static com.emc.pravega.service.contracts.ReadResultEntryType.Future;
-import static com.emc.pravega.common.SegmentStoreMetricsNames.ALL_READ_BYTES;
-import static com.emc.pravega.common.SegmentStoreMetricsNames.CREATE_SEGMENT;
-import static com.emc.pravega.common.SegmentStoreMetricsNames.READ_SEGMENT;
-import static com.emc.pravega.common.SegmentStoreMetricsNames.SEGMENT_READ_BYTES;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -89,15 +87,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     static final int MAX_READ_SIZE = 2 * 1024 * 1024;
 
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("HOST");
-    // A dynamic logger
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
-
-    public static class Metrics {
-        static final OpStatsLogger CREATE_STREAM_SEGMENT = STATS_LOGGER.createStats(CREATE_SEGMENT);
-        static final OpStatsLogger READ_STREAM_SEGMENT = STATS_LOGGER.createStats(READ_SEGMENT);
-        static final OpStatsLogger READ_BYTES_STATS = STATS_LOGGER.createStats(SEGMENT_READ_BYTES);
-        static final Counter READ_BYTES = STATS_LOGGER.createCounter(ALL_READ_BYTES);
-    }
+    static final OpStatsLogger CREATE_STREAM_SEGMENT = STATS_LOGGER.createStats(SegmentStoreMetricsNames.CREATE_SEGMENT);
 
     private final StreamSegmentStore segmentStore;
 
@@ -118,12 +109,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         CompletableFuture<ReadResult> future = segmentStore.read(segment, readSegment.getOffset(), readSize, TIMEOUT);
         future.thenApply((ReadResult t) -> {
-            Metrics.READ_STREAM_SEGMENT.reportSuccessEvent(timer.getElapsed());
-            DYNAMIC_LOGGER.incCounterValue("readSegment." + segment, 1);
             handleReadResult(readSegment, t);
+            DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), t.getConsumedLength());
+            DYNAMIC_LOGGER.reportGaugeValue(nameFromSegment(SEGMENT_READ_LATENCY, segment), timer.getElapsedMillis());
             return null;
         }).exceptionally((Throwable t) -> {
-            Metrics.READ_STREAM_SEGMENT.reportFailEvent(timer.getElapsed());
             handleException(segment, "Read segment", t);
             return null;
         });
@@ -188,9 +178,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
      */
     private ByteBuffer copyData(List<ReadResultEntryContents> contents) {
         int totalSize = contents.stream().mapToInt(ReadResultEntryContents::getLength).sum();
-
-        Metrics.READ_BYTES_STATS.reportSuccessValue(totalSize);
-        Metrics.READ_BYTES.add(totalSize);
 
         ByteBuffer data = ByteBuffer.allocate(totalSize);
         int bytesCopied = 0;
@@ -259,11 +246,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         Timer timer = new Timer();
         CompletableFuture<Void> future = segmentStore.createStreamSegment(createStreamsSegment.getSegment(), TIMEOUT);
         future.thenApply((Void v) -> {
-            Metrics.CREATE_STREAM_SEGMENT.reportSuccessEvent(timer.getElapsed());
+            CREATE_STREAM_SEGMENT.reportSuccessEvent(timer.getElapsed());
             connection.send(new SegmentCreated(createStreamsSegment.getSegment()));
             return null;
         }).exceptionally((Throwable e) -> {
-            Metrics.CREATE_STREAM_SEGMENT.reportFailEvent(timer.getElapsed());
+            CREATE_STREAM_SEGMENT.reportFailEvent(timer.getElapsed());
             handleException(createStreamsSegment.getSegment(), "Create segment", e);
             return null;
         });

--- a/service/server/host/src/test/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessorTest.java
+++ b/service/server/host/src/test/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessorTest.java
@@ -18,8 +18,6 @@
 package com.emc.pravega.service.server.host.handler;
 
 import com.emc.pravega.common.concurrent.FutureHelpers;
-import com.emc.pravega.common.metrics.Counter;
-import com.emc.pravega.common.metrics.MetricsProvider;
 import com.emc.pravega.common.metrics.OpStatsData;
 import com.emc.pravega.common.netty.WireCommands.CreateSegment;
 import com.emc.pravega.common.netty.WireCommands.DeleteSegment;
@@ -59,11 +57,9 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -152,27 +148,6 @@ public class PravegaRequestProcessorTest {
         entry2.complete(new ReadResultEntryContents(new ByteArrayInputStream(data), data.length));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
-
-        // Have readSegment once, so here readSegmentStats and readBytesStats both succeeded once.
-        OpStatsData readSegmentStats = PravegaRequestProcessor.Metrics.READ_STREAM_SEGMENT.toOpStatsData();
-        assertEquals(1, readSegmentStats.getNumSuccessfulEvents());
-        assertEquals(0, readSegmentStats.getNumFailedEvents());
-
-        OpStatsData readBytesStats = PravegaRequestProcessor.Metrics.READ_BYTES_STATS.toOpStatsData();
-        assertEquals(1, readBytesStats.getNumSuccessfulEvents());
-        assertEquals(0, readBytesStats.getNumFailedEvents());
-
-        // Have read all the bytes in data[], so readBytes count equals to data.length.
-        Counter readBytes = PravegaRequestProcessor.Metrics.READ_BYTES;
-        assertEquals(data.length, readBytes.get());
-
-        // Test dynamic counter in readSegment, it should be with name "DYNAMIC.testReadSegment.Counter"
-        com.codahale.metrics.Counter dynamicCounter = MetricsProvider.YAMMERMETRICS.
-                getCounters().get("DYNAMIC.readSegment.testReadSegment.Counter");
-        assertNotEquals(0, dynamicCounter.getCount());
-
-        // Test dynamic gauge in readSegment, it should be with name "DYNAMIC.testReadSegment.Gauge"
-        assertNotNull(MetricsProvider.YAMMERMETRICS.getGauges().get("DYNAMIC.readSegment.testReadSegment.Gauge"));
     }
 
     @Test(timeout = 20000)
@@ -197,7 +172,7 @@ public class PravegaRequestProcessorTest {
 
         // TestCreateSealDelete may executed before this test case,
         // so createSegmentStats may record 1 or 2 createSegment operation here.
-        OpStatsData createSegmentStats = PravegaRequestProcessor.Metrics.CREATE_STREAM_SEGMENT.toOpStatsData();
+        OpStatsData createSegmentStats = PravegaRequestProcessor.CREATE_STREAM_SEGMENT.toOpStatsData();
         assertNotEquals(0, createSegmentStats.getNumSuccessfulEvents());
         assertEquals(0, createSegmentStats.getNumFailedEvents());
     }


### PR DESCRIPTION
**Change log description**
Added segment-level metrics for Bytes + Latency for Writes/Reads in the SegmentStore.

**Purpose of the change**
Fixes #507.

**What the code does**
Reports metrics.

**How to verify it**
See files being created under /tmp/csv