### PR TITLE
Issue 1246: Increase the number of events in a txn to 100

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -266,7 +266,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                             .throwingOn(RuntimeException.class)
                             .run(() -> createTransaction(writer, exitFlag));
 
-                    for (int i = 0; i < 10; i++) {
+                    for (int i = 0; i < 100; i++) {
                         long value = data.incrementAndGet();
                         transaction.writeEvent(String.valueOf(value), value);
                     }


### PR DESCRIPTION
**Change log description**
Increase the number of events written per transaction in ReadWithAutoScaleTest.java from 10 to 100 to circumvent issue #1223
Note: This PR can be closed if issue #1223 is resolved.

**Purpose of the change**
Fixes #1246
**What the code does**
Increases the number of events per txn to 100.
**How to verify it**
Tests should pass and stream scaling should happen in ReadWithAutoScaleTest.java