### PR TITLE
Issue 941: Perform retries if concurrent createTxn on a stream fails.

### DIFF
--- a/controller/server/src/main/java/com/emc/pravega/controller/server/ControllerService.java
+++ b/controller/server/src/main/java/com/emc/pravega/controller/server/ControllerService.java
@@ -57,8 +57,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class ControllerService {
     private static final long RETRY_INITIAL_DELAY_MS = 100;
     private static final int RETRY_MULTIPLIER = 2;
-    private static final int RETRY_MAX_ATTEMPTS = 100;
-    private static final long RETRY_MAX_DELAY_MS = Duration.ofSeconds(5).toMillis();
+    private static final int RETRY_MAX_ATTEMPTS = 10;
+    private static final long RETRY_MAX_DELAY_MS = Duration.ofSeconds(1).toMillis();
 
     private final StreamMetadataStore streamStore;
     private final HostControllerStore hostStore;

--- a/integrationtests/src/test/java/com/emc/pravega/integrationtests/endtoendtest/EndToEndTxnWithScaleTest.java
+++ b/integrationtests/src/test/java/com/emc/pravega/integrationtests/endtoendtest/EndToEndTxnWithScaleTest.java
@@ -149,8 +149,8 @@ public class EndToEndTxnWithScaleTest {
                 EventWriterConfig.builder().build());
 
         CountDownLatch latch = new CountDownLatch(1);
-        ExecutorService service = Executors.newFixedThreadPool(2);
-        List<Future<?>> futures = new ArrayList<>(2);
+        ExecutorService service = Executors.newFixedThreadPool(5);
+        List<Future<?>> futures = new ArrayList<>(10);
 
         final Runnable createTxn = () -> {
             try {
@@ -164,8 +164,10 @@ public class EndToEndTxnWithScaleTest {
             }
         };
 
-        futures.add(service.submit(createTxn));
-        futures.add(service.submit(createTxn));
+        //create 10 txns on the same stream.
+        for (int i = 0; i < 10; i++) {
+            futures.add(service.submit(createTxn));
+        }
 
         latch.countDown(); //Trigger concurrent createTxn for a given stream.
 


### PR DESCRIPTION
**Change log description**
Multiple txns are allowed to co-exist. 
When concurrent `createTxn` are created one of them gets a lock on '/scope/stream' while the other is failed with an exception ` Failed locking resource scope/streamName`.
In this PR the controller retries on receiving  such an exception.

**Purpose of the change**
Fix issue #941

**How to verify it**
All tests should pass.