### PR TITLE
Issue 318: Changed DL namespace to "pravega/segmentstore/containers"

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -10,7 +10,7 @@ pravegaservice.clusterName=pravega-cluster
 
 dlog.hostname=zk1
 dlog.port=2181
-dlog.namespace=messaging/distributedlog/mynamespace
+dlog.namespace=pravega/segmentstore/containers
 
 hdfs.fs.default.name=localhost:9000
 hdfs.hdfsRoot=

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -7,7 +7,7 @@ PRAVEGA_PATH=${PRAVEGA_PATH:-"pravega"}
 BK_CLUSTER_NAME=${BK_CLUSTER_NAME:-"bookkeeper"}
 
 BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${BK_CLUSTER_NAME}/ledgers"
-DL_NS_PATH="/messaging/distributedlog/mynamespace"
+DL_NS_PATH="/pravega/segmentstore/containers"
 
 echo "bookie service port0 is $PORT0 "
 echo "ZK_URL is $ZK_URL"

--- a/integrationtests/config.properties
+++ b/integrationtests/config.properties
@@ -11,7 +11,7 @@ metrics.enableStatistics=false
 
 dlog.hostname=master.mesos
 dlog.port=2181
-dlog.namespace=messaging/distributedlog/mynamespace
+dlog.namespace=pravega/segmentstore/containers
 
 hdfs.fs.default.name=localhost:9000
 hdfs.hdfsRoot=

--- a/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/distributedlog/DistributedLogConfig.java
+++ b/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/distributedlog/DistributedLogConfig.java
@@ -23,7 +23,7 @@ public class DistributedLogConfig extends ComponentConfig {
 
     private static final String DEFAULT_HOSTNAME = "zk1";
     private static final int DEFAULT_PORT = 2181;
-    private static final String DEFAULT_NAMESPACE = "messaging/distributedlog/mynamespace";
+    private static final String DEFAULT_NAMESPACE = "pravega/segmentstore/containers";
 
     private String distributedLogHost;
     private int distributedLogPort;

--- a/singlenode/config.properties
+++ b/singlenode/config.properties
@@ -10,7 +10,7 @@ pravegaservice.clusterName=pravega-cluster
 
 dlog.hostname=zk1
 dlog.port=2181
-dlog.namespace=messaging/distributedlog/mynamespace
+dlog.namespace=pravega/segmentstore/containers
 
 hdfs.fs.default.name=localhost:9000
 hdfs.hdfsRoot=

--- a/singlenode/src/main/java/com/emc/pravega/local/LocalPravegaEmulator.java
+++ b/singlenode/src/main/java/com/emc/pravega/local/LocalPravegaEmulator.java
@@ -129,7 +129,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
         DistributedLogAdmin admin = new DistributedLogAdmin();
         String[] params = {"bind", "-dlzr", "localhost:" + zkPort, "-dlzw", "localhost:" + 7000, "-s", "localhost:" +
                 zkPort, "-bkzr", "localhost:" + 7000, "-l", "/ledgers", "-i", "false", "-r", "true", "-c",
-                "distributedlog://localhost:" + zkPort + "/messaging/distributedlog/mynamespace"};
+                "distributedlog://localhost:" + zkPort + "/pravega/segmentstore/containers"};
         try {
             admin.run(params);
         } catch (Exception e) {


### PR DESCRIPTION
**Change log description**
Changed DL namespace to "pravega/segmentstore/containers"

**Purpose of the change**
Fixes #318. We were using the default namespace, which was not good. We now use a personalized one.

**What the code does**
Same thing.

**How to verify it**
Everything should still work.
