### PR TITLE
Issue 1371: Exclude transitive dependencies on log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ project('common') {
     }
 }
 
+def withoutLog4j = { exclude group: 'org.slf4j', module: 'slf4j-log4j12' }
 
 project ('shared') {
     dependencies {
@@ -145,7 +146,7 @@ project('test:testcommon') {
         compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
-        compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
+        compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLog4j
     }
 }
 
@@ -167,18 +168,16 @@ project('segmentstore:storage') {
 
 project('segmentstore:storage:impl') {
     dependencies {
-        compile (group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: bookKeeperVersion) {
-            exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-        }
+        compile group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: bookKeeperVersion, withoutLog4j
 
         compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
 
         // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common
-        compile group: 'org.apache.hadoop', name: 'hadoop-common', version:hadoopVersion
+        compile group: 'org.apache.hadoop', name: 'hadoop-common', version:hadoopVersion, withoutLog4j
 
         // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common
-        compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion
-        testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion
+        compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion, withoutLog4j
+        testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLog4j
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
         compile project(':common')
@@ -225,7 +224,7 @@ project('segmentstore:server:host') {
         testCompile project(':test:testcommon')
         testCompile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
         testCompile project(path:':segmentstore:server', configuration:'testRuntime')
-        testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion
+        testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLog4j
         testCompile project(path:':segmentstore:storage:impl', configuration:'testRuntime')
     }
 }
@@ -394,9 +393,9 @@ project('standalone') {
         runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
         // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common
-        compile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion
-        compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion
-        compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion
+        compile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion, withoutLog4j
+        compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion, withoutLog4j
+        compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLog4j
 
         testCompile project(':test:testcommon')
         testCompile project(path:':common', configuration:'testRuntime')

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,11 +38,11 @@ marathonClientVersion=0.3.0
 nettyVersion=4.1.8.Final
 protobufGradlePlugin=0.8.0
 protobufProtocVersion=3.0.2
-qosLogbackVersion=1.1.7
+qosLogbackVersion=1.2.3
 rocksdbjniVersion=4.11.2
 shadowGradlePlugin=1.2.4
 swaggerJersey2JaxrsVersion=1.5.9
-slf4jApiVersion=1.7.14
+slf4jApiVersion=1.7.25
 typesafeConfigVersion=1.3.0
 apacheCommonsCsvVersion=1.1
 


### PR DESCRIPTION
**Change log description**
Prevents hadoop libraries from pulling in dependencies on log4j.
Updates the version of slf4jApiVersion and logback to the latest

**Purpose of the change**
Fix #1371 

**What the code does**
Excludes slf4j-log4j12 from the dependencies pulled in from those packages that depend on it.

**How to verify it**
All tests should continue to pass and logging should work without warnings.