### PR TITLE
Issue 621: Update readNextEvent javadoc

### DIFF
--- a/clients/streaming/src/main/java/com/emc/pravega/stream/EventStreamReader.java
+++ b/clients/streaming/src/main/java/com/emc/pravega/stream/EventStreamReader.java
@@ -25,7 +25,8 @@ public interface EventStreamReader<T> extends AutoCloseable {
      * be sure they have read all the events within a time range.)
      *
      * @param timeout An upper bound on how long the call may block before returning null.
-     * @return The next event in the stream, or null if timeout is reached.
+     * @return An instance of {@link EventRead}, which contains the next event in the stream. In the case the timeout
+     *         is reached, {@link EventRead#getEvent()} returns null.
      * @throws ReinitializationRequiredException Is throw in the event that
      *         {@link ReaderGroup#resetReadersToCheckpoint(Checkpoint)} or
      *         {@link ReaderGroup#alterConfig(ReaderGroupConfig, java.util.List)} was called


### PR DESCRIPTION
**Change log description**
Updates the javadoc of `EventStreamReader#readNextEvent`, see #621 .

**Purpose of the change**
Javadoc change.

**What the code does**
Documentation not code.

**How to verify it**
Read it!