### PR TITLE
Issue 614: Autoscale system test

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
@@ -278,7 +278,7 @@ public class AutoScaleTest {
         return Retry.withExpBackoff(10, 10, 200, Duration.ofSeconds(10).toMillis())
                 .retryingOn(NotDoneException.class)
                 .throwingOn(RuntimeException.class)
-                .runAsync(() -> controller.getCurrentSegments(SCOPE, SCALE_UP_STREAM_NAME)
+                .runAsync(() -> controller.getCurrentSegments(SCOPE, SCALE_UP_TXN_STREAM_NAME)
                         .thenAccept(x -> {
                             if (x.getSegments().size() == 1) {
                                 throw new NotDoneException();
@@ -310,7 +310,7 @@ public class AutoScaleTest {
     private void startNewTxnWriter(ClientFactory clientFactory, AtomicBoolean exit) {
         CompletableFuture.runAsync(() -> {
             @Cleanup
-            EventStreamWriter<String> writer = clientFactory.createEventWriter(SCALE_UP_STREAM_NAME,
+            EventStreamWriter<String> writer = clientFactory.createEventWriter(SCALE_UP_TXN_STREAM_NAME,
                     new JavaSerializer<>(),
                     EventWriterConfig.builder().build());
 


### PR DESCRIPTION
Change log description
System test for auto scale
This has three tests -
For each test we use a separate stream so that tests can run in parallel.
1st Stream is for scale up
2nd Stream is for scale down
3rd Stream is to verify that scale happens despite all writes happening in transactions.

Purpose of the change
To test scale feature end to end.
What the code does
It floods 1st and 3rd streams with lots of traffic while leaves 2nd stream with no traffic.

Fixes #614
How to verify it
System test should pass.

Note: the test lasts for over 20 minutes.


