### PR TITLE
Issue 1324: Use attributes to track event offsets.

### DIFF
--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -53,6 +53,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
             PendingEvent event = new PendingEvent(null, serialized, wasWritten, offset);
             synchronized (lock) {
                 out.write(event);
+                out.flush();
             }
         } catch (SegmentSealedException e) {
             throw new CorruptedStateException("Unexpected end of segment ", e);
@@ -80,6 +81,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
             log.trace("Unconditionally writing: {}", value);
             synchronized (lock) {
                 out.write(event);
+                out.flush();
             }
         } catch (SegmentSealedException e) {
             throw new CorruptedStateException("Unexpected end of segment ", e);

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ dockerExecutable=/usr/bin/docker
 #3rd party Versions
 apacheCuratorVersion=2.11.0
 checkstyleToolVersion=7.1
+findbugsVersion=3.0.1
 commonsioVersion=2.5
 commonsLangVersion=2.6
 commonsLang3Version=3.3.2

--- a/gradle/findbugs.gradle
+++ b/gradle/findbugs.gradle
@@ -9,8 +9,11 @@
  *
  */
 plugins.withId('findbugs') {
-    tasks.withType(FindBugs) {
+    findbugs {
+        toolVersion = findbugsVersion
         effort = "default"
+    }
+    tasks.withType(FindBugs) {
         includeFilter = file("$rootDir/checkstyle/findbugs-include.xml")
         excludeFilter = file("$rootDir/checkstyle/findbugs-exclude.xml")
         reports {

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdate.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdate.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Getter
 @Setter
-@EqualsAndHashCode(of = {"attributeId", "value"})
+@EqualsAndHashCode
 @NotThreadSafe
 public class AttributeUpdate {
     /**

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -46,7 +46,7 @@ public enum AttributeUpdateType {
 
     /**
      * Any updates will replace the current attribute value, but only if the existing value matches an expected value.
-     * If the value does not exist or is different the update will fail. This can be used to perfrom compare and set operations.
+     * If the value does not exist or is different the update will fail. This can be used to perform compare and set operations.
      */
     ReplaceIfEquals((byte) 4);
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -45,8 +45,8 @@ public enum AttributeUpdateType {
     Accumulate((byte) 3),
 
     /**
-     * Any updates will replace the current attribute value, but only if the existing value matches an expected value
-     * (or if there is no value defined currently). This is essentially Compare-And-Set.
+     * Any updates will replace the current attribute value, but only if the existing value matches an expected value.
+     * If the value does not exist or is different the update will fail. This can be used to perfrom compare and set operations.
      */
     ReplaceIfEquals((byte) 4);
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -50,14 +50,13 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.annotation.concurrent.GuardedBy;
-
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_BYTES;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_LATENCY;
 import static io.pravega.shared.MetricsNames.nameFromSegment;
-import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
 
 /**
  * Process incoming Append requests and write them to the appropriate store.
@@ -112,26 +111,26 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     @Override
     public void setupAppend(SetupAppend setupAppend) {
         String newSegment = setupAppend.getSegment();
-        UUID newConnection = setupAppend.getConnectionId();
+        UUID writer = setupAppend.getWriterId();
         store.getStreamSegmentInfo(newSegment, true, TIMEOUT)
                 .whenComplete((info, u) -> {
                     try {
                         if (u != null) {
-                            handleException(setupAppend.getRequestId(), newSegment, "setting up append", u);
+                            handleException(writer, setupAppend.getRequestId(), newSegment, "setting up append", u);
                         } else {
-                            long eventNumber = info.getAttributes().getOrDefault(newConnection, SegmentMetadata.NULL_ATTRIBUTE_VALUE);
+                            long eventNumber = info.getAttributes().getOrDefault(writer, SegmentMetadata.NULL_ATTRIBUTE_VALUE);
                             if (eventNumber == SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
                                 // First append to this segment.
-                                eventNumber = 0;
+                                eventNumber = -1;
                             }
 
                             synchronized (lock) {
-                                latestEventNumbers.putIfAbsent(newConnection, eventNumber);
+                                latestEventNumbers.putIfAbsent(writer, eventNumber);
                             }
-                            connection.send(new AppendSetup(setupAppend.getRequestId(), newSegment, newConnection, eventNumber));
+                            connection.send(new AppendSetup(setupAppend.getRequestId(), newSegment, writer, eventNumber));
                         }
                     } catch (Throwable e) {
-                        handleException(setupAppend.getRequestId(), newSegment, "handling setupAppend result", e);
+                        handleException(writer, setupAppend.getRequestId(), newSegment, "handling setupAppend result", e);
                     }
                 });
     }
@@ -142,17 +141,32 @@ public class AppendProcessor extends DelegatingRequestProcessor {
      * that is written.
      */
     public void performNextWrite() {
-        Append append;
+        Append append = getNextAppend();
+        if (append == null) {
+            return;
+        }
 
-        synchronized (lock) {
-            if (outstandingAppend != null || waitingAppends.isEmpty()) {
-                return;
+        Timer timer = new Timer();
+        storeAppend(append).whenComplete((v, e) -> {
+            handleAppendResult(append, e);
+            if (e == null) {
+                WRITE_STREAM_SEGMENT.reportSuccessEvent(timer.getElapsed());
+            } else {
+                WRITE_STREAM_SEGMENT.reportFailEvent(timer.getElapsed());
             }
+            append.getData().release();
+        });
+    }
 
+    private Append getNextAppend() {
+        synchronized ("lock") {
+            if (outstandingAppend != null || waitingAppends.isEmpty()) {
+                return null;
+            }
             UUID writer = waitingAppends.keys().iterator().next();
             List<Append> appends = waitingAppends.get(writer);
             if (appends.get(0).isConditional()) {
-                append = appends.remove(0);
+                outstandingAppend = appends.remove(0);
             } else {
                 ByteBuf[] toAppend = new ByteBuf[appends.size()];
                 Append last = appends.get(0);
@@ -174,77 +188,66 @@ public class AppendProcessor extends DelegatingRequestProcessor {
 
                 String segment = last.getSegment();
                 long eventNumber = last.getEventNumber();
-                append = new Append(segment, writer, eventNumber, eventCount, data, null);
+                outstandingAppend = new Append(segment, writer, eventNumber, eventCount, data, null);
             }
-            outstandingAppend = append;
+            return outstandingAppend;
         }
-        write(append);
     }
 
-    /**
-     * Write the provided append to the store, and upon completion ack it back to the producer.
-     */
-    private void write(final Append toWrite) {
-        Timer timer = new Timer();
-        ByteBuf buf = toWrite.getData().asReadOnly();
+    private CompletableFuture<Void> storeAppend(Append append) {
+        val attributes = Arrays.asList(new AttributeUpdate(append.getWriterId(), AttributeUpdateType.ReplaceIfGreater,
+                                                           append.getEventNumber()),
+                                       new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate,
+                                                           append.getEventCount()));
+        ByteBuf buf = append.getData().asReadOnly();
         byte[] bytes = new byte[buf.readableBytes()];
         buf.readBytes(bytes);
-
-        val attributes = Arrays.asList(new AttributeUpdate(
-                        toWrite.getConnectionId(),
-                        AttributeUpdateType.ReplaceIfGreater,
-                        toWrite.getEventNumber()),
-                new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, toWrite.getEventCount()));
-
-        CompletableFuture<Void> future;
-        String segment = toWrite.getSegment();
-        if (toWrite.isConditional()) {
-            future = store.append(segment, toWrite.getExpectedLength(), bytes, attributes, TIMEOUT);
+        if (append.isConditional()) {
+            return store.append(append.getSegment(), append.getExpectedLength(), bytes, attributes, TIMEOUT);
         } else {
-            future = store.append(segment, bytes, attributes, TIMEOUT);
+            return store.append(append.getSegment(), bytes, attributes, TIMEOUT);
         }
-        future.whenComplete((t, u) -> {
-            try {
-                boolean conditionalFailed = u != null && (ExceptionHelpers.getRealException(u) instanceof BadOffsetException);
-                synchronized (lock) {
-                    if (outstandingAppend != toWrite) {
-                        throw new IllegalStateException(
-                                "Synchronization error in: " + AppendProcessor.this.getClass().getName());
-                    }
-
-                    toWrite.getData().release();
-                    outstandingAppend = null;
-                    if (u != null && !conditionalFailed) {
-                        waitingAppends.removeAll(toWrite.getConnectionId());
-                        latestEventNumbers.remove(toWrite.getConnectionId());
-                    }
-                }
-
-                if (u != null) {
-                    if (conditionalFailed) {
-                        connection.send(new ConditionalCheckFailed(toWrite.getConnectionId(), toWrite.getEventNumber()));
-                    } else {
-                        handleException(toWrite.getEventNumber(), segment, "appending data", u);
-                    }
-                } else {
-                    DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, toWrite.getSegment()), bytes.length);
-                    WRITE_STREAM_SEGMENT.reportSuccessEvent(timer.getElapsed());
-                    connection.send(new DataAppended(toWrite.getConnectionId(), toWrite.getEventNumber()));
-
-                    if (statsRecorder != null) {
-                        statsRecorder.record(segment, bytes.length, toWrite.getEventCount());
-                    }
-                }
-
-                pauseOrResumeReading();
-                performNextWrite();
-            } catch (Throwable e) {
-                handleException(toWrite.getEventNumber(), segment, "handling append result", e);
-            }
-        });
     }
 
-    private void handleException(long requestId, String segment, String doingWhat, Throwable u) {
+    private void handleAppendResult(final Append append, Throwable exception) {
+        try {
+            boolean conditionalFailed = exception != null && (ExceptionHelpers.getRealException(exception) instanceof BadOffsetException);
+            synchronized (lock) {
+                if (outstandingAppend != append) {
+                    throw new IllegalStateException(
+                            "Synchronization error in: " + AppendProcessor.this.getClass().getName());
+                }
+                outstandingAppend = null;
+                latestEventNumbers.put(append.getWriterId(), append.getEventNumber());
+                if (exception != null && !conditionalFailed) {
+                    waitingAppends.removeAll(append.getWriterId());
+                    latestEventNumbers.remove(append.getWriterId());
+                }
+            }
+      
+            if (exception != null) {
+                if (conditionalFailed) {
+                    connection.send(new ConditionalCheckFailed(append.getWriterId(), append.getEventNumber()));
+                } else {
+                    handleException(append.getWriterId(), append.getEventNumber(), append.getSegment(), "appending data", exception);
+                }
+            } else {
+                DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
+                connection.send(new DataAppended(append.getWriterId(), append.getEventNumber()));
+      
+                if (statsRecorder != null) {
+                    statsRecorder.record(append.getSegment(), append.getDataLength(), append.getEventCount());
+                }
+            }
+      
+            pauseOrResumeReading();
+            performNextWrite();
+        } catch (Throwable e) {
+            handleException(append.getWriterId(), append.getEventNumber(), append.getSegment(), "handling append result", e);
+        }
+    }
+
+    private void handleException(UUID writerId, long requestId, String segment, String doingWhat, Throwable u) {
         if (u == null) {
             IllegalStateException exception = new IllegalStateException("No exception to handle.");
             log.error("Append processor: Error {} onsegment = '{}'", doingWhat, segment, exception);
@@ -300,7 +303,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     @Override
     public void append(Append append) {
         synchronized (lock) {
-            UUID id = append.getConnectionId();
+            UUID id = append.getWriterId();
             Long lastEventNumber = latestEventNumbers.get(id);
             if (lastEventNumber == null) {
                 throw new IllegalStateException("Data from unexpected connection: " + id);
@@ -308,7 +311,6 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             if (append.getEventNumber() <= lastEventNumber) {
                 throw new IllegalStateException("Event was already appended.");
             }
-            latestEventNumbers.put(id, append.getEventNumber());
             waitingAppends.put(id, append);
         }
         pauseOrResumeReading();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -156,7 +156,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     }
 
     private Append getNextAppend() {
-        synchronized ("lock") {
+        synchronized (lock) {
             if (outstandingAppend != null || waitingAppends.isEmpty()) {
                 return null;
             }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -223,11 +223,13 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                             "Synchronization error in: " + AppendProcessor.this.getClass().getName());
                 }
                 outstandingAppend = null;
-                if (exception != null && !conditionalFailed) {
-                    waitingAppends.removeAll(append.getWriterId());
-                    latestEventNumbers.remove(Pair.of(append.getSegment(), append.getWriterId()));
+                if (exception == null) {
+                    latestEventNumbers.put(Pair.of(append.getSegment(), append.getWriterId()), append.getEventNumber());                 
                 } else {
-                    latestEventNumbers.put(Pair.of(append.getSegment(), append.getWriterId()), append.getEventNumber());                    
+                    if (!conditionalFailed) {
+                        waitingAppends.removeAll(append.getWriterId());
+                        latestEventNumbers.remove(Pair.of(append.getSegment(), append.getWriterId()));
+                    } 
                 }
             }
       

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -151,7 +151,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             } else {
                 WRITE_STREAM_SEGMENT.reportFailEvent(timer.getElapsed());
             }
-            append.getData().release();
+        }).whenComplete((v, e) -> {
+            append.getData().release();  
         });
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -318,7 +318,6 @@ public class AppendProcessorTest {
         processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName));
         verify(store).getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT);
         
-        
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
         int eventCount = 100;
         when(store.append(streamSegmentName, data,

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -360,7 +360,6 @@ public class AppendProcessorTest {
         processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName));
         verify(store).getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT);
 
-
         int eventCount = 10;
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
         when(store.append(streamSegmentName, data, updateEventNumber(clientId, 200, 100, eventCount),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
@@ -17,19 +17,19 @@ import lombok.Data;
 @Data
 public class Append implements Request, Comparable<Append> {
     final String segment;
-    final UUID connectionId;
+    final UUID writerId;
     final long eventNumber;
     final int eventCount;
     final ByteBuf data;
     final Long expectedLength;
 
-    public Append(String segment, UUID connectionId, long eventNumber, ByteBuf data, Long expectedLength) {
-        this(segment, connectionId, eventNumber, 1, data, expectedLength);
+    public Append(String segment, UUID writerId, long eventNumber, ByteBuf data, Long expectedLength) {
+        this(segment, writerId, eventNumber, 1, data, expectedLength);
     }
 
-    public Append(String segment, UUID connectionId, long eventNumber, int eventCount, ByteBuf data, Long expectedLength) {
+    public Append(String segment, UUID writerId, long eventNumber, int eventCount, ByteBuf data, Long expectedLength) {
         this.segment = segment;
-        this.connectionId = connectionId;
+        this.writerId = writerId;
         this.eventNumber = eventNumber;
         this.eventCount = eventCount;
         this.data = data;

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
@@ -35,6 +35,10 @@ public class Append implements Request, Comparable<Append> {
         this.data = data;
         this.expectedLength = expectedLength;
     }
+    
+    public int getDataLength() {
+        return data.readableBytes();
+    }
 
     public boolean isConditional() {
         return expectedLength != null;

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -69,24 +69,24 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
             break;
         case SETUP_APPEND:
             WireCommands.SetupAppend append = (WireCommands.SetupAppend) command;
-            appendingSegments.put(append.getConnectionId(), new Segment(append.getSegment()));
+            appendingSegments.put(append.getWriterId(), new Segment(append.getSegment()));
             result = append;
             break;
         case CONDITIONAL_APPEND:
             WireCommands.ConditionalAppend ca = (WireCommands.ConditionalAppend) command;
-            segment = getSegment(ca.getConnectionId());
+            segment = getSegment(ca.getWriterId());
             if (ca.getEventNumber() < segment.lastEventNumber) {
                 throw new InvalidMessageException("Last event number went backwards.");
             }
             segment.lastEventNumber = ca.getEventNumber();
             result = new Append(segment.getName(),
-                    ca.getConnectionId(),
+                    ca.getWriterId(),
                     ca.getEventNumber(),
                     ca.getData(),
                     ca.getExpectedOffset());
             break;
         case APPEND_BLOCK:
-            getSegment(((WireCommands.AppendBlock) command).getConnectionId());
+            getSegment(((WireCommands.AppendBlock) command).getWriterId());
             currentBlock = (WireCommands.AppendBlock) command;
             result = null;
             break;
@@ -95,11 +95,11 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
             if (currentBlock == null) {
                 throw new InvalidMessageException("AppendBlockEnd without AppendBlock.");
             }
-            UUID connectionId = blockEnd.getWriterId();
-            if (!connectionId.equals(currentBlock.getConnectionId())) {
+            UUID writerId = blockEnd.getWriterId();
+            if (!writerId.equals(currentBlock.getWriterId())) {
                 throw new InvalidMessageException("AppendBlockEnd for wrong connection.");
             }
-            segment = getSegment(connectionId);
+            segment = getSegment(writerId);
             if (blockEnd.getLastEventNumber() < segment.lastEventNumber) {
                 throw new InvalidMessageException("Last event number went backwards.");
             }
@@ -110,7 +110,7 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
             ByteBuf appendDataBuf = getAppendDataBuf(blockEnd, sizeOfWholeEventsInBlock);
             segment.lastEventNumber = blockEnd.getLastEventNumber();
             currentBlock = null;
-            result = new Append(segment.name, connectionId, segment.lastEventNumber, blockEnd.numEvents, appendDataBuf, null);
+            result = new Append(segment.name, writerId, segment.lastEventNumber, blockEnd.numEvents, appendDataBuf, null);
             break;
             //$CASES-OMITTED$
         default:
@@ -146,8 +146,8 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
         return appendDataBuf;
     }
 
-    private Segment getSegment(UUID connectionId) {
-        Segment segment = appendingSegments.get(connectionId);
+    private Segment getSegment(UUID writerId) {
+        Segment segment = appendingSegments.get(writerId);
         if (segment == null) {
             throw new InvalidMessageException("ConnectionID refrenced before SetupAppend");
         }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -89,7 +89,7 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
         if (msg instanceof Append) {
             Append append = (Append) msg;
             Session session = setupSegments.get(append.segment);
-            if (session == null || !session.id.equals(append.getConnectionId())) {
+            if (session == null || !session.id.equals(append.getWriterId())) {
                 throw new InvalidMessageException("Sending appends without setting up the append.");
             }
             if (append.getEventNumber() <= session.lastEventNumber) {
@@ -98,7 +98,7 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
             }
             if (append.isConditional()) {
                 breakFromAppend(out);
-                ConditionalAppend ca = new ConditionalAppend(append.connectionId,
+                ConditionalAppend ca = new ConditionalAppend(append.writerId,
                         append.eventNumber,
                         append.getExpectedLength(),
                         wrappedBuffer(serializeMessage(new Event(append.getData()))));
@@ -150,7 +150,7 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
             breakFromAppend(out);
             writeMessage((SetupAppend) msg, out);
             SetupAppend setup = (SetupAppend) msg;
-            setupSegments.put(setup.getSegment(), new Session(setup.getConnectionId()));
+            setupSegments.put(setup.getSegment(), new Session(setup.getWriterId()));
         } else if (msg instanceof Flush) {
             Flush flush = (Flush) msg;
             if (currentBlockSize == flush.getBlockSize()) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
@@ -9,6 +9,8 @@
  */
 package io.pravega.shared.protocol.netty;
 
+import io.pravega.shared.protocol.netty.WireCommands.InvalidEventNumber;
+
 /**
  * A ReplyProcessor that hands off all implementation to another ReplyProcessor.
  * This is useful for creating subclasses that only handle a subset of Commands.
@@ -38,8 +40,14 @@ public abstract class DelegatingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
-    public void noSuchBatch(WireCommands.NoSuchTransaction noSuchBatch) {
-        getNextReplyProcessor().noSuchBatch(noSuchBatch);
+    public void noSuchTransaction(WireCommands.NoSuchTransaction noSuchTransaction) {
+        getNextReplyProcessor().noSuchTransaction(noSuchTransaction);
+    }
+    
+
+    @Override
+    public void invalidEventNumber(InvalidEventNumber invalidEventNumber) {
+        getNextReplyProcessor().invalidEventNumber(invalidEventNumber);
     }
 
     @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -13,6 +13,7 @@ import io.pravega.shared.protocol.netty.WireCommands.AppendSetup;
 import io.pravega.shared.protocol.netty.WireCommands.ConditionalCheckFailed;
 import io.pravega.shared.protocol.netty.WireCommands.DataAppended;
 import io.pravega.shared.protocol.netty.WireCommands.Hello;
+import io.pravega.shared.protocol.netty.WireCommands.InvalidEventNumber;
 import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.NoSuchSegment;
 import io.pravega.shared.protocol.netty.WireCommands.NoSuchTransaction;
@@ -65,8 +66,13 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
-    public void noSuchBatch(NoSuchTransaction noSuchTxn) {
+    public void noSuchTransaction(NoSuchTransaction noSuchTxn) {
         throw new IllegalStateException("No such Transaction: " + noSuchTxn.txn);
+    }
+
+    @Override
+    public void invalidEventNumber(InvalidEventNumber invalidEventNumber) {
+        throw new IllegalStateException("Invalid event number: " + invalidEventNumber);
     }
 
     @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -25,7 +25,9 @@ public interface ReplyProcessor {
 
     void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment);
 
-    void noSuchBatch(WireCommands.NoSuchTransaction noSuchBatch);
+    void noSuchTransaction(WireCommands.NoSuchTransaction noSuchTransaction);
+    
+    void invalidEventNumber(WireCommands.InvalidEventNumber invalidEventNumber);
 
     void appendSetup(WireCommands.AppendSetup appendSetup);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -75,6 +75,7 @@ public enum WireCommandType {
     SEGMENT_ALREADY_EXISTS(52, WireCommands.SegmentAlreadyExists::readFrom),
     NO_SUCH_SEGMENT(53, WireCommands.NoSuchSegment::readFrom),
     NO_SUCH_TRANSACTION(54, WireCommands.NoSuchTransaction::readFrom),
+    INVALID_EVENT_NUMBER(55, WireCommands.InvalidEventNumber::readFrom),
 
     KEEP_ALIVE(100, WireCommands.KeepAlive::readFrom);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -211,7 +211,7 @@ public final class WireCommands {
 
         @Override
         public void process(ReplyProcessor cp) {
-            cp.noSuchBatch(this);
+            cp.noSuchTransaction(this);
         }
 
         @Override
@@ -232,6 +232,36 @@ public final class WireCommands {
         }
     }
 
+    @Data
+    public static final class InvalidEventNumber implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.INVALID_EVENT_NUMBER;
+        final UUID writerId;
+        final long eventNumber;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.invalidEventNumber(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(writerId.getMostSignificantBits());
+            out.writeLong(writerId.getLeastSignificantBits());
+            out.writeLong(eventNumber);
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            UUID writerId = new UUID(in.readLong(), in.readLong());
+            long eventNumber = in.readLong();
+            return new InvalidEventNumber(writerId, eventNumber);
+        }
+
+        @Override
+        public String toString() {
+            return "Invalid event number: " + eventNumber +" for writer: "+ writerId;
+        }
+    }
+    
     @Data
     public static final class Padding implements WireCommand {
         final WireCommandType type = WireCommandType.PADDING;

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -202,6 +202,11 @@ public class WireCommandsTest {
     public void testNoSuchTransaction() throws IOException {
         testCommand(new WireCommands.NoSuchTransaction(l, testString1));
     }
+    
+    @Test
+    public void testInvalidEventNumber() throws IOException {
+        testCommand(new WireCommands.InvalidEventNumber(uuid, i));
+    }
 
     @Test
     public void testKeepAlive() throws IOException {

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -119,11 +119,11 @@ public class AppendTest {
         AppendSetup setup = (AppendSetup) sendRequest(channel, new SetupAppend(2, uuid, segment));
 
         assertEquals(segment, setup.getSegment());
-        assertEquals(uuid, setup.getConnectionId());
+        assertEquals(uuid, setup.getWriterId());
 
         DataAppended ack = (DataAppended) sendRequest(channel,
                                                       new Append(segment, uuid, data.readableBytes(), data, null));
-        assertEquals(uuid, ack.getConnectionId());
+        assertEquals(uuid, ack.getWriterId());
         assertEquals(data.readableBytes(), ack.getEventNumber());
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -158,7 +158,7 @@ public class MultiReadersEndToEndTest {
                 int emptyCount = 0;
                 while (emptyCount <= numSegments) {
                     try {
-                        final Integer integerEventRead = reader.readNextEvent(1000).getEvent();
+                        final Integer integerEventRead = reader.readNextEvent(100).getEvent();
                         if (integerEventRead != null) {
                             read.add(integerEventRead);
                             emptyCount = 0;

--- a/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
@@ -13,10 +13,6 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetector.Level;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
-import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.store.ServiceBuilder;
-import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.Revision;
 import io.pravega.client.state.Revisioned;
@@ -24,9 +20,12 @@ import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.client.state.Update;
 import io.pravega.client.state.examples.SetSynchronizer;
-import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.mock.MockStreamManager;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.TestUtils;
 import java.io.Serializable;
 import java.util.Collections;
@@ -85,7 +84,7 @@ public class StateSynchronizerTest {
     }
     
     @Test(timeout = 20000)
-    public void testStateTracker() throws TxnFailedException {
+    public void testStateTracker() {
         String endpoint = "localhost";
         String stateName = "abc";
         int port = TestUtils.getAvailableListenPort();

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -153,7 +153,7 @@ public class PravegaTest {
                 new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
         for (int i = 0; i < NUM_EVENTS; i++) {
-            String event = "\n Publish \n";
+            String event = "Publish " + i + "\n";
             log.debug("Producing event: {} ", event);
             writer.writeEvent("", event);
             writer.flush();


### PR DESCRIPTION
**Change log description**
* Take advantage of the compare and set update added in #1323 to make sure appends are going at the expected location.
* Rename connectionId to writerId (as this is how it is used)
* Added a call to flush that was causing unit tests to run slow.

**Purpose of the change**
See #1324 

**What the code does**
Tracks the previous append to succeed in AppendProcessor so that when the next one is written it is conditional on that writer having not written any in the meantime. 

**How to verify it**
Everything should work as before, all tests should continue to pass. New tests have been added to verify the changes to AppendProcessor.
