### PR TITLE
Fix local Pravega cluster configuration to have all znodes under the cluster subtree

### DIFF
--- a/singlenode/src/main/java/com/emc/pravega/local/InProcPravegaCluster.java
+++ b/singlenode/src/main/java/com/emc/pravega/local/InProcPravegaCluster.java
@@ -60,7 +60,7 @@ public class InProcPravegaCluster implements AutoCloseable {
     private final boolean isInMemStorage;
 
     /* Cluster name */
-    private String clusterName = "singlenode-" + UUID.randomUUID();
+    private final String clusterName = "singlenode-" + UUID.randomUUID();
 
     /*Controller related variables*/
     private boolean isInprocController;


### PR DESCRIPTION
**Change log description**
Adds configuration to `InProcPravegaCluster` so that all znodes and subtrees go under the same cluster name.

**Purpose of the change**
Configure the chroot of zookeeper consistently across components for single node deployment.

**What the code does**
Configures Pravega components for single node deployment.

**How to verify it**
Start single node deployment and use the zkCli to check that the znodes are going to the right place.