### PR TITLE
Some gradle fixes/tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
     apply from: "$rootDir/gradle/java.gradle"
     apply from: "$rootDir/gradle/maven.gradle"
     apply from: "$rootDir/gradle/protobuf.gradle"
-    apply plugin: "org.nosphere.apache.rat"
+    apply from: "$rootDir/gradle/rat.gradle"
 
     repositories {
         jcenter()
@@ -50,13 +50,6 @@ allprojects {
 
     version = pravegaVersion
     group = "io.pravega"
-
-
-
-    rat {
-        // List of exclude directives, defaults to ['**/.gradle/**']
-        excludes = [ '**/build/**', '**/.gradle/**', '**/.idea/**', '**/gradle/wrapper/**', '**/.github/**', '**/generated/**', '**/checkstyle/**', 'PravegaGroup.json' ]
-    }
 }
 
 project('common') {

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -9,6 +9,11 @@
  *
  */
 plugins.withId('application') {
+    configurations.archives.with {
+        artifacts.remove artifacts.find { it.archiveTask.is distZip }
+        artifacts.remove artifacts.find { it.archiveTask.is distTar }
+    }
+
     startScripts {
         doLast {
             unixScript.text = unixScript.text.replace('PRAVEGA_APP_HOME', '\$APP_HOME')

--- a/gradle/protobuf.gradle
+++ b/gradle/protobuf.gradle
@@ -40,4 +40,14 @@ plugins.withId('com.google.protobuf') {
         compile group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
         compile group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
     }
+
+    idea {
+        module {
+            sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/java")
+            sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/grpc")
+        }
+    }
+
+    ideaModule.dependsOn(['generateProto', 'generateTestProto'])
+    eclipseClasspath.dependsOn(['generateProto', 'generateTestProto'])
 }

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+apply plugin: "org.nosphere.apache.rat"
+
+rat {
+    excludes = [
+            '**/.github/**',
+            '**/.gradle/**',
+            '**/.classpath',
+            '**/.project',
+            '**/.settings/**',
+            '**/.idea/**',
+            '**/*.iml',
+            '**/*.iws',
+            '**/*.ipr',
+            '**/gradle/wrapper/**',
+            '**/build/**',
+            '**/generated/**',
+            '**/checkstyle/**',
+            'PravegaGroup.json'
+    ]
+}

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -25,6 +25,6 @@ rat {
             '**/build/**',
             '**/generated/**',
             '**/checkstyle/**',
-            'PravegaGroup.json'
+            '**/*.json'
     ]
 }


### PR DESCRIPTION
**Change log description**
- Updated the protobuf plugin to generate the source before IDE tasks (`ideaModule`, `eclipseClasspath`)
- Removed application tar/zip from archives so it is not published
- Moved the rat plugin configuration to a separate file and added more exclusions for intellij/eclipse files.

**Purpose of the change**
To make the initial setup for a new developer better.

**What the code does**
Build tweaks, no code changes.

**How to verify it**
- Intellj/eclipse project generation: from a clean checkout (`git clean -xdf`) run `./gradlew idea` or `./gradlew eclipse`, all generated source will be present.
- rat changes: after generating eclipse/intellij files, running `./gradlew build` should not cause the build to fail because of those files