### PR TITLE
Stop codecov failing when coverage reduces by small %

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
       default:
         against: parent
         target: auto
-        threshold: 1%
+        threshold: 0.5%
         branches:
           - master
   ignore:


### PR DESCRIPTION
**Change log description**
All builds look like they are failing in the PR list. But some of them are due the fact that coverage is reduced by minor percentage. 

**Purpose of the change**
Avoid marking builds as failed when code coverage reduction is minor

**What the code does**
changed codecov config. 

**How to verify it**
Let the build succeed.