### PR TITLE
Issue 1348: re-enable MultiSegmentStoreTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,7 +49,6 @@ import java.util.UUID;
  * Test cases for deploying multiple segment stores.
  */
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiSegmentStoreTest {
 


### PR DESCRIPTION
**Change log description**
Re-enable MultiSegmentStore test, since system tests are successful with HDFS version 2.7.2 and 2.7.3. All the system tests now run on 2.7.3.
**Purpose of the change**
#1348 
**What the code does**
Enable all the tests
**How to verify it**
System tests should succeed. 
