### PR TITLE
Issue 1404: Remove generated folders from code coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,6 @@ coverage:
         branches:
           - master
   ignore:
-    - "generated"
+    - "**/generated/**"
     - "standalone"
     - "test"


### PR DESCRIPTION
**Change log description**
Ignoring generated folders for generating code coverage

**Purpose of the change**
Fixes #1404 

**What the code does**
Adds generated folder to codecov's ignore path

**How to verify it**
Check code coverage statistics