### PR TITLE
Issue 979: Simplified container epoch setting by using the metadata.

### DIFF
--- a/service/server/src/main/java/com/emc/pravega/service/server/OperationLog.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/OperationLog.java
@@ -53,14 +53,5 @@ public interface OperationLog extends Container {
      * point will have completed (normally or exceptionally).
      */
     CompletableFuture<Void> operationProcessingBarrier(Duration timeout);
-
-    /**
-     * Gets a value indicating the current Epoch of this DurableDataLog.
-     *
-     * See DurableDataLog for a more detailed description of this.
-     *
-     * @return The current Epoch value. This value is never changed during the lifetime of this object.
-     */
-    long getEpoch();
 }
 

--- a/service/server/src/main/java/com/emc/pravega/service/server/containers/StreamSegmentContainer.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/containers/StreamSegmentContainer.java
@@ -140,7 +140,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         this.durableLog.startAsync();
         runAsyncOrFail(() -> {
             this.durableLog.awaitRunning();
-            this.storage.initialize(this.durableLog.getEpoch());
+            this.storage.initialize(this.metadata.getContainerEpoch());
 
             // DurableLog is running. Now start all other components that depend on it.
             this.metadataCleaner.startAsync();

--- a/service/server/src/main/java/com/emc/pravega/service/server/logs/DurableLog.java
+++ b/service/server/src/main/java/com/emc/pravega/service/server/logs/DurableLog.java
@@ -286,11 +286,6 @@ public class DurableLog extends AbstractService implements OperationLog {
                 });
     }
 
-    @Override
-    public long getEpoch() {
-        return this.durableDataLog.getEpoch();
-    }
-
     //endregion
 
     //region Recovery

--- a/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentMapperTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/containers/StreamSegmentMapperTests.java
@@ -585,11 +585,6 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public long getEpoch() {
-            return -1;
-        }
-
-        @Override
         public Service startAsync() {
             return null;
         }

--- a/service/server/src/test/java/com/emc/pravega/service/server/logs/DurableLogTests.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/logs/DurableLogTests.java
@@ -1021,30 +1021,6 @@ public class DurableLogTests extends OperationLogTestBase {
 
     //endregion
 
-    //region Others
-
-    /**
-     * Tests the getEpoch method.
-     */
-    @Test
-    public void testEpoch() {
-        // Setup a DurableLog and start it.
-        @Cleanup
-        ContainerSetup setup = new ContainerSetup(executorService());
-        @Cleanup
-        DurableLog durableLog = setup.createDurableLog();
-        AssertExtensions.assertThrows(
-                "getEpoch did not throw before initialization.",
-                durableLog::getEpoch,
-                ex -> ex instanceof IllegalStateException);
-        durableLog.startAsync().awaitRunning();
-
-        long expectedEpoch = setup.dataLog.get().getEpoch();
-        Assert.assertEquals("Unexpected value from getEpoch.", expectedEpoch, durableLog.getEpoch());
-    }
-
-    //endregion
-
     //region Helpers
 
     private void performLogOperationChecks(Collection<OperationWithCompletion> operations, DurableLog durableLog) {

--- a/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/hdfs/HDFSStorage.java
+++ b/service/storage/impl/src/main/java/com/emc/pravega/service/storage/impl/hdfs/HDFSStorage.java
@@ -122,7 +122,7 @@ class HDFSStorage implements Storage {
     public void initialize(long epoch) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         Preconditions.checkState(this.context == null, "HDFSStorage has already been initialized.");
-        Preconditions.checkArgument(epoch > 0, "epoch must be a positive number.");
+        Preconditions.checkArgument(epoch > 0, "epoch must be a positive number. Given %s.", epoch);
         Configuration conf = new Configuration();
         conf.set("fs.default.name", this.config.getHdfsHostURL());
         conf.set("fs.default.fs", this.config.getHdfsHostURL());

--- a/service/storage/src/main/java/com/emc/pravega/service/storage/mocks/InMemoryStorage.java
+++ b/service/storage/src/main/java/com/emc/pravega/service/storage/mocks/InMemoryStorage.java
@@ -100,7 +100,7 @@ public class InMemoryStorage implements TruncateableStorage, ListenableStorage {
     @Override
     public void initialize(long epoch) {
         // InMemoryStorage does not use epochs; we don't do anything with it.
-        Preconditions.checkArgument(epoch > 0, "epoch must be a positive number.");
+        Preconditions.checkArgument(epoch > 0, "epoch must be a positive number. Given %s.", epoch);
         Preconditions.checkState(this.initialized.compareAndSet(false, true), "InMemoryStorage is already initialized.");
 
     }


### PR DESCRIPTION
Enhanced the error message to include the epoch value too.

**Change log description**
Pull request #981 attempted to fix an issue but it solved it in a rather complex manner, when all the required info was readily available in the container metadata.

This PR fixes that by simplifying container epoch setting by using the metadata.

**Purpose of the change**
Improve code. 

**What the code does**
Same thing.

**How to verify it**
Tests.