### PR TITLE
Issue 724 : updating group id, artifact id in system tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -656,7 +656,8 @@ project('systemtests:tests') {
         maxParallelForks = 1
         systemProperty "dockerImageRegistry", project.property("dockerRegistryUrl")
         systemProperty "testVersion", project.property("pravegaVersion")
-        systemProperty "testArtifactUrl", project.property('repoUrl') + "/pravega/systemtests/"+pravegaVersion+"/systemtests-"+pravegaVersion+".jar"
+        systemProperty "testArtifactUrl", project.property('repoUrl') + "/com/emc/pravega/pravega-systemtests/" +
+                pravegaVersion+"/pravega-systemtests-"+ pravegaVersion + ".jar"
     }
     publishing {
         publications {

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/RemoteSequential.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/RemoteSequential.java
@@ -105,7 +105,7 @@ public class RemoteSequential implements TestExecutor {
 
         run.setCmd("docker run --rm -v $(pwd):/data " + System.getProperty("dockerImageRegistry")+"/java:8 java" +
                 " -DmasterIP=" + MESOS_MASTER +
-                " -cp /data/systemtests-"+System.getProperty("testVersion")+".jar com.emc.pravega.SingleJUnitTestRunner " +
+                " -cp /data/pravega-systemtests-"+System.getProperty("testVersion")+".jar com.emc.pravega.SingleJUnitTestRunner " +
                 className + "#" + methodName + " > server.log 2>&1" +
                 "; exit $?");
 


### PR DESCRIPTION
**Change log description**
change the artifact url (build.gradle) and system tests path in docker run command(remote sequential.java)

**Purpose of the change**
The recent changes in group id , artifact id of the artifacts are not reflected in system tests .
Group id changed to` com.emc.pravega`(new) from'pravega'
New Artifact id comes with a prefix` pravega-`

**What the code does**
fix #724 

**How to verify it**
Run ./gradlew startSystemTests