### PR TITLE
Simplify a section of code for compiler's benefit.

### DIFF
--- a/controller/server/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/server/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -373,23 +373,23 @@ public abstract class PersistentStreamBase<T> implements Stream {
                     return ActiveTxnRecord.parse(ok.getData()).getTxnStatus();
                 });
 
-        return verifyLegalState(activeTx
-                .thenCompose(x -> {
-                    if (x.equals(TxnStatus.UNKNOWN)) {
-                        return getCompletedTx(txId)
-                                .handle((ok, ex) -> {
-                                    if (ok == null ||
-                                            (ex != null && ex instanceof DataNotFoundException)) {
-                                        return TxnStatus.UNKNOWN;
-                                    } else if (ex != null) {
-                                        throw new CompletionException(ex);
-                                    }
-                                    return CompletedTxnRecord.parse(ok.getData()).getCompletionStatus();
-                                });
-                    } else {
-                        return CompletableFuture.completedFuture(x);
-                    }
-                }));
+        return verifyLegalState(activeTx.thenCompose(x -> {
+            return parseStatus(txId, x);
+        }));
+    }
+
+    private CompletionStage<TxnStatus> parseStatus(final UUID txId, TxnStatus x) {
+        if (!x.equals(TxnStatus.UNKNOWN)) {
+            return CompletableFuture.completedFuture(x);
+        }
+        return getCompletedTx(txId).handle((ok, ex) -> {
+            if (ok == null || (ex != null && ex instanceof DataNotFoundException)) {
+                return TxnStatus.UNKNOWN;
+            } else if (ex != null) {
+                throw new CompletionException(ex);
+            }
+            return CompletedTxnRecord.parse(ok.getData()).getCompletionStatus();
+        });
     }
 
     @Override


### PR DESCRIPTION
**Change log description**
Reduce complexity of generic inference for lesser compilers benefit.

**Purpose of the change**
Unlike javac, the eclipse compiler sometimes struggles with very complicated generic type inferences. 
This simplifies one such location where it falsely flagged a compile error.

**What the code does**
Exactly what it does now. This is a pure refactoring.

**How to verify it**
All tests should continue to pass.