### PR TITLE
Issue 1045: Adding missing javadocs for common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,12 @@ project('common') {
         }
     }
     javadoc {
-        exclude 'io/pravega/common/*'
+        title = "Pravega Common Libraries"
+        failOnError = false
+        source  =  project(':common').sourceSets.main.java
+        def javadocs = new File(rootDir, "javadocs")
+        javadocs.mkdirs()
+        destinationDir = javadocs
     }
 }
 

--- a/common/src/main/java/io/pravega/common/AbstractTimer.java
+++ b/common/src/main/java/io/pravega/common/AbstractTimer.java
@@ -16,11 +16,15 @@ public abstract class AbstractTimer {
 
     /**
      * Gets the elapsed time, in nanoseconds.
+     *
+     * @return Long indicating elapsed time, in nanoseconds.
      */
     public abstract long getElapsedNanos();
 
     /**
      * Gets the elapsed time, in milliseconds.
+     *
+     *  @return Long indicating elapsed time, in milliseconds.
      */
     public long getElapsedMillis() {
         return getElapsedNanos() / NANOS_TO_MILLIS;
@@ -28,6 +32,8 @@ public abstract class AbstractTimer {
 
     /**
      * Gets the elapsed time.
+     *
+     * @return Duration indicating elapsed time.
      */
     public Duration getElapsed() {
         return Duration.ofNanos(getElapsedNanos());

--- a/common/src/main/java/io/pravega/common/ExceptionHelpers.java
+++ b/common/src/main/java/io/pravega/common/ExceptionHelpers.java
@@ -29,6 +29,7 @@ public class ExceptionHelpers {
      * Extracts the inner exception from any Exception that may have an inner exception.
      *
      * @param ex The exception to query.
+     * @return Throwable corresponding to the inner exception.
      */
     public static Throwable getRealException(Throwable ex) {
         if (canInspectCause(ex)) {

--- a/common/src/main/java/io/pravega/common/Exceptions.java
+++ b/common/src/main/java/io/pravega/common/Exceptions.java
@@ -57,6 +57,7 @@ public final class Exceptions {
      * @param <ExceptionT> The type of exception.
      * @param <ResultT>    The type of the result.
      * @throws ExceptionT If thrown by call.
+     * @return The result of the call.
      */
     @SneakyThrows(InterruptedException.class)
     public static <ExceptionT extends Exception, ResultT> ResultT handleInterrupted(InterruptibleCall<ExceptionT, ResultT> call)

--- a/common/src/main/java/io/pravega/common/ExponentialMovingAverage.java
+++ b/common/src/main/java/io/pravega/common/ExponentialMovingAverage.java
@@ -35,6 +35,8 @@ public class ExponentialMovingAverage {
     
     /**
      * Returns the current moving average.
+     *
+     * @return Double indicating the current moving average.
      */
     public double getCurrentValue() {
         double result = Double.longBitsToDouble(valueEncodedAsLong.get());
@@ -46,6 +48,7 @@ public class ExponentialMovingAverage {
      * Adds a new sample to the moving average and returns the updated value.
      * 
      * @param newSample the new value to be added
+     * @return Double indicating the updated moving average value after adding a new sample.
      */
     public double addNewSample(double newSample) {
         final double sample = calculateLog(newSample);

--- a/common/src/main/java/io/pravega/common/TimeoutTimer.java
+++ b/common/src/main/java/io/pravega/common/TimeoutTimer.java
@@ -48,6 +48,8 @@ public class TimeoutTimer {
     
     /**
      * Returns true if there is time remaining.
+     *
+     * @return False if there is no time remaining from the given timeout.
      */
     public boolean hasRemaining() {
         return (getNanos.get() - initialNanos) < timeout.toNanos();

--- a/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
@@ -41,6 +41,7 @@ public final class FutureHelpers {
      *
      * @param f   The future to wait for.
      * @param <T> The Type of the future's result.
+     * @return True if the provided CompletableFuture is complete and successful.
      */
     public static <T> boolean await(CompletableFuture<T> f) {
         return await(f, Long.MAX_VALUE);
@@ -53,6 +54,7 @@ public final class FutureHelpers {
      * @param timeout The maximum number of milliseconds to block
      * @param f       The future to wait for.
      * @param <T>     The Type of the future's result.
+     * @return True if the given CompletableFuture is completed and successful within the given timeout.
      */
     public static <T> boolean await(CompletableFuture<T> f, long timeout) {
         Exceptions.handleInterrupted(() -> {
@@ -94,6 +96,7 @@ public final class FutureHelpers {
      *
      * @param f   The future to inspect.
      * @param <T> The Type of the future's result.
+     * @return True if the given CompletableFuture has completed successfully.
      */
     public static <T> boolean isSuccessful(CompletableFuture<T> f) {
         return f.isDone() && !f.isCompletedExceptionally() && !f.isCancelled();
@@ -139,6 +142,7 @@ public final class FutureHelpers {
      * @param <ExceptionT>         Type of the Exception.
      * @throws ExceptionT       If thrown by the future.
      * @throws TimeoutException If the timeout expired prior to the future completing.
+     * @return The result of calling future.get().
      */
     @SneakyThrows(InterruptedException.class)
     public static <ResultT, ExceptionT extends Exception> ResultT getAndHandleExceptions(Future<ResultT> future,
@@ -163,6 +167,7 @@ public final class FutureHelpers {
      *
      * @param exception The exception to fail the CompletableFuture.
      * @param <T>       The Type of the future's result.
+     * @return A CompletableFuture that fails with the given exception.
      */
     public static <T> CompletableFuture<T> failedFuture(Throwable exception) {
         CompletableFuture<T> result = new CompletableFuture<>();
@@ -256,6 +261,7 @@ public final class FutureHelpers {
      *
      * @param futures A List of CompletableFutures to wait on.
      * @param <T>     The type of the results items.
+     * @return  A new CompletableFuture List that is completed when all of the given CompletableFutures complete.
      */
     public static <T> CompletableFuture<List<T>> allOfWithResults(List<CompletableFuture<T>> futures) {
         CompletableFuture<Void> allDoneFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
@@ -286,6 +292,7 @@ public final class FutureHelpers {
      *
      * @param futures A Collection of CompletableFutures to wait on.
      * @param <T>     The type of the results items.
+     * @return A new CompletableFuture that is completed when all of the given CompletableFutures complete.
      */
     public static <T> CompletableFuture<Void> allOf(Collection<CompletableFuture<T>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
@@ -323,6 +330,7 @@ public final class FutureHelpers {
      * @param timeout         The timeout for the future.
      * @param executorService An ExecutorService that will be used to invoke the timeout on.
      * @param <T>             The Type argument for the CompletableFuture to create.
+     * @return A CompletableFuture with a timeout.
      */
     public static <T> CompletableFuture<T> futureWithTimeout(Duration timeout, ScheduledExecutorService executorService) {
         return futureWithTimeout(timeout, null, executorService);

--- a/common/src/main/java/io/pravega/common/hash/HashHelper.java
+++ b/common/src/main/java/io/pravega/common/hash/HashHelper.java
@@ -39,6 +39,7 @@ public class HashHelper {
      * Returns a double uniformly randomly distributed between 0 and 1 using the hash function.
      *
      * @param str The input string.
+     * @return Uniformly distributed double between 0 and 1.
      */
     public double hashToRange(String str) {
         return longToDoubleFraction(hash.hashUnencodedChars(str).asLong());

--- a/common/src/main/java/io/pravega/common/io/EnhancedByteArrayOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/EnhancedByteArrayOutputStream.java
@@ -15,7 +15,8 @@ import io.pravega.common.util.ByteArraySegment;
 public class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
     /**
      * Returns a readonly ByteArraySegment wrapping the current buffer of the ByteArrayOutputStream.
-     * @return
+     *
+     * @return A readonly ByteArraySegment from the current buffer of the ByteArrayOutputStream.
      */
     public ByteArraySegment getData() {
         return new ByteArraySegment(this.buf, 0, this.count, true);

--- a/common/src/main/java/io/pravega/common/netty/AppendBatchSizeTracker.java
+++ b/common/src/main/java/io/pravega/common/netty/AppendBatchSizeTracker.java
@@ -24,11 +24,15 @@ public interface AppendBatchSizeTracker {
 
     /**
      * Returns the size that should be used for the next append block.
+     *
+     * @return Integer indicating block size that should be used for the next append.
      */
     int getAppendBlockSize();
     
     /**
      * Returns the timeout that should be used for append blocks.
+     *
+     * @return Integer indicating the batch timeout.
      */
     int getBatchTimeout();
 

--- a/common/src/main/java/io/pravega/common/segment/SegmentToContainerMapper.java
+++ b/common/src/main/java/io/pravega/common/segment/SegmentToContainerMapper.java
@@ -28,6 +28,8 @@ public final class SegmentToContainerMapper {
 
     /**
      * Gets a value representing the total number of available SegmentContainers available within the cluster.
+     *
+     * @return Integer indicating the total number of available SegmentContainers available within the cluster.
      */
     public int getTotalContainerCount() {
         return this.containerCount;
@@ -43,6 +45,7 @@ public final class SegmentToContainerMapper {
      * </ul>
      *
      * @param streamSegmentName The name of the StreamSegment.
+     * @return Integer indicating the container id for the given StreamSegment.
      */
     public int getContainerId(String streamSegmentName) {
         String parentStreamSegmentName = StreamSegmentNameUtils.getParentStreamSegmentName(streamSegmentName);

--- a/common/src/main/java/io/pravega/common/util/ArrayView.java
+++ b/common/src/main/java/io/pravega/common/util/ArrayView.java
@@ -16,6 +16,7 @@ public interface ArrayView {
      *
      * @param index The index to query.
      * @throws ArrayIndexOutOfBoundsException If index is invalid.
+     * @return Byte indicating the value at the given index.
      */
     byte get(int index);
 

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -243,6 +243,8 @@ public class ByteArraySegment implements ArrayView {
      * Returns a new ByteArraySegment that wraps the same underlying array that this ByteSegmentDoes, except that the
      * new instance is marked as Read-Only.
      * If this instance is already Read-Only, this instance is returned instead.
+     *
+     * @return  A new read-only ByteArraySegment.
      */
     public ByteArraySegment asReadOnly() {
         if (isReadOnly()) {

--- a/common/src/main/java/io/pravega/common/util/CircularBuffer.java
+++ b/common/src/main/java/io/pravega/common/util/CircularBuffer.java
@@ -104,6 +104,8 @@ public class CircularBuffer {
 
     /**
      * Gets the number of bytes that can be read.
+     *
+     * @return Integer indicating the number of bytes that can be read.
      */
     public int dataAvailable() {
         if (readBuffer.position() < fillBuffer.position()) {

--- a/common/src/main/java/io/pravega/common/util/Property.java
+++ b/common/src/main/java/io/pravega/common/util/Property.java
@@ -25,6 +25,7 @@ public class Property<T> {
      *
      * @param name The name of the property.
      * @param <T>  The type of the property values.
+     * @return A new instance of the Property class with no default value.
      */
     public static <T> Property<T> named(String name) {
         return new Property<>(name, null);
@@ -36,6 +37,7 @@ public class Property<T> {
      * @param name         The name of the property.
      * @param defaultValue The default value of the property.
      * @param <T>          The type of the property values.
+     * @return A new instance of the Property class with the given default value.
      */
     public static <T> Property<T> named(String name, T defaultValue) {
         return new Property<>(name, defaultValue);

--- a/common/src/main/java/io/pravega/common/util/ReusableLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableLatch.java
@@ -69,6 +69,8 @@ public class ReusableLatch {
 
     /**
      * Returns whether or not release has been called and threads can call await without blocking.
+     *
+     * @return True if the latch is set to release state.
      */
     public boolean isReleased() {
         return released.get();

--- a/common/src/main/java/io/pravega/common/util/SequencedItemList.java
+++ b/common/src/main/java/io/pravega/common/util/SequencedItemList.java
@@ -232,6 +232,8 @@ public class SequencedItemList<T extends SequencedItemList.Element> {
         /**
          * Gets a value indicating the Sequence Number for this item.
          * The Sequence Number is a unique, strictly monotonically increasing number that assigns order to items.
+         *
+         * @return Long indicating the Sequence number for this item.
          */
         long getSequenceNumber();
     }

--- a/common/src/main/java/io/pravega/common/util/SortedIndex.java
+++ b/common/src/main/java/io/pravega/common/util/SortedIndex.java
@@ -44,6 +44,8 @@ public interface SortedIndex<V extends SortedIndex.IndexEntry> {
 
     /**
      * Gets a value indicating the number of items in the Index.
+     *
+     * @return Integer indicating the size or number of items in the Index.
      */
     int size();
 
@@ -100,6 +102,8 @@ public interface SortedIndex<V extends SortedIndex.IndexEntry> {
         /**
          * Gets a value representing the key of the entry. The Key should not change for the lifetime of the entry and
          * should be very cheap to return (as it is used very frequently).
+         *
+         * @return The entry key.
          */
         long key();
     }


### PR DESCRIPTION
**Change log description**
Javadocs are to be generated for common along with client.
Do not suppress the common classes and interfaces while generating javadocs.

**Purpose of the change**
Adding missing return statements to common javadocs.

**What the code does**
Fixes #1045 

**How to verify it**
gradle genJavaDocs