### PR TITLE
Issue 1211: Add convenience method to delete a reader group.

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -53,6 +53,14 @@ public interface ReaderGroupManager extends AutoCloseable {
     ReaderGroup createReaderGroup(String groupName, ReaderGroupConfig config, Set<String> streamNames);
     
     /**
+     * Deletes a reader group, removing any state associated with it.
+     * If there are still readers on the group they will encounter an exception.
+     * 
+     * @param groupName The group to be deleted.
+     */
+    void deleteReaderGroup(String groupName);
+    
+    /**
      * Returns the requested reader group.
      * 
      * @param groupName The name of the group

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -53,8 +53,9 @@ public interface ReaderGroupManager extends AutoCloseable {
     ReaderGroup createReaderGroup(String groupName, ReaderGroupConfig config, Set<String> streamNames);
     
     /**
-     * Deletes a reader group, removing any state associated with it.
-     * If there are still readers on the group they will encounter an exception.
+     * Deletes a reader group, removing any state associated with it. There should be no reader left
+     * on the group when this is called. If there are any, the group will be deleted from underneath
+     * them and they will encounter exceptions.
      * 
      * @param groupName The group to be deleted.
      */

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -23,10 +23,12 @@ import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.ReaderGroupImpl;
 import io.pravega.client.stream.impl.StreamImpl;
-import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.shared.NameUtils;
 import java.net.URI;
 import java.util.Set;
+
+import static io.pravega.common.concurrent.FutureHelpers.getAndHandleExceptions;
+import static io.pravega.shared.NameUtils.getStreamForReaderGroup;
 
 /**
  * A stream manager. Used to bootstrap the client.
@@ -50,46 +52,41 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
     }
 
     private Stream createStreamHelper(String streamName, StreamConfiguration config) {
-        FutureHelpers.getAndHandleExceptions(controller.createStream(StreamConfiguration.builder()
-                                                                                        .scope(scope)
-                                                                                        .streamName(streamName)
-                                                                                        .scalingPolicy(config.getScalingPolicy())
-                                                                                        .build()),
-                RuntimeException::new);
+        getAndHandleExceptions(controller.createStream(StreamConfiguration.builder()
+                                                                          .scope(scope)
+                                                                          .streamName(streamName)
+                                                                          .scalingPolicy(config.getScalingPolicy())
+                                                                          .build()),
+                               RuntimeException::new);
         return new StreamImpl(scope, streamName);
     }
     
     @Override
     public ReaderGroup createReaderGroup(String groupName, ReaderGroupConfig config, Set<String> streams) {
         NameUtils.validateReaderGroupName(groupName);
-        createStreamHelper(NameUtils.getStreamForReaderGroup(groupName),
-                           StreamConfiguration.builder()
-                                              .scope(scope)
-                                              .streamName(NameUtils.getStreamForReaderGroup(groupName))
-                                              .scalingPolicy(ScalingPolicy.fixed(1))
-                                              .build());
+        createStreamHelper(getStreamForReaderGroup(groupName), StreamConfiguration.builder()
+                                                                                  .scope(scope)
+                                                                                  .streamName(getStreamForReaderGroup(groupName))
+                                                                                  .scalingPolicy(ScalingPolicy.fixed(1))
+                                                                                  .build());
         SynchronizerConfig synchronizerConfig = SynchronizerConfig.builder().build();
-        ReaderGroupImpl result = new ReaderGroupImpl(scope,
-                                                     groupName,
-                                                     synchronizerConfig,
-                                                     new JavaSerializer<>(),
-                                                     new JavaSerializer<>(),
-                                                     clientFactory,
-                                                     controller);
+        ReaderGroupImpl result = new ReaderGroupImpl(scope, groupName, synchronizerConfig, new JavaSerializer<>(),
+                                                     new JavaSerializer<>(), clientFactory, controller);
         result.initializeGroup(config, streams);
         return result;
     }
-    
+
+    @Override
+    public void deleteReaderGroup(String groupName) {
+        getAndHandleExceptions(controller.deleteStream(scope, getStreamForReaderGroup(groupName)),
+                               RuntimeException::new);
+    }
+
     @Override
     public ReaderGroup getReaderGroup(String groupName) {
         SynchronizerConfig synchronizerConfig = SynchronizerConfig.builder().build();
-        return new ReaderGroupImpl(scope,
-                                   groupName,
-                                   synchronizerConfig,
-                                   new JavaSerializer<>(),
-                                   new JavaSerializer<>(),
-                                   clientFactory,
-                                   controller);
+        return new ReaderGroupImpl(scope, groupName, synchronizerConfig, new JavaSerializer<>(), new JavaSerializer<>(),
+                                   clientFactory, controller);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -15,6 +15,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.RoundRobinLoadBalancerFactory;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.InvalidStreamException;
 import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -299,10 +300,10 @@ public class ControllerImpl implements Controller {
                 throw new ControllerFailureException("Failed to seal stream: " + streamName);
             case SCOPE_NOT_FOUND:
                 log.warn("Scope not found: {}", scope);
-                throw new IllegalArgumentException("Scope does not exist: " + scope);
+                throw new InvalidStreamException("Scope does not exist: " + scope);
             case STREAM_NOT_FOUND:
                 log.warn("Stream does not exist: {}", streamName);
-                throw new IllegalArgumentException("Stream does not exist: " + streamName);
+                throw new InvalidStreamException("Stream does not exist: " + streamName);
             case SUCCESS:
                 log.info("Successfully sealed stream: {}", streamName);
                 return true;

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import io.pravega.client.ClientFactory;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
@@ -47,6 +48,20 @@ import static org.junit.Assert.assertTrue;
 public class ReaderGroupStateManagerTest {
     private static final int SERVICE_PORT = 12345;
 
+    private static class MockControllerWithSuccessors extends MockController {
+        private StreamSegmentsWithPredecessors successors;
+
+        public MockControllerWithSuccessors(String endpoint, int port, ConnectionFactory connectionFactory, StreamSegmentsWithPredecessors successors) {
+            super(endpoint, port, connectionFactory);
+            this.successors = successors;
+        }
+
+        @Override
+        public CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors(Segment segment) {
+            return completedFuture(successors);
+        }
+    }
+    
     @Test(timeout = 20000)
     public void testSegmentSplit() throws ReinitializationRequiredException {
         String scope = "scope";
@@ -56,19 +71,15 @@ public class ReaderGroupStateManagerTest {
         Segment initialSegment = new Segment(scope, stream, 0);
         Segment successorA = new Segment(scope, stream, 1);
         Segment successorB = new Segment(scope, stream, 2);
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory) {
-            @Override
-            public CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors(Segment segment) {
-                assertEquals(initialSegment, segment);
-                return completedFuture(new StreamSegmentsWithPredecessors(
+        MockController controller = new MockControllerWithSuccessors(endpoint.getEndpoint(), endpoint.getPort(),
+                connectionFactory,
+                new StreamSegmentsWithPredecessors(
                         ImmutableMap.of(new SegmentWithRange(successorA, 0.0, 0.5), singletonList(0),
-                                new SegmentWithRange(successorB, 0.5, 1.0), singletonList(0))));
-            }
-        };
+                                        new SegmentWithRange(successorB, 0.5, 1.0), singletonList(0))));
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
-                streamFactory);
+                streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                 new JavaSerializer<>(),
@@ -104,21 +115,12 @@ public class ReaderGroupStateManagerTest {
         Segment initialSegmentA = new Segment(scope, stream, 0);
         Segment initialSegmentB = new Segment(scope, stream, 1);
         Segment successor = new Segment(scope, stream, 2);
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory) {
-            @Override
-            public CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors(Segment segment) {
-                if (segment.getSegmentNumber() == 0) {
-                    assertEquals(initialSegmentA, segment);
-                } else {
-                    assertEquals(initialSegmentB, segment);
-                }
-                return completedFuture(new StreamSegmentsWithPredecessors(Collections.singletonMap(new
-                        SegmentWithRange(successor, 0.0, 1.0), ImmutableList.of(0, 1))));
-            }
-        };
+        MockController controller = new MockControllerWithSuccessors(endpoint.getEndpoint(), endpoint.getPort(),
+                connectionFactory, new StreamSegmentsWithPredecessors(
+                        Collections.singletonMap(new SegmentWithRange(successor, 0.0, 1.0), ImmutableList.of(0, 1))));
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
@@ -159,7 +161,7 @@ public class ReaderGroupStateManagerTest {
         MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
@@ -194,7 +196,7 @@ public class ReaderGroupStateManagerTest {
         MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
@@ -253,7 +255,7 @@ public class ReaderGroupStateManagerTest {
         MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
@@ -266,19 +268,13 @@ public class ReaderGroupStateManagerTest {
         segments.put(new Segment(scope, stream, 1), 1L);
         segments.put(new Segment(scope, stream, 2), 2L);
         segments.put(new Segment(scope, stream, 3), 3L);
-        ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer,
-                                                      ReaderGroupConfig.builder().build(),
-                                                      segments);
+        ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
 
-        ReaderGroupStateManager reader1 = new ReaderGroupStateManager("reader1",
-                stateSynchronizer,
-                controller,
+        ReaderGroupStateManager reader1 = new ReaderGroupStateManager("reader1", stateSynchronizer, controller,
                 clock::get);
         reader1.initializeReader(0);
 
-        ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2",
-                stateSynchronizer,
-                controller,
+        ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2", stateSynchronizer, controller,
                 clock::get);
         reader2.initializeReader(0);
 
@@ -334,7 +330,7 @@ public class ReaderGroupStateManagerTest {
         MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
@@ -348,21 +344,15 @@ public class ReaderGroupStateManagerTest {
         segments.put(new Segment(scope, stream, 3), 3L);
         segments.put(new Segment(scope, stream, 4), 4L);
         segments.put(new Segment(scope, stream, 5), 5L);
-        ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer,
-                                                      ReaderGroupConfig.builder().build(),
-                                                      segments);
+        ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
 
-        ReaderGroupStateManager reader1 = new ReaderGroupStateManager("reader1",
-                stateSynchronizer,
-                controller,
+        ReaderGroupStateManager reader1 = new ReaderGroupStateManager("reader1", stateSynchronizer, controller,
                 clock::get);
         reader1.initializeReader(0);
         Map<Segment, Long> segments1 = reader1.acquireNewSegmentsIfNeeded(0);
         assertEquals(6, segments1.size());
 
-        ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2",
-                stateSynchronizer,
-                controller,
+        ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2", stateSynchronizer, controller,
                 clock::get);
         reader2.initializeReader(0);
         assertTrue(reader2.acquireNewSegmentsIfNeeded(0).isEmpty());
@@ -397,9 +387,7 @@ public class ReaderGroupStateManagerTest {
         Map<Segment, Long> segments2 = reader2.acquireNewSegmentsIfNeeded(0);
         assertEquals(3, segments2.size());
 
-        ReaderGroupStateManager reader3 = new ReaderGroupStateManager("reader3",
-                stateSynchronizer,
-                controller,
+        ReaderGroupStateManager reader3 = new ReaderGroupStateManager("reader3", stateSynchronizer, controller,
                 clock::get);
         reader3.initializeReader(0);
         assertTrue(reader3.acquireNewSegmentsIfNeeded(0).isEmpty());
@@ -432,22 +420,15 @@ public class ReaderGroupStateManagerTest {
         Segment initialSegment = new Segment(scope, stream, 0);
         Segment successorA = new Segment(scope, stream, 1);
         Segment successorB = new Segment(scope, stream, 2);
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory) {
-            @Override
-            public CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors(Segment segment) {
-                assertEquals(initialSegment, segment);
-                return completedFuture(new StreamSegmentsWithPredecessors(ImmutableMap.of(
-                        new SegmentWithRange(successorA, 0.0, 0.5), singletonList(0),
-                        new SegmentWithRange(successorB, 0.5, 1.0), singletonList(0))));
-            }
-        };
+        MockController controller = new MockControllerWithSuccessors(endpoint.getEndpoint(), endpoint.getPort(),
+                connectionFactory,
+                new StreamSegmentsWithPredecessors(
+                        ImmutableMap.of(new SegmentWithRange(successorA, 0.0, 0.5), singletonList(0),
+                                        new SegmentWithRange(successorB, 0.5, 1.0), singletonList(0))));
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(scope,
-                                                            controller,
-                                                            connectionFactory,
-                                                            streamFactory,
-                                                            streamFactory);
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
+                                                            streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -34,6 +34,7 @@ import io.pravega.shared.protocol.netty.WireCommands.AbortTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.CommitTransaction;
 import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
 import io.pravega.shared.protocol.netty.WireCommands.CreateTransaction;
+import io.pravega.shared.protocol.netty.WireCommands.DeleteSegment;
 import io.pravega.shared.protocol.netty.WireCommands.TransactionAborted;
 import io.pravega.shared.protocol.netty.WireCommands.TransactionCommitted;
 import io.pravega.shared.protocol.netty.WireCommands.TransactionCreated;
@@ -146,8 +147,18 @@ public class MockController implements Controller {
     }
 
     @Override
+    @Synchronized
     public CompletableFuture<Boolean> deleteStream(String scope, String streamName) {
-        throw new NotImplementedException();
+        Stream stream = new StreamImpl(scope, streamName);
+        if (createdStreams.get(stream) == null) {
+            return CompletableFuture.completedFuture(false);
+        }
+        for (Segment segment : getSegmentsForStream(stream)) {
+            deleteSegment(segment.getScopedName(), new PravegaNodeUri(endpoint, port));
+        }
+        createdStreams.remove(stream);
+        createdScopes.get(scope).remove(stream);
+        return CompletableFuture.completedFuture(true);
     }
 
     private boolean createSegment(String name, PravegaNodeUri uri) {
@@ -180,6 +191,40 @@ public class MockController implements Controller {
             }
         };
         CreateSegment command = new WireCommands.CreateSegment(idGenerator.get(), name, WireCommands.CreateSegment.NO_SCALE, 0);
+        sendRequestOverNewConnection(command, replyProcessor, result);
+        return getAndHandleExceptions(result, RuntimeException::new);
+    }
+    
+    private boolean deleteSegment(String name, PravegaNodeUri uri) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+                result.completeExceptionally(new ConnectionClosedException());
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                result.completeExceptionally(new NotImplementedException());
+            }
+
+            @Override
+            public void segmentDeleted(WireCommands.SegmentDeleted segmentDeleted) {
+                result.complete(true);
+            }
+
+            @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                result.complete(false);
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                result.completeExceptionally(error);
+            }
+        };
+        DeleteSegment command = new WireCommands.DeleteSegment(idGenerator.get(), name);
         sendRequestOverNewConnection(command, replyProcessor, result);
         return getAndHandleExceptions(result, RuntimeException::new);
     }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -154,6 +154,8 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
 
     @Override
     public void deleteReaderGroup(String groupName) {
-        throw new NotImplementedException();
+        FutureHelpers.getAndHandleExceptions(controller.deleteStream(scope,
+                                                                     NameUtils.getStreamForReaderGroup(groupName)),
+                                             RuntimeException::new);
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -151,4 +151,9 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
     public boolean deleteStream(String scopeName, String toDelete) {
         throw new NotImplementedException();
     }
+
+    @Override
+    public void deleteReaderGroup(String groupName) {
+        throw new NotImplementedException();
+    }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -139,6 +139,7 @@ public class MultiReadersEndToEndTest {
         Assert.assertEquals(NUM_TEST_EVENTS * streamNames.size(), read.size());
         // Check unique events.
         Assert.assertEquals(NUM_TEST_EVENTS, new TreeSet<>(read).size());
+        readerGroupManager.deleteReaderGroup(readerGroupName);
     }
 
     private Collection<Integer> readAllEvents(final int numParallelReaders, ClientFactory clientFactory,
@@ -220,5 +221,6 @@ public class MultiReadersEndToEndTest {
         Assert.assertEquals(NUM_TEST_EVENTS * streamNames.size(), read.size());
         // Check unique events.
         Assert.assertEquals(NUM_TEST_EVENTS, new TreeSet<>(read).size());
+        streamManager.deleteReaderGroup(readerGroupName);
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
@@ -108,6 +108,7 @@ public class ReaderGroupTest {
         if (r2.exception.get() != null) {
             throw r2.exception.get();
         }
+        streamManager.deleteReaderGroup(READER_GROUP);
     }
     
     @Test
@@ -138,6 +139,7 @@ public class ReaderGroupTest {
 
         writeEvents(100, clientFactory);
         new ReaderThread(100, "Reader", clientFactory).run();
+        streamManager.deleteReaderGroup(READER_GROUP);
     }
     
     public void writeEvents(int eventsToWrite, ClientFactory clientFactory) {

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -186,9 +186,9 @@ public class MultiSegmentStoreTest {
 
         log.info("Invoking reader with controller URI: {}", controllerUri);
         final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
-        ReaderGroupManager.withScope(scope, controllerUri)
-                .createReaderGroup(readerGroup, ReaderGroupConfig.builder().startingTime(0).build(),
-                        Collections.singleton(stream));
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerUri);
+        groupManager.createReaderGroup(readerGroup, ReaderGroupConfig.builder().startingTime(0).build(),
+                                       Collections.singleton(stream));
 
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),
@@ -204,5 +204,6 @@ public class MultiSegmentStoreTest {
                 throw new IllegalStateException("Unexpected request to reinitialize");
             }
         }
+        groupManager.deleteReaderGroup(readerGroup);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -204,6 +204,5 @@ public class MultiSegmentStoreTest {
                 throw new IllegalStateException("Unexpected request to reinitialize");
             }
         }
-        groupManager.deleteReaderGroup(readerGroup);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -160,9 +160,9 @@ public class PravegaTest {
             Thread.sleep(500);
         }
         log.info("Invoking Reader test.");
-        ReaderGroupManager.withScope(STREAM_SCOPE, controllerUri)
-                .createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().startingTime(0).build(),
-                        Collections.singleton(STREAM_NAME));
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(STREAM_SCOPE, controllerUri);
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().startingTime(0).build(),
+                                       Collections.singleton(STREAM_NAME));
         EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),
                 READER_GROUP,
                 new JavaSerializer<>(),
@@ -179,6 +179,7 @@ public class PravegaTest {
             }
         }
         reader.close();
+        groupManager.deleteReaderGroup(READER_GROUP);
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -207,6 +207,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                 .whenComplete((r, e) -> {
                     recordResult(testResult, "ScaleUpWithTxnWithReaderGroup");
                 }), RuntimeException::new);
+        readerGroupManager.deleteReaderGroup(READER_GROUP_NAME);
     }
 
     //Helper methods


### PR DESCRIPTION
**Change log description**
* Add convenience method to delete a reader group.

**Purpose of the change**
Fixes #1211 

**What the code does**
Adds a method to delete a reader group's stream

**How to verify it**
Calls to delete created reader groups have been added to the integration tests. All tests should pass.