### PR TITLE
Issue 1063: Remove alpha label from pravegaVersion in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -52,6 +52,6 @@ typesafeConfigVersion=1.3.0
 apacheCommonsCsvVersion=1.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.1.0-alpha-SNAPSHOT
+pravegaVersion=0.1.0-SNAPSHOT
 pravegaControllerBaseTag=pravega/pravega-controller
 pravegaHostBaseTag=pravega/pravega-host


### PR DESCRIPTION
**Change log description**
Remove alpha label in `gradle.properties`.

**Purpose of the change**
The alpha label is unnecessary.

**What the code does**
Configuration change.

**How to verify it**
There is no automated verification for this.