### PR TITLE
Issue #1056:  Correct the flag passed to the reader

### DIFF
--- a/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
+++ b/systemtests/tests/src/test/java/com/emc/pravega/ReadWithAutoScaleTest.java
@@ -211,7 +211,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
 
     private CompletableFuture<Void> startReader(final String id, final ClientFactory clientFactory, final String
             readerGroupName, final ConcurrentLinkedQueue<Long> readResult, final AtomicLong writeCount, final
-    AtomicLong readCount , final AtomicBoolean exitFlag) {
+    AtomicLong readCount, final AtomicBoolean exitFlag) {
 
         return CompletableFuture.runAsync(() -> {
             @Cleanup


### PR DESCRIPTION
**Change log description**
Correct the flag passed to the reader in the systemtest ReadWithAutoScale.java

**Purpose of the change**
Fixes #1056 

**How to verify it**
Ran the system tests on caliban with image 0.1.0-1307.f13642a. the test ran as expected and issue #1060 was observed.
