### PR TITLE
Increasing timeout values for Flink Connector tests

### DIFF
--- a/integrationtests/src/test/java/com/emc/pravega/integrationtests/connectors/FlinkPravegaReaderTest.java
+++ b/integrationtests/src/test/java/com/emc/pravega/integrationtests/connectors/FlinkPravegaReaderTest.java
@@ -48,7 +48,7 @@ public class FlinkPravegaReaderTest {
 
     //Ensure each test completes within 30 seconds.
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Before
     public void setup() throws Exception {

--- a/integrationtests/src/test/java/com/emc/pravega/integrationtests/connectors/FlinkPravegaWriterTest.java
+++ b/integrationtests/src/test/java/com/emc/pravega/integrationtests/connectors/FlinkPravegaWriterTest.java
@@ -43,7 +43,7 @@ public class FlinkPravegaWriterTest {
 
     // Ensure each test completes within 30 seconds.
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     // Setup utility.
     private SetupUtils setupUtils = new SetupUtils();


### PR DESCRIPTION
**Change log description**
The Flink connector tests are timing out locally for me, and increasing the timeout makes them pass consistently. It looks like those tests needs a little more time, so I'm increasing the test timeout values seems to solve it.

**Purpose of the change**
Fix test time out failures.

**What the code does**
Increases the timeout values of the Flink connector test cases.

**How to verify it**
Run `./gradlew :integrationists:test`