### PR TITLE
Issue 625: Make maxParallelForks configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ allprojects {
         testLogging.showExceptions = true
         testLogging.showStackTraces = true
         testLogging.events = ["PASSED", "FAILED"]
-        maxParallelForks = maxParFork
+        maxParallelForks = System.properties['maxParallelForks'] ? System.properties['maxParallelForks'].toInteger() : 1
         minHeapSize = "128m"
         maxHeapSize = "512m"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ dockerUrl=unix:///var/run/docker.sock
 dockerRegistryUser=username
 dockerRegistryPass=password
 dockerRegistryUrl=url
-maxParFork=1
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.0-PRERELEASE


### PR DESCRIPTION
**Change log description**
change the value of  maxParallelForks, see issue #625 

**Purpose of the change**
Setting maxParallelForks to 2 causes intermittent build failures due to port conflicts.

**What the code does**
Sets default value  'maxParallelForks' to 1 and make it   configurable from cmd

**How to verify it**
`./gradlew <command>  -DmaxParallelForks=<>.`