### PR TITLE
Issue flink-connectors#15: Feature delay acquiring segments

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderConfig.java
@@ -19,5 +19,10 @@ import lombok.Data;
 public class ReaderConfig implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
+    private final long initialAllocationDelay;
+    
+    public static class ReaderConfigBuilder {
+        private long initialAllocationDelay = 0;
+    }
+    
 }

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -20,9 +20,11 @@ import lombok.Getter;
 public class ReaderGroupConfig implements Serializable {
    @Getter
    private final Sequence startingPosition;
+   @Getter
    private final long groupRefreshTimeMillis;
 
    public static final class ReaderGroupConfigBuilder {
+       long groupRefreshTimeMillis = 3000;
 
        /**
          * Returns a config builder that started at  a given time.

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -115,7 +115,7 @@ public class ClientFactoryImpl implements ClientFactory {
                 new JavaSerializer<>(),
                 synchronizerConfig);
         ReaderGroupStateManager stateManager = new ReaderGroupStateManager(readerId, sync, controller, nanoTime);
-        stateManager.initializeReader();
+        stateManager.initializeReader(config.getInitialAllocationDelay());
         return new EventStreamReaderImpl<T>(inFactory, s, stateManager, new Orderer(), milliTime, config);
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.val;
+import org.apache.commons.lang.math.RandomUtils;
 
 import static io.pravega.common.concurrent.FutureHelpers.getAndHandleExceptions;
 
@@ -113,7 +114,8 @@ public class ReaderGroupStateManager {
             throw new IllegalStateException("The requested reader: " + readerId
                     + " cannot be added to the group because it is already in the group. Perhaps close() was not called?");
         }
-        acquireTimer.reset(Duration.ofMillis(initialAllocationDelay));
+        long randomDelay = (long) (RandomUtils.nextFloat() * sync.getState().getConfig().getGroupRefreshTimeMillis());
+        acquireTimer.reset(Duration.ofMillis(initialAllocationDelay + randomDelay));
     }
     
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -64,7 +64,6 @@ import static io.pravega.common.concurrent.FutureHelpers.getAndHandleExceptions;
 public class ReaderGroupStateManager {
     
     static final Duration TIME_UNIT = Duration.ofMillis(1000);
-    static final Duration FETCH_STATE_INTERVAL = Duration.ofMillis(3000);
     static final Duration UPDATE_WINDOW = Duration.ofMillis(30000);
     private final Object decisionLock = new Object();
     private final HashHelper hashHelper;
@@ -253,8 +252,9 @@ public class ReaderGroupStateManager {
 
     private void fetchUpdatesIfNeeded() {
         if (!fetchStateTimer.hasRemaining()) {
-            fetchStateTimer.reset(FETCH_STATE_INTERVAL);
             sync.fetchUpdates();
+            long groupRefreshTimeMillis = sync.getState().getConfig().getGroupRefreshTimeMillis();
+            fetchStateTimer.reset(Duration.ofMillis(groupRefreshTimeMillis));
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -114,7 +114,7 @@ public class ReaderGroupStateManager {
             throw new IllegalStateException("The requested reader: " + readerId
                     + " cannot be added to the group because it is already in the group. Perhaps close() was not called?");
         }
-        long randomDelay = (long) (RandomUtils.nextFloat() * sync.getState().getConfig().getGroupRefreshTimeMillis());
+        long randomDelay = (long) (RandomUtils.nextFloat() * Math.min(initialAllocationDelay, sync.getState().getConfig().getGroupRefreshTimeMillis()));
         acquireTimer.reset(Duration.ofMillis(initialAllocationDelay + randomDelay));
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -99,7 +99,7 @@ public class ReaderGroupStateManager {
     /**
      * Add this reader to the reader group so that it is able to acquire segments
      */
-    void initializeReader() {
+    void initializeReader(long initialAllocationDelay) {
         AtomicBoolean alreadyAdded = new AtomicBoolean(false);
         sync.updateState(state -> {
             if (state.getSegments(readerId) == null) {
@@ -113,7 +113,7 @@ public class ReaderGroupStateManager {
             throw new IllegalStateException("The requested reader: " + readerId
                     + " cannot be added to the group because it is already in the group. Perhaps close() was not called?");
         }
-        acquireTimer.zero();
+        acquireTimer.reset(Duration.ofMillis(initialAllocationDelay));
     }
     
     /**

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -80,7 +80,7 @@ public class ReaderGroupStateManagerTest {
                 ReaderGroupConfig.builder().build(),
                 segments);
         val readerState = new ReaderGroupStateManager("testReader", stateSynchronizer, controller, null);
-        readerState.initializeReader();
+        readerState.initializeReader(0);
         Map<Segment, Long> newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertEquals(1, newSegments.size());
         assertEquals(Long.valueOf(1), newSegments.get(initialSegment));
@@ -131,7 +131,7 @@ public class ReaderGroupStateManagerTest {
                                                       ReaderGroupConfig.builder().build(),
                                                       segments);
         val readerState = new ReaderGroupStateManager("testReader", stateSynchronizer, controller, null);
-        readerState.initializeReader();
+        readerState.initializeReader(0);
         Map<Segment, Long> newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertEquals(2, newSegments.size());
         assertEquals(Long.valueOf(1), newSegments.get(initialSegmentA));
@@ -175,7 +175,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 null);
-        readerState.initializeReader();
+        readerState.initializeReader(0);
         Segment toRelease = readerState.findSegmentToReleaseIfRequired();
         assertNull(toRelease);
         Map<Segment, Long> newSegments = readerState.acquireNewSegmentsIfNeeded(0);
@@ -212,7 +212,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        readerState1.initializeReader();
+        readerState1.initializeReader(0);
         Segment toRelease = readerState1.findSegmentToReleaseIfRequired();
         assertNull(toRelease);
         Map<Segment, Long> newSegments = readerState1.acquireNewSegmentsIfNeeded(0);
@@ -223,7 +223,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        readerState2.initializeReader();
+        readerState2.initializeReader(0);
 
         boolean released = readerState1.releaseSegment(new Segment(scope, stream, 0), 789L, 0L);
         assertTrue(released);
@@ -274,13 +274,13 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        reader1.initializeReader();
+        reader1.initializeReader(0);
 
         ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2",
                 stateSynchronizer,
                 controller,
                 clock::get);
-        reader2.initializeReader();
+        reader2.initializeReader(0);
 
         Map<Segment, Long> segments1 = reader1.acquireNewSegmentsIfNeeded(0);
         assertFalse(segments1.isEmpty());
@@ -319,7 +319,7 @@ public class ReaderGroupStateManagerTest {
         segments2.putAll(segmentsRecovered);
         reader2.readerShutdown(new PositionImpl(segments2));
 
-        reader1.initializeReader();
+        reader1.initializeReader(0);
         segments1 = reader1.acquireNewSegmentsIfNeeded(0);
         assertEquals(4, segments1.size());
         assertEquals(segments2, segments1);
@@ -356,7 +356,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        reader1.initializeReader();
+        reader1.initializeReader(0);
         Map<Segment, Long> segments1 = reader1.acquireNewSegmentsIfNeeded(0);
         assertEquals(6, segments1.size());
 
@@ -364,7 +364,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        reader2.initializeReader();
+        reader2.initializeReader(0);
         assertTrue(reader2.acquireNewSegmentsIfNeeded(0).isEmpty());
 
         assertNull(reader1.findSegmentToReleaseIfRequired());
@@ -401,7 +401,7 @@ public class ReaderGroupStateManagerTest {
                 stateSynchronizer,
                 controller,
                 clock::get);
-        reader3.initializeReader();
+        reader3.initializeReader(0);
         assertTrue(reader3.acquireNewSegmentsIfNeeded(0).isEmpty());
 
         assertNotNull(reader1.findSegmentToReleaseIfRequired());
@@ -457,7 +457,7 @@ public class ReaderGroupStateManagerTest {
         segments.put(initialSegment, 1L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
         val readerState = new ReaderGroupStateManager("testReader", stateSynchronizer, controller, null);
-        readerState.initializeReader();
+        readerState.initializeReader(0);
         assertNull(readerState.getCheckpoint());
         stateSynchronizer.updateStateUnconditionally(new CreateCheckpoint("CP1"));
         stateSynchronizer.fetchUpdates();


### PR DESCRIPTION
**Change log description**
* Add an `initialAllocationDelay` parameter as part of the reader configuration. 
* Use the `groupRefreshTimeMillis` in the ReaderGroupConfiguration

**Purpose of the change**
To support https://github.com/pravega/flink-connectors/issues/15 more easily we can delay aquiring segments for a bit to allow for time for other readers to come online to acheive a more equal distribution.

**What the code does**
Adds a config parameter that instructs the reader how long to wait on startup before acquiring any new segments. 

**How to verify it**
Run the scenario in https://github.com/pravega/flink-connectors/issues/15 with this paramerter set.