### PR TITLE
Issue 976: Gradle support to publish shared.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,15 @@ project ('shared') {
     compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     compile project(':common')
    }
+
+   publishing {
+        publications {
+            maven(MavenPublication) {
+                artifactId 'pravega-shared'
+                from components.java
+            }
+        }
+    }
 }
 
 project('clients:streaming') {
@@ -805,6 +814,7 @@ task publishAllJars() {
     dependsOn ':service:storage:impl:publish'
     dependsOn ':service:server:publish'
     dependsOn ':service:server:host:publish'
+    dependsOn ':shared:publish'
     dependsOn ':controller:contract:publish'
     dependsOn ':controller:server:publish'
     dependsOn ':connectors:flink:publish'


### PR DESCRIPTION
**Change log description**
It does two things:

1. Adds a like to the publish task to depend on `shared`
2. Adds a `publishing` task to `shared` 

**Purpose of the change**
Publish `shared` artifact.

**What the code does**
Fixes #976.

**How to verify it**
Run pravega-samples.