### PR TITLE
Bug: Replace null check with empty check

### DIFF
--- a/clients/streaming/src/main/java/com/emc/pravega/stream/impl/EventStreamReaderImpl.java
+++ b/clients/streaming/src/main/java/com/emc/pravega/stream/impl/EventStreamReaderImpl.java
@@ -164,8 +164,8 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
 
     private void acquireSegmentsIfNeeded() throws ReinitializationRequiredException {
         Map<Segment, Long> newSegments = groupState.acquireNewSegmentsIfNeeded(getLag());
-        if (newSegments != null) {
-            log.info("{} aquiring segments {}", this, newSegments);
+        if (!newSegments.isEmpty()) {
+            log.info("{} acquiring segments {}", this, newSegments);
             for (Entry<Segment, Long> newSegment : newSegments.entrySet()) {
                 SegmentInputStream in = inputStreamFactory.createInputStreamForSegment(newSegment.getKey());
                 in.setOffset(newSegment.getValue());


### PR DESCRIPTION
**Change log description**
Replaces an incorrect check in the event stream reader.

**Purpose of the change**
Fix a bug.

**What the code does**
Replaces an incorrect check in the event stream reader.

**How to verify it**
Run single node and check that it isn't outputting lots `acquiring segments` messages with an empty set of segments to acquire.