### PR TITLE
Issue 579: NoClassDefFound calling ClientFactory.withScope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,7 @@ project('clients') {
     }
     jar {
         from project(":clients:streaming").sourceSets.main.output
+        from project(":controller:contract").sourceSets.main.output
     }
     publishing {
         publications {


### PR DESCRIPTION
**Change log description**
Controller contract classes are not available to client calls and this is inducing a `java.lang.NoClassDefFoundError`. This PR simply adds the controller classes to the clients artifact.
Fixes: #579 

**Purpose of the change**
Avoid the `java.lang.NoClassDefFoundError` error due to the absence of controller contract classes.

**What the code does**
Change to `build.gradle` to add the `:controller:contract` classes.

**How to verify it**
`./gradlew :clients:jar` and then `jar tvf clients/build/libs/clients.jar`.
