### PR TITLE
Service Name in system test framework should be in lower case

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
@@ -51,7 +51,7 @@ public abstract class MarathonBasedService implements Service {
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(3);
 
     MarathonBasedService(final String id) {
-        this.id = id;
+        this.id = id.toLowerCase(); //Marathon allows only lowercase ids.
         this.marathonClient = AuthEnabledMarathonClient.getClient();
     }
 

--- a/systemtests/tests/src/test/java/com/emc/pravega/ControllerFailoverTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ControllerFailoverTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ControllerFailoverTest {
-    private static final String TEST_CONTROLLER_SERVICE_NAME = "testController";
+    private static final String TEST_CONTROLLER_SERVICE_NAME = "testcontroller";
 
     @Environment
     public static void setup() throws InterruptedException, MarathonException, URISyntaxException {


### PR DESCRIPTION
**Change log description**
Changed the service id in ControllerFailoverTest.java to lowercase.
**Purpose of the change**
Fixes 997.
**How to verify it**
Tested that service with id TEST_CONTROLLER_SERVICE_NAME is deployed successfully by system test framework.
