### PR TITLE
Issue 950: Set log.level env to DEBUG in test-framework

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaControllerService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaControllerService.java
@@ -121,10 +121,8 @@ public class PravegaControllerService extends MarathonBasedService {
         //set docker container parameters
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         List<Parameter> parameterList = new ArrayList<>();
-        Parameter element1 = new Parameter("env", "SERVER_OPTS=\"-DZK_URL=" + zk + "\" \"-Dlog.level=DEBUG\"");
-        Parameter element2 = new Parameter("env", "JAVA_OPTS=-Xmx512m");
+        Parameter element1 = new Parameter("env", "JAVA_OPTS=-Xmx512m");
         parameterList.add(element1);
-        parameterList.add(element2);
         app.getContainer().getDocker().setParameters(parameterList);
         //set port
         app.setPorts(Arrays.asList(CONTROLLER_PORT, REST_PORT));
@@ -133,9 +131,12 @@ public class PravegaControllerService extends MarathonBasedService {
         healthCheckList.add(setHealthCheck(900, "TCP", false, 60, 20, 0));
         app.setHealthChecks(healthCheckList);
         //set env
+        String controllerSystemProperties = setSystemProperty("ZK_URL", zk) +
+                                           setSystemProperty("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT)) +
+                                           setSystemProperty("REST_SERVER_PORT", String.valueOf(REST_PORT)) +
+                                           setSystemProperty("log.level", "DEBUG");
         Map<String, String> map = new HashMap<>();
-        map.put("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT));
-        map.put("REST_SERVER_PORT", String.valueOf(REST_PORT));
+        map.put("SERVER_OPTS", controllerSystemProperties);
         app.setEnv(map);
 
         return app;

--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/PravegaSegmentStoreService.java
@@ -138,7 +138,6 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
 
         Map<String, String> map = new HashMap<>();
         map.put("HOST_OPTS", hostSystemProperties);
-        map.put("ZK_URL", zk);
         app.setEnv(map);
 
         return app;


### PR DESCRIPTION
**Change log description**
SERVER_OPTS is overrided in PravegaControllerService.java.
```
Parameter element1 = new Parameter("env", "SERVER_OPTS=\"-DZK_URL=" + zk + "\"");
  map.put("SERVER_OPTS", setSystemProperty("log.level", "DEBUG"));
```
**Purpose of the change**
To set log.level in controller deployment

**What the code does**
Fixes #950 

**How to verify it**
Test-Framework system tests 