### PR TITLE
Issue 786: Marathon and Metronome clients should retry on receiving 503 or 500

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/LoginClient.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/LoginClient.java
@@ -70,7 +70,7 @@ public class LoginClient {
     }
 
     public static RequestInterceptor getAuthenticationRequestInterceptor() {
-        return new BasicAuthRequestInterceptor("admin", "password");
+        return new BasicAuthRequestInterceptor(getUsername(), getPassword());
     }
 
     private static String getMesosMasterIP() {

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/marathon/AuthEnabledMarathonClient.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/marathon/AuthEnabledMarathonClient.java
@@ -1,15 +1,16 @@
 /**
- *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
- *
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries.
  */
 package com.emc.pravega.framework.marathon;
 
 import com.emc.pravega.framework.LoginClient;
 import feign.Feign;
+import feign.Logger;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import feign.Response;
+import feign.RetryableException;
+import feign.Retryer;
 import feign.codec.ErrorDecoder;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
@@ -18,10 +19,15 @@ import mesosphere.marathon.client.auth.TokenAuthRequestInterceptor;
 import mesosphere.marathon.client.utils.MarathonException;
 import mesosphere.marathon.client.utils.ModelUtils;
 
+import java.util.Calendar;
+
 import static com.emc.pravega.framework.LoginClient.MESOS_URL;
 import static com.emc.pravega.framework.LoginClient.getAuthenticationRequestInterceptor;
 import static com.emc.pravega.framework.LoginClient.getClientHostVerificationDisabled;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Marathon client with authentication enabled.
@@ -47,7 +53,17 @@ public class AuthEnabledMarathonClient {
     static class MarathonErrorDecoder implements ErrorDecoder {
         @Override
         public Exception decode(String methodKey, Response response) {
-            return new MarathonException(response.status(), response.reason());
+            //Retry in-case marathon service returns 503 or 500
+            if (response.status() == SERVICE_UNAVAILABLE.code() || response.status() ==
+                    INTERNAL_SERVER_ERROR.code()) {
+                //retry after 5 seconds.
+                Calendar retryAfter = Calendar.getInstance();
+                retryAfter.add(Calendar.SECOND, 5);
+
+                return new RetryableException("Received response code: " + response.status(), retryAfter.getTime());
+            } else {
+                return new MarathonException(response.status(), response.reason());
+            }
         }
     }
 
@@ -58,9 +74,13 @@ public class AuthEnabledMarathonClient {
 
     private static Marathon getInstance(String endpoint, RequestInterceptor... interceptors) {
         Feign.Builder b = Feign.builder().client(getClientHostVerificationDisabled())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.BASIC)
                 .encoder(new GsonEncoder(ModelUtils.GSON))
                 .decoder(new GsonDecoder(ModelUtils.GSON))
-                .errorDecoder(new MarathonErrorDecoder());
+                .errorDecoder(new MarathonErrorDecoder())
+                //max wait period = 5 seconds ; max attempts = 5
+                .retryer(new Retryer.Default(SECONDS.toMillis(1), SECONDS.toMillis(5), 5));
         if (interceptors != null) {
             b.requestInterceptors(asList(interceptors));
         }

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/metronome/MetronomeClient.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/metronome/MetronomeClient.java
@@ -1,23 +1,29 @@
 /**
- *
- *  Copyright (c) 2017 Dell Inc., or its subsidiaries.
- *
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries.
  */
 
 package com.emc.pravega.framework.metronome;
 
 import feign.Feign;
+import feign.Logger;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import feign.Response;
+import feign.RetryableException;
+import feign.Retryer;
 import feign.auth.BasicAuthRequestInterceptor;
 import feign.codec.ErrorDecoder;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import mesosphere.marathon.client.auth.TokenAuthRequestInterceptor;
 
+import java.util.Calendar;
+
 import static com.emc.pravega.framework.LoginClient.getClientHostVerificationDisabled;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class MetronomeClient {
     private static class MetronomeHeadersInterceptor implements RequestInterceptor {
@@ -27,10 +33,20 @@ public class MetronomeClient {
         }
     }
 
-    private static class MetronomeErrorDecoder implements ErrorDecoder {
+    static class MetronomeErrorDecoder implements ErrorDecoder {
         @Override
         public Exception decode(String methodKey, Response response) {
-            return new MetronomeException(response.status(), response.reason());
+            //Retry in case Metronome service returns 503 or 500
+            if (response.status() == SERVICE_UNAVAILABLE.code() || response.status() ==
+                    INTERNAL_SERVER_ERROR.code()) {
+                //retry after 5 seconds.
+                Calendar retryAfter = Calendar.getInstance();
+                retryAfter.add(Calendar.SECOND, 5);
+
+                return new RetryableException("Received response code: " + response.status(), retryAfter.getTime());
+            } else {
+                return new MetronomeException(response.status(), response.reason());
+            }
         }
     }
 
@@ -46,9 +62,13 @@ public class MetronomeClient {
      */
     public static Metronome getInstance(String endpoint, RequestInterceptor... interceptors) {
         Feign.Builder b = Feign.builder().client(getClientHostVerificationDisabled())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.BASIC)
                 .encoder(new GsonEncoder(mesosphere.marathon.client.utils.ModelUtils.GSON))
                 .decoder(new GsonDecoder(mesosphere.marathon.client.utils.ModelUtils.GSON))
-                .errorDecoder(new MetronomeClient.MetronomeErrorDecoder());
+                //max wait period = 5 seconds ; max attempts = 5
+                .retryer(new Retryer.Default(SECONDS.toMillis(1), SECONDS.toMillis(5), 5))
+                .errorDecoder(new MetronomeErrorDecoder());
         if (interceptors != null) {
             b.requestInterceptors(asList(interceptors));
         }


### PR DESCRIPTION
**Change log description**
* Fix for #786 
* The marathon and metronome clients should retry on receiving 500 and 503 error codes from the mesos services.

**Purpose of the change**
* Ensure retries happen if Marathon and Metronome services are not responding.

**What the code does**
Retry incase the Marathon / Metronome services do not respond. In the current configuration we retry every 5 seconds for a max of 5 times. (Total duration is around 30 seconds.)
**How to verify it**
gradle startSystemTests
Sample retry logs:
`[Marathon#getApp] ---> GET https://10.240.124.4/marathon/v2/apps//pravega/exhibitor HTTP/1.1
[Marathon#getApp] <--- HTTP/1.1 503 Unavailable (293ms)
[Marathon#getApp] ---> RETRYING
[Marathon#getApp] ---> GET https://10.240.124.4/marathon/v2/apps//pravega/exhibitor HTTP/1.1
[Marathon#getApp] <--- HTTP/1.1 503 Unavailable (253ms)
[Marathon#getApp] ---> RETRYING
[Marathon#getApp] ---> GET https://10.240.124.4/marathon/v2/apps//pravega/exhibitor HTTP/1.1
[Marathon#getApp] <--- HTTP/1.1 503 Unavailable (296ms)
[Marathon#getApp] ---> RETRYING
[Marathon#getApp] ---> GET https://10.240.124.4/marathon/v2/apps//pravega/exhibitor HTTP/1.1
[Marathon#getApp] <--- HTTP/1.1 503 Unavailable (297ms)
[Marathon#getApp] ---> RETRYING
[Marathon#getApp] ---> GET https://10.240.124.4/marathon/v2/apps//pravega/exhibitor HTTP/1.1
Disconnected from the target VM, address: '127.0.0.1:41875', transport: 'socket'
[Marathon#getApp] <--- HTTP/1.1 503 Unavailable (5173ms)
`
