### PR TITLE
Issue 1128: Update hdfsUrl for systemtests

### DIFF
--- a/PravegaGroup.json
+++ b/PravegaGroup.json
@@ -117,7 +117,7 @@
                   },
                   {
                     "key": "env",
-                    "value": "HOST_OPTS=\"-Dpravegaservice.zkURL=master.mesos:2181\" \"-Ddlog.hostname=master.mesos\" \"-Ddlog.port=2181\" \"-Dhdfs.hdfsUrl=namenode-0.hdfs.mesos:9001\" \"-DautoScale.muteInSeconds=120\" \"-DautoScale.cooldownInSeconds=120\"  \"-DautoScale.cacheExpiryInSeconds=120\" \"-DautoScale.cacheCleanUpInSeconds=120\" \"-DautoScale.controllerUri=tcp://controller.pravega.marathon.mesos:9090\" \"-Dlog.level=INFO\""
+                    "value": "HOST_OPTS=\"-Dpravegaservice.zkURL=master.mesos:2181\" \"-Ddlog.hostname=master.mesos\" \"-Ddlog.port=2181\" \"-Dhdfs.hdfsUrl=hdfs.marathon.containerip.dcos.thisdcos.directory:8020\" \"-DautoScale.muteInSeconds=120\" \"-DautoScale.cooldownInSeconds=120\"  \"-DautoScale.cacheExpiryInSeconds=120\" \"-DautoScale.cacheCleanUpInSeconds=120\" \"-DautoScale.controllerUri=tcp://controller.pravega.marathon.mesos:9090\" \"-Dlog.level=INFO\""
                   }
                   ],
 		  "forcePullImage": true

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -124,7 +124,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         //System properties to configure SS service.
         String hostSystemProperties = setSystemProperty("pravegaservice.zkURL", zk) +
                 setSystemProperty("dlog.hostname", zkUri.getHost()) +
-                setSystemProperty("hdfs.hdfsUrl", "namenode-0.hdfs.mesos:9001") +
+                setSystemProperty("hdfs.hdfsUrl", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020") +
                 setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +


### PR DESCRIPTION
**Change log description**
`hdfsUrl`  used while deploying pravega segmentstore need to be updated to match with the deployed HDFS on jarvis cluster.
**Purpose of the change**
Moving to HDFS 2.7
**What the code does**
Fixes #1128 
**How to verify it**
gradle startSystemTests