### PR TITLE
Bugfix: SystemIntegrationTest for Read with AutoScale

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
@@ -225,7 +225,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                     } else {
                         isLastEventNull = true;
                     }
-                } catch (Throwable e) {
+                } catch (Throwable e) { //TODO: Remove throwable once issue #862 is resolved.
                     log.warn("Test Exception while reading from the stream", e);
                     break;
                 }
@@ -267,6 +267,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         try {
             //Default max scale grace period is 30000
             txn = writer.beginTxn(5000, 3600000, 29000);
+            log.debug("Transaction created with id:{} ", txn.getTxnId());
         } catch (RuntimeException ex) {
             log.info("Exception encountered while trying to begin Transaction ", ex.getCause());
             final Class<? extends Throwable> exceptionClass = ex.getCause().getClass();


### PR DESCRIPTION
**Change log description**
The following changes are done to ReadWithAutoScaleTest.java

1. Reduce the number of retries since the auto scale is configured for 120seconds…
2. Catch all exceptions during Read.
3. Stop retry for create Txn if the exit flag is set to true

**Purpose of the change**
Fix the issue of the system test failing.

**How to verify it**
gradle startSystemTests succeeds.
