### PR TITLE
Issues 891 and 892: Fix  javadoc errors in  clients:streaming dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,9 @@ project('common') {
             }
         }
     }
+    javadoc {
+        exclude 'com/emc/pravega/common/*'
+    }
 }
 
 project('clients:streaming') {
@@ -185,6 +188,7 @@ project('clients:streaming') {
         }
     }
     javadoc {
+        title = "Pravega Client API"
         failOnError = false
         exclude "**/impl/**";
         source  =  project(':clients:streaming').sourceSets.main.java
@@ -494,6 +498,9 @@ project('controller:contract') {
                 from components.java
             }
         }
+    }
+    javadoc {
+        exclude 'com/emc/pravega/controller/*'
     }
 }
 


### PR DESCRIPTION
**Change log description**
Error while running genJavaDocs task

**Purpose of the change**
Errors  in dependencies ':controller:contract', ':common' while generating client javadocs. 

**What the code does**
Fixes #891 , #892

**How to verify it**
./gradlew genJavaDocs