### PR TITLE
Issue 832: Start rest server in standalone gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     dependencies {
         classpath group: 'com.google.protobuf', name:'protobuf-gradle-plugin', version: protobufGradlePlugin
         classpath "gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.3.0"
-        classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
     }
 }
 
@@ -375,8 +374,6 @@ project('controller') {
 
 project('standalone') {
     apply plugin: 'application'
-    apply plugin: 'java'
-    apply plugin: 'com.github.johnrengelman.shadow'
     applicationName = "pravega-standalone"
     mainClassName = "io.pravega.local.LocalPravegaEmulator"
     applicationDefaultJvmArgs = ["-server", "-Xmx4g", "-XX:+HeapDumpOnOutOfMemoryError",
@@ -407,27 +404,9 @@ project('standalone') {
         testCompile project(path:':segmentstore:server:host', configuration:'testRuntime')
     }
 
-    shadowJar {
-        dependencies {
-            /*include (project(":common"))
-            include (project(":client"))
-            include (project(":segmentstore:server"))
-            include (project(":segmentstore:server:host"))
-            include (project(":controller"))
-            include (project(":segmentstore:contracts"))
-            include (project(":segmentstore:storage"))
-            include (project(":segmentstore:storage:impl"))
-
-            include dependency("org.apache.curator:curator-test")
-            include dependency("org.apache.hadoop:hadoop-common")
-            include dependency("org.apache.hadoop:hadoop-hdfs")
-            include dependency("org.apache.hadoop:hadoop-minicluster")*/
-            //include dependency("com.sun.jersey:jersey-core")
-            //include dependency("com.sun.jersey:jersey-server")
-        }
-
-        relocate "com.sun.jersey", "io.pravega.shaded.com.sun.jersey"
-        mergeServiceFiles()
+    configurations {
+        runtime.exclude group: "com.sun.jersey", module: "jersey-core"
+        runtime.exclude group: "com.sun.jersey", module: "jersey-server"
     }
 
     task startStandalone(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     dependencies {
         classpath group: 'com.google.protobuf', name:'protobuf-gradle-plugin', version: protobufGradlePlugin
         classpath "gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.3.0"
+        classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
     }
 }
 
@@ -374,6 +375,8 @@ project('controller') {
 
 project('standalone') {
     apply plugin: 'application'
+    apply plugin: 'java'
+    apply plugin: 'com.github.johnrengelman.shadow'
     applicationName = "pravega-standalone"
     mainClassName = "io.pravega.local.LocalPravegaEmulator"
     applicationDefaultJvmArgs = ["-server", "-Xmx4g", "-XX:+HeapDumpOnOutOfMemoryError",
@@ -402,6 +405,29 @@ project('standalone') {
         testCompile project(path:':common', configuration:'testRuntime')
         testCompile project(path:':segmentstore:server', configuration:'testRuntime')
         testCompile project(path:':segmentstore:server:host', configuration:'testRuntime')
+    }
+
+    shadowJar {
+        dependencies {
+            /*include (project(":common"))
+            include (project(":client"))
+            include (project(":segmentstore:server"))
+            include (project(":segmentstore:server:host"))
+            include (project(":controller"))
+            include (project(":segmentstore:contracts"))
+            include (project(":segmentstore:storage"))
+            include (project(":segmentstore:storage:impl"))
+
+            include dependency("org.apache.curator:curator-test")
+            include dependency("org.apache.hadoop:hadoop-common")
+            include dependency("org.apache.hadoop:hadoop-hdfs")
+            include dependency("org.apache.hadoop:hadoop-minicluster")*/
+            //include dependency("com.sun.jersey:jersey-core")
+            //include dependency("com.sun.jersey:jersey-server")
+        }
+
+        relocate "com.sun.jersey", "io.pravega.shaded.com.sun.jersey"
+        mergeServiceFiles()
     }
 
     task startStandalone(type: JavaExec) {

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -178,11 +178,8 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
                 log.info("Awaiting termination of controller services");
                 starter.awaitTerminated();
             }
-        }/* finally {
-            log.
+        } finally {
             LoggerHelpers.traceLeave(log, this.objectId, "run", traceId);
-        }*/ catch(Exception e) {
-            log.info("\n**EXCEPTION cause ",e.getCause());
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -178,8 +178,11 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
                 log.info("Awaiting termination of controller services");
                 starter.awaitTerminated();
             }
-        } finally {
+        }/* finally {
+            log.
             LoggerHelpers.traceLeave(log, this.objectId, "run", traceId);
+        }*/ catch(Exception e) {
+            log.info("\n**EXCEPTION cause ",e.getCause());
         }
     }
 

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -304,7 +304,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                 .publishedRPCPort(this.controllerPorts[controllerId])
                 .build();
 
-        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder().host("localhost").port(9092).build();
+        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder().host("localhost").port(9091).build();
 
         ControllerServiceConfig serviceConfig = ControllerServiceConfigImpl.builder()
                 .serviceThreadPoolSize(Config.ASYNC_TASK_POOL_SIZE)

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -67,6 +67,9 @@ public class InProcPravegaCluster implements AutoCloseable {
 
     private String controllerURI = null;
 
+    /*REST server related variables*/
+    private int restServerPort;
+
     /*SegmentStore related variables*/
     private boolean isInProcSegmentStore;
     private int segmentStoreCount = 0;
@@ -93,13 +96,14 @@ public class InProcPravegaCluster implements AutoCloseable {
     private ControllerServiceMain[] controllerServers;
 
     private String zkUrl;
-    private boolean startRestServer = false;
+    private boolean startRestServer = true;
 
     @Builder
     public InProcPravegaCluster(boolean isInProcZK, String zkUrl, int zkPort, boolean isInMemStorage,
                                 boolean isInProcHDFS,
                                 boolean isInProcController, int controllerCount, String controllerURI,
-                                boolean isInProcSegmentStore, int segmentStoreCount, int containerCount, boolean startRestServer) {
+                                boolean isInProcSegmentStore, int segmentStoreCount, int containerCount,
+                                boolean startRestServer, int restServerPort) {
 
         //Check for valid combinations of flags
         //For ZK
@@ -130,6 +134,7 @@ public class InProcPravegaCluster implements AutoCloseable {
         this.segmentStoreCount = segmentStoreCount;
         this.containerCount = containerCount;
         this.startRestServer = startRestServer;
+        this.restServerPort = restServerPort;
     }
 
     @Synchronized
@@ -304,7 +309,10 @@ public class InProcPravegaCluster implements AutoCloseable {
                 .publishedRPCPort(this.controllerPorts[controllerId])
                 .build();
 
-        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder().host("localhost").port(9091).build();
+        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder()
+                .host("localhost")
+                .port(this.restServerPort)
+                .build();
 
         ControllerServiceConfig serviceConfig = ControllerServiceConfigImpl.builder()
                 .serviceThreadPoolSize(Config.ASYNC_TASK_POOL_SIZE)

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -14,6 +14,8 @@ import io.pravega.controller.server.ControllerServiceMain;
 import io.pravega.controller.server.eventProcessor.ControllerEventProcessorConfig;
 import io.pravega.controller.server.eventProcessor.impl.ControllerEventProcessorConfigImpl;
 import io.pravega.controller.server.impl.ControllerServiceConfigImpl;
+import io.pravega.controller.server.rest.RESTServerConfig;
+import io.pravega.controller.server.rest.impl.RESTServerConfigImpl;
 import io.pravega.controller.server.rpc.grpc.GRPCServerConfig;
 import io.pravega.controller.server.rpc.grpc.impl.GRPCServerConfigImpl;
 import io.pravega.controller.store.client.StoreClientConfig;
@@ -302,6 +304,8 @@ public class InProcPravegaCluster implements AutoCloseable {
                 .publishedRPCPort(this.controllerPorts[controllerId])
                 .build();
 
+        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder().host("localhost").port(9092).build();
+
         ControllerServiceConfig serviceConfig = ControllerServiceConfigImpl.builder()
                 .serviceThreadPoolSize(Config.ASYNC_TASK_POOL_SIZE)
                 .taskThreadPoolSize(Config.ASYNC_TASK_POOL_SIZE)
@@ -314,7 +318,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                 .timeoutServiceConfig(timeoutServiceConfig)
                 .eventProcessorConfig(Optional.of(eventProcessorConfig))
                 .grpcServerConfig(Optional.of(grpcServerConfig))
-                .restServerConfig(Optional.empty())
+                .restServerConfig(Optional.of(restServerConfig))
                 .build();
 
         ControllerServiceMain controllerService = new ControllerServiceMain(serviceConfig);

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -20,7 +20,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
     private final InProcPravegaCluster inProcPravegaCluster;
 
     @Builder
-    private LocalPravegaEmulator(int zkPort, int controllerPort, int segmentStorePort) {
+    private LocalPravegaEmulator(int zkPort, int controllerPort, int segmentStorePort, int restServerPort) {
         inProcPravegaCluster = InProcPravegaCluster
                 .builder()
                 .isInProcZK(true)
@@ -32,6 +32,8 @@ public class LocalPravegaEmulator implements AutoCloseable {
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)
+                .startRestServer(true)
+                .restServerPort(restServerPort)
                 .build();
         inProcPravegaCluster.setControllerPorts(new int[] {controllerPort});
         inProcPravegaCluster.setSegmentStorePorts(new int[] {segmentStorePort});
@@ -50,6 +52,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
                     .controllerPort(conf.getControllerPort())
                     .segmentStorePort(conf.getSegmentStorePort())
                     .zkPort(conf.getZkPort())
+                    .restServerPort(conf.getRestServerPort())
                     .build();
 
             Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
+++ b/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
@@ -19,6 +19,7 @@ public class SingleNodeConfig {
     public final static Property<Integer> ZK_PORT = Property.named("zkPort", 4000);
     public final static Property<Integer> SEGMENTSTORE_PORT = Property.named("segmentstorePort", 6000);
     public final static Property<Integer> CONTROLLER_PORT = Property.named("controllerPort", 9090);
+    public final static Property<Integer> REST_SERVER_PORT = Property.named("restServerPort", 9091);
     private static final String COMPONENT_CODE = "singlenode";
     //end region
 
@@ -42,6 +43,12 @@ public class SingleNodeConfig {
     @Getter
     private final int controllerPort;
 
+    /**
+     * The REST server port for singlenode
+     */
+    @Getter
+    private final int restServerPort;
+
     //end region
 
     //region constructor
@@ -49,6 +56,7 @@ public class SingleNodeConfig {
         this.zkPort = properties.getInt(ZK_PORT);
         this.segmentStorePort = properties.getInt(SEGMENTSTORE_PORT);
         this.controllerPort = properties.getInt(CONTROLLER_PORT);
+        this.restServerPort = properties.getInt(REST_SERVER_PORT);
     }
 
     /**


### PR DESCRIPTION
**Change log description**
Starting a rest server along with other Pravega components in standalone gradle task.

**Purpose of the change**
Fixes #832 

**What the code does**
Excludes com.sun.jersey dependency. 

**How to verify it**
./gradlew startStandalone 
Use curl/rest client to call rest apis on localhost:9091
eg.
`curl -i -X GET http://localhost:9091/ping`
```
HTTP/1.1 200 OK
content-length: 0
connection: keep-alive
```
