### PR TITLE
Issue 1348: Temporarily disable MultiSegmentStoreTest inside system tests.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,6 +50,7 @@ import java.util.UUID;
  * Test cases for deploying multiple segment stores.
  */
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiSegmentStoreTest {
 


### PR DESCRIPTION
**Change log description**
It has been observed that Transaction Commits fail (causing failure of AutoScale tests) when the tests are run after SS failover tests (MultiSegmentStoreTest). 
Disabling this test temporarily to root cause the issue.

**Purpose of the change**
Fixes #1348 

**How to verify it**
System tests should pass.