### PR TITLE
Issue 848: Bump up Pravega version in master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,6 +51,6 @@ slf4jApiVersion=1.7.14
 typesafeConfigVersion=1.3.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.0-PRERELEASE
+pravegaVersion=0.1.0-alpha-SNAPSHOT
 pravegaControllerBaseTag=pravega/pravega-controller
 pravegaHostBaseTag=pravega/pravega-host


### PR DESCRIPTION
**Change log description**
Change to `gradle.properties` to reflect the creation of the first release branch.

**Purpose of the change**
Bump up the Pravega version in master.

**What the code does**
Fix for #848 .
