### PR TITLE
Issue 821: Pravega config error

### DIFF
--- a/service/server/src/main/java/com/emc/pravega/service/server/store/ServiceConfig.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/store/ServiceConfig.java
@@ -27,8 +27,8 @@ public class ServiceConfig {
     public static final Property<Integer> ZK_RETRY_COUNT = Property.named("zkRetryCount", 5);
     public static final Property<String> CLUSTER_NAME = Property.named("clusterName", "pravega-cluster");
     public static final Property<String> CONTROLLER_URI = Property.named("controllerUri", "tcp://localhost:9090");
-    public static final Property<String> REQUEST_STREAM  = Property.named("internalRequestStream", "pravega");
-    public static final Property<String> INTERNAL_SCOPE = Property.named("internalScope", "requeststream");
+    public static final Property<String> REQUEST_STREAM  = Property.named("internalRequestStream", "requeststream");
+    public static final Property<String> INTERNAL_SCOPE = Property.named("internalScope", "pravega");
     private static final String COMPONENT_CODE = "pravegaservice";
 
     //endregion

--- a/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
@@ -315,7 +315,7 @@ public class AutoScaleTest {
 
             while (!exit.get()) {
                 try {
-                    Transaction<String> transaction = writer.beginTxn(5000, 3600000, 60000);
+                    Transaction<String> transaction = writer.beginTxn(5000, 3600000, 29000);
 
                     for (int i = 0; i < 10; i++) {
                         transaction.writeEvent("0", "txntest");


### PR DESCRIPTION
**Change log description**
PR #772 incorrectly flipped request stream name and scope. So SSS is not able to create writer for request stream.

Another thing is to reduce grace period in auto-scale system test to below 30000 (default configuration set in controller). 

**Purpose of the change**

**What the code does**
Rectifies the configuration

Fix for #821 
**How to verify it**
integration and system tests. 