### PR TITLE
Issue 1153: Fix client javadoc errors

### DIFF
--- a/clients/streaming/src/main/java/io/pravega/stream/StreamSegmentsWithPredecessors.java
+++ b/clients/streaming/src/main/java/io/pravega/stream/StreamSegmentsWithPredecessors.java
@@ -34,7 +34,7 @@ public class StreamSegmentsWithPredecessors {
     /**
      * Get Segment to Predecessor mapping.
      *
-     * @return Map<Segment, List<Integer>> Segment to Predecessor mapping.
+     * @return A {@link Map} with {@link Segment} as key and {@link List} of {@link Integer} as value.
      */
     public Map<Segment, List<Integer>> getSegmentToPredecessor() {
         return segmentWithPredecessors;
@@ -43,7 +43,7 @@ public class StreamSegmentsWithPredecessors {
     /**
      * Get Segment to Key Range mapping.
      *
-     * @return Map<Segment, Range> segment to range mapping.
+     * @return A {@link Map} with {@link Segment} as key and {@link Range} as value.
      */
     public Map<Segment, Range> getSegmentToRange() {
         return segmentWithKeyRange;


### PR DESCRIPTION
**Change log description**
Fixing errors while generating client javadocs due to recent addition of `Map<>` in return statement.
`<` and `>` symbols cannot be used in  `@return` statement in javadocs.
**Purpose of the change**
Errors while generating javadocs for StreamSegmentsWithPredecessors.java
**What the code does**
Fixes #1153
**How to verify it**
gradle genJavaDocs