### PR TITLE
Issue-1004: Fix sporadic timeout failure of listStream unit test

### DIFF
--- a/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -62,9 +62,9 @@ import static org.mockito.Mockito.when;
  */
 public class StreamMetaDataTests extends JerseyTest {
 
-    //Ensure each test completes within 5 seconds.
+    //Ensure each test completes within 20 seconds.
     @Rule
-    public Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
 
     ControllerService mockControllerService;
     StreamMetadataStore mockStreamStore;


### PR DESCRIPTION
**Change log description**
Increased timeout for REST unit tests.

**Purpose of the change**
Fixes #1004 

**What the code does**
Timeout value increased for REST unit tests.

**How to verify it**
Gradle build