### PR TITLE
Fixes #819 Changes to configuring SSS

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
@@ -5,13 +5,14 @@ package com.emc.pravega.framework.services;
 
 import com.emc.pravega.framework.TestFrameworkException;
 import lombok.extern.slf4j.Slf4j;
-import mesosphere.marathon.client.utils.MarathonException;
 import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.Container;
 import mesosphere.marathon.client.model.v2.Docker;
 import mesosphere.marathon.client.model.v2.HealthCheck;
 import mesosphere.marathon.client.model.v2.Parameter;
 import mesosphere.marathon.client.model.v2.Volume;
+import mesosphere.marathon.client.utils.MarathonException;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import static com.emc.pravega.framework.TestFrameworkException.Type.InternalError;
 import static com.emc.pravega.framework.Utils.isSkipServiceInstallationEnabled;
 
@@ -122,14 +124,22 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         app.setHealthChecks(healthCheckList);
         //set env
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
+
+        //System properties to configure SS service.
+        String hostSystemProperties = setSystemProperty("pravegaservice.zkURL", zk) +
+                setSystemProperty("dlog.hostname", zkUri.getHost()) +
+                setSystemProperty("hdfs.fs.default.name", "namenode-0.hdfs.mesos:9001") +
+                setSystemProperty("pravegaservice.controllerUri", conUri.toString());
+
         Map<String, String> map = new HashMap<>();
+        map.put("HOST_OPTS", hostSystemProperties);
         map.put("ZK_URL", zk);
-        map.put("pravegaservice_zkURL", zk);
-        map.put("dlog_hostname", zkUri.getHost());
-        map.put("hdfs_fs_default_name", "namenode-0.hdfs.mesos:9001");
-        map.put("pravegaservice_controllerUri", conUri.toString());
         app.setEnv(map);
 
         return app;
+    }
+
+    private String setSystemProperty(final String propertyName, final String propertyValue) {
+        return new StringBuilder().append(" -D").append(propertyName).append("=").append(propertyValue).toString();
     }
 }


### PR DESCRIPTION
**Change log description**
The latest SSS does not support reading configuration from env variables. Modifying the system test frameworks implementation to handle this change.

**Purpose of the change**
Fixes 819.
**What the code does**
Sets the required properties via HOST_OPTS Env variable. This variable is read in the startup script of SSS.
**How to verify it**
Verified that the SS service starts successfully on jarvis using the system test framework.