### PR TITLE
Issue 1058: PravegaRequestProcessor cannot read from empty sealed segments.

### DIFF
--- a/service/server/host/src/main/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessor.java
+++ b/service/server/host/src/main/java/com/emc/pravega/service/server/host/handler/PravegaRequestProcessor.java
@@ -141,7 +141,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         boolean endOfSegment = nonCachedEntry != null && nonCachedEntry.getType() == EndOfStreamSegment;
         boolean atTail = nonCachedEntry != null && nonCachedEntry.getType() == Future;
 
-        if (!cachedEntries.isEmpty()) {
+        if (!cachedEntries.isEmpty() || endOfSegment) {
             ByteBuffer data = copyData(cachedEntries);
             SegmentRead reply = new SegmentRead(segment, request.getOffset(), atTail, endOfSegment, data);
             connection.send(reply);


### PR DESCRIPTION
**Change log description**
Fixed a bug in PravegaRequestProcessor where it is not able to handle reading from empty sealed segments.

**Purpose of the change**
Fixes #1058.

**What the code does**
Better things.

**How to verify it**
New unit test added.