### PR TITLE
issue-733

### DIFF
--- a/common/src/main/java/com/emc/pravega/common/MetricsNames.java
+++ b/common/src/main/java/com/emc/pravega/common/MetricsNames.java
@@ -36,9 +36,9 @@ public final class MetricsNames {
     public static final String OPEN_TRANSACTIONS = "transactions_opened";     // Dynamic Gauge
 
     // Stream segment counts (Dynamic)
-    //public static final String SEGMENTS_COUNT = "segments_count";   // Dynamic Counter
-    //public static final String SEGMENTS_SPLITS = "segments_splits"; // Dynamic Guage
-    //public static final String SEGMENTS_MERGES = "segments_merges"; // Dynamic Guage
+    public static final String SEGMENTS_COUNT = "segments_count";   // Dynamic Counter
+    public static final String SEGMENTS_SPLITS = "segments_splits"; // Dynamic Guage
+    public static final String SEGMENTS_MERGES = "segments_merges"; // Dynamic Guage
 
     private static String escapeSpecialChar(String name) {
         return name.replace('/', '.').replace(':', '.').replace('|', '.').replaceAll("\\s+", "_");


### PR DESCRIPTION
**Change log description**
Readding metric code that got removed with some merge
 
**Purpose of the change**
readding mertic changes
**What the code does**
Added support for following stream segment metrics (issue #508).

NUMBER_OF_SEGMENTS.scope.stream, (counter)
SPLITS.scope.stream, (guage)
MERGES.scope.stream, (guage)
Purpose of the change
Controller stream segment metrics.

Uses dynamic logger for emitting stream segment metrics.


**How to verify it**
Copied over older code that was removed with some merge