### PR TITLE
Issue 1074: Define all the gradle  projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -815,16 +815,11 @@ subprojects {
 }
 
 task publishAllJars() {
-    dependsOn ':clients:streaming:publish'
+    dependsOn  clientPkgs.collect{it + ":publish"}
     dependsOn ':common:publish'
-    dependsOn ':service:contracts:publish'
-    dependsOn ':service:storage:publish'
-    dependsOn ':service:storage:impl:publish'
-    dependsOn ':service:server:publish'
-    dependsOn ':service:server:host:publish'
+    dependsOn  servicePkgs.collect{it+ ":publish"}
     dependsOn ':shared:publish'
-    dependsOn ':controller:contract:publish'
-    dependsOn ':controller:server:publish'
+    dependsOn  controllerPkgs.collect{it + ":publish"}
     dependsOn ':connectors:flink:publish'
     dependsOn ':singlenode:publish'
     dependsOn ':systemtests:tests:publish'


### PR DESCRIPTION
**Change log description**
Update pkgs in build.gradle
https://github.com/pravega/pravega/blob/master/build.gradle#L121

**Purpose of the change**
All gradle projects are not defined in build.gradle 

**What the code does**
Fixes #1074 

**How to verify it**
There is no functional change. Pull the diff and check gradle build. It should be successful.