### PR TITLE
Issue 1002: ScaleService API fix

### DIFF
--- a/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
+++ b/systemtests/tests/src/main/java/com/emc/pravega/framework/services/MarathonBasedService.java
@@ -101,7 +101,7 @@ public abstract class MarathonBasedService implements Service {
         try {
             App updatedConfig = new App();
             updatedConfig.setInstances(instanceCount);
-            marathonClient.updateApp(getID(), updatedConfig, false);
+            marathonClient.updateApp(getID(), updatedConfig, true);
             if (wait) {
                 waitUntilServiceRunning().get(); // wait until scale operation is complete.
             }


### PR DESCRIPTION
**Change log description**
- Ensure that the force flag is updated to true while using scaleservice api.
- If a marathon app is in a "deploying" state then the scale API returns a conflict status.
The health check mentioned for marathon app causes the service state to be shown as deploying even though the app/container is deployed and running.
- Also the current code already waits until the number of staging tasks is zero.

**Purpose of the change**
Fix for #1002

**How to verify it**
Scale operations should succeed and 409 error code should not be returned.
