### PR TITLE
Issue 1316: (SegmentStore) Compare-And-Set Attribute Update Type

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdate.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdate.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.service.contracts;
 
+import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.AllArgsConstructor;
@@ -25,9 +26,39 @@ import lombok.Setter;
 @EqualsAndHashCode(of = {"attributeId", "value"})
 @NotThreadSafe
 public class AttributeUpdate {
+    /**
+     * The ID of the Attribute to update.
+     */
     private final UUID attributeId;
+
+    /**
+     * The UpdateType of the attribute.
+     */
     private final AttributeUpdateType updateType;
+
+    /**
+     * The new Value of the attribute.
+     */
     private long value;
+
+    /**
+     * If UpdateType is ReplaceIfEquals, then this is the value that the attribute must currently have before making the
+     * update. Otherwise this field is ignored.
+     */
+    private final long comparisonValue;
+
+    /**
+     * Creates a new instance of the AttributeUpdate class, except for ReplaceIfEquals.
+     *
+     * @param attributeId A UUID representing the ID of the attribute to update.
+     * @param updateType  The UpdateType. All update types except ReplaceIfEquals work with this method.
+     * @param value       The new value to set.
+     */
+    public AttributeUpdate(UUID attributeId, AttributeUpdateType updateType, long value) {
+        this(attributeId, updateType, value, Long.MIN_VALUE);
+        Preconditions.checkArgument(updateType != AttributeUpdateType.ReplaceIfEquals,
+                "Cannot use this constructor with ReplaceIfEquals.");
+    }
 
     @Override
     public String toString() {

--- a/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
@@ -40,7 +40,14 @@ public enum AttributeUpdateType {
     /**
      * Accumulates the new value to the existing attribute value (i.e., adds two numbers).
      */
-    Accumulate((byte) 3);
+    Accumulate((byte) 3),
+
+    /**
+     * Any updates will replace the current attribute value, but only if the existing value matches an expected value
+     * (or if there is no value defined currently). This is essentially Compare-And-Set.
+     */
+    ReplaceIfEquals((byte) 4);
+
 
     private static final AttributeUpdateType[] MAPPING = EnumHelpers.indexById(AttributeUpdateType.class, AttributeUpdateType::getTypeId);
     @Getter

--- a/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AttributeUpdateType {
     /**
-     * No updates allowed: attribute value is fixed once set.
+     * Only allows setting the value if it has not already been set. If it is set, the update will fail.
      */
     None((byte) 0),
 

--- a/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/service/contracts/AttributeUpdateType.java
@@ -25,7 +25,8 @@ public enum AttributeUpdateType {
     None((byte) 0),
 
     /**
-     * Any updates will replace the current attribute value.
+     * Replaces the current value of the attribute with the one given. If no value is currently set, it sets the value
+     * to the given one.
      */
     Replace((byte) 1),
 
@@ -38,7 +39,8 @@ public enum AttributeUpdateType {
     ReplaceIfGreater((byte) 2),
 
     /**
-     * Accumulates the new value to the existing attribute value (i.e., adds two numbers).
+     * Replaces the current value of the attribute with the sum of the current value and the one given. If no value is
+     * currently set, it sets the given value as the attribute value.
      */
     Accumulate((byte) 3),
 

--- a/segmentstore/server/src/main/java/io/pravega/service/server/AttributeSerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/service/server/AttributeSerializer.java
@@ -79,6 +79,7 @@ public final class AttributeSerializer {
                 stream.writeLong(attributeId.getLeastSignificantBits());
                 stream.writeByte(au.getUpdateType().getTypeId());
                 stream.writeLong(au.getValue());
+                stream.writeLong(au.getComparisonValue());
             }
         }
     }
@@ -102,7 +103,8 @@ public final class AttributeSerializer {
                 UUID attributeId = new UUID(idMostSig, idLeastSig);
                 AttributeUpdateType updateType = AttributeUpdateType.get(stream.readByte());
                 long value = stream.readLong();
-                result.add(new AttributeUpdate(attributeId, updateType, value));
+                long comparisonValue = stream.readLong();
+                result.add(new AttributeUpdate(attributeId, updateType, value, comparisonValue));
             }
         } else {
             result = Collections.emptyList();

--- a/segmentstore/server/src/main/java/io/pravega/service/server/logs/OperationMetadataUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/service/server/logs/OperationMetadataUpdater.java
@@ -1232,10 +1232,10 @@ class OperationMetadataUpdater implements ContainerMetadata {
 
                         break;
                     case None:
-                        // Attribute cannot be updated once set.
+                        // Verify value is not already set.
                         if (previousValue != SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
                             throw new BadAttributeUpdateException(this.baseMetadata.getName(), u,
-                                    String.format("Attribute value already exists and cannot be updated (%s).", previousValue));
+                                    String.format("Attribute value already set (%s).", previousValue));
                         }
 
                         break;

--- a/segmentstore/server/src/test/java/io/pravega/service/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/service/server/containers/StreamSegmentMapperTests.java
@@ -441,7 +441,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
         Collection<AttributeUpdate> result = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
             AttributeUpdateType ut = AttributeUpdateType.values()[i % AttributeUpdateType.values().length];
-            result.add(new AttributeUpdate(UUID.randomUUID(), ut, i));
+            result.add(new AttributeUpdate(UUID.randomUUID(), ut, i, i));
         }
 
         return result;

--- a/segmentstore/server/src/test/java/io/pravega/service/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/service/server/logs/OperationMetadataUpdaterTests.java
@@ -290,7 +290,7 @@ public class OperationMetadataUpdaterTests {
         expectedValues.put(attributeAccumulate, 2L);
         expectedValues.put(attributeReplace, 2L);
         expectedValues.put(attributeReplaceIfGreater, 2L);
-        expectedValues.put(attributeReplaceIfEquals,2L);
+        expectedValues.put(attributeReplaceIfEquals, 2L);
 
         op = createOperation.apply(attributeUpdates);
         updater.preProcessOperation(op);
@@ -364,7 +364,7 @@ public class OperationMetadataUpdaterTests {
 
         // Append #4: Try to update attribute with bad value for ReplaceIfEquals attribute.
         attributeUpdates.clear();
-        attributeUpdates.add(new AttributeUpdate(attributeReplaceIfEquals, AttributeUpdateType.ReplaceIfEquals, 3,3));
+        attributeUpdates.add(new AttributeUpdate(attributeReplaceIfEquals, AttributeUpdateType.ReplaceIfEquals, 3, 3));
         AssertExtensions.assertThrows(
                 "preProcessOperation accepted an operation that was trying to update an attribute with the wrong comparison value for ReplaceIfGreater.",
                 () -> updater.preProcessOperation(createOperation.apply(attributeUpdates)),

--- a/segmentstore/server/src/test/java/io/pravega/service/server/logs/operations/StreamSegmentAppendOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/service/server/logs/operations/StreamSegmentAppendOperationTests.java
@@ -53,7 +53,7 @@ public class StreamSegmentAppendOperationTests extends OperationTestsBase<Stream
         val result = new ArrayList<AttributeUpdate>();
         long currentValue = 0;
         for (AttributeUpdateType ut : AttributeUpdateType.values()) {
-            result.add(new AttributeUpdate(UUID.randomUUID(), ut, ++currentValue));
+            result.add(new AttributeUpdate(UUID.randomUUID(), ut, ++currentValue, currentValue));
         }
 
         return result;


### PR DESCRIPTION
**Change log description**
Added `ReplaceIfEquals` as an `AttributeUpdateType`, which is effectively an atomic Compare-And-Set. This applies to both attributes updated as part of Appends, and stand-alone Attribute Updates.

**Purpose of the change**
Fixes #1316. This is required to ensure correctness of appends via the client in some scenarios.

**What the code does**
New AttributeUpdateType added, as well as supporting code for it.

**How to verify it**
Unit tests updated to include the new update type.