### PR TITLE
Issue 917: Changed server log level to INFO.

### DIFF
--- a/service/server/host/src/config/logback.xml
+++ b/service/server/host/src/config/logback.xml
@@ -34,7 +34,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="consoleAppender"/>
         <appender-ref ref="FILE"/>
     </root>


### PR DESCRIPTION
**Change log description**
The amount of logging generated is overwhelming if we leave it on `DEBUG` by default, so I'm increasing it to `INFO`. We should make this value configurable so that we can run, e.g., system tests with DEBUG level when desirable.

**Purpose of the change**
Reduce the log level of the server.

**What the code does**
Fixes issue #917 .

**How to verify it**
Run and check that no `DEBUG` messages are being output.