### PR TITLE
Issue 1248: Bookkeeper startup script should have reference to pravega cluster config

### DIFF
--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -45,4 +45,4 @@ BOOKIE_CONF=/opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf /opt/bk_all/
 
 echo "start a new bookie"
 # start bookie,
-SERVICE_PORT=$PORT0 /opt/bk_all/bookkeeper-server-4.4.0/bin/bookkeeper bookie --conf  /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
+SERVICE_PORT=$PORT0 /opt/bk_all/bookkeeper-server-4.4.0/bin/bookkeeper bookie --conf /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf


### PR DESCRIPTION
**Change log description**
Updated bookkeeper startup script to include default pravega cluster config.
**Purpose of the change**
Make sure that Pravega segment store and the bookkeeper deployment script point to the same path for ledgers. This fixes #1248.
**What the code does**
Adds a new env var PRAVEGA_CLUSTER_NAME which points to "pravega-cluster" as default value.
**How to verify it**
Run and deploy default instance of Pravega Segment store against the BK image.