### PR TITLE
Issue 1301: Add license headers to deployment/AWS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,16 @@ allprojects {
 
     rat {
         // List of exclude directives, defaults to ['**/.gradle/**']
-        excludes = [ '**/build/**', '**/.gradle/**', '**/.idea/**', '**/gradle/wrapper/**', '**/.github/**', '**/generated/**', '**/checkstyle/**', 'PravegaGroup.json' ]
+        excludes = [ '**/build/**',
+		     '**/.gradle/**',
+                     '**/.idea/**',
+                     '**/gradle/wrapper/**',
+                     '**/.github/**',
+                     '**/generated/**',
+                     '**/checkstyle/**',
+                     'PravegaGroup.json',
+                     'deployment/aws/installer/hosts-template',
+                     '**/*.log' ]
     }
 }
 

--- a/deployment/aws/aws.tf
+++ b/deployment/aws/aws.tf
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 provider "aws" {
  access_key = "${var.aws_access_key}"
  secret_key = "${var.aws_secret_key}"

--- a/deployment/aws/bootstrap.sh
+++ b/deployment/aws/bootstrap.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
 
 # Prepare installer
 cd ../../ && ./gradlew distTar && cd deployment/aws && mv ../../build/distributions/pravega-0.1.0-SNAPSHOT.tgz installer/data/

--- a/deployment/aws/installer/ansible.cfg
+++ b/deployment/aws/installer/ansible.cfg
@@ -1,2 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
 [defaults]
 host_key_checking = False

--- a/deployment/aws/installer/data/variable_template.yml
+++ b/deployment/aws/installer/data/variable_template.yml
@@ -1,2 +1,9 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 high_performance_mode: HIGH_PERFORMANCE_BUTTON

--- a/deployment/aws/installer/entry_point_template.yml
+++ b/deployment/aws/installer/entry_point_template.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
 - hosts: all 
   roles:
     - { role: install-prereqs }

--- a/deployment/aws/installer/roles/install-bk/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-bk/tasks/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 - include_vars: data/variable.yml
 

--- a/deployment/aws/installer/roles/install-controller/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-controller/tasks/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 - name: Run controller
   shell: nohup /opt/pravega/bin/pravega-controller 2>&1 &> /tmp/controller.log &

--- a/deployment/aws/installer/roles/install-hosts/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-hosts/tasks/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 - name: Copy config.properties
   copy:

--- a/deployment/aws/installer/roles/install-prereqs/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-prereqs/tasks/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 - name: add ppa
   command: add-apt-repository ppa:openjdk-r/ppa -y

--- a/deployment/aws/installer/roles/install-zk/defaults/main.yml
+++ b/deployment/aws/installer/roles/install-zk/defaults/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 zookeeper_data_dir: "/var/lib/zookeeper"
 

--- a/deployment/aws/installer/roles/install-zk/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-zk/tasks/main.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 ---
 - name: Untar zookeeper
   command: tar -xvf zookeeper-3.5.1-alpha.tar.gz

--- a/deployment/aws/installer/roles/install-zk/templates/zoo.cfg.j2
+++ b/deployment/aws/installer/roles/install-zk/templates/zoo.cfg.j2
@@ -1,3 +1,10 @@
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
 
 maxClientCnxns={{ zookeeper_maxClientCnxns }}
 

--- a/deployment/aws/variable.tf
+++ b/deployment/aws/variable.tf
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 variable "aws_access_key" {
   description = "AWS Access Key"
 }


### PR DESCRIPTION
**Change log description**
* Add license files to all files that can accommodate comments
* Exclude log files so that the build doesn't fail because some existing log files
* Exclude `deployment/aws/installer/hosts-template`
 
**Purpose of the change**
Fixes #1301 

Adds missing license headers and excludes one file that doesn't need (and I believe I can't have a comment there).