### PR TITLE
Issue 1237: Removed the dependency on uploadArchives from the startSystemTests tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,6 +444,9 @@ project('test:system') {
 
     //This is  used to invoke systemTests
     task startSystemTests(type: Test) {
+        ext.dockerRegistryUrl = project.hasProperty("dockerRegistryUrl") ? project.dockerRegistryUrl : ""
+        ext.repoUrl = project.hasProperty("repoUrl") ? project.repoUrl : ""
+
         description 'Used to invoke system tests, example usage: gradle startSystemTests -DmasterIP=xx.xx.xx.xx'
         testClassesDir = sourceSets.test.output.classesDir
         classpath = sourceSets.test.runtimeClasspath
@@ -468,10 +471,12 @@ project('test:system') {
             systemProperty "skipServiceInstallation", "true"
         }
         maxParallelForks = 1
-        systemProperty "dockerImageRegistry", "${->dockerRegistryUrl}"
+        systemProperty "dockerImageRegistry", "${dockerRegistryUrl}"
         systemProperty "testVersion", pravegaVersion
-        systemProperty "testArtifactUrl", "${->repoUrl}/io/pravega/pravega-test-system/" +
+        systemProperty "testArtifactUrl", "${repoUrl}/io/pravega/pravega-test-system/" +
                 pravegaVersion+"/pravega-test-system-"+ pravegaVersion + ".jar"
+
+        onlyIf { dockerRegistryUrl && repoUrl }
     }
 }
 


### PR DESCRIPTION
**Change log description**
This removes the publish dependency from startSystemTests.  This was never used, it was explicitly excluded. 

**Purpose of the change**
Publish isn't required normally because it is running from a version that is already published.

Fixes #1237.