### PR TITLE
Missed initialization in ServiceStarter

### DIFF
--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/ServiceStarter.java
@@ -7,6 +7,7 @@ package com.emc.pravega.service.server.host;
 
 import com.emc.pravega.common.Exceptions;
 import com.emc.pravega.common.cluster.Host;
+import com.emc.pravega.common.metrics.MetricsConfig;
 import com.emc.pravega.common.metrics.MetricsProvider;
 import com.emc.pravega.common.metrics.StatsProvider;
 import com.emc.pravega.service.contracts.StreamSegmentStore;
@@ -89,6 +90,7 @@ public final class ServiceStarter {
         Exceptions.checkNotClosed(this.closed, this);
 
         log.info("Initializing metrics provider ...");
+        MetricsProvider.initialize(builderConfig.getConfig(MetricsConfig::new));
         statsProvider = MetricsProvider.getMetricsProvider();
         statsProvider.start();
 


### PR DESCRIPTION
**Change log description**
In PR #798, I missed an initialization line in `ServiceStarter`. This PR is to fix it.

**Purpose of the change**
Metrics initialization in `ServiceStarter`.

**What the code does**
Initializes metrics.

**How to verify it**
```
./gradlew :service:server:host:distTar
tar xvf ~/code/pravega/service/server/host/build/distributions/host.tar
host/bin/host
```

Look for metrics initialization in the output.