### PR TITLE
Issue-948: Fix rest system test

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ControllerRestApiTest.java
@@ -211,8 +211,8 @@ public class ControllerRestApiTest {
         response = client.target(resourceURl).request(MediaType.APPLICATION_JSON_TYPE)
                 .put(Entity.json(updateStreamRequest));
         assertEquals("Update stream status", OK.getStatusCode(), response.getStatus());
-        assertEquals("Verify updated property", 3, response.readEntity(StreamProperty.class)
-                .getScalingPolicy().getScaleFactor().intValue());
+        assertEquals("Verify updated property", 4, response.readEntity(StreamProperty.class)
+                .getScalingPolicy().getMinSegments().intValue());
         log.info("Update stream successful");
 
         // Test getStream


### PR DESCRIPTION
**Change log description**
With recent changes in Scaling policy, if the type is FIXED_NUM_SEGMENTS, the response json doesn't have targetRate and scaleFactor. So, we can't retrieve those fields. Changed the systemTest to only retrieve minSegments field.

**Purpose of the change**
Fixes #948 

**What the code does**
Only retrieve minSegments field if type is FIXED_NUM_SEGMENTS.

**How to verify it**
Run gradle task systemTest.
