### PR TITLE
Issue 723 : Set max heap memory for pravega segmentstore

### DIFF
--- a/PravegaGroup.json
+++ b/PravegaGroup.json
@@ -113,7 +113,7 @@
                   "parameters": [
                   {
                     "key": "env",
-                    "value": "HOST_OPTS=-Xmx900m"
+                    "value": "JAVA_OPTS=-Xmx900m"
                   }
                   ],
 		  "forcePullImage": true
@@ -164,7 +164,9 @@
                   "network": "HOST",
 		   "parameters": [
         				{ "key": "env",
-        				  "value": "SERVER_OPTS=\"-DZK_URL=master.mesos:2181\"" }
+        				  "value": "SERVER_OPTS=\"-DZK_URL=master.mesos:2181\"" },
+                        { "key": "env",
+                          "value": "JAVA_OPTS=-Xmx512m" }
 		    ],
 		  "forcePullImage": true
               }

--- a/build.gradle
+++ b/build.gradle
@@ -477,7 +477,7 @@ project('controller:server') {
 
     apply plugin: 'application'
     mainClassName = "com.emc.pravega.controller.server.Main"
-    applicationDefaultJvmArgs = ["-server", "-Xms128m", "-Xmx512m", "-XX:+HeapDumpOnOutOfMemoryError",
+    applicationDefaultJvmArgs = ["-server", "-Xms128m", "-XX:+HeapDumpOnOutOfMemoryError",
                                  "-Dconfig.file=CONTROLLER_APP_HOME/conf/application.conf",
                                  "-Dlogback.configurationFile=CONTROLLER_APP_HOME/conf/logback.xml"]
 

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaControllerService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaControllerService.java
@@ -119,7 +119,9 @@ public class PravegaControllerService extends MarathonBasedService {
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         List<Parameter> parameterList = new ArrayList<>();
         Parameter element1 = new Parameter("env", "SERVER_OPTS=\"-DZK_URL=" + zk + "\"");
+        Parameter element2 = new Parameter("env", "JAVA_OPTS=-Xmx512m");
         parameterList.add(element1);
+        parameterList.add(element2);
         app.getContainer().getDocker().setParameters(parameterList);
         //set port
         app.setPorts(Arrays.asList(CONTROLLER_PORT, REST_PORT));

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
@@ -107,7 +107,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         app.getContainer().getDocker().setNetwork(NETWORK_TYPE);
         app.getContainer().getDocker().setForcePullImage(FORCE_IMAGE);
         List<Parameter> parameterList = new ArrayList<>();
-        Parameter element1 = new Parameter("env", "HOST_OPTS=-Xmx900m");
+        Parameter element1 = new Parameter("env", "JAVA_OPTS=-Xmx900m");
         parameterList.add(element1);
         app.getContainer().getDocker().setParameters(parameterList);
         //set port


### PR DESCRIPTION
**Change log description**
 We need to set Xmx in accordance with the container memory allocated leaving ~100m for stack and other things.

**Purpose of the change**
Xmx is not set for pravega host

**What the code does**
fixes #723 , #634 , #706 

**How to verify it**
1. ./gradlew :service:server:host:distTar 
2. cd  service/serevr/host/build/distributions
3. tar xvf host.tar
4. vim host/bin/host
5. check for JVM argument in host startup script.
