### PR TITLE
Issue 617: REST API system tests

### DIFF
--- a/controller/server/src/main/java/com/emc/pravega/controller/server/rest/v1/ApiV1.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/rest/v1/ApiV1.java
@@ -219,8 +219,7 @@ public final class ApiV1 {
         @Path("/{scopeName}/streams/{streamName}/state")
         @Consumes({ "application/json" })
         @Produces({ "application/json" })
-        @io.swagger.annotations.ApiOperation(
-                value = "", notes = "Updates the current state of the stream",
+        @io.swagger.annotations.ApiOperation(value = "", notes = "Updates the current state of the stream",
                 response = StreamState.class, tags = {  })
         @io.swagger.annotations.ApiResponses(value = {
                 @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully updated the stream state",

--- a/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
@@ -8,8 +8,8 @@ import com.emc.pravega.controller.server.rest.generated.model.CreateScopeRequest
 import com.emc.pravega.controller.server.rest.generated.model.CreateStreamRequest;
 import com.emc.pravega.controller.server.rest.generated.model.RetentionConfig;
 import com.emc.pravega.controller.server.rest.generated.model.ScalingConfig;
-import com.emc.pravega.controller.server.rest.generated.model.ScopeProperty;
 import com.emc.pravega.controller.server.rest.generated.model.StreamProperty;
+import com.emc.pravega.controller.server.rest.generated.model.ScopeProperty;
 import com.emc.pravega.controller.server.rest.generated.model.StreamState;
 import com.emc.pravega.controller.server.rest.generated.model.StreamsList;
 import com.emc.pravega.controller.server.rest.generated.model.UpdateStreamRequest;


### PR DESCRIPTION
**Change log description**
Added system tests for more REST APIs.

**Purpose of the change**
https://github.com/pravega/pravega/issues/617 subtask-2

**What the code does**
Adds system test for getScope, getStream, updateStreamState, deleteStream, deleteScope REST APIs.

**How to verify it**
Run gradle task systemTests.
Desired output:

```

2017-03-17 11:25:26,356 910  [main] INFO  c.emc.pravega.ControllerRestApiTest - REST Server URI: http://172.16.18.9:10080
2017-03-17 11:25:27,043 1597 [main] INFO  c.emc.pravega.ControllerRestApiTest - REST Server is running. Ping successful.
2017-03-17 11:25:27,406 1960 [main] INFO  c.emc.pravega.ControllerRestApiTest - Create scope: oGehFzfn7j successful 
2017-03-17 11:25:27,699 2253 [main] INFO  c.emc.pravega.ControllerRestApiTest - Create stream: 7IVTGI6EOh successful
2017-03-17 11:25:27,718 2272 [main] INFO  c.emc.pravega.ControllerRestApiTest - List scopes successful
2017-03-17 11:25:27,750 2304 [main] INFO  c.emc.pravega.ControllerRestApiTest - List streams successful
2017-03-17 11:25:27,759 2313 [main] INFO  c.emc.pravega.ControllerRestApiTest - Get scope successful
2017-03-17 11:25:27,889 2443 [main] INFO  c.emc.pravega.ControllerRestApiTest - Update stream successful
2017-03-17 11:25:27,899 2453 [main] INFO  c.emc.pravega.ControllerRestApiTest - Get stream successful
2017-03-17 11:25:28,039 2593 [main] INFO  c.emc.pravega.ControllerRestApiTest - Update stream state successful
2017-03-17 11:25:28,205 2759 [main] INFO  c.emc.pravega.ControllerRestApiTest - Delete stream successful
2017-03-17 11:25:28,219 2773 [main] INFO  c.emc.pravega.ControllerRestApiTest - Delete Scope successful
2017-03-17 11:25:28,219 2773 [main] INFO  c.emc.pravega.ControllerRestApiTest - Test restApiTests passed successfully!
```