### PR TITLE
Issue 1029: Intermittent task test failure fix

### DIFF
--- a/controller/server/src/test/java/com/emc/pravega/controller/task/TaskTest.java
+++ b/controller/server/src/test/java/com/emc/pravega/controller/task/TaskTest.java
@@ -341,9 +341,14 @@ public class TaskTest {
         // Ensure that a transaction is created.
         map = streamStore.getActiveTxns(SCOPE, stream1, null, executor).join();
         assertEquals(2, map.size());
-        txId = map.keySet().iterator().next();
+        Optional<UUID> txIdOpt = map.entrySet().stream()
+                .filter(e -> e.getValue().getTxnStatus() == TxnStatus.OPEN)
+                .map(e -> e.getKey())
+                .findAny();
+        Assert.assertTrue(txIdOpt.isPresent());
 
         // Commit the transaction.
+        txId = txIdOpt.get();
         completePartialTask(mockTxnTasks.commitTxn(SCOPE, stream1, txId, null), deadHost, sweeper);
         // Ensure that transaction state is COMMITTING.
         status = streamStore.getTransactionData(SCOPE, stream1, txId, null, executor).join().getStatus();


### PR DESCRIPTION
**Change log description**
Fixed intermittent test failure issue. The second transaction was being fetched by randomly fetching a transaction from the list of transactions returned from the API. However, second transaction should be filtered from the list as the one in `OPEN` state.

**Purpose of the change**
Fixing intermittent test failure.

**What the code does**
As described above. Fixes #1029 .

**How to verify it**
TaskTest unit test should succeed always.