### PR TITLE
Issue 789: Reduced ControllerStreamMetadataTest.streamMetadata test timeout

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerStreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerStreamMetadataTest.java
@@ -100,7 +100,7 @@ public class ControllerStreamMetadataTest {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 10000)
     public void streamMetadataTest() throws Exception {
         // Create test scope. This operation should succeed.
         assertTrue(controller.createScope(SCOPE).join());


### PR DESCRIPTION
**Change log description**
Reduced timeout of test ControllerStreamMetadataTest.streamMetadata to 10seconds.

**Purpose of the change**
Fixes #789 

**What the code does**
As described above.

**How to verify it**
ControllerStreamMetadataTest.streamMetadata test should pass, other behaviour is unchanged.