### PR TITLE
Issue 411 : Gradle task to assemble source artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -693,3 +693,16 @@ task publishAllJars() {
     dependsOn ':singlenode:publish'
     dependsOn ':systemtests:tests:publish'
 }
+
+task sourceCopy(type: Copy) {
+    from rootDir
+    into 'source'
+}
+
+task sourceTar(type: Tar) {
+    dependsOn 'sourceCopy'
+    from  'source'
+    destinationDir = file('sourceArtifacts')
+    extension = 'tgz'
+    compression = Compression.GZIP
+}


### PR DESCRIPTION
**Change log description**
Gradle task to collect source artifacts.

**Purpose of the change**
We need artifacts that contain the sources so that a user can build Pravega from the sources. 

**What the code does**
Fixes #411 

**How to verify it**
1. ./gradlew sourceTar  
2. From the root directory,  check the 'sourceArtifacts'  directory for the tar version and
check the  'source' directory for untar version.