### PR TITLE
Issue 700: startSingleNode using 2 process to isolate guava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ buildscript {
 
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 allprojects {
     apply plugin: 'java'
@@ -594,11 +597,41 @@ project('singlenode') {
     }
 
     task startSinglenode(type: JavaExec) {
+
+        // Configuration to resolve to full path of the guava version which we need for bookkeeper.
+        configurations {
+            bkguavaversion
+        }
+
+        dependencies {
+            // bookkeeper emulator is not compatible with guava version > 16.
+            bkguavaversion "com.google.guava:guava:16.0"
+        }
+
+        // Filter out existing guava dependency and replace it with the specific version thats needed by bookkeeper.
         main = "com.emc.pravega.local.LocalPravegaEmulator"
-        classpath = sourceSets.main.runtimeClasspath
+        def allJars = files(sourceSets.main.runtimeClasspath)
+        allJars = allJars.filter { !it.path.contains("com.google.guava") && !it.path.contains("guava-") } +
+                configurations.bkguavaversion.files
+        classpath allJars
         standardInput = System.in
-        args = ["4000", "5000", "6000"]
+        args = ["true", "4000", "5000", "6000"]
+
+        doFirst {
+            ExecutorService es = Executors.newSingleThreadExecutor()
+            es.submit({
+                project.javaexec {
+                    main = "com.emc.pravega.local.LocalPravegaEmulator"
+                    classpath = sourceSets.main.runtimeClasspath
+
+                    standardInput = System.in
+                    // Starts all services other than bookkeeper.
+                    args = ["false", "4000", "5000", "6000"]
+                }
+            } as Callable)
+        }
     }
+
     publishing {
         publications {
             maven(MavenPublication) {
@@ -608,7 +641,6 @@ project('singlenode') {
         }
     }
 }
-
 
 project('systemtests:tests') {
     dependencies {


### PR DESCRIPTION
**Change log description**
Lauching 2 processes as part of startSingleNode gradle task.
One process runs the zookeeper and bookkeeper.
The other runs the pravega services (host and controller).

This was required due to bookkeeper's hard dependency on guava 16.0 which prevents us from upgrading guava and also using libraries which depend on newer versions of guava.

**Purpose of the change**
Fix for https://github.com/pravega/pravega/issues/700

**What the code does**
Updated the gradle task to launch 2 processes with different classpath so that each process can have different guava jar version loaded at runtime.

**How to verify it**
Run ./gradlew startSinglenode
