### PR TITLE
Issue 1243: gradle builds and pushes Pravega image instead of BookKeeper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -587,7 +587,7 @@ task buildPravegaImage(type: DockerBuildTask, dependsOn: preparePravegaImage) {
 }
 
 task buildBookkeeperImage(type: DockerBuildTask) {
-    baseTag = pravegaBaseTag
+    baseTag = bookkeeperBaseTag
     dockerDir = "docker/bookkeeper"
 }
 


### PR DESCRIPTION
**Change log description**
Build.gradle script is using Pravega tag to build and publish bookkeeper image.
Updated the script to point to bookkeeperBaseTag

**Purpose of the change**
Fix the issue with docker build through gradle.

**What the code does**
Uses bookkeeperBaseTag instead of pravegaBaseTag for building bookkeeper image.

Fixes #1243 

**How to verify it**
Execute buildBookkeeperImage and pushBookkeeperImage through gradle.