### PR TITLE
Issue 588: Renaming alterStream to updateStream to make the terminology consistent

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -53,7 +53,7 @@ public interface StreamManager extends AutoCloseable {
      * @param config     The new configuration.
      * @return True if stream configuration is updated
      */
-    boolean alterStream(String scopeName, String streamName, StreamConfiguration config);
+    boolean updateStream(String scopeName, String streamName, StreamConfiguration config);
 
     /**
      * Seal an existing stream.

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -48,8 +48,8 @@ public class StreamManagerImpl implements StreamManager {
     }
 
     @Override
-    public boolean alterStream(String scopeName, String streamName, StreamConfiguration config) {
-        return FutureHelpers.getAndHandleExceptions(controller.alterStream(StreamConfiguration.builder()
+    public boolean updateStream(String scopeName, String streamName, StreamConfiguration config) {
+        return FutureHelpers.getAndHandleExceptions(controller.updateStream(StreamConfiguration.builder()
                         .scope(scopeName)
                         .streamName(streamName)
                         .scalingPolicy(config.getScalingPolicy())

--- a/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
@@ -30,7 +30,7 @@ public interface EventStreamReader<T> extends AutoCloseable {
      *         is reached, {@link EventRead#getEvent()} returns null.
      * @throws ReinitializationRequiredException Is throw in the event that
      *         {@link ReaderGroup#resetReadersToCheckpoint(Checkpoint)} or
-     *         {@link ReaderGroup#alterConfig(ReaderGroupConfig, java.util.Set)} was called
+     *         {@link ReaderGroup#updateConfig(ReaderGroupConfig, java.util.Set)} was called
      *         which requires readers to be reinitialized.
      */
     EventRead<T> readNextEvent(long timeout) throws ReinitializationRequiredException;

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -84,7 +84,7 @@ public interface ReaderGroup {
      * @param config The configuration for the new ReaderGroup.
      * @param streamNames The name of the streams the reader will read from.
      */
-    void alterConfig(ReaderGroupConfig config, Set<String> streamNames);
+    void updateConfig(ReaderGroupConfig config, Set<String> streamNames);
     
     /**
      * Invoked when a reader that was added to the group is no longer consuming events. This will

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -62,7 +62,7 @@ public interface Controller {
      * @return A future which will throw if the operation fails, otherwise returning a boolean to
      *         indicate that the stream was altered because the config is now different from before.
      */
-    CompletableFuture<Boolean> alterStream(final StreamConfiguration streamConfig);
+    CompletableFuture<Boolean> updateStream(final StreamConfiguration streamConfig);
 
     /**
      * Api to seal stream.

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -56,11 +56,11 @@ public interface Controller {
     CompletableFuture<Boolean> createStream(final StreamConfiguration streamConfig);
 
     /**
-     * Api to alter stream.
+     * Api to update stream.
      *
      * @param streamConfig Stream configuration to updated
      * @return A future which will throw if the operation fails, otherwise returning a boolean to
-     *         indicate that the stream was altered because the config is now different from before.
+     *         indicate that the stream was updated because the config is now different from before.
      */
     CompletableFuture<Boolean> updateStream(final StreamConfiguration streamConfig);
 
@@ -91,7 +91,7 @@ public interface Controller {
      * @param sealedSegments List of segments to be sealed.
      * @param newKeyRanges Key ranges after scaling the stream.
      * @return A future which will throw if the operation fails, otherwise returning a boolean to
-     *         indicate that the stream was altered or false if the segments to seal have already
+     *         indicate that the stream was scaled or false if the segments to seal have already
      *         been sealed.
      */
     CompletableFuture<Boolean> scaleStream(final Stream stream, final List<Integer> sealedSegments,

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -205,17 +205,17 @@ public class ControllerImpl implements Controller {
     }
 
     @Override
-    public CompletableFuture<Boolean> alterStream(final StreamConfiguration streamConfig) {
-        long traceId = LoggerHelpers.traceEnter(log, "alterStream", streamConfig);
+    public CompletableFuture<Boolean> updateStream(final StreamConfiguration streamConfig) {
+        long traceId = LoggerHelpers.traceEnter(log, "updateStream", streamConfig);
         Preconditions.checkNotNull(streamConfig, "streamConfig");
 
         RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>();
-        client.alterStream(ModelHelper.decode(streamConfig), callback);
+        client.updateStream(ModelHelper.decode(streamConfig), callback);
         return callback.getFuture().thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
-                log.warn("Failed to alter stream: {}", streamConfig.getStreamName());
-                throw new ControllerFailureException("Failed to alter stream: " + streamConfig);
+                log.warn("Failed to update stream: {}", streamConfig.getStreamName());
+                throw new ControllerFailureException("Failed to update stream: " + streamConfig);
             case SCOPE_NOT_FOUND:
                 log.warn("Scope not found: {}", streamConfig.getScope());
                 throw new IllegalArgumentException("Scope does not exist: " + streamConfig);
@@ -223,18 +223,18 @@ public class ControllerImpl implements Controller {
                 log.warn("Stream does not exist: {}", streamConfig.getStreamName());
                 throw new IllegalArgumentException("Stream does not exist: " + streamConfig);
             case SUCCESS:
-                log.info("Successfully altered stream: {}", streamConfig.getStreamName());
+                log.info("Successfully updated stream: {}", streamConfig.getStreamName());
                 return true;
             case UNRECOGNIZED:
             default:
-                throw new ControllerFailureException("Unknown return status altering stream " + streamConfig
+                throw new ControllerFailureException("Unknown return status updating stream " + streamConfig
                                                      + " " + x.getStatus());
             }
         }).whenComplete((x, e) -> {
             if (e != null) {
-                log.warn("alterStream failed: ", e);
+                log.warn("updateStream failed: ", e);
             }
-            LoggerHelpers.traceLeave(log, "alterStream", traceId);
+            LoggerHelpers.traceLeave(log, "updateStream", traceId);
         });
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -142,7 +142,7 @@ public class ReaderGroupImpl implements ReaderGroup {
     }
 
     @Override
-    public void alterConfig(ReaderGroupConfig config, Set<String> streamNames) {
+    public void updateConfig(ReaderGroupConfig config, Set<String> streamNames) {
         @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         Map<Segment, Long> segments = getSegmentsForStreams(streamNames);

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -139,7 +139,7 @@ public class ControllerImplTest {
             }
 
             @Override
-            public void alterStream(StreamConfig request,
+            public void updateStream(StreamConfig request,
                     StreamObserver<UpdateStreamStatus> responseObserver) {
                 if (request.getStreamInfo().getStream().equals("stream1")) {
                     responseObserver.onNext(UpdateStreamStatus.newBuilder()
@@ -589,35 +589,35 @@ public class ControllerImplTest {
     @Test
     public void testAlterStream() throws Exception {
         CompletableFuture<Boolean> updateStreamStatus;
-        updateStreamStatus = controllerClient.alterStream(StreamConfiguration.builder()
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream1")
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
         assertTrue(updateStreamStatus.get());
 
-        updateStreamStatus = controllerClient.alterStream(StreamConfiguration.builder()
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream2")
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
         AssertExtensions.assertThrows("Server should throw exception", updateStreamStatus, Throwable -> true);
 
-        updateStreamStatus = controllerClient.alterStream(StreamConfiguration.builder()
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream3")
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
         AssertExtensions.assertThrows("Server should throw exception", updateStreamStatus, Throwable -> true);
 
-        updateStreamStatus = controllerClient.alterStream(StreamConfiguration.builder()
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream4")
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
         AssertExtensions.assertThrows("Server should throw exception", updateStreamStatus, Throwable -> true);
 
-        updateStreamStatus = controllerClient.alterStream(StreamConfiguration.builder()
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream5")
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -161,6 +161,11 @@ public class ControllerImplTest {
                                                     .setStatus(UpdateStreamStatus.Status.STREAM_NOT_FOUND)
                                                     .build());
                     responseObserver.onCompleted();
+                } else if (request.getStreamInfo().getStream().equals("stream5")) {
+                    responseObserver.onNext(UpdateStreamStatus.newBuilder()
+                            .setStatus(UpdateStreamStatus.Status.UNRECOGNIZED)
+                            .build());
+                    responseObserver.onCompleted();
                 } else {
                     responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
                 }
@@ -587,7 +592,7 @@ public class ControllerImplTest {
     }
 
     @Test
-    public void testAlterStream() throws Exception {
+    public void testUpdateStream() throws Exception {
         CompletableFuture<Boolean> updateStreamStatus;
         updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
                                                                   .streamName("stream1")
@@ -622,6 +627,13 @@ public class ControllerImplTest {
                                                                   .scope("scope1")
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
+        AssertExtensions.assertThrows("Should throw Exception", updateStreamStatus, throwable -> true);
+
+        updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
+                .streamName("stream6")
+                .scope("scope1")
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build());
         AssertExtensions.assertThrows("Should throw Exception", updateStreamStatus, throwable -> true);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -630,10 +630,10 @@ public class ControllerImplTest {
         AssertExtensions.assertThrows("Should throw Exception", updateStreamStatus, throwable -> true);
 
         updateStreamStatus = controllerClient.updateStream(StreamConfiguration.builder()
-                .streamName("stream6")
-                .scope("scope1")
-                .scalingPolicy(ScalingPolicy.fixed(1))
-                .build());
+                                                                  .streamName("stream6")
+                                                                  .scope("scope1")
+                                                                  .scalingPolicy(ScalingPolicy.fixed(1))
+                                                                  .build());
         AssertExtensions.assertThrows("Should throw Exception", updateStreamStatus, throwable -> true);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -132,7 +132,7 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Boolean> alterStream(StreamConfiguration streamConfig) {
+    public CompletableFuture<Boolean> updateStream(StreamConfiguration streamConfig) {
         throw new NotImplementedException();
     }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -78,7 +78,7 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
     }
 
     @Override
-    public boolean alterStream(String scopeName, String streamName, StreamConfiguration config) {
+    public boolean updateStream(String scopeName, String streamName, StreamConfiguration config) {
         if (config == null) {
             config = StreamConfiguration.builder()
                                         .scope(scopeName)
@@ -87,7 +87,7 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
                                         .build();
         }
 
-        return FutureHelpers.getAndHandleExceptions(controller.alterStream(StreamConfiguration.builder()
+        return FutureHelpers.getAndHandleExceptions(controller.updateStream(StreamConfiguration.builder()
                                                                                               .scope(scopeName)
                                                                                               .streamName(streamName)
                                                                                               .scalingPolicy(config.getScalingPolicy())

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -106,9 +106,9 @@ public class ControllerService {
                 .thenApplyAsync(status -> CreateStreamStatus.newBuilder().setStatus(status).build(), executor);
     }
 
-    public CompletableFuture<UpdateStreamStatus> alterStream(final StreamConfiguration streamConfig) {
+    public CompletableFuture<UpdateStreamStatus> updateStream(final StreamConfiguration streamConfig) {
         Preconditions.checkNotNull(streamConfig, "streamConfig");
-        return streamMetadataTasks.alterStream(
+        return streamMetadataTasks.updateStream(
                 streamConfig.getScope(), streamConfig.getStreamName(), streamConfig, null)
                 .thenApplyAsync(status -> UpdateStreamStatus.newBuilder().setStatus(status).build(), executor);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -103,11 +103,11 @@ public class LocalController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Boolean> alterStream(final StreamConfiguration streamConfig) {
-        return this.controller.alterStream(streamConfig).thenApply(x -> {
+    public CompletableFuture<Boolean> updateStream(final StreamConfiguration streamConfig) {
+        return this.controller.updateStream(streamConfig).thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
-                throw new ControllerFailureException("Failed to altering stream: " + streamConfig);
+                throw new ControllerFailureException("Failed to update stream: " + streamConfig);
             case SCOPE_NOT_FOUND:
                 throw new IllegalArgumentException("Scope does not exist: " + streamConfig);
             case STREAM_NOT_FOUND:
@@ -115,7 +115,7 @@ public class LocalController implements Controller {
             case SUCCESS:
                 return true;
             default:
-                throw new ControllerFailureException("Unknown return status altering stream " + streamConfig
+                throw new ControllerFailureException("Unknown return status updating stream " + streamConfig
                                                      + " " + x.getStatus());
             }
         });

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -347,7 +347,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
 
         StreamConfiguration streamConfiguration = ModelHelper.getUpdateStreamConfig(
                 updateStreamRequest, scopeName, streamName);
-        controllerService.alterStream(streamConfiguration).thenApply(streamStatus -> {
+        controllerService.updateStream(streamConfiguration).thenApply(streamStatus -> {
             if (streamStatus.getStatus() == UpdateStreamStatus.Status.SUCCESS) {
                 log.info("Successfully updated stream config for: {}/{}", scopeName, streamName);
                 return Response.status(Status.OK)

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -76,10 +76,10 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void alterStream(StreamConfig request, StreamObserver<UpdateStreamStatus> responseObserver) {
-        log.info("alterStream called for stream {}/{}.", request.getStreamInfo().getScope(),
+    public void updateStream(StreamConfig request, StreamObserver<UpdateStreamStatus> responseObserver) {
+        log.info("updateStream called for stream {}/{}.", request.getStreamInfo().getScope(),
                 request.getStreamInfo().getStream());
-        processResult(controllerService.alterStream(ModelHelper.encode(request)), responseObserver);
+        processResult(controllerService.updateStream(ModelHelper.encode(request)), responseObserver);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -112,7 +112,7 @@ public class StreamMetadataTasks extends TaskBase {
      * @return update status.
      */
     @Task(name = "updateConfig", version = "1.0", resource = "{scope}/{stream}")
-    public CompletableFuture<UpdateStreamStatus.Status> alterStream(String scope, String stream, StreamConfiguration config, OperationContext contextOpt) {
+    public CompletableFuture<UpdateStreamStatus.Status> updateStream(String scope, String stream, StreamConfiguration config, OperationContext contextOpt) {
         return execute(
                 new Resource(scope, stream),
                 new Serializable[]{scope, stream, config, null},

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -269,7 +269,7 @@ public class StreamMetaDataTests {
         String resourceURI = getURI() + "v1/scopes/" + scope1 + "/streams/" + stream1;
 
         // Test to update an existing stream
-        when(mockControllerService.alterStream(any())).thenReturn(updateStreamStatus);
+        when(mockControllerService.updateStream(any())).thenReturn(updateStreamStatus);
         Response response = client.target(resourceURI).request().buildPut(Entity.json(updateStreamRequest)).invoke();
         assertEquals("Update Stream Status", 200, response.getStatus());
         StreamProperty streamResponseActual = response.readEntity(StreamProperty.class);
@@ -284,13 +284,13 @@ public class StreamMetaDataTests {
         response.close();
 
         // Test to update an non-existing stream
-        when(mockControllerService.alterStream(any())).thenReturn(updateStreamStatus2);
+        when(mockControllerService.updateStream(any())).thenReturn(updateStreamStatus2);
         response = client.target(resourceURI).request().buildPut(Entity.json(updateStreamRequest2)).invoke();
         assertEquals("Update Stream Status", 404, response.getStatus());
         response.close();
 
         // Test for validation of request object
-        when(mockControllerService.alterStream(any())).thenReturn(updateStreamStatus3);
+        when(mockControllerService.updateStream(any())).thenReturn(updateStreamStatus3);
         response = client.target(resourceURI).request().buildPut(Entity.json(updateStreamRequest3)).invoke();
         // TODO: Server should be returning 400 here, change this once issue
         // https://github.com/pravega/pravega/issues/531 is fixed.
@@ -298,7 +298,7 @@ public class StreamMetaDataTests {
         response.close();
 
         // Test to update stream for non-existent scope
-        when(mockControllerService.alterStream(any())).thenReturn(updateStreamStatus4);
+        when(mockControllerService.updateStream(any())).thenReturn(updateStreamStatus4);
         response = client.target(resourceURI).request().buildPut(Entity.json(updateStreamRequest)).invoke();
         assertEquals("Update Stream Status", 404, response.getStatus());
         response.close();

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -68,22 +68,22 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
                         .setStatus(Controller.CreateScopeStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createScope("scope").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.createScope("scope").join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.createScope(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
                         .setStatus(Controller.CreateScopeStatus.Status.INVALID_SCOPE_NAME).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.createScope("scope").join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.createScope("scope").join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.createScope(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createScope("scope").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.createScope("scope").join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -102,22 +102,22 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
                         .setStatus(Controller.DeleteScopeStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteScope("scope").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.deleteScope("scope").join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.deleteScope(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
                         .setStatus(Controller.DeleteScopeStatus.Status.SCOPE_NOT_EMPTY).build()));
         assertThrows("Expected IllegalStateException",
-                () -> this.testController.deleteScope("scope").join()
-                , ex -> ex instanceof IllegalStateException);
+                () -> this.testController.deleteScope("scope").join(),
+                ex -> ex instanceof IllegalStateException);
 
         when(this.mockControllerService.deleteScope(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteScope("scope").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.deleteScope("scope").join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -136,29 +136,29 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
                         .setStatus(Controller.CreateStreamStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
                         .setStatus(Controller.CreateStreamStatus.Status.INVALID_STREAM_NAME).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
                         .setStatus(Controller.CreateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -179,22 +179,22 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.STREAM_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.updateStream(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.updateStream(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -208,29 +208,29 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.sealStream("scope", "stream").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.sealStream("scope", "stream").join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.sealStream(any(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.STREAM_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.sealStream("scope", "stream").join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.sealStream("scope", "stream").join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.sealStream(any(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.sealStream("scope", "stream").join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.sealStream("scope", "stream").join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.sealStream(any(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.sealStream("scope", "stream").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.sealStream("scope", "stream").join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -244,8 +244,8 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
                         .setStatus(Controller.DeleteStreamStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteStream("scope", "stream").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.deleteStream("scope", "stream").join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
@@ -256,15 +256,15 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
                         .setStatus(Controller.DeleteStreamStatus.Status.STREAM_NOT_SEALED).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.deleteStream("scope", "stream").join()
-                , ex -> ex instanceof IllegalArgumentException);
+                () -> this.testController.deleteStream("scope", "stream").join(),
+                ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteStream("scope", "stream").join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.deleteStream("scope", "stream").join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 
     @Test
@@ -286,23 +286,23 @@ public class LocalControllerTest {
                         .setStatus(Controller.ScaleResponse.ScaleStreamStatus.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
-                        new ArrayList<>(), new HashMap<>()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                        new ArrayList<>(), new HashMap<>()).join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
                         .setStatus(Controller.ScaleResponse.ScaleStreamStatus.TXN_CONFLICT).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
-                        new ArrayList<>(), new HashMap<>()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                        new ArrayList<>(), new HashMap<>()).join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
-                        new ArrayList<>(), new HashMap<>()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                        new ArrayList<>(), new HashMap<>()).join(),
+                ex -> ex instanceof ControllerFailureException);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -172,8 +172,8 @@ public class LocalControllerTest {
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
                         .setStatus(Controller.UpdateStreamStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
-                , ex -> ex instanceof ControllerFailureException);
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.updateStream(any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.eventProcessor;
+
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ControllerFailureException;
+import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.controller.server.ControllerService;
+import io.pravega.controller.stream.api.grpc.v1.Controller;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for LocalController.
+ */
+@Slf4j
+public class LocalControllerTest {
+
+    //Ensure each test completes within 10 seconds.
+    @Rule
+    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+
+    private ControllerService mockControllerService;
+    private LocalController testController;
+
+    @Before
+    public void setup() {
+        this.mockControllerService = mock(ControllerService.class);
+        this.testController = new LocalController(this.mockControllerService);
+    }
+
+    @Test
+    public void testCreateScope() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.createScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
+                        .setStatus(Controller.CreateScopeStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.createScope("scope").join());
+
+        when(this.mockControllerService.createScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
+                        .setStatus(Controller.CreateScopeStatus.Status.SCOPE_EXISTS).build()));
+        Assert.assertFalse(this.testController.createScope("scope").join());
+
+        when(this.mockControllerService.createScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
+                        .setStatus(Controller.CreateScopeStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.createScope("scope").join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.createScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
+                        .setStatus(Controller.CreateScopeStatus.Status.INVALID_SCOPE_NAME).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.createScope("scope").join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.createScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.createScope("scope").join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testDeleteScope() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.deleteScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
+                        .setStatus(Controller.DeleteScopeStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.deleteScope("scope").join());
+
+        when(this.mockControllerService.deleteScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
+                        .setStatus(Controller.DeleteScopeStatus.Status.SCOPE_NOT_FOUND).build()));
+        Assert.assertFalse(this.testController.deleteScope("scope").join());
+
+        when(this.mockControllerService.deleteScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
+                        .setStatus(Controller.DeleteScopeStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.deleteScope("scope").join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.deleteScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
+                        .setStatus(Controller.DeleteScopeStatus.Status.SCOPE_NOT_EMPTY).build()));
+        assertThrows("Expected IllegalStateException",
+                () -> this.testController.deleteScope("scope").join()
+                , ex -> ex instanceof IllegalStateException);
+
+        when(this.mockControllerService.deleteScope(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.deleteScope("scope").join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testCreateStream() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatus(Controller.CreateStreamStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.createStream(StreamConfiguration.builder().build()).join());
+
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatus(Controller.CreateStreamStatus.Status.STREAM_EXISTS).build()));
+        Assert.assertFalse(this.testController.createStream(StreamConfiguration.builder().build()).join());
+
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatus(Controller.CreateStreamStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatus(Controller.CreateStreamStatus.Status.INVALID_STREAM_NAME).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatus(Controller.CreateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.createStream(any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.createStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testUpdateStream() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.updateStream(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.updateStream(StreamConfiguration.builder().build()).join());
+
+        when(this.mockControllerService.updateStream(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.updateStream(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.STREAM_NOT_FOUND).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.updateStream(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.updateStream(any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.updateStream(StreamConfiguration.builder().build()).join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testSealStream() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.sealStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.sealStream("scope", "stream").join());
+
+        when(this.mockControllerService.sealStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.sealStream("scope", "stream").join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.sealStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.STREAM_NOT_FOUND).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.sealStream("scope", "stream").join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.sealStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatus(Controller.UpdateStreamStatus.Status.SCOPE_NOT_FOUND).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.sealStream("scope", "stream").join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.sealStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.sealStream("scope", "stream").join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testDeleteStream() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
+                        .setStatus(Controller.DeleteStreamStatus.Status.SUCCESS).build()));
+        Assert.assertTrue(this.testController.deleteStream("scope", "stream").join());
+
+        when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
+                        .setStatus(Controller.DeleteStreamStatus.Status.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.deleteStream("scope", "stream").join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
+                        .setStatus(Controller.DeleteStreamStatus.Status.STREAM_NOT_FOUND).build()));
+        Assert.assertFalse(this.testController.deleteStream("scope", "stream").join());
+
+        when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
+                        .setStatus(Controller.DeleteStreamStatus.Status.STREAM_NOT_SEALED).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.deleteStream("scope", "stream").join()
+                , ex -> ex instanceof IllegalArgumentException);
+
+        when(this.mockControllerService.deleteStream(any(), any())).thenReturn(
+                CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.deleteStream("scope", "stream").join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testScaleStream() throws ExecutionException, InterruptedException {
+        when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
+                        .setStatus(Controller.ScaleResponse.ScaleStreamStatus.SUCCESS).build()));
+        Assert.assertTrue(this.testController.scaleStream(new StreamImpl("scope", "stream"),
+                new ArrayList<>(), new HashMap<>()).join());
+
+        when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
+                        .setStatus(Controller.ScaleResponse.ScaleStreamStatus.PRECONDITION_FAILED).build()));
+        Assert.assertFalse(this.testController.scaleStream(new StreamImpl("scope", "stream"),
+                new ArrayList<>(), new HashMap<>()).join());
+
+        when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
+                        .setStatus(Controller.ScaleResponse.ScaleStreamStatus.FAILURE).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
+                        new ArrayList<>(), new HashMap<>()).join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
+                        .setStatus(Controller.ScaleResponse.ScaleStreamStatus.TXN_CONFLICT).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
+                        new ArrayList<>(), new HashMap<>()).join()
+                , ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.scale(any(), any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.ScaleResponse.newBuilder()
+                        .setStatusValue(-1).build()));
+        assertThrows("Expected ControllerFailureException",
+                () -> this.testController.scaleStream(new StreamImpl("scope", "stream"),
+                        new ArrayList<>(), new HashMap<>()).join()
+                , ex -> ex instanceof ControllerFailureException);
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -229,13 +229,13 @@ public abstract class ControllerServiceImplTest {
     }
 
     @Test
-    public void alterStreamTests() {
+    public void updateStreamTests() {
         createScopeAndStream(SCOPE1, STREAM1, ScalingPolicy.fixed(2));
 
         final StreamConfiguration configuration2 = StreamConfiguration.builder().scope(SCOPE1).streamName(STREAM1)
                 .scalingPolicy(ScalingPolicy.fixed(3)).build();
         ResultObserver<UpdateStreamStatus> result2 = new ResultObserver<>();
-        this.controllerService.alterStream(ModelHelper.decode(configuration2), result2);
+        this.controllerService.updateStream(ModelHelper.decode(configuration2), result2);
         UpdateStreamStatus updateStreamStatus = result2.get();
         Assert.assertEquals(updateStreamStatus.getStatus(), UpdateStreamStatus.Status.SUCCESS);
 
@@ -243,7 +243,7 @@ public abstract class ControllerServiceImplTest {
         ResultObserver<UpdateStreamStatus> result3 = new ResultObserver<>();
         final StreamConfiguration configuration3 = StreamConfiguration.builder().scope(SCOPE1)
                 .streamName("unknownstream").scalingPolicy(ScalingPolicy.fixed(1)).build();
-        this.controllerService.alterStream(ModelHelper.decode(configuration3), result3);
+        this.controllerService.updateStream(ModelHelper.decode(configuration3), result3);
         updateStreamStatus = result3.get();
         Assert.assertEquals(UpdateStreamStatus.Status.STREAM_NOT_FOUND, updateStreamStatus.getStatus());
     }

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -239,7 +239,7 @@ public abstract class ControllerServiceImplTest {
         UpdateStreamStatus updateStreamStatus = result2.get();
         Assert.assertEquals(updateStreamStatus.getStatus(), UpdateStreamStatus.Status.SUCCESS);
 
-        // Alter stream for non-existent stream.
+        // Update stream for non-existent stream.
         ResultObserver<UpdateStreamStatus> result3 = new ResultObserver<>();
         final StreamConfiguration configuration3 = StreamConfiguration.builder().scope(SCOPE1)
                 .streamName("unknownstream").scalingPolicy(ScalingPolicy.fixed(1)).build();

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -306,7 +306,7 @@ public class TaskTest {
                 deadHost, sweeper);
         Assert.assertEquals(initialSegments, streamStore.getActiveSegments(SCOPE, stream, null, executor).join().size());
 
-        // Alter stream test.
+        // Update stream test.
         completePartialTask(mockStreamTasks.updateStream(SCOPE, stream, configuration1, null), deadHost, sweeper);
 
         // Scale test.

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -307,7 +307,7 @@ public class TaskTest {
         Assert.assertEquals(initialSegments, streamStore.getActiveSegments(SCOPE, stream, null, executor).join().size());
 
         // Alter stream test.
-        completePartialTask(mockStreamTasks.alterStream(SCOPE, stream, configuration1, null), deadHost, sweeper);
+        completePartialTask(mockStreamTasks.updateStream(SCOPE, stream, configuration1, null), deadHost, sweeper);
 
         // Scale test.
         completePartialTask(mockStreamTasks.scale(SCOPE, stream, sealSegments, newRanges,

--- a/docs/basic-reader-and-writer.md
+++ b/docs/basic-reader-and-writer.md
@@ -95,14 +95,14 @@ related to Scopes and Streams:
 |                 |                                                                   | A StreamConfiguration is built using a builder pattern                                                                                                               |
 |                 |                                                                   | Returns true if the Stream is created, returns false if the Stream already exists.                                                                                                               |
 |                 |                                                                   | You can call this method even if the Stream already exists, it won't harm anything.                                                                                                               |
-| alterStream     | (String scopeName, String streamName, StreamConfiguration config) | Swap out the Stream's configuration.                                                                           |
-|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you alter a nonexistent stream.                                                                                                               |
+| updateStream    | (String scopeName, String streamName, StreamConfiguration config) | Swap out the Stream's configuration.                                                                           |
+|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you update a nonexistent stream.                                                                                                              |
 |                 |                                                                   | Returns true if the Stream was changed                                                                                                               |
 | sealStream      | (String scopeName, String streamName)                             | Prevent any further writes to a Stream                                                                         |
-|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you alter a nonexistent stream.                                                                                                               |
+|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you seal a nonexistent stream.                                                                                                                |
 |                 |                                                                   | Returns true if the Stream is successfully sealed                                                                                                               |
 | deleteStream    | (String scopeName, String streamName)                             | Remove the Stream from Pravega and recover any resources used by that Stream                                   |
-|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you alter a nonexistent stream.                                                                                                               |
+|                 |                                                                   | Note the Stream must already exist, an exception is thrown if you delete a nonexistent stream.                                                                                                              |
 |                 |                                                                   | Returns true if the stream was deleted.                                                                                                               |
 
 After line 3 in the code is finished, we have established that the Scope exists,
@@ -142,7 +142,7 @@ Events or Kilobytes) is exceeded.  The minimum number of Segments is a factor
 that sets the minimum degree of read parallelism to be maintained; if this value
 is set at 3, for example, there will always be 3 Stream Segments available on
 the Stream.  Currently, this property is effective only when the stream is
-created; at some point in the future, alter stream will allow this factor to be
+created; at some point in the future, update stream will allow this factor to be
 used to change the minimum degree of read parallelism on an existing Stream.
 
 Once the StreamConfiguration object is created, creating the Stream is straight

--- a/docs/pravega-concepts.md
+++ b/docs/pravega-concepts.md
@@ -28,7 +28,7 @@ Pravega itself is composed of two kinds of workload: Controller instances and
 Pravega Servers. The set of Pravega Servers is known collectively as the Segment Store. 
 
 The set of Controller instances make up the control plane of Pravega, providing
-functionality to create, alter and delete Streams, retrieve information about
+functionality to create, update and delete Streams, retrieve information about
 Streams, monitor the health of the Pravega cluster, gather metrics etc.  There
 are usually multiple (recommended at least 3) Controller instances running in a
 cluster for high availability.  

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -18,7 +18,7 @@ option optimize_for = SPEED;
 service ControllerService {
     rpc getControllerServerList(ServerRequest) returns (ServerResponse);
     rpc createStream(StreamConfig) returns (CreateStreamStatus);
-    rpc alterStream(StreamConfig) returns (UpdateStreamStatus);
+    rpc updateStream(StreamConfig) returns (UpdateStreamStatus);
     rpc sealStream(StreamInfo) returns (UpdateStreamStatus);
     rpc deleteStream(StreamInfo) returns (DeleteStreamStatus);
     rpc getCurrentSegments(StreamInfo) returns (SegmentRanges);

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -252,7 +252,7 @@ public class ControllerServiceTest {
 
 
     private static void alterConfigOfNonExistantStream(Controller controller) {
-        assertFalse(FutureHelpers.await(controller.alterStream(StreamConfiguration.builder()
+        assertFalse(FutureHelpers.await(controller.updateStream(StreamConfiguration.builder()
                                                                .scope("scope")
                                                                .streamName("streamName")
                                                                .scalingPolicy(ScalingPolicy.byEventRate(200, 2, 3))
@@ -261,7 +261,7 @@ public class ControllerServiceTest {
 
     private static void updataMinSegmentes(Controller controller, final String scope,
                                            final String streamName) throws InterruptedException, ExecutionException {
-        assertTrue(controller.alterStream(StreamConfiguration.builder()
+        assertTrue(controller.updateStream(StreamConfiguration.builder()
                                           .scope(scope)
                                           .streamName(streamName)
                                           .scalingPolicy(ScalingPolicy.byEventRate(200, 2, 3))
@@ -270,7 +270,7 @@ public class ControllerServiceTest {
 
     private static void updateScaleFactor(Controller controller, final String scope,
                                           final String streamName) throws InterruptedException, ExecutionException {
-        assertTrue(controller.alterStream(StreamConfiguration.builder()
+        assertTrue(controller.updateStream(StreamConfiguration.builder()
                                           .scope(scope)
                                           .streamName(streamName)
                                           .scalingPolicy(ScalingPolicy.byEventRate(100, 3, 2))
@@ -279,7 +279,7 @@ public class ControllerServiceTest {
 
     private static void updateTargetRate(Controller controller, final String scope,
                                          final String streamName) throws InterruptedException, ExecutionException {
-        assertTrue(controller.alterStream(StreamConfiguration.builder()
+        assertTrue(controller.updateStream(StreamConfiguration.builder()
                                           .scope(scope)
                                           .streamName(streamName)
                                           .scalingPolicy(ScalingPolicy.byEventRate(200, 2, 2))
@@ -288,7 +288,7 @@ public class ControllerServiceTest {
 
     private static void updateScalingPolicy(Controller controller, final String scope,
                                             final String streamName) throws InterruptedException, ExecutionException {
-        assertTrue(controller.alterStream(StreamConfiguration.builder()
+        assertTrue(controller.updateStream(StreamConfiguration.builder()
                                           .scope(scope)
                                           .streamName(streamName)
                                           .scalingPolicy(ScalingPolicy.byEventRate(100, 2, 2))
@@ -297,7 +297,7 @@ public class ControllerServiceTest {
 
     private static void updateStreamName(Controller controller, final String scope,
                                          final ScalingPolicy scalingPolicy) {
-        assertFalse(FutureHelpers.await(controller.alterStream(StreamConfiguration.builder()
+        assertFalse(FutureHelpers.await(controller.updateStream(StreamConfiguration.builder()
                                                                .scope(scope)
                                                                .streamName("stream4")
                                                                .scalingPolicy(scalingPolicy)

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -180,7 +180,7 @@ public class ControllerServiceTest {
 
         updataMinSegmentes(controller, scope1, streamName1);
 
-        alterConfigOfNonExistantStream(controller);
+        updateConfigOfNonExistantStream(controller);
 
         //get currently active segments
 
@@ -251,7 +251,7 @@ public class ControllerServiceTest {
     }
 
 
-    private static void alterConfigOfNonExistantStream(Controller controller) {
+    private static void updateConfigOfNonExistantStream(Controller controller) {
         assertFalse(FutureHelpers.await(controller.updateStream(StreamConfiguration.builder()
                                                                .scope("scope")
                                                                .streamName("streamName")

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
@@ -126,7 +126,7 @@ public class StreamMetadataTest {
 
         assertTrue(controller.createStream(config3).get());
 
-        // update stream config(alter Stream)
+        // update stream config(update Stream)
 
         // AS3:update the type of scaling policy
         final StreamConfiguration config6 = StreamConfiguration.builder()
@@ -160,14 +160,14 @@ public class StreamMetadataTest {
                                                                .build();
         assertTrue(controller.updateStream(config9).get());
 
-        // AS7:alter configuration of non-existent stream.
+        // AS7:Update configuration of non-existent stream.
         final StreamConfiguration config = StreamConfiguration.builder()
                                                               .scope("scope")
                                                               .streamName("streamName")
                                                               .scalingPolicy(ScalingPolicy.fixed(2))
                                                               .build();
         CompletableFuture<Boolean> updateStatus = controller.updateStream(config);
-        assertThrows("FAILURE: Altering the configuration of a non-existent stream", updateStatus, t -> true);
+        assertThrows("FAILURE: Updating the configuration of a non-existent stream", updateStatus, t -> true);
 
         // get currently active segments
 

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
@@ -134,7 +134,7 @@ public class StreamMetadataTest {
                                                                .streamName(streamName1)
                                                                .scalingPolicy(ScalingPolicy.byDataRate(100, 2, 2))
                                                                .build();
-        assertTrue(controller.alterStream(config6).get());
+        assertTrue(controller.updateStream(config6).get());
 
         // AS4:update the target rate of scaling policy
         final StreamConfiguration config7 = StreamConfiguration.builder()
@@ -142,7 +142,7 @@ public class StreamMetadataTest {
                                                                .streamName(streamName1)
                                                                .scalingPolicy(ScalingPolicy.byDataRate(200, 2, 2))
                                                                .build();
-        assertTrue(controller.alterStream(config7).get());
+        assertTrue(controller.updateStream(config7).get());
 
         // AS5:update the scale factor of scaling policy
         final StreamConfiguration config8 = StreamConfiguration.builder()
@@ -150,7 +150,7 @@ public class StreamMetadataTest {
                                                                .streamName(streamName1)
                                                                .scalingPolicy(ScalingPolicy.byDataRate(200, 4, 2))
                                                                .build();
-        assertTrue(controller.alterStream(config8).get());
+        assertTrue(controller.updateStream(config8).get());
 
         // AS6:update the minNumsegments of scaling policy
         final StreamConfiguration config9 = StreamConfiguration.builder()
@@ -158,7 +158,7 @@ public class StreamMetadataTest {
                                                                .streamName(streamName1)
                                                                .scalingPolicy(ScalingPolicy.byDataRate(200, 4, 3))
                                                                .build();
-        assertTrue(controller.alterStream(config9).get());
+        assertTrue(controller.updateStream(config9).get());
 
         // AS7:alter configuration of non-existent stream.
         final StreamConfiguration config = StreamConfiguration.builder()
@@ -166,7 +166,7 @@ public class StreamMetadataTest {
                                                               .streamName("streamName")
                                                               .scalingPolicy(ScalingPolicy.fixed(2))
                                                               .build();
-        CompletableFuture<Boolean> updateStatus = controller.alterStream(config);
+        CompletableFuture<Boolean> updateStatus = controller.updateStream(config);
         assertThrows("FAILURE: Altering the configuration of a non-existent stream", updateStatus, t -> true);
 
         // get currently active segments


### PR DESCRIPTION
**Change log description**
Alter stream and update stream are being used interchangeably in pravega code. Here we update the code and documentation to consistently use 'update' since its a standard terminology for modify APIs.

**Purpose of the change**
Fixes #588 

**What the code does**
Replaces all occurrences of alter stream with update stream

**How to verify it**
No functionality change, all existing tests should pass.