### PR TITLE
removed new version of guava getting automatically pulled in.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -433,7 +433,10 @@ project('controller:server') {
         compile project(":controller:contract")
         compile project(":clients:streaming")
         compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
-        compile group: 'io.swagger', name: 'swagger-jersey2-jaxrs', version: '1.5.9'
+        compile('io.swagger:swagger-jersey2-jaxrs:1.5.9') {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+
         compile group: 'com.typesafe', name: 'config', version: '1.3.0'
         compile group: 'org.apache.curator', name: 'curator-framework', version: '2.11.0'
         compile group: 'org.apache.curator', name: 'curator-recipes', version: '2.11.0'
@@ -504,7 +507,6 @@ project('singlenode') {
         compile('com.twitter:distributedlog-client:0.3.51-RC1') {
             exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         }
-        compile group: 'com.google.guava', name: 'guava', version: '16.0'
 
         testCompile project(':testcommon')
         testCompile files(project(':common').sourceSets.test.output)


### PR DESCRIPTION
**Change log description**
Removed the guava version which was automatically getting pulled in. This was conflicting with other modules (bookkeeper client) using guava.

**Purpose of the change**
Fix for https://github.com/pravega/pravega/issues/570

**What the code does**
Exclude the guava version which gets automatically pulled in by swagger modules.

**How to verify it**
./gradlew startSinglenode
