### PR TITLE
Using testutils to get free port for the starting rest server container

### DIFF
--- a/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/PingTest.java
+++ b/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/PingTest.java
@@ -6,8 +6,10 @@
 package com.emc.pravega.controller.rest.v1;
 
 import com.emc.pravega.controller.server.rest.resources.PingImpl;
+import com.emc.pravega.testcommon.TestUtils;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.core.Application;
@@ -22,6 +24,7 @@ public class PingTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        this.forceSet(TestProperties.CONTAINER_PORT, String.valueOf(TestUtils.getAvailableListenPort()));
         return new ResourceConfig(PingImpl.class);
     }
 

--- a/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/server/src/test/java/com/emc/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -41,9 +41,12 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
+
+import com.emc.pravega.testcommon.TestUtils;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -197,6 +200,7 @@ public class StreamMetaDataTests extends JerseyTest {
     protected Application configure() {
         mockControllerService = mock(ControllerService.class);
         streamMetadataResource = new StreamMetadataResourceImpl(mockControllerService);
+        this.forceSet(TestProperties.CONTAINER_PORT, String.valueOf(TestUtils.getAvailableListenPort()));
 
         final ResourceConfig resourceConfig = new ResourceConfig().register(streamMetadataResource)
                 .register(new AbstractBinder() {


### PR DESCRIPTION
**Change log description**
Using getAvailablePort() for starting the test REST server instead of a hard-coded port.

**Purpose of the change**
Fixes #1014

**What the code does**
Uses getAvailablePort() for starting the test REST server instead of the default hard-coded port.

**How to verify it**
All REST API tests should succeed