### PR TITLE
Issue 1383: Fixing port conflicts in parallel gradle builds. Also enabled gradle parallel builds by default

### DIFF
--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -22,8 +23,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TestUtils {
     // Linux uses ports from range 32768 - 61000.
     private static final int BASE_PORT = 32768;
-    private static final int MAX_PORT_COUNT = 28232;
-    private static final AtomicInteger NEXT_PORT = new AtomicInteger(1);
+    private static final int MAX_PORT_COUNT = 28233;
+    private static final AtomicInteger NEXT_PORT = new AtomicInteger(new Random().nextInt(MAX_PORT_COUNT));
 
     /**
      * A helper method to get a random free port.

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -24,6 +24,9 @@ public class TestUtils {
     // Linux uses ports from range 32768 - 61000.
     private static final int BASE_PORT = 32768;
     private static final int MAX_PORT_COUNT = 28233;
+
+    // We use a random start position here to avoid ports conflicts when this method is executed from multiple processes
+    // in parallel. This is needed since the processes will contend for the same port sequence.
     private static final AtomicInteger NEXT_PORT = new AtomicInteger(new Random().nextInt(MAX_PORT_COUNT));
 
     /**


### PR DESCRIPTION
**Change log description**
When we use TestUtils.getAvailableListenPort() from parallel processes this method starts scanning for ports in the same sequence and hence can cause port conflicts when they find the same port to be available. To avoid this we will now start scanning for ports from a randomized start index within the same range. The probability of port clashes will reduce significantly.

**Purpose of the change**
Fixes #1383 

**What the code does**
Avoids port clashes.

**How to verify it**
Enable gradle parallel builds (Enable org.gradle.parallel=true in gradle properties) and execute ./gradlew clean build