### PR TITLE
Applying proto plugin only to the contract project where is it required.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ allprojects {
     apply plugin: 'findbugs'
     apply plugin: 'com.bmuschko.docker-java-application'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.google.protobuf'
 
     apply plugin: 'jacoco'
 
@@ -422,7 +421,7 @@ project('controller') {
 }
 
 project('controller:contract') {
-
+    apply plugin: 'com.google.protobuf'
     protobuf {
         protoc {
             artifact = "com.google.protobuf:protoc:3.0.2"


### PR DESCRIPTION
**Change log description**
Fixes - https://github.com/pravega/pravega/issues/690

**Purpose of the change**
To reduce build time.

**What the code does**
Applied protobuf plugin only to the contract project.

**How to verify it**
Run "./gradlew build" and verify that protobuf plugin is not applied to all projects

