### PR TITLE
Fixes #649 : Added scaleService API

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
@@ -7,23 +7,29 @@ package com.emc.pravega.framework.services;
 import com.emc.pravega.common.concurrent.FutureHelpers;
 import com.emc.pravega.framework.TestFrameworkException;
 import com.emc.pravega.framework.marathon.AuthEnabledMarathonClient;
+import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.Marathon;
+import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.GetAppResponse;
 import mesosphere.marathon.client.model.v2.HealthCheck;
 import mesosphere.marathon.client.model.v2.Volume;
 import mesosphere.marathon.client.utils.MarathonException;
+
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
+import static com.emc.pravega.framework.TestFrameworkException.Type.InternalError;
 import static com.emc.pravega.framework.TestFrameworkException.Type.RequestFailed;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
 /**
@@ -86,6 +92,27 @@ public abstract class MarathonBasedService implements Service {
                     .collect(Collectors.toList());
         } catch (MarathonException ex) {
             throw new TestFrameworkException(RequestFailed, "Marathon Exception while fetching service details", ex);
+        }
+    }
+
+    @Override
+    public void scaleService(final int instanceCount, final boolean wait) {
+        Preconditions.checkArgument(instanceCount >= 0, "negative value: %s", instanceCount);
+        try {
+            App updatedConfig = new App();
+            updatedConfig.setInstances(instanceCount);
+            marathonClient.updateApp(getID(), updatedConfig, false);
+            if (wait) {
+                waitUntilServiceRunning().get(); // wait until scale operation is complete.
+            }
+        } catch (MarathonException ex) {
+            if (ex.getStatus() == CONFLICT.code()) {
+                log.error("Scaling operation failed as the application is locked by an ongoing deployment", ex);
+                throw new TestFrameworkException(RequestFailed, "Scaling operation failed", ex);
+            }
+            handleMarathonException(ex);
+        } catch (InterruptedException | ExecutionException ex) {
+            throw new TestFrameworkException(InternalError, "Exception during scale operation", ex);
         }
     }
 

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/Service.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/Service.java
@@ -1,7 +1,5 @@
 /**
- *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
- *
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries.
  */
 
 package com.emc.pravega.framework.services;
@@ -53,4 +51,17 @@ public interface Service {
      *  @return List<URI> list of Host:port where the service is running.
      */
     public List<URI> getServiceDetails();
+
+    /**
+     * Scale service to the new instance count.
+     *
+     * Increasing instance count will result in new deployments while decreasing the instance count will result in
+     * killing of running instances.
+     *
+     * An instance count of zero would suspend the service.
+     * @param instanceCount new instance count for the service.
+     * @param wait wait until the the service reaches the desired instance count.
+     *
+     */
+    public void scaleService(final int instanceCount, final boolean wait);
 }


### PR DESCRIPTION
**Change log description**
Addition of scaleService api in the testFramework.

**Purpose of the change**
Fix for #649 

Test framework should support dynamic scaling of services. This feature will be useful to test fail over scenarios
E.g:
*    Bring pravega hosts up and down, specifically, add hosts to the cluster and crash hosts to exercise fail-over.
*    Kill bookies and make sure that it works fine for us


**What the code does**
Implements the scaleService API

**How to use it**
`service.scaleService(3, true); // this scales the service to a count of 3 and waits untils the scaling operation is completed.`
`service.scaleService(1, false); // trigger scaleService operation to change the instanceCount to 1.`


