### PR TITLE
Issue-914: REST API scaling policy modified

### DIFF
--- a/common/src/main/java/com/emc/pravega/common/MetricsNames.java
+++ b/common/src/main/java/com/emc/pravega/common/MetricsNames.java
@@ -35,7 +35,7 @@ public final class MetricsNames {
     public static final String COMMIT_TRANSACTION = "transactions_committed"; // Dynamic Counter
     public static final String ABORT_TRANSACTION = "transactions_aborted";    // Dynamic Counter
     public static final String OPEN_TRANSACTIONS = "transactions_opened";     // Dynamic Gauge
-    public static final String TIMEDOUT_TRANSACTIONS = "transactions_timedout";     // Dynamic Gauge
+    public static final String TIMEDOUT_TRANSACTIONS = "transactions_timedout";     // Dynamic Counter
 
     // Stream segment counts (Dynamic)
     public static final String SEGMENTS_COUNT = "segments_count";   // Dynamic Gauge

--- a/controller/contract/src/main/swagger/Controller.yaml
+++ b/controller/contract/src/main/swagger/Controller.yaml
@@ -275,7 +275,7 @@ definitions:
         - BY_RATE_IN_EVENTS_PER_SEC
       targetRate:
         type: integer
-        format: int64
+        format: int32
       scaleFactor:
         type: integer
         format: int32

--- a/controller/server/src/main/java/com/emc/pravega/controller/server/rest/generated/api/StringUtil.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/rest/generated/api/StringUtil.java
@@ -1,4 +1,4 @@
-package com.emc.pravega.controller.server.rest.generated;
+package com.emc.pravega.controller.server.rest.generated.api;
 
 
 public class StringUtil {

--- a/controller/server/src/main/java/com/emc/pravega/controller/server/rest/generated/model/ScalingConfig.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/rest/generated/model/ScalingConfig.java
@@ -39,7 +39,7 @@ public class ScalingConfig   {
 
   private TypeEnum type = null;
 
-  private Long targetRate = null;
+  private Integer targetRate = null;
 
   private Integer scaleFactor = null;
 
@@ -63,7 +63,7 @@ public class ScalingConfig   {
     this.type = type;
   }
 
-  public ScalingConfig targetRate(Long targetRate) {
+  public ScalingConfig targetRate(Integer targetRate) {
     this.targetRate = targetRate;
     return this;
   }
@@ -73,11 +73,11 @@ public class ScalingConfig   {
    * @return targetRate
   **/
   @ApiModelProperty(value = "")
-  public Long getTargetRate() {
+  public Integer getTargetRate() {
     return targetRate;
   }
 
-  public void setTargetRate(Long targetRate) {
+  public void setTargetRate(Integer targetRate) {
     this.targetRate = targetRate;
   }
 

--- a/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
@@ -151,7 +151,7 @@ public class ControllerRestApiTest {
         CreateStreamRequest createStreamRequest = new CreateStreamRequest();
         ScalingConfig scalingConfig = new ScalingConfig();
         scalingConfig.setType(FIXED_NUM_SEGMENTS);
-        scalingConfig.setTargetRate(2L);
+        scalingConfig.setTargetRate(2);
         scalingConfig.scaleFactor(2);
         scalingConfig.minSegments(2);
 
@@ -202,7 +202,7 @@ public class ControllerRestApiTest {
         UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest();
         ScalingConfig scalingConfig1 = new ScalingConfig();
         scalingConfig1.setType(FIXED_NUM_SEGMENTS);
-        scalingConfig1.setTargetRate(2L);
+        scalingConfig1.setTargetRate(2);
         scalingConfig1.scaleFactor(3); // update existing scaleFactor from 2 to 3
         scalingConfig1.minSegments(4); // update existing minSegments from 2 to 4
         updateStreamRequest.setScalingPolicy(scalingConfig1);


### PR DESCRIPTION
**Change log description**
Scaling policy request json shouldn't require `targetRate` and `scalingFactor` if the type is FIXED_NUM_SEGMENTS. Modified REST code to accommodate the same.

**Purpose of the change**
https://github.com/pravega/pravega/issues/914

**What the code does**
1. Doesn't enforce the values to be present for `targetRate` and `scalingFactor` if the type of scaling policy is FIXED_NUM_SEGMENTS
2. Internal code changed `targetRate` to int from long, reflected the same in rest objects
3. Fixed typo for transactions_timedout from Gauge to Counter

**How to verify it**
Unit tests and rest client.

Note: Please don't review swagger auto-generated files.