### PR TITLE
Issue 485: removing deplicate usage of clustername

### DIFF
--- a/common/src/main/java/com/emc/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/common/src/main/java/com/emc/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -52,13 +52,11 @@ public class ClusterZKImpl implements Cluster {
     private final static int INIT_SIZE = 3;
 
     private final CuratorFramework client;
-    private final String clusterName;
 
     private final Map<Host, PersistentNode> entryMap = new HashMap<>(INIT_SIZE);
     private Optional<PathChildrenCache> cache = Optional.empty();
 
-    public ClusterZKImpl(CuratorFramework zkClient, String clusterName) {
-        this.clusterName = clusterName;
+    public ClusterZKImpl(CuratorFramework zkClient) {
         this.client = zkClient;
         if (client.getState().equals(CuratorFrameworkState.LATENT)) {
             client.start();
@@ -76,7 +74,7 @@ public class ClusterZKImpl implements Cluster {
         Preconditions.checkNotNull(host, "host");
         Exceptions.checkArgument(!entryMap.containsKey(host), "host", "host is already registered to cluster.");
 
-        String hostPath = ZKPaths.makePath(PATH_CLUSTER, clusterName, HOSTS, host.getIpAddr() + ":" + host.getPort());
+        String hostPath = ZKPaths.makePath(PATH_CLUSTER, HOSTS, host.getIpAddr() + ":" + host.getPort());
         PersistentNode node = new PersistentNode(client, CreateMode.EPHEMERAL, false, hostPath,
                 SerializationUtils.serialize(host));
 
@@ -171,24 +169,24 @@ public class ClusterZKImpl implements Cluster {
     }
 
     private void initializeCache() throws Exception {
-        cache = Optional.of(new PathChildrenCache(client, ZKPaths.makePath(PATH_CLUSTER, clusterName, HOSTS), true));
+        cache = Optional.of(new PathChildrenCache(client, ZKPaths.makePath(PATH_CLUSTER, HOSTS), true));
         cache.get().start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
     }
 
     private PathChildrenCacheListener pathChildrenCacheListener(final ClusterListener listener) {
         return (client, event) -> {
-            log.debug("Event {} generated on cluster:{}", event, clusterName);
+            log.debug("Event {} generated on cluster", event);
             switch (event.getType()) {
                 case CHILD_ADDED:
-                    log.info("Node {} added to cluster:{}", getServerName(event), clusterName);
+                    log.info("Node {} added to cluster", getServerName(event));
                     listener.onEvent(HOST_ADDED, (Host) SerializationUtils.deserialize(event.getData().getData()));
                     break;
                 case CHILD_REMOVED:
-                    log.info("Node {} removed from cluster:{}", getServerName(event), clusterName);
+                    log.info("Node {} removed from cluster", getServerName(event));
                     listener.onEvent(HOST_REMOVED, (Host) SerializationUtils.deserialize(event.getData().getData()));
                     break;
                 case CHILD_UPDATED:
-                    log.warn("Invalid usage: Node {} updated externally for cluster:{}", getServerName(event), clusterName);
+                    log.warn("Invalid usage: Node {} updated externally for cluster", getServerName(event));
                     break;
                 case CONNECTION_LOST:
                     log.error("Connection lost with Zookeeper");

--- a/common/src/test/java/com/emc/pravega/common/cluster/zkImpl/ClusterZKTest.java
+++ b/common/src/test/java/com/emc/pravega/common/cluster/zkImpl/ClusterZKTest.java
@@ -54,9 +54,14 @@ public class ClusterZKTest {
         LinkedBlockingQueue<String> nodeRemovedQueue = new LinkedBlockingQueue();
 
         //ClusterListener for testing purposes
-        CuratorFramework client2 = CuratorFrameworkFactory.newClient(zkUrl, new ExponentialBackoffRetry(
-                RETRY_SLEEP_MS, MAX_RETRY));
-        Cluster clusterListener = new ClusterZKImpl(client2, CLUSTER_NAME);
+        CuratorFramework client2 = CuratorFrameworkFactory.builder()
+                .connectString(zkUrl)
+                .retryPolicy(new ExponentialBackoffRetry(
+                        RETRY_SLEEP_MS, MAX_RETRY))
+                .namespace(CLUSTER_NAME)
+                .build();
+
+        Cluster clusterListener = new ClusterZKImpl(client2);
         clusterListener.addListener((eventType, host) -> {
             switch (eventType) {
                 case HOST_ADDED:
@@ -68,16 +73,20 @@ public class ClusterZKTest {
             }
         });
 
-        CuratorFramework client = CuratorFrameworkFactory.newClient(zkUrl, new ExponentialBackoffRetry(
-                RETRY_SLEEP_MS, MAX_RETRY));
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(zkUrl)
+                .retryPolicy(new ExponentialBackoffRetry(
+                        RETRY_SLEEP_MS, MAX_RETRY))
+                .namespace(CLUSTER_NAME)
+                .build();
 
         //Create Add a node to the cluster.
-        Cluster clusterZKInstance1 = new ClusterZKImpl(client, CLUSTER_NAME);
+        Cluster clusterZKInstance1 = new ClusterZKImpl(client);
         clusterZKInstance1.registerHost(new Host(HOST_1, PORT));
         assertEquals(HOST_1, nodeAddedQueue.poll(5, TimeUnit.SECONDS));
 
         //Create a separate instance of Cluster and add node to same Cluster
-        Cluster clusterZKInstance2 = new ClusterZKImpl(client, CLUSTER_NAME);
+        Cluster clusterZKInstance2 = new ClusterZKImpl(client);
         clusterZKInstance1.registerHost(new Host(HOST_2, PORT));
         assertEquals(HOST_2, nodeAddedQueue.poll(5, TimeUnit.SECONDS));
         assertEquals(2, clusterListener.getClusterMembers().size());
@@ -93,9 +102,13 @@ public class ClusterZKTest {
         LinkedBlockingQueue<String> nodeAddedQueue = new LinkedBlockingQueue();
         LinkedBlockingQueue<String> nodeRemovedQueue = new LinkedBlockingQueue();
 
-        CuratorFramework client2 = CuratorFrameworkFactory.newClient(zkUrl, new ExponentialBackoffRetry(
-                RETRY_SLEEP_MS, MAX_RETRY));
-        Cluster clusterListener = new ClusterZKImpl(client2, CLUSTER_NAME_2);
+        CuratorFramework client2 = CuratorFrameworkFactory.builder()
+                .connectString(zkUrl)
+                .retryPolicy(new ExponentialBackoffRetry(
+                        RETRY_SLEEP_MS, MAX_RETRY))
+                .namespace(CLUSTER_NAME_2)
+                .build();
+        Cluster clusterListener = new ClusterZKImpl(client2);
         clusterListener.addListener((eventType, host) -> {
             switch (eventType) {
                 case HOST_ADDED:
@@ -107,10 +120,14 @@ public class ClusterZKTest {
             }
         });
 
-        CuratorFramework client = CuratorFrameworkFactory.newClient(zkUrl, new ExponentialBackoffRetry(
-                RETRY_SLEEP_MS, MAX_RETRY));
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(zkUrl)
+                .retryPolicy(new ExponentialBackoffRetry(
+                        RETRY_SLEEP_MS, MAX_RETRY))
+                .namespace(CLUSTER_NAME_2)
+                .build();
         //Create Add a node to the cluster.
-        Cluster clusterZKInstance1 = new ClusterZKImpl(client, CLUSTER_NAME_2);
+        Cluster clusterZKInstance1 = new ClusterZKImpl(client);
         clusterZKInstance1.registerHost(new Host(HOST_1, PORT));
         assertEquals(HOST_1, nodeAddedQueue.poll(5, TimeUnit.SECONDS));
 

--- a/controller/server/src/main/java/com/emc/pravega/controller/fault/SegmentContainerMonitor.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/fault/SegmentContainerMonitor.java
@@ -36,21 +36,19 @@ public class SegmentContainerMonitor extends AbstractIdleService {
      *
      * @param hostStore             The store to read and write the host container mapping data.
      * @param client                The curator client for coordination.
-     * @param clusterName           The unique name for this cluster.
      * @param balancer              The host to segment container balancer implementation.
      * @param minRebalanceInterval  The minimum interval between any two rebalance operations in seconds.
      *                              0 indicates there can be no waits between retries.
      */
-    public SegmentContainerMonitor(HostControllerStore hostStore, CuratorFramework client, String clusterName,
-            ContainerBalancer balancer, int minRebalanceInterval) {
+    public SegmentContainerMonitor(HostControllerStore hostStore, CuratorFramework client, ContainerBalancer balancer,
+            int minRebalanceInterval) {
         Preconditions.checkNotNull(hostStore, "hostStore");
         Preconditions.checkNotNull(client, "client");
-        Preconditions.checkNotNull(clusterName, "clusterName");
         Preconditions.checkNotNull(balancer, "balancer");
 
-        leaderZKPath = ZKPaths.makePath("cluster", clusterName, "faulthandlerleader");
+        leaderZKPath = ZKPaths.makePath("cluster", "faulthandlerleader");
 
-        segmentMonitorLeader = new SegmentMonitorLeader(clusterName, hostStore, balancer, minRebalanceInterval);
+        segmentMonitorLeader = new SegmentMonitorLeader(hostStore, balancer, minRebalanceInterval);
         leaderSelector = new LeaderSelector(client, leaderZKPath, segmentMonitorLeader);
 
         //Listen for any zookeeper connectivity error and relinquish leadership.

--- a/controller/server/src/main/java/com/emc/pravega/controller/fault/SegmentMonitorLeader.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/fault/SegmentMonitorLeader.java
@@ -35,9 +35,6 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
     //The store for reading and writing the host to container mapping.
     private final HostControllerStore hostStore;
 
-    //The name of the cluster which has to be monitored.
-    private final String clusterName;
-
     //The host to containers balancer.
     private final ContainerBalancer segBalancer;
 
@@ -64,20 +61,16 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
     /**
      * The leader instance which monitors the data node cluster.
      *
-     * @param clusterName           The unique name for this cluster.
      * @param hostStore             The store for reading and writing the host to container mapping.
      * @param balancer              The host to segment container balancer implementation.
      * @param minRebalanceInterval  The minimum interval between any two rebalance operations in seconds.
      *                              0 indicates there can be no waits between retries.
      */
-    public SegmentMonitorLeader(String clusterName, HostControllerStore hostStore, ContainerBalancer balancer,
-            int minRebalanceInterval) {
-        Preconditions.checkNotNull(clusterName, "clusterName");
+    public SegmentMonitorLeader(HostControllerStore hostStore, ContainerBalancer balancer, int minRebalanceInterval) {
         Preconditions.checkNotNull(hostStore, "hostStore");
         Preconditions.checkNotNull(balancer, "balancer");
         Preconditions.checkArgument(minRebalanceInterval >= 0, "minRebalanceInterval should not be negative");
 
-        this.clusterName = clusterName;
         this.hostStore = hostStore;
         this.segBalancer = balancer;
         this.minRebalanceInterval = Duration.ofSeconds(minRebalanceInterval);
@@ -115,7 +108,7 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
         hostsChange.release();
 
         //Start cluster monitor.
-        pravegaServiceCluster = new ClusterZKImpl(client, clusterName);
+        pravegaServiceCluster = new ClusterZKImpl(client);
 
         //Add listener to track host changes on the monitored pravega cluster.
         pravegaServiceCluster.addListener((type, host) -> {

--- a/controller/server/src/main/java/com/emc/pravega/controller/server/Main.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/Main.java
@@ -80,8 +80,7 @@ public class Main {
         if (Config.HOST_MONITOR_ENABLED) {
             //Start the Segment Container Monitor.
             log.info("Starting the segment container monitor");
-            SegmentContainerMonitor monitor = new SegmentContainerMonitor(hostStore,
-                    ZKUtils.getCuratorClient(), Config.CLUSTER_NAME,
+            SegmentContainerMonitor monitor = new SegmentContainerMonitor(hostStore, ZKUtils.getCuratorClient(),
                     new UniformContainerBalancer(), Config.CLUSTER_MIN_REBALANCE_INTERVAL);
             monitor.startAsync();
         }

--- a/controller/server/src/main/java/com/emc/pravega/controller/store/host/HostStoreFactory.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/store/host/HostStoreFactory.java
@@ -35,7 +35,7 @@ public class HostStoreFactory {
             
         case Zookeeper:
             log.info("Creating Zookeeper based host store");
-            return new ZKHostStore(ZKUtils.getCuratorClient(), Config.CLUSTER_NAME);
+            return new ZKHostStore(ZKUtils.getCuratorClient());
             
         default:
             throw new NotImplementedException();

--- a/controller/server/src/main/java/com/emc/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/store/host/ZKHostStore.java
@@ -44,14 +44,12 @@ public class ZKHostStore implements HostControllerStore {
      * Zookeeper based host store implementation.
      *
      * @param client                    The curator client instance.
-     * @param clusterName               The name of the cluster.
      */
-    public ZKHostStore(CuratorFramework client, String clusterName) {
+    public ZKHostStore(CuratorFramework client) {
         Preconditions.checkNotNull(client, "client");
-        Preconditions.checkNotNull(clusterName, "clusterName");
 
         zkClient = client;
-        zkPath = ZKPaths.makePath("cluster", clusterName, "segmentContainerHostMapping");
+        zkPath = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
         segmentMapper = new SegmentToContainerMapper(Config.HOST_STORE_CONTAINER_COUNT);
     }
 

--- a/controller/server/src/test/java/com/emc/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/server/src/test/java/com/emc/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -36,8 +36,6 @@ public class SegmentContainerMonitorTest {
     private static CuratorFramework zkClient;
     private static Cluster cluster;
 
-    private final static String CLUSTER_NAME = "testcluster";
-
     //Ensure each test completes within 30 seconds.
     @Rule
     public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
@@ -49,7 +47,7 @@ public class SegmentContainerMonitorTest {
 
         zkClient = CuratorFrameworkFactory.newClient(zkUrl, new ExponentialBackoffRetry(200, 10, 5000));
         zkClient.start();
-        cluster = new ClusterZKImpl(zkClient, CLUSTER_NAME);
+        cluster = new ClusterZKImpl(zkClient);
     }
 
     @After
@@ -60,7 +58,7 @@ public class SegmentContainerMonitorTest {
 
     @Test
     public void testMonitorWithZKStore() throws Exception {
-        HostControllerStore hostStore = new ZKHostStore(zkClient, CLUSTER_NAME);
+        HostControllerStore hostStore = new ZKHostStore(zkClient);
         testMonitor(hostStore);
     }
 
@@ -101,7 +99,7 @@ public class SegmentContainerMonitorTest {
         }
 
         SegmentContainerMonitor monitor = new SegmentContainerMonitor(new MockHostControllerStore(), zkClient,
-                CLUSTER_NAME, new UniformContainerBalancer(), 5);
+                new UniformContainerBalancer(), 5);
         monitor.startAsync().awaitRunning();
 
         assertEquals(hostStore.getContainerCount(), Config.HOST_STORE_CONTAINER_COUNT);

--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
@@ -165,8 +165,7 @@ public final class ServiceStarter {
             return new ZKSegmentContainerManager(setup.getContainerRegistry(),
                     setup.getSegmentToContainerMapper(),
                     zkClient,
-                    new Host(this.serviceConfig.getListeningIPAddress(), this.serviceConfig.getListeningPort()),
-                    this.serviceConfig.getClusterName());
+                    new Host(this.serviceConfig.getListeningIPAddress(), this.serviceConfig.getListeningPort()));
         });
     }
 

--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/ZKSegmentContainerManager.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/ZKSegmentContainerManager.java
@@ -78,28 +78,26 @@ public class ZKSegmentContainerManager implements SegmentContainerManager {
      *                                 cluster (i.e., number of containers).
      * @param zkClient                 ZooKeeper client.
      * @param pravegaServiceEndpoint   Pravega service endpoint details.
-     * @param clusterName              Cluster Name.
      * @throws NullPointerException If containerRegistry is null.
      * @throws NullPointerException If segmentToContainerMapper is null.
      * @throws NullPointerException If logger is null.
      */
     public ZKSegmentContainerManager(SegmentContainerRegistry containerRegistry,
                                      SegmentToContainerMapper segmentToContainerMapper,
-                                     CuratorFramework zkClient, Host pravegaServiceEndpoint, String clusterName) {
+                                     CuratorFramework zkClient, Host pravegaServiceEndpoint) {
         Preconditions.checkNotNull(containerRegistry, "containerRegistry");
         Preconditions.checkNotNull(segmentToContainerMapper, "segmentToContainerMapper");
         Preconditions.checkNotNull(zkClient, "zkClient");
         Preconditions.checkNotNull(pravegaServiceEndpoint, "pravegaServiceEndpoint");
-        Exceptions.checkNotNullOrEmpty(clusterName, "clusterName");
 
         this.registry = containerRegistry;
         this.segmentToContainerMapper = segmentToContainerMapper;
         this.handles = new HashMap<>();
 
         this.client = zkClient;
-        this.clusterPath = ZKPaths.makePath("cluster", clusterName, "segmentContainerHostMapping");
+        this.clusterPath = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
         this.segContainerHostMapping = new NodeCache(zkClient, this.clusterPath);
-        this.cluster = new ClusterZKImpl(zkClient, clusterName);
+        this.cluster = new ClusterZKImpl(zkClient);
 
         this.host = pravegaServiceEndpoint;
     }

--- a/service/server/host/src/test/java/com/emc/pravega/service/server/host/ZKSegmentContainerManagerTest.java
+++ b/service/server/host/src/test/java/com/emc/pravega/service/server/host/ZKSegmentContainerManagerTest.java
@@ -49,8 +49,7 @@ public class ZKSegmentContainerManagerTest {
     private final static int MAX_RETRY = 5;
     private final static int PORT = 12345;
     private final static Host PRAVEGA_SERVICE_ENDPOINT = new Host(getHostAddress(), PORT);
-    private final static String CLUSTER_NAME = "cluster-1";
-    private final static String PATH = ZKPaths.makePath("cluster", CLUSTER_NAME, "segmentContainerHostMapping");
+    private final static String PATH = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
     private static String zkUrl;
 
     private static TestingServer zkTestServer;
@@ -85,7 +84,7 @@ public class ZKSegmentContainerManagerTest {
 
         ZKSegmentContainerManager segManager = new ZKSegmentContainerManager(createMockContainerRegistry(),
                 segmentToContainerMapper, zkClient,
-                PRAVEGA_SERVICE_ENDPOINT, CLUSTER_NAME);
+                PRAVEGA_SERVICE_ENDPOINT);
 
         CompletableFuture<Void> result = segManager.initialize();
 
@@ -108,7 +107,7 @@ public class ZKSegmentContainerManagerTest {
 
         ZKSegmentContainerManager segManager = new ZKSegmentContainerManager(containerRegistry,
                 segmentToContainerMapper, zkClient,
-                PRAVEGA_SERVICE_ENDPOINT, CLUSTER_NAME);
+                PRAVEGA_SERVICE_ENDPOINT);
 
         segManager.initialize().get();
 
@@ -145,7 +144,7 @@ public class ZKSegmentContainerManagerTest {
 
         ZKSegmentContainerManager segManager = new ZKSegmentContainerManager(containerRegistry,
                 segmentToContainerMapper, zkClient,
-                PRAVEGA_SERVICE_ENDPOINT, CLUSTER_NAME);
+                PRAVEGA_SERVICE_ENDPOINT);
 
         CompletableFuture<Void> result = segManager.initialize();
 

--- a/singlenode/src/main/java/com/emc/pravega/local/LocalPravegaEmulator.java
+++ b/singlenode/src/main/java/com/emc/pravega/local/LocalPravegaEmulator.java
@@ -239,8 +239,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
 
         //Start the Segment Container Monitor.
         log.info("Starting the segment container monitor");
-        SegmentContainerMonitor monitor = new SegmentContainerMonitor(hostStore,
-                ZKUtils.getCuratorClient(), Config.CLUSTER_NAME,
+        SegmentContainerMonitor monitor = new SegmentContainerMonitor(hostStore, ZKUtils.getCuratorClient(),
                 new UniformContainerBalancer(), Config.CLUSTER_MIN_REBALANCE_INTERVAL);
         monitor.startAsync();
 


### PR DESCRIPTION
**Change log description**
The clusername appears twice the zookeeper znode paths. This change removes the redundant entry in the path

**Purpose of the change**
Fix for https://github.com/pravega/pravega/issues/485

**What the code does**
Removes the redundant usage of cluster name

**How to verify it**
Existing test cases have been updated.
Also check the paths created in zookeeper so that the cluster name does not appear twice for the same znodes.