### PR TITLE
Retry logic for  system test with AutoScale with reader groups and transactions

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
@@ -221,14 +221,16 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                     readerGroupName,
                     new JavaSerializer<Long>(),
                     ReaderConfig.builder().build());
-
-            while (!exitFlag.get()) {
+            boolean isLastEventNull = false;
+            while (!(exitFlag.get() && isLastEventNull)) { // exit only if exitFlag and isLastEventNull are true
                 final Long longEvent;
                 try {
                     longEvent = reader.readNextEvent(SECONDS.toMillis(60)).getEvent();
                     if (longEvent != null) {
                         //update if event read is not null.
                         result.add(longEvent);
+                    } else {
+                        isLastEventNull = true;
                     }
                 } catch (ReinitializationRequiredException e) {
                     log.warn("Test Exception while reading from the stream", e);


### PR DESCRIPTION
**Change log description**
Added a retry logic to handle exceptions while creating parallel transactions on a given stream.
**Purpose of the change**
Handle error conditions.
**What the code does**
Retries create txn operation incase of following exceptions
io.grpc.StatusRuntimeException and ConnectionClosedException observed during create transactions.

**How to verify it**
gradle startSystemTests.