### PR TITLE
Issue 1220 :  Correct System property used while starting SSS

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -135,7 +135,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
 
         //System properties to configure SS service.
         String hostSystemProperties = setSystemProperty("pravegaservice.zkURL", zk) +
-                setSystemProperty("dlog.hostname", zkUri.getHost()) +
+                setSystemProperty("bookkeeper.zkAddress", zk) +
                 setSystemProperty("hdfs.hdfsUrl", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020") +
                 setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +


### PR DESCRIPTION
**Change log description**
System properties `dlog.hostname` and `dlog.port` are no longer used. 
`bookkeeper.zkAddress` should be used now.
**Purpose of the change**
Ensure SSS starts with right configuration.
**What the code does**
Fixes #1220 .
**How to verify it**
Ran startSystemTests gradle task and ensured stream creation is successful.