### PR TITLE
Prevent stalling in unit tests.

### DIFF
--- a/clients/streaming/src/main/java/com/emc/pravega/stream/impl/segment/SegmentOutputStreamImpl.java
+++ b/clients/streaming/src/main/java/com/emc/pravega/stream/impl/segment/SegmentOutputStreamImpl.java
@@ -353,9 +353,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         if (state.isClosed()) {
             return;
         }
-        if (!state.isInflightEmpty()) {
-            flush();
-        }
+        flush();
         state.setClosed(true);
         ClientConnection connection = state.getConnection();
         if (connection != null) {
@@ -370,9 +368,11 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
     @Synchronized
     public void flush() throws SegmentSealedException {
         try {
-            ClientConnection connection = getConnection();
-            connection.send(new KeepAlive());
-            state.waitForEmptyInflight();
+            if (!state.isInflightEmpty()) {
+                ClientConnection connection = getConnection();
+                connection.send(new KeepAlive());
+                state.waitForEmptyInflight();
+            }
         } catch (ConnectionFailedException e) {
             state.failConnection(e);
         }


### PR DESCRIPTION
**Change log description**
Optimize flush to do nothing if it is not required.

**Purpose of the change**
Some tests particularly ControllerServiceTest can end up stalling for a very long time in cleanup as they are performing exponential backoff trying to reconnect to send a flush call at the end of a test even though everything has long sense been acked. 

**What the code does**
Checks to see if there actually is anything inflight that needs to be flushed before flushing.

**How to verify it**
ControllerServiceTest and several others should be consistently fast.