### PR TITLE
Adding logback configuration for standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -703,6 +703,7 @@ project('singlenode') {
 
         main = "io.pravega.local.LocalPravegaEmulator"
         classpath = sourceSets.main.runtimeClasspath
+        systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         environment "JAVA_OPTS", "-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
     }
 

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <logger name="org.apache.zookeeper" level="WARN"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
**Change log description**
Adds logback configuration for running Pravega standalone.

**Purpose of the change**
Adds logback configuration for running Pravega standalone.

**What the code does**
Fixes #1186 

**How to verify it**
Run `. /gradlew startSingleNode` and verify that the logging corresponds to the configuration. It is also possible to check that it is loading the correct file by configuring a listener:

```
systemProperties 'logback.statusListenerClass' : 'ch.qos.logback.core.status.OnConsoleStatusListener'
```