### PR TITLE
Issue 1147: Add toString for checkpoint debugging

### DIFF
--- a/clients/streaming/src/main/java/io/pravega/stream/impl/CheckpointState.java
+++ b/clients/streaming/src/main/java/io/pravega/stream/impl/CheckpointState.java
@@ -110,4 +110,16 @@ public class CheckpointState {
         }
     }
 
+    @Override
+    @Synchronized
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("CheckpointState { ongoingCheckpoints: ");
+        sb.append(checkpoints.toString());
+        sb.append(",  readersBlockingEachCheckpoint: ");
+        sb.append(uncheckpointedHosts.toString());
+        sb.append(" }");
+        return sb.toString();
+    }
+    
 }

--- a/clients/streaming/src/main/java/io/pravega/stream/impl/ReaderGroupImpl.java
+++ b/clients/streaming/src/main/java/io/pravega/stream/impl/ReaderGroupImpl.java
@@ -35,10 +35,12 @@ import java.util.stream.Collectors;
 
 import lombok.Data;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.pravega.common.concurrent.FutureHelpers.allOfWithResults;
 import static io.pravega.common.concurrent.FutureHelpers.getAndHandleExceptions;
 
+@Slf4j
 @Data
 public class ReaderGroupImpl implements ReaderGroup {
 
@@ -102,6 +104,9 @@ public class ReaderGroupImpl implements ReaderGroup {
             return FutureHelpers.delayedTask(() -> {
                 synchronizer.fetchUpdates();
                 checkpointPending.set(!synchronizer.getState().isCheckpointComplete(checkpointName));
+                if (checkpointPending.get()) {
+                    log.debug("Waiting on checkpoint: {} currentState is: {}", checkpointName, synchronizer.getState());                    
+                }
                 return null;
             }, Duration.ofMillis(500), backgroundExecutor);
         }, backgroundExecutor).thenApply(v ->  completeCheckpoint(checkpointName, synchronizer)

--- a/clients/streaming/src/main/java/io/pravega/stream/impl/ReaderGroupState.java
+++ b/clients/streaming/src/main/java/io/pravega/stream/impl/ReaderGroupState.java
@@ -187,6 +187,21 @@ class ReaderGroupState implements Revisioned {
         return checkpointState.getPositionsForCompletedCheckpoint(checkpointId);
     }
     
+    @Override
+    @Synchronized
+    public String toString() {
+        StringBuffer sb = new StringBuffer("ReaderGroupState{ ");
+        sb.append(checkpointState.toString());
+        sb.append(" futureSegments: ");
+        sb.append(futureSegments);
+        sb.append(" assignedSegments: ");
+        sb.append(assignedSegments);
+        sb.append(" unassignedSegments: ");
+        sb.append(unassignedSegments);
+        sb.append(" }");
+        return sb.toString();
+    }
+    
     @RequiredArgsConstructor
     static class ReaderGroupStateInit implements InitialUpdate<ReaderGroupState>, Serializable {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
**Change log description**
Add toString to ReaderGroupState and CheckpointState for debugging info.

**Purpose of the change**
This will help us debug, Issues seen in https://github.com/pravega/pravega/issues/1152

**What the code does**
Fixes https://github.com/pravega/pravega/issues/1147

**How to verify it**
No functional changes. We should just see additional info at debug levels.
