### PR TITLE
Issue 978: Suppressing javadocs for 'shared'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,9 @@ project ('shared') {
             }
         }
     }
+    javadoc {
+        exclude 'com/emc/pravega/shared/*'
+    }
 }
 
 project('clients:streaming') {


### PR DESCRIPTION
**Change log description**
Javadocs are generated for  recently included project 'shared' also, while running genJavaDocs.
Don't generate javadocs for 'shared'.

**Purpose of the change**
To fix warnings while generating javadocs.

**What the code does**
Fixes #978. 

**How to verify it**
Run ./gradlew genJavaDocs.