### PR TITLE
Bug: AutoScale test failure due to scope validation.

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/AutoScaleTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SystemTestRunner.class)
 public class AutoScaleTest extends AbstractScaleTests {
 
-    private final static String SCOPE = "testAutoScale" + new Random().nextInt();
+    private final static String SCOPE = "testAutoScale" + new Random().nextInt(Integer.MAX_VALUE);
     private final static String SCALE_UP_STREAM_NAME = "testScaleUp";
     private final static String SCALE_UP_TXN_STREAM_NAME = "testTxnScaleUp";
     private final static String SCALE_DOWN_STREAM_NAME = "testScaleDown";


### PR DESCRIPTION
**Change log description**
Ensures a valid scope name is generated. -ve numbers lead to `java.lang.IllegalArgumentException: Illegal scope name:`
**Purpose of the change**
Fix a bug
**What the code does**
Ensure invalid scope names are not generated.
**How to verify it**
Autoscale tests now passes tried it with pravega: 0.1.0-1272.7fecfed  
