### PR TITLE
Issue 887: Adding max values to error messages

### DIFF
--- a/controller/server/src/main/java/com/emc/pravega/controller/server/ControllerService.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/ControllerService.java
@@ -188,12 +188,14 @@ public class ControllerService {
 
         // If scaleGracePeriod is larger than maxScaleGracePeriod return error
         if (scaleGracePeriod > timeoutService.getMaxScaleGracePeriod()) {
-            return FutureHelpers.failedFuture(new IllegalArgumentException("scaleGracePeriod too large"));
+            return FutureHelpers.failedFuture(new IllegalArgumentException("scaleGracePeriod too large, max value is "
+                                                                            + timeoutService.getMaxScaleGracePeriod()));
         }
 
         // If lease value is too large return error
         if (lease > scaleGracePeriod || lease > maxExecutionTime || lease > timeoutService.getMaxLeaseValue()) {
-            return FutureHelpers.failedFuture(new IllegalArgumentException("lease value too large"));
+            return FutureHelpers.failedFuture(new IllegalArgumentException("lease value too large, max value is "
+            + Math.min(scaleGracePeriod, Math.min(maxExecutionTime, timeoutService.getMaxLeaseValue()))));
         }
 
         return streamTransactionMetadataTasks.createTxn(scope, stream, lease, maxExecutionTime, scaleGracePeriod, null)


### PR DESCRIPTION
**Change log description**
Adds max value to error messages about txn timeouts.

**Purpose of the change**
Fix error message to report useful information about the input parameters when creating a txn.

**What the code does**
Fixes #887 

**How to verify it**
Create a txn with a large timeout value and check the error message reported.