### PR TITLE
Issue 1313: Add some excludes to Rat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,16 +56,16 @@ allprojects {
     rat {
         // List of exclude directives, defaults to ['**/.gradle/**']
         excludes = [ '**/.*/**',
-					 '**/bin/**',
-					 '**/build/**',
-					 '**/checkstyle/**',
-					 '**/generated/**',
+                     '**/bin/**',
+                     '**/build/**',
+                     '**/checkstyle/**',
+                     '**/generated/**',
                      '**/gradle/**',
-					 '**/out/**',
+                     '**/out/**',
                      'PravegaGroup.json',
                      'deployment/aws/installer/hosts-template',
                      '**/*.log',
-					 '**/*.lock']
+                     '**/*.lock']
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,16 +55,17 @@ allprojects {
 
     rat {
         // List of exclude directives, defaults to ['**/.gradle/**']
-        excludes = [ '**/build/**',
-		     '**/.gradle/**',
-                     '**/.idea/**',
-                     '**/gradle/wrapper/**',
-                     '**/.github/**',
-                     '**/generated/**',
-                     '**/checkstyle/**',
+        excludes = [ '**/.*/**',
+					 '**/bin/**',
+					 '**/build/**',
+					 '**/checkstyle/**',
+					 '**/generated/**',
+                     '**/gradle/**',
+					 '**/out/**',
                      'PravegaGroup.json',
                      'deployment/aws/installer/hosts-template',
-                     '**/*.log' ]
+                     '**/*.log',
+					 '**/*.lock']
     }
 }
 


### PR DESCRIPTION
**Change log description**
* Excludes the following from the RAT audit:
   - `**/bin/**`
   - `**/gradle/**`
   - `**/out/**`
   - `**/*.lock` 

**Purpose of the change**
Prevent Local rat failures due to files/metadata generated by IDEs/Tools.

**What the code does**
This excludes hidden directories and .lock files.

Fixes #1313 .
**How to verify it**
Rat should pass