### PR TITLE
Issue 906: Add missing metrics to alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,7 @@ project('integrationtests') {
         testCompile group: 'org.apache.flink', name: 'flink-tests_2.11', version: flinkVersion
         testCompile group: 'org.apache.flink', name: 'flink-test-utils_2.11', version: flinkVersion
         testCompile group: 'org.apache.flink', name: 'flink-streaming-contrib_2.11', version: flinkVersion
+        testCompile group: 'org.apache.commons', name: 'commons-csv', version: apacheCommonsCsvVersion
         testCompile files(project(':common').sourceSets.test.output)
         compile files(project(':clients:streaming').sourceSets.test.output)
         testCompile files(project(':service:server').sourceSets.test.output)

--- a/common/src/main/java/com/emc/pravega/common/MetricsNames.java
+++ b/common/src/main/java/com/emc/pravega/common/MetricsNames.java
@@ -26,14 +26,16 @@ public final class MetricsNames {
 
     // Metrics in Controller
     // Stream request counts (Static)
-    public static final String CREATE_STREAM = "stream_created"; // Histogram
-    public static final String SEAL_STREAM = "stream_sealed";    // Histogram
+    public static final String CREATE_STREAM = "stream_created";    // Histogram
+    public static final String SEAL_STREAM = "stream_sealed";       // Histogram
+    public static final String DELETE_STREAM = "stream_deleted";    // Histogram
 
     // Transaction request Operations (Dynamic)
     public static final String CREATE_TRANSACTION = "transactions_created";   // Dynamic Meter
     public static final String COMMIT_TRANSACTION = "transactions_committed"; // Dynamic Meter
     public static final String ABORT_TRANSACTION = "transactions_aborted";    // Dynamic Meter
     public static final String OPEN_TRANSACTIONS = "transactions_opened";     // Dynamic Gauge
+    public static final String TIMEDOUT_TRANSACTIONS = "transactions_timedout";     // Dynamic Gauge
 
     // Stream segment counts (Dynamic)
     public static final String SEGMENTS_COUNT = "segments_count";   // Dynamic Gauge

--- a/common/src/main/java/com/emc/pravega/common/metrics/OpStatsLogger.java
+++ b/common/src/main/java/com/emc/pravega/common/metrics/OpStatsLogger.java
@@ -13,14 +13,14 @@ import java.time.Duration;
 public interface OpStatsLogger {
 
     /**
-     * Increment the failed op counter with the given eventLatency in NanoSeconds.
+     * Increment the succeeded op counter with the given eventLatency in NanoSeconds.
      *
      * @param duration the event latency
      */
     void reportSuccessEvent(Duration duration);
 
     /**
-     * Increment the succeeded op counter with the given eventLatency in NanoSeconds.
+     * Increment the failed op counter with the given eventLatency in NanoSeconds.
      *
      * @param duration the event latency
      */

--- a/controller/server/src/main/java/com/emc/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -58,6 +58,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     private static final StatsLogger STATS_LOGGER = METRICS_PROVIDER.createStatsLogger("controller");
     private static final OpStatsLogger CREATE_STREAM = STATS_LOGGER.createStats(MetricsNames.CREATE_STREAM);
     private static final OpStatsLogger SEAL_STREAM = STATS_LOGGER.createStats(MetricsNames.SEAL_STREAM);
+    private static final OpStatsLogger DELETE_STREAM = STATS_LOGGER.createStats(MetricsNames.DELETE_STREAM);
 
     private final LoadingCache<String, Scope> scopeCache;
     private final LoadingCache<Pair<String, String>, Stream> cache;
@@ -136,7 +137,11 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                                                 final String name,
                                                 final OperationContext context,
                                                 final Executor executor) {
-        return withCompletion(getStream(scope, name, context).delete(), executor);
+        return withCompletion(getStream(scope, name, context).delete(), executor)
+                .thenApply(result -> {
+                    DELETE_STREAM.reportSuccessValue(1);
+                    return result;
+                });
     }
 
     @Override

--- a/controller/server/src/main/java/com/emc/pravega/controller/timeout/TimerWheelTimeoutService.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/timeout/TimerWheelTimeoutService.java
@@ -5,6 +5,8 @@
  */
 package com.emc.pravega.controller.timeout;
 
+import com.emc.pravega.common.metrics.DynamicLogger;
+import com.emc.pravega.common.metrics.MetricsProvider;
 import com.emc.pravega.controller.store.stream.DataNotFoundException;
 import com.emc.pravega.controller.store.stream.OperationOnTxNotAllowedException;
 import com.emc.pravega.controller.store.stream.TransactionNotFoundException;
@@ -33,6 +35,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import static com.emc.pravega.common.MetricsNames.TIMEDOUT_TRANSACTIONS;
+import static com.emc.pravega.common.MetricsNames.nameFromStream;
+
 /**
  * Transaction ping manager. It maintains a local hashed timer wheel to manage txn timeouts.
  * It provides the following two methods.
@@ -51,7 +56,7 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
     private static final boolean LEAK_DETECTION = true;
 
     // endregion
-
+    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     private final StreamTransactionMetadataTasks streamTransactionMetadataTasks;
     private final HashedWheelTimer hashedWheelTimer;
     private final ConcurrentHashMap<String, TxnData> map;
@@ -101,6 +106,7 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
                                 hashedWheelTimer.newTimeout(this, 2 * TICK_DURATION, TIME_UNIT);
                             }
                         } else {
+                            DYNAMIC_LOGGER.incCounterValue(nameFromStream(TIMEDOUT_TRANSACTIONS, scope, stream), 1);
                             log.debug("Successfully executed abort on tx {} ", key);
                             map.remove(key);
                             notifyCompletion(null);

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,7 @@ shadowGradlePlugin=1.2.4
 swaggerJersey2JaxrsVersion=1.5.9
 slf4jApiVersion=1.7.14
 typesafeConfigVersion=1.3.0
+apacheCommonsCsvVersion=1.1
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.0-PRERELEASE


### PR DESCRIPTION
**Change log description**
Added support for following two metrics:
1. controller.stream_deleted
2. DYNAMIC.$scope.$stream.transactions_timedout

**Purpose of the change**
#906 

**What the code does**
It hooks the respective metrics in code.

**How to verify it**
Csv files generated locally.
