### PR TITLE
Issue 1046: Including shared project in the flink connectors shaded jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -627,6 +627,7 @@ project('connectors:flink') {
     shadowJar {
         dependencies {
             // 'include' specific dependencies in the shadow jar
+            // IMPORTANT: transitive dependencies must be manually listed here!
             include dependency("com.google.guava:guava")
             include dependency("commons-lang:commons-lang")
             include dependency("org.apache.commons:commons-lang3")
@@ -652,6 +653,7 @@ project('connectors:flink') {
             include dependency("com.google.code.gson:gson")
             include dependency("com.google.instrumentation:instrumentation-api")
             include(project(":common"))
+            include(project(":shared"))
             include(project(":controller:contract"))
             include(project(":clients:streaming"))
         }


### PR DESCRIPTION
**Change log description**
Some code from common project was moved to shared, but was not included in the flink connectors' shaded jar. Now including it.

**Purpose of the change**
Fixes #1046 

**What the code does**
Includes the missing shared project in flink connectors dependency, as suggested by @EronWright.

**How to verify it**
Build and link to flink connector and verify
