### PR TITLE
Issue 828: Publish only shaded version of flink connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -673,6 +673,7 @@ project('connectors:flink') {
         relocate "io.grpc", "io.pravega.shaded.io.grpc"
         relocate "io.netty", "io.pravega.shaded.io.netty"
 
+        classifier = null
         mergeServiceFiles()
     }
 


### PR DESCRIPTION
**Change log description**
Now publishing only the shaded flink connector. 
Also the artifact id is now just: pravega-connectors-flink_2.11:<pravega-version>

**Purpose of the change**
Fixes #828

**What the code does**
Removes the unshaded jar and only publishes the shaded version to simplify client dependency.

**How to verify it**
./gradlew publish and verify the contents of flink connector jar.
