### PR TITLE
Issue 1216 part-1: Add client access to segment attributes

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -45,8 +45,11 @@ public enum AttributeUpdateType {
     Accumulate((byte) 3),
 
     /**
-     * Any updates will replace the current attribute value, but only if the existing value matches an expected value.
-     * If the value does not exist or is different the update will fail. This can be used to perform compare and set operations.
+     * Any updates will replace the current attribute value, but only if the existing value matches
+     * an expected value. If the value is different the update will fail. This can be used to
+     * perform compare and set operations. The value {@link SegmentMetadata#NULL_ATTRIBUTE_VALUE} is
+     * used to indicate a non value. IE: to remove the attribute or if the value is expected not to
+     * exist.
      */
     ReplaceIfEquals((byte) 4);
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -196,13 +196,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         ArrayList<AttributeUpdate> attributes = new ArrayList<>(2);
         synchronized (lock) {
             long lastEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
-            if (lastEventNumber == SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
-                attributes.add(new AttributeUpdate(append.getWriterId(), AttributeUpdateType.None,
-                                                   append.getEventNumber()));
-            } else {
-                attributes.add(new AttributeUpdate(append.getWriterId(), AttributeUpdateType.ReplaceIfEquals,
-                                                   append.getEventNumber(), lastEventNumber));
-            }
+            attributes.add(new AttributeUpdate(append.getWriterId(), AttributeUpdateType.ReplaceIfEquals,
+                                               append.getEventNumber(), lastEventNumber));
         }
         attributes.add(new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, append.getEventCount()));
         ByteBuf buf = append.getData().asReadOnly();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -231,6 +231,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
       
             if (exception != null) {
                 if (conditionalFailed) {
+                    log.debug("Conditional apend failed due to incorrect offset: {}, {}", append, exception.getMessage());
                     connection.send(new ConditionalCheckFailed(append.getWriterId(), append.getEventNumber()));
                 } else {
                     handleException(append.getWriterId(), append.getEventNumber(), append.getSegment(), "appending data", exception);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -229,6 +229,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 connection.send(new SegmentAttributeUpdated(requestId, true));
             } else {
                 if (ExceptionHelpers.getRealException(e) instanceof BadAttributeUpdateException) {
+                    log.debug("Updating segment attribute {} failed due to: {}", update, e.getMessage());
                     connection.send(new SegmentAttributeUpdated(requestId, false));
                 } else {
                     handleException(requestId, segmentName, "Update attribute", e);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -388,14 +388,9 @@ public class AppendProcessorTest {
     }
 
     private Collection<AttributeUpdate> updateEventNumber(UUID clientId, long eventNum, long previousValue, long eventCount) {
-        if (previousValue == SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
-            return Arrays.asList(new AttributeUpdate(clientId, AttributeUpdateType.None, eventNum),
-                                 new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, eventCount));
-        } else {
-            return Arrays.asList(new AttributeUpdate(clientId, AttributeUpdateType.ReplaceIfEquals, eventNum,
-                                                     previousValue),
-                                 new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, eventCount));
-        }
+        return Arrays.asList(new AttributeUpdate(clientId, AttributeUpdateType.ReplaceIfEquals, eventNum,
+                                                 previousValue),
+                             new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, eventCount));
     }
 
     private void setupGetStreamSegmentInfo(String streamSegmentName, UUID clientId, StreamSegmentStore store) {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -210,31 +210,40 @@ public class PravegaRequestProcessorTest {
         InOrder order = inOrder(connection);
         PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection);
 
-        processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName, WireCommands.CreateSegment.NO_SCALE, 0));
+        processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
+                                                               WireCommands.CreateSegment.NO_SCALE, 0));
         order.verify(connection).send(new WireCommands.SegmentCreated(0, streamSegmentName));
-        
+
         processor.createTransaction(new WireCommands.CreateTransaction(1, streamSegmentName, txnid));
         assertTrue(append(StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid), 1, store));
         processor.getTransactionInfo(new WireCommands.GetTransactionInfo(2, streamSegmentName, txnid));
         assertTrue(append(StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid), 2, store));
         order.verify(connection).send(new WireCommands.TransactionCreated(1, streamSegmentName, txnid));
-        order.verify(connection).send(Mockito.argThat(t -> {return t instanceof TransactionInfo && ((TransactionInfo) t).exists();}));
+        order.verify(connection).send(Mockito.argThat(t -> {
+            return t instanceof TransactionInfo && ((TransactionInfo) t).exists();
+        }));
         processor.commitTransaction(new WireCommands.CommitTransaction(3, streamSegmentName, txnid));
         order.verify(connection).send(new WireCommands.TransactionCommitted(3, streamSegmentName, txnid));
         processor.getTransactionInfo(new WireCommands.GetTransactionInfo(4, streamSegmentName, txnid));
-        order.verify(connection).send(new WireCommands.NoSuchSegment(4, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid)));
-        
+        order.verify(connection)
+             .send(new WireCommands.NoSuchSegment(4, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName,
+                                                                                                     txnid)));
+
         txnid = UUID.randomUUID();
         processor.createTransaction(new WireCommands.CreateTransaction(1, streamSegmentName, txnid));
         assertTrue(append(StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid), 1, store));
         order.verify(connection).send(new WireCommands.TransactionCreated(1, streamSegmentName, txnid));
         processor.getTransactionInfo(new WireCommands.GetTransactionInfo(2, streamSegmentName, txnid));
-        order.verify(connection).send(Mockito.argThat(t -> {return t instanceof TransactionInfo && ((TransactionInfo) t).exists();}));
+        order.verify(connection).send(Mockito.argThat(t -> {
+            return t instanceof TransactionInfo && ((TransactionInfo) t).exists();
+        }));
         processor.abortTransaction(new WireCommands.AbortTransaction(3, streamSegmentName, txnid));
         order.verify(connection).send(new WireCommands.TransactionAborted(3, streamSegmentName, txnid));
         processor.getTransactionInfo(new WireCommands.GetTransactionInfo(4, streamSegmentName, txnid));
-        order.verify(connection).send(new WireCommands.NoSuchSegment(4, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid)));
-        
+        order.verify(connection)
+             .send(new WireCommands.NoSuchSegment(4, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName,
+                                                                                                     txnid)));
+
         order.verifyNoMoreInteractions();
     }
     

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -20,7 +20,7 @@ public interface SegmentMetadata extends SegmentProperties {
     /**
      * Defines an attribute value that denotes a missing value.
      */
-    Long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE;
+    Long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as WireCommands.NULL_ATTRIBUTE_VALUE
 
     /**
      * Gets a value indicating the id of this StreamSegment.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
@@ -1249,7 +1249,7 @@ class OperationMetadataUpdater implements ContainerMetadata {
                         break;
                     case ReplaceIfEquals:
                         // Verify value against existing value, if any.
-                        if (!hasValue || u.getComparisonValue() != previousValue) {
+                        if (u.getComparisonValue() != previousValue) {
                             throw new BadAttributeUpdateException(this.baseMetadata.getName(), u,
                                     String.format("Expected existing value to be '%s', actual '%s'.",
                                             u.getComparisonValue(), hasValue ? previousValue : "(not set)"));

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
@@ -71,6 +71,11 @@ public abstract class DelegatingReplyProcessor implements ReplyProcessor {
     }
     
     @Override
+    public void segmentAttributeUpdated(WireCommands.SegmentAttributeUpdated segmentAttributeUpdated) {
+        getNextReplyProcessor().segmentAttributeUpdated(segmentAttributeUpdated);
+    }
+    
+    @Override
     public void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute) {
         getNextReplyProcessor().segmentAttribute(segmentAttribute);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
@@ -69,6 +69,11 @@ public abstract class DelegatingReplyProcessor implements ReplyProcessor {
     public void segmentRead(WireCommands.SegmentRead data) {
         getNextReplyProcessor().segmentRead(data);
     }
+    
+    @Override
+    public void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute) {
+        getNextReplyProcessor().segmentAttribute(segmentAttribute);
+    }
 
     @Override
     public void streamSegmentInfo(WireCommands.StreamSegmentInfo streamInfo) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -21,6 +21,7 @@ import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SealSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentPolicy;
 
 /**
@@ -44,6 +45,11 @@ public abstract class DelegatingRequestProcessor implements RequestProcessor {
     @Override
     public void readSegment(ReadSegment readSegment) {
         getNextRequestProcessor().readSegment(readSegment);
+    }
+
+    @Override
+    public void updateSegmentAttribute(UpdateSegmentAttribute updateSegmentAttribute) {
+        getNextRequestProcessor().updateSegmentAttribute(updateSegmentAttribute);
     }
     
     @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -14,6 +14,7 @@ import io.pravega.shared.protocol.netty.WireCommands.CommitTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
 import io.pravega.shared.protocol.netty.WireCommands.CreateTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.DeleteSegment;
+import io.pravega.shared.protocol.netty.WireCommands.GetSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.GetStreamSegmentInfo;
 import io.pravega.shared.protocol.netty.WireCommands.GetTransactionInfo;
 import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
@@ -44,7 +45,12 @@ public abstract class DelegatingRequestProcessor implements RequestProcessor {
     public void readSegment(ReadSegment readSegment) {
         getNextRequestProcessor().readSegment(readSegment);
     }
-
+    
+    @Override
+    public void getSegmentAttribute(GetSegmentAttribute getSegmentAttribute) {
+        getNextRequestProcessor().getSegmentAttribute(getSegmentAttribute);
+    }
+    
     @Override
     public void getStreamSegmentInfo(GetStreamSegmentInfo getStreamInfo) {
         getNextRequestProcessor().getStreamSegmentInfo(getStreamInfo);

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -94,6 +94,11 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     public void segmentRead(SegmentRead data) {
         throw new IllegalStateException("Unexpected operation: " + data);
     }
+    
+    @Override
+    public void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute) {
+        throw new IllegalStateException("Unexpected operation: " + segmentAttribute);
+    }
 
     @Override
     public void streamSegmentInfo(StreamSegmentInfo streamInfo) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -96,6 +96,11 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
     
     @Override
+    public void segmentAttributeUpdated(WireCommands.SegmentAttributeUpdated segmentAttributeUpdated) {
+        throw new IllegalStateException("Unexpected operation: " + segmentAttributeUpdated);
+    }
+    
+    @Override
     public void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute) {
         throw new IllegalStateException("Unexpected operation: " + segmentAttribute);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -14,6 +14,7 @@ import io.pravega.shared.protocol.netty.WireCommands.CommitTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
 import io.pravega.shared.protocol.netty.WireCommands.CreateTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.DeleteSegment;
+import io.pravega.shared.protocol.netty.WireCommands.GetSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.GetStreamSegmentInfo;
 import io.pravega.shared.protocol.netty.WireCommands.GetTransactionInfo;
 import io.pravega.shared.protocol.netty.WireCommands.Hello;
@@ -49,7 +50,12 @@ public class FailingRequestProcessor implements RequestProcessor {
     public void readSegment(ReadSegment readSegment) {
         throw new IllegalStateException("Unexpected operation");
     }
-
+    
+    @Override
+    public void getSegmentAttribute(GetSegmentAttribute getSegmentAttribute) {
+        throw new IllegalStateException("Unexpected operation");
+    }
+    
     @Override
     public void getStreamSegmentInfo(GetStreamSegmentInfo getStreamInfo) {
         throw new IllegalStateException("Unexpected operation");

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -22,6 +22,7 @@ import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SealSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentPolicy;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +49,11 @@ public class FailingRequestProcessor implements RequestProcessor {
 
     @Override
     public void readSegment(ReadSegment readSegment) {
+        throw new IllegalStateException("Unexpected operation");
+    }
+    
+    @Override
+    public void updateSegmentAttribute(UpdateSegmentAttribute updateSegmentAttribute) {
         throw new IllegalStateException("Unexpected operation");
     }
     

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -37,6 +37,8 @@ public interface ReplyProcessor {
 
     void segmentRead(WireCommands.SegmentRead segmentRead);
     
+    void segmentAttributeUpdated(WireCommands.SegmentAttributeUpdated segmentAttributeUpdated);
+    
     void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute);
     
     void streamSegmentInfo(WireCommands.StreamSegmentInfo streamInfo);

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -36,7 +36,9 @@ public interface ReplyProcessor {
     void conditionalCheckFailed(WireCommands.ConditionalCheckFailed dataNotAppended);
 
     void segmentRead(WireCommands.SegmentRead segmentRead);
-
+    
+    void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute);
+    
     void streamSegmentInfo(WireCommands.StreamSegmentInfo streamInfo);
     
     void transactionInfo(WireCommands.TransactionInfo transactionInfo);

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -14,6 +14,7 @@ import io.pravega.shared.protocol.netty.WireCommands.CommitTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
 import io.pravega.shared.protocol.netty.WireCommands.CreateTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.DeleteSegment;
+import io.pravega.shared.protocol.netty.WireCommands.GetSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.GetStreamSegmentInfo;
 import io.pravega.shared.protocol.netty.WireCommands.GetTransactionInfo;
 import io.pravega.shared.protocol.netty.WireCommands.Hello;
@@ -34,6 +35,8 @@ public interface RequestProcessor {
     void append(Append append);
 
     void readSegment(ReadSegment readSegment);
+    
+    void getSegmentAttribute(GetSegmentAttribute getSegmentAttribute);
 
     void getStreamSegmentInfo(GetStreamSegmentInfo getStreamInfo);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -22,6 +22,7 @@ import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SealSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentPolicy;
 
 /**
@@ -35,6 +36,8 @@ public interface RequestProcessor {
     void append(Append append);
 
     void readSegment(ReadSegment readSegment);
+    
+    void updateSegmentAttribute(UpdateSegmentAttribute updateSegmentAttribute);
     
     void getSegmentAttribute(GetSegmentAttribute getSegmentAttribute);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -69,6 +69,9 @@ public enum WireCommandType {
 
     UPDATE_SEGMENT_POLICY(32, WireCommands.UpdateSegmentPolicy::readFrom),
     SEGMENT_POLICY_UPDATED(33, WireCommands.SegmentPolicyUpdated::readFrom),
+    
+    GET_SEGMENT_ATTRIBUTE(34, WireCommands.GetSegmentAttribute::readFrom),
+    SEGMENT_ATTRIBUTE(35, WireCommands.SegmentAttribute::readFrom),
 
     WRONG_HOST(50, WireCommands.WrongHost::readFrom),
     SEGMENT_IS_SEALED(51, WireCommands.SegmentIsSealed::readFrom),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -72,6 +72,9 @@ public enum WireCommandType {
     
     GET_SEGMENT_ATTRIBUTE(34, WireCommands.GetSegmentAttribute::readFrom),
     SEGMENT_ATTRIBUTE(35, WireCommands.SegmentAttribute::readFrom),
+    
+    UPDATE_SEGMENT_ATTRIBUTE(36, WireCommands.UpdateSegmentAttribute::readFrom),
+    SEGMENT_ATTRIBUTE_UPDATED(37, WireCommands.SegmentAttributeUpdated::readFrom),
 
     WRONG_HOST(50, WireCommands.WrongHost::readFrom),
     SEGMENT_IS_SEALED(51, WireCommands.SegmentIsSealed::readFrom),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -680,8 +680,8 @@ public final class WireCommands {
         final long requestId;
         final String segmentName;
         final UUID attributeId;
-        final long expectedValue;
         final long newValue;
+        final long expectedValue;
 
         @Override
         public void process(RequestProcessor cp) {
@@ -694,17 +694,17 @@ public final class WireCommands {
             out.writeUTF(segmentName);
             out.writeLong(attributeId.getMostSignificantBits());
             out.writeLong(attributeId.getLeastSignificantBits());
-            out.writeLong(expectedValue);
             out.writeLong(newValue);
+            out.writeLong(expectedValue);
         }
 
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             long requestId = in.readLong();
             String segment = in.readUTF();
             UUID attributeId = new UUID(in.readLong(), in.readLong());
-            long excpecteValue = in.readLong();                
             long newValue = in.readLong();                
-            return new UpdateSegmentAttribute(requestId, segment, attributeId, excpecteValue, newValue);
+            long excpecteValue = in.readLong();                
+            return new UpdateSegmentAttribute(requestId, segment, attributeId, newValue, excpecteValue);
         }
     }
     

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -47,6 +47,9 @@ public final class WireCommands {
     public static final int TYPE_SIZE = 4;
     public static final int TYPE_PLUS_LENGTH_SIZE = 8;
     public static final int MAX_WIRECOMMAND_SIZE = 0x007FFFFF; // 8MB
+    
+    public static final long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as SegmentMetadata.NULL_ATTRIBUTE_VALUE
+    
     private static final Map<Integer, WireCommandType> MAPPING;
     static {
         HashMap<Integer, WireCommandType> map = new HashMap<>();
@@ -651,7 +654,7 @@ public final class WireCommands {
     public static final class SegmentAttribute implements Reply, WireCommand {
         final WireCommandType type = WireCommandType.SEGMENT_ATTRIBUTE;
         final long requestId;
-        final Long value;
+        final long value;
 
         @Override
         public void process(ReplyProcessor cp) {
@@ -661,23 +664,12 @@ public final class WireCommands {
         @Override
         public void writeFields(DataOutput out) throws IOException {
             out.writeLong(requestId);
-            if (value == null) {
-                out.writeBoolean(false);
-            } else { 
-                out.writeBoolean(true);
-                out.writeLong(value);
-            }
+            out.writeLong(value);
         }
 
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             long requestId = in.readLong();
-            Long value;
-            boolean found = in.readBoolean();
-            if (found) {
-                value = in.readLong();                
-            } else { 
-                value = null;
-            }
+            long value = in.readLong();                
             return new SegmentAttribute(requestId, value);
         }
     }
@@ -688,8 +680,8 @@ public final class WireCommands {
         final long requestId;
         final String segmentName;
         final UUID attributeId;
-        final Long expectedValue;
-        final Long newValue;
+        final long expectedValue;
+        final long newValue;
 
         @Override
         public void process(RequestProcessor cp) {
@@ -702,36 +694,16 @@ public final class WireCommands {
             out.writeUTF(segmentName);
             out.writeLong(attributeId.getMostSignificantBits());
             out.writeLong(attributeId.getLeastSignificantBits());
-            if (expectedValue == null) {
-                out.writeBoolean(false);
-            } else { 
-                out.writeBoolean(true);
-                out.writeLong(expectedValue);
-            }
-            if (newValue == null) {
-                out.writeBoolean(false);
-            } else { 
-                out.writeBoolean(true);
-                out.writeLong(newValue);
-            }
+            out.writeLong(expectedValue);
+            out.writeLong(newValue);
         }
 
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             long requestId = in.readLong();
             String segment = in.readUTF();
             UUID attributeId = new UUID(in.readLong(), in.readLong());
-            Long excpecteValue;
-            if (in.readBoolean()) {
-                excpecteValue = in.readLong();                
-            } else { 
-                excpecteValue = null;
-            }
-            Long newValue;
-            if (in.readBoolean()) {
-                newValue = in.readLong();                
-            } else { 
-                newValue = null;
-            }
+            long excpecteValue = in.readLong();                
+            long newValue = in.readLong();                
             return new UpdateSegmentAttribute(requestId, segment, attributeId, excpecteValue, newValue);
         }
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -620,6 +620,69 @@ public final class WireCommands {
     }
 
     @Data
+    public static final class GetSegmentAttribute implements Request, WireCommand {
+        final WireCommandType type = WireCommandType.GET_SEGMENT_ATTRIBUTE;
+        final long requestId;
+        final String segmentName;
+        final UUID attributeId;
+
+        @Override
+        public void process(RequestProcessor cp) {
+            cp.getSegmentAttribute(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeUTF(segmentName);
+            out.writeLong(attributeId.getMostSignificantBits());
+            out.writeLong(attributeId.getLeastSignificantBits());
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            long requestId = in.readLong();
+            String segment = in.readUTF();
+            UUID attributeId = new UUID(in.readLong(), in.readLong());
+            return new GetSegmentAttribute(requestId, segment, attributeId);
+        }
+    }
+    
+    @Data
+    public static final class SegmentAttribute implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.SEGMENT_ATTRIBUTE;
+        final long requestId;
+        final Long value;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.segmentAttribute(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            if (value == null) {
+                out.writeBoolean(false);
+            } else { 
+                out.writeBoolean(true);
+                out.writeLong(value);
+            }
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            long requestId = in.readLong();
+            Long value;
+            boolean found = in.readBoolean();
+            if (found) {
+                value = in.readLong();                
+            } else { 
+                value = null;
+            }
+            return new SegmentAttribute(requestId, value);
+        }
+    }
+    
+    @Data
     public static final class GetStreamSegmentInfo implements Request, WireCommand {
         final WireCommandType type = WireCommandType.GET_STREAM_SEGMENT_INFO;
         final long requestId;

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -683,6 +683,84 @@ public final class WireCommands {
     }
     
     @Data
+    public static final class UpdateSegmentAttribute implements Request, WireCommand {
+        final WireCommandType type = WireCommandType.UPDATE_SEGMENT_ATTRIBUTE;
+        final long requestId;
+        final String segmentName;
+        final UUID attributeId;
+        final Long expectedValue;
+        final Long newValue;
+
+        @Override
+        public void process(RequestProcessor cp) {
+            cp.updateSegmentAttribute(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeUTF(segmentName);
+            out.writeLong(attributeId.getMostSignificantBits());
+            out.writeLong(attributeId.getLeastSignificantBits());
+            if (expectedValue == null) {
+                out.writeBoolean(false);
+            } else { 
+                out.writeBoolean(true);
+                out.writeLong(expectedValue);
+            }
+            if (newValue == null) {
+                out.writeBoolean(false);
+            } else { 
+                out.writeBoolean(true);
+                out.writeLong(newValue);
+            }
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            long requestId = in.readLong();
+            String segment = in.readUTF();
+            UUID attributeId = new UUID(in.readLong(), in.readLong());
+            Long excpecteValue;
+            if (in.readBoolean()) {
+                excpecteValue = in.readLong();                
+            } else { 
+                excpecteValue = null;
+            }
+            Long newValue;
+            if (in.readBoolean()) {
+                newValue = in.readLong();                
+            } else { 
+                newValue = null;
+            }
+            return new UpdateSegmentAttribute(requestId, segment, attributeId, excpecteValue, newValue);
+        }
+    }
+    
+    @Data
+    public static final class SegmentAttributeUpdated implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.SEGMENT_ATTRIBUTE_UPDATED;
+        final long requestId;
+        final boolean success;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.segmentAttributeUpdated(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeBoolean(success);
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            long requestId = in.readLong();
+            boolean success = in.readBoolean();
+            return new SegmentAttributeUpdated(requestId, success);
+        }
+    }
+    
+    @Data
     public static final class GetStreamSegmentInfo implements Request, WireCommand {
         final WireCommandType type = WireCommandType.GET_STREAM_SEGMENT_INFO;
         final long requestId;

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -91,9 +91,6 @@ public class WireCommandsTest {
     @Test
     public void testUpdateSegmentAttribute() throws IOException {
         testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, l, l));
-        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, l, null));
-        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, null, l));
-        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, null, null));
     }
     
     @Test

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -89,6 +89,16 @@ public class WireCommandsTest {
     }
 
     @Test
+    public void testGetSegmentAttribute() throws IOException {
+        testCommand(new WireCommands.GetSegmentAttribute(l, testString1, uuid));
+    }
+    
+    @Test
+    public void testSegmentAttribute() throws IOException {
+        testCommand(new WireCommands.SegmentAttribute(l, l+1));
+    }
+    
+    @Test
     public void testGetStreamSegmentInfo() throws IOException {
         testCommand(new WireCommands.GetStreamSegmentInfo(l, testString1));
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -87,6 +87,20 @@ public class WireCommandsTest {
     public void testSegmentRead() throws IOException {
         testCommand(new WireCommands.SegmentRead(testString1, l, true, false, buffer));
     }
+    
+    @Test
+    public void testUpdateSegmentAttribute() throws IOException {
+        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, l, l));
+        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, l, null));
+        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, null, l));
+        testCommand(new WireCommands.UpdateSegmentAttribute(l, testString1, uuid, null, null));
+    }
+    
+    @Test
+    public void testSegmentAttributeUpdated() throws IOException {
+        testCommand(new WireCommands.SegmentAttributeUpdated(l, true));
+        testCommand(new WireCommands.SegmentAttributeUpdated(l, false));
+    }
 
     @Test
     public void testGetSegmentAttribute() throws IOException {


### PR DESCRIPTION
**Change log description**
* Adds GetSegmentAttribute and UpdateSegmentAttribute wire commands and server support. (Note this is a backwards compatible wire format change.)
* Exposes SegmentMetadata.NULL_ATTRIBUTE_VALUE to the client by duplicating the value in WireCommand.

**Purpose of the change**
This adds wire-protocol support for clients to use Attributes. This is a prerequisite for #1216 

**What the code does**
Adds new requests and replies that are handled by PravegaRequestProcessor

**How to verify it**
Tests are added for serialization, and for the new processor methods.