### PR TITLE
Issue 979: Fix epoch precondition in HDFSStorage.initialize

### DIFF
--- a/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/hdfs/HDFSStorage.java
+++ b/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/hdfs/HDFSStorage.java
@@ -122,7 +122,7 @@ class HDFSStorage implements Storage {
     public void initialize(long epoch) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         Preconditions.checkState(this.context == null, "HDFSStorage has already been initialized.");
-        Preconditions.checkArgument(epoch > 0, "epoch must be a positive number.");
+        Preconditions.checkArgument(epoch >= 0, "epoch must be a positive number.");
         Configuration conf = new Configuration();
         conf.set("fs.default.name", this.config.getHdfsHostURL());
         conf.set("fs.default.fs", this.config.getHdfsHostURL());


### PR DESCRIPTION
**Change log description**
Changes precondition in `HDFSStorage.initialize` to accept non-negative values.
 
**Purpose of the change**
Fix a bug in the precondition logic of `HDFSStorage.initialize`.

**What the code does**
Fixes #979 

**How to verify it**
Run system tests.