### PR TITLE
Issue 1082: Increase testEndToEnd time out

### DIFF
--- a/service/server/src/test/java/com/emc/pravega/service/server/store/StreamSegmentStoreTestBase.java
+++ b/service/server/src/test/java/com/emc/pravega/service/server/store/StreamSegmentStoreTestBase.java
@@ -96,7 +96,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If an exception occurred.
      */
-    @Test(timeout = 120000)
+    @Test(timeout = 300000)
     public void testEndToEnd() throws Exception {
         AtomicReference<Storage> storage = new AtomicReference<>();
 


### PR DESCRIPTION
**Change log description**
Increase test timeout after seeing a test failure due to a timeout exception.

**Purpose of the change**
Fix build failure.

**What the code does**
Fixes #1082 

**How to verify it**
Build.