### PR TITLE
Issue 1370: Renaming Pravega Metrics

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -70,7 +70,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private static final int HIGH_WATER_MARK = 128 * 1024;
     private static final int LOW_WATER_MARK = 64 * 1024;
 
-    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("host");
+    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("store");
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -70,7 +70,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private static final int HIGH_WATER_MARK = 128 * 1024;
     private static final int LOW_WATER_MARK = 64 * 1024;
 
-    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("store");
+    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -100,7 +100,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
     static final int MAX_READ_SIZE = 2 * 1024 * 1024;
 
-    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("store");
+    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     @VisibleForTesting

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -100,7 +100,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
     static final int MAX_READ_SIZE = 2 * 1024 * 1024;
 
-    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("host");
+    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("store");
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     @VisibleForTesting

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Metrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Metrics.java
@@ -20,6 +20,6 @@ import io.pravega.shared.metrics.StatsLogger;
  */
 final class Metrics {
     static final StatsLogger DURABLE_DATALOG_LOGGER = MetricsProvider.createStatsLogger("durablelog");
-    static final OpStatsLogger WRITE_LATENCY = DURABLE_DATALOG_LOGGER.createStats(MetricsNames.DURABLE_DATALOG_WRITE_LATENCY);
-    static final Counter WRITE_BYTES = DURABLE_DATALOG_LOGGER.createCounter(MetricsNames.DURABLE_DATALOG_WRITE_BYTES);
+    static final OpStatsLogger WRITE_LATENCY = DURABLE_DATALOG_LOGGER.createStats(MetricsNames.TIER1_WRITE_BYTES);
+    static final Counter WRITE_BYTES = DURABLE_DATALOG_LOGGER.createCounter(MetricsNames.TIER1_WRITE_BYTES);
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -15,8 +15,8 @@ public final class MetricsNames {
     public static final String SEGMENT_CREATE_LATENCY = "segment_create_latency_ms"; // Timer
     public static final String SEGMENT_READ_LATENCY = "segment_read_latency_ms";     // Timer
     public static final String SEGMENT_WRITE_LATENCY = "segment_write_latency_ms";   // Timer
-    public static final String SEGMENT_READ_BYTES = "segment_read_bytes";            // Dynamic Counter
-    public static final String SEGMENT_WRITE_BYTES = "segment_write_bytes";          // Dynamic Counter
+    public static final String SEGMENT_READ_BYTES = "store.segment_read_bytes";            // Dynamic Counter
+    public static final String SEGMENT_WRITE_BYTES = "store.segment_write_bytes";          // Dynamic Counter
 
     //hdfs stats
     public static final String HDFS_READ_LATENCY = "hdfs_read_latency_ms";   // Timer
@@ -35,28 +35,28 @@ public final class MetricsNames {
     public static final String DELETE_STREAM = "stream_deleted";    // Histogram
 
     // Transaction request Operations (Dynamic)
-    public static final String CREATE_TRANSACTION = "transactions_created";   // Dynamic Counter
-    public static final String COMMIT_TRANSACTION = "transactions_committed"; // Dynamic Counter
-    public static final String ABORT_TRANSACTION = "transactions_aborted";    // Dynamic Counter
-    public static final String OPEN_TRANSACTIONS = "transactions_opened";     // Dynamic Gauge
-    public static final String TIMEDOUT_TRANSACTIONS = "transactions_timedout";     // Dynamic Counter
+    public static final String CREATE_TRANSACTION = "controller.transactions_created";   // Dynamic Counter
+    public static final String COMMIT_TRANSACTION = "controller.transactions_committed"; // Dynamic Counter
+    public static final String ABORT_TRANSACTION = "controller.transactions_aborted";    // Dynamic Counter
+    public static final String OPEN_TRANSACTIONS = "controller.transactions_opened";     // Dynamic Gauge
+    public static final String TIMEDOUT_TRANSACTIONS = "controller.transactions_timedout";     // Dynamic Counter
 
     // Stream segment counts (Dynamic)
-    public static final String SEGMENTS_COUNT = "segments_count";   // Dynamic Gauge
-    public static final String SEGMENTS_SPLITS = "segment_splits"; // Dynamic Counter
-    public static final String SEGMENTS_MERGES = "segment_merges"; // Dynamic Counter
+    public static final String SEGMENTS_COUNT = "controller.segments_count";   // Dynamic Gauge
+    public static final String SEGMENTS_SPLITS = "controller.segment_splits"; // Dynamic Counter
+    public static final String SEGMENTS_MERGES = "controller.segment_merges"; // Dynamic Counter
 
     private static String escapeSpecialChar(String name) {
         return name.replace('/', '.').replace(':', '.').replace('|', '.').replaceAll("\\s+", "_");
     }
 
     public static String nameFromStream(String metric, String scope, String stream) {
-        String name = scope + "." + stream + "." + metric;
+        String name = metric + "." + scope + "." + stream;
         return escapeSpecialChar(name);
     }
 
     public static String nameFromSegment(String metric, String segmentName) {
-        String name = segmentName + "." + metric;
+        String name = metric + "." + segmentName;
         return escapeSpecialChar(name);
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -15,8 +15,8 @@ public final class MetricsNames {
     public static final String SEGMENT_CREATE_LATENCY = "segment_create_latency_ms"; // Timer
     public static final String SEGMENT_READ_LATENCY = "segment_read_latency_ms";     // Timer
     public static final String SEGMENT_WRITE_LATENCY = "segment_write_latency_ms";   // Timer
-    public static final String SEGMENT_READ_BYTES = "store.segment_read_bytes";            // Dynamic Counter
-    public static final String SEGMENT_WRITE_BYTES = "store.segment_write_bytes";          // Dynamic Counter
+    public static final String SEGMENT_READ_BYTES = "segmentstore.segment_read_bytes";            // Dynamic Counter
+    public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
 
     //hdfs stats
     public static final String HDFS_READ_LATENCY = "hdfs_read_latency_ms";   // Timer

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -19,14 +19,14 @@ public final class MetricsNames {
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
 
     //hdfs stats
-    public static final String HDFS_READ_LATENCY = "hdfs_read_latency_ms";   // Timer
-    public static final String HDFS_WRITE_LATENCY = "hdfs_write_latency_ms"; // Timer
-    public static final String HDFS_READ_BYTES = "hdfs_read_bytes";          // Counter
-    public static final String HDFS_WRITE_BYTES = "hdfs_write_bytes";        // Counter
+    public static final String HDFS_READ_LATENCY = "tier2_read_latency_ms";   // Timer
+    public static final String HDFS_WRITE_LATENCY = "tier2_write_latency_ms"; // Timer
+    public static final String HDFS_READ_BYTES = "tier2_read_bytes";          // Counter
+    public static final String HDFS_WRITE_BYTES = "tier2_write_bytes";        // Counter
 
     //DurableLog stats
-    public static final String DURABLE_DATALOG_WRITE_LATENCY = "durable_datalog_write_latency"; // Timer
-    public static final String DURABLE_DATALOG_WRITE_BYTES = "durable_datalog_write_bytes";     // Counter
+    public static final String TIER1_WRITE_LATENCY = "tier1_write_latency"; // Timer
+    public static final String TIER1_WRITE_BYTES = "tier1_datalog_write_bytes";     // Counter
 
     // Metrics in Controller
     // Stream request counts (Static)

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
@@ -152,12 +152,12 @@ public class StatsProviderImpl implements StatsProvider {
     @Override
     public StatsLogger createStatsLogger(String name) {
         init();
-        return new StatsLoggerImpl(getMetrics(), name);
+        return new StatsLoggerImpl(getMetrics(), new StringBuffer("pravega.").append(name).toString());
     }
 
     @Override
     public DynamicLogger createDynamicLogger() {
         init();
-        return new DynamicLoggerImpl(conf, metrics, new StatsLoggerImpl(getMetrics(), "DYNAMIC"));
+        return new DynamicLoggerImpl(conf, metrics, new StatsLoggerImpl(getMetrics(), "pravega"));
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 public class MetricsProviderTest {
 
-    private final StatsLogger statsLogger = MetricsProvider.createStatsLogger("");
+    private final StatsLogger statsLogger = MetricsProvider.createStatsLogger("testStatsLogger");
     private final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
 
     @Before
@@ -71,7 +71,7 @@ public class MetricsProviderTest {
         for (int i = 1; i < 10; i++) {
             sum += i;
             dynamicLogger.incCounterValue("dynamicCounter", i);
-            assertEquals(sum, MetricsProvider.METRIC_REGISTRY.getCounters().get("DYNAMIC.dynamicCounter.Counter").getCount());
+            assertEquals(sum, MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.dynamicCounter.Counter").getCount());
         }
     }
 
@@ -92,7 +92,7 @@ public class MetricsProviderTest {
         for (int i = 1; i < 10; i++) {
             sum += i;
             dynamicLogger.recordMeterEvents("dynamicMeter", i);
-            assertEquals(sum, MetricsProvider.METRIC_REGISTRY.getMeters().get("DYNAMIC.dynamicMeter.Meter").getCount());
+            assertEquals(sum, MetricsProvider.METRIC_REGISTRY.getMeters().get("pravega.dynamicMeter.Meter").getCount());
         }
     }
 
@@ -107,8 +107,8 @@ public class MetricsProviderTest {
         for (int i = 1; i < 10; i++) {
             value.set(i);
             dynamicLogger.reportGaugeValue("dynamicGauge", i);
-            assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("testGauge").getValue());
-            assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("DYNAMIC.dynamicGauge.Gauge").getValue());
+            assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("pravega.testStatsLogger.testGauge").getValue());
+            assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("pravega.dynamicGauge.Gauge").getValue());
         }
     }
 
@@ -131,7 +131,8 @@ public class MetricsProviderTest {
         MetricsProvider.initialize(config);
         statsLogger.createCounter("counterEnabled");
 
-        Assert.assertNotNull(MetricsProvider.METRIC_REGISTRY.getCounters().get("counterEnabled"));
+        Assert.assertNotNull(
+                MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.testStatsLogger.counterEnabled"));
     }
 
     /**
@@ -145,7 +146,8 @@ public class MetricsProviderTest {
                                             .build();
         MetricsProvider.initialize(config);
 
-        Assert.assertNotNull(null, MetricsProvider.METRIC_REGISTRY.getCounters().get("continuity-counter"));
+        Assert.assertNotNull(null,
+                MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.testStatsLogger.continuity-counter"));
     }
 
     /**


### PR DESCRIPTION
**Change log description**
Renaming metrics reported in pravega.

**Purpose of the change**
Fixes #1370 

**What the code does**
Renames metrics in pravega. Removes 'DYNAMIC' from names. Adds relevant prefix controller, store, hdfs etc.

**How to verify it**
startStandlaone gradle task will start pravega services and some metrics can be seen in /tmp/csv/pravega folder.