### PR TITLE
Issue 517: (SegmentStore) Added timeouts to all unit tests

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheKeyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheKeyTests.java
@@ -10,7 +10,9 @@
 package io.pravega.segmentstore.server;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the CacheKey class.
@@ -19,6 +21,8 @@ public class CacheKeyTests {
     private static final int SEGMENT_COUNT = 1000;
     private static final int OFFSET_COUNT = 10000;
     private static final long OFFSET_MULTIPLIER = 1024 * 1024;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the Serialization of CacheKey.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -22,7 +22,9 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Defines tests for a generic State Store (AsyncMap(String, SegmentState))
@@ -30,6 +32,8 @@ import org.junit.Test;
 public abstract class StateStoreTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
     private static final int ATTRIBUTE_COUNT = 10;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     //region Test Definitions
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
@@ -27,7 +27,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for StreamSegmentContainerMetadata class.
@@ -36,6 +38,9 @@ public class StreamSegmentContainerMetadataTests {
     private static final int CONTAINER_ID = 1234567;
     private static final int SEGMENT_COUNT = 100;
     private static final int TRANSACTIONS_PER_SEGMENT_COUNT = 2;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests SequenceNumber-related operations.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -24,13 +24,13 @@ import io.pravega.segmentstore.contracts.TooManyActiveSegmentsException;
 import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.OperationLog;
-import io.pravega.segmentstore.server.UpdateableContainerMetadata;
-import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
-import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
-import io.pravega.segmentstore.server.logs.operations.TransactionMapOperation;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.SegmentMetadataComparer;
+import io.pravega.segmentstore.server.UpdateableContainerMetadata;
+import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
+import io.pravega.segmentstore.server.logs.operations.TransactionMapOperation;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
@@ -62,7 +62,9 @@ import lombok.Cleanup;
 import lombok.val;
 import org.apache.commons.lang.NotImplementedException;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for StreamSegmentMapper class.
@@ -71,6 +73,8 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
     private static final int CONTAINER_ID = 123;
     private static final int ATTRIBUTE_COUNT = 10;
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
@@ -10,8 +10,8 @@
 package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.util.ImmutableDate;
-import io.pravega.segmentstore.server.SegmentMetadataComparer;
 import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.SegmentMetadataComparer;
 import io.pravega.test.common.AssertExtensions;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +19,9 @@ import java.util.Random;
 import java.util.UUID;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for StreamSegmentMetadata class.
@@ -30,6 +32,8 @@ public class StreamSegmentMetadataTests {
     private static final long PARENT_SEGMENT_ID = 2;
     private static final int CONTAINER_ID = 1234567;
     private static final int ATTRIBUTE_COUNT = 100;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests that Attributes are properly recorded and updated

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -76,7 +75,7 @@ public class ContainerMetadataUpdateTransactionTests {
             AttributeUpdateType.Replace, AttributeUpdateType.Accumulate};
     private static final Supplier<Long> NEXT_ATTRIBUTE_VALUE = System::nanoTime;
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(30);
     private ManualTimer timeProvider;
 
     @Before

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
@@ -27,7 +27,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,7 +57,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
     private static final int RECORD_COUNT = 200;
 
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
@@ -19,12 +19,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for DataFrameOutputStream class.
  */
 public class DataFrameOutputStreamTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
     /**
      * Tests the basic functionality of startNewRecord(), endRecord() and discardRecord().
      */

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameReaderTests.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import lombok.val;
@@ -48,7 +47,7 @@ public class DataFrameReaderTests extends ThreadPooledTestSuite {
     private static final int FRAME_SIZE = 512;
 
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     /**
      * Tests the happy case: DataFrameReader can read from a DataLog when the are no exceptions.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
@@ -15,13 +15,17 @@ import io.pravega.test.common.AssertExtensions;
 import java.util.List;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the DataFrame class.
  */
 public class DataFrameTests {
     private static final int ENTRY_HEADER_SIZE = 5; // This is a copy of DataFrame.EntryHeader.HeaderSize, but that's not accessible from here.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the ability to append a set of records to a DataFrame and then read them back, without using serialization.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -98,7 +98,7 @@ public class DurableLogTests extends OperationLogTestBase {
             .build();
 
     @Rule
-    public Timeout globalTimeout = new Timeout(TEST_TIMEOUT_MILLIS, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     //region Adding operations
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -15,17 +15,16 @@ import io.pravega.common.util.SequencedItemList;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.server.ContainerMetadata;
+import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
+import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
+import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
-import io.pravega.segmentstore.server.DataCorruptionException;
-import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
-import io.pravega.segmentstore.server.logs.operations.Operation;
-import io.pravega.segmentstore.storage.mocks.InMemoryCache;
 import io.pravega.test.common.AssertExtensions;
 import java.io.InputStream;
 import java.time.Duration;
@@ -37,15 +36,18 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
-import lombok.Cleanup;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for MemoryStateUpdater class.
  */
 public class MemoryStateUpdaterTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
     /**
      * Tests the functionality of the process() method.
      */
@@ -58,8 +60,6 @@ public class MemoryStateUpdaterTests {
         SequencedItemList<Operation> opLog = new SequencedItemList<>();
         ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
         TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
-        @Cleanup
-        InMemoryCache cache = new InMemoryCache("0");
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
         ArrayList<Operation> operations = populate(updater, segmentCount, operationCountPerType);
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicyTests.java
@@ -12,12 +12,16 @@ package io.pravega.segmentstore.server.logs;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for MetadataCheckpointPolicy.
  */
 public class MetadataCheckpointPolicyTests extends ThreadPooledTestSuite {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests invoking the callback upon calls to commit.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -66,8 +66,7 @@ import org.junit.Assert;
  * Base class for all Operation Log-based classes (i.e., DurableLog and OperationProcessor).
  */
 abstract class OperationLogTestBase extends ThreadPooledTestSuite {
-    protected static final int TEST_TIMEOUT_MILLIS = 30000;
-    protected static final Duration TIMEOUT = Duration.ofMillis(TEST_TIMEOUT_MILLIS);
+    protected static final Duration TIMEOUT = Duration.ofMillis(30000);
     private static final Supplier<CompletableFuture<Void>> NO_OP_METADATA_CLEANUP = () -> CompletableFuture.completedFuture(null);
     private static final int MAX_SEGMENT_COUNT = 1000 * 1000;
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -50,7 +49,7 @@ public class OperationMetadataUpdaterTests {
     private static final int MAX_ACTIVE_SEGMENT_COUNT = TRANSACTION_COUNT * 100;
     private static final Supplier<Long> NEXT_ATTRIBUTE_VALUE = System::nanoTime;
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(30);
     private final Supplier<Integer> nextAppendLength = () -> Math.max(1, (int) System.nanoTime() % 1000);
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -68,9 +68,8 @@ public class OperationProcessorTests extends OperationLogTestBase {
     private static final int CONTAINER_ID = 1234567;
     private static final int MAX_DATA_LOG_APPEND_SIZE = 8 * 1024;
     private static final int METADATA_CHECKPOINT_EVERY = 100;
-
     @Rule
-    public Timeout globalTimeout = new Timeout(TEST_TIMEOUT_MILLIS, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     /**
      * Tests the ability of the OperationProcessor to process Operations in a failure-free environment.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
@@ -18,10 +18,6 @@ import io.pravega.segmentstore.contracts.ReadResultEntryType;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import lombok.Cleanup;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -34,13 +30,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.Cleanup;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for AsyncReadResultProcessor.
  */
 public class AsyncReadResultProcessorTests extends ThreadPooledTestSuite {
     private static final int ENTRY_COUNT = 10000;
-    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/CacheManagerTests.java
@@ -12,21 +12,25 @@ package io.pravega.segmentstore.server.reading;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import lombok.Cleanup;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import lombok.Cleanup;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the CacheManager class.
  */
 public class CacheManagerTests extends ThreadPooledTestSuite {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
     @Override
     protected int getThreadPoolSize() {
         return 3;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -72,10 +72,10 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                                                     .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
                                                     .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024))
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
@@ -9,15 +9,15 @@
  */
 package io.pravega.segmentstore.server.reading;
 
-import lombok.Cleanup;
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.pravega.test.common.AssertExtensions;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import lombok.Cleanup;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for FutureReadResultEntryCollection class.
@@ -25,6 +25,8 @@ import java.util.List;
 public class FutureReadResultEntryCollectionTests {
     private static final int ENTRY_COUNT = 100;
     private static final int OFFSET_MULTIPLIER = 1000;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the ability to poll entries based on their offsets.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
@@ -13,7 +13,9 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Random;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the ReadIndexSummary class.
@@ -22,6 +24,8 @@ public class ReadIndexSummaryTests {
     private static final int GENERATION_COUNT = 100;
     private static final int ITEMS_PER_GENERATION = 100;
     private static final int MAX_ITEM_SIZE = 1000;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the basic functionality of adding elements and then removing them.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
@@ -17,20 +17,23 @@ import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import lombok.val;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for RedirectedReadResultEntry.
  */
 public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofSeconds(3);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the ability of the ReadResultEntry base class to adjust offsets when instructed so.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReaderTests.java
@@ -11,8 +11,8 @@ package io.pravega.segmentstore.server.reading;
 
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
-import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
 import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
 import io.pravega.segmentstore.storage.ReadOnlyStorage;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
@@ -20,22 +20,22 @@ import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import java.util.concurrent.TimeUnit;
-
-import lombok.Cleanup;
-import lombok.val;
-import org.apache.commons.lang.NotImplementedException;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.val;
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the StorageReader class.
@@ -45,6 +45,8 @@ public class StorageReaderTests extends ThreadPooledTestSuite {
     private static final int MAX_SEGMENT_LENGTH = MIN_SEGMENT_LENGTH * 100;
     private static final SegmentMetadata SEGMENT_METADATA = new StreamSegmentMetadata("Segment1", 0, 0);
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -14,12 +14,12 @@ import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
 import io.pravega.test.common.AssertExtensions;
-
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicReference;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for StreamSegmentReadResult class.
@@ -28,6 +28,8 @@ public class StreamSegmentReadResultTests {
     private static final int START_OFFSET = 123456;
     private static final int MAX_RESULT_LENGTH = 1024;
     private static final int READ_ITEM_LENGTH = 1;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the next() method which ends when the result is fully consumed (via offsets).

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
@@ -10,33 +10,33 @@
 package io.pravega.segmentstore.server.store;
 
 import io.pravega.common.util.ConfigBuilder;
+import io.pravega.common.util.Property;
+import io.pravega.segmentstore.server.logs.DurableLogConfig;
 import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.writer.WriterConfig;
+import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.test.common.AssertExtensions;
 import java.io.File;
 import java.io.FileWriter;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-
-import io.pravega.common.util.Property;
-import io.pravega.segmentstore.server.logs.DurableLogConfig;
-import lombok.Cleanup;
-import lombok.val;
-import io.pravega.shared.metrics.MetricsConfig;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Cleanup;
+import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the ServiceBuilderConfig class.
@@ -47,6 +47,8 @@ public class ServiceBuilderConfigTests {
             .of(Integer.class.getName(), Long.class.getName(), String.class.getName(), Boolean.class.getName())
             .map(s -> Property.class.getSimpleName() + "<" + s + ">")
             .collect(Collectors.toList());
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests the Builder for ServiceBuilderConfig.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
@@ -10,12 +10,16 @@
 package io.pravega.segmentstore.server.store;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests for the ServiceConfig class
  */
 public class ServiceConfigTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
     @Test
     public void testListeningAndPublicIPAndPort() {
         // When the published IP and port are not specified, it should default to listening IP and port

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.store;
 
+import com.google.common.util.concurrent.AbstractService;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.concurrent.ServiceShutdownListener;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
@@ -21,7 +22,6 @@ import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import com.google.common.util.concurrent.AbstractService;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,16 +30,19 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.Cleanup;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the StreamSegmentContainerRegistry class.
  */
 public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     /**
      * Tests the getContainer method for registered and unregistered containers.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -49,7 +49,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Base class for any test that verifies the functionality of a StreamSegmentStore class.
@@ -63,6 +65,8 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int TRANSACTIONS_PER_SEGMENT = 1;
     private static final int APPENDS_PER_SEGMENT = 100;
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds() * 10);
 
     protected final ServiceBuilderConfig.Builder configBuilder = ServiceBuilderConfig
             .builder()

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/AckCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/AckCalculatorTests.java
@@ -9,17 +9,21 @@
  */
 package io.pravega.segmentstore.server.writer;
 
-import lombok.val;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Random;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the AckCalculator class.
  */
 public class AckCalculatorTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
     /**
      * Tests the getHighestCommittedSequenceNumber method.
      */

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -14,12 +14,11 @@ import io.pravega.common.io.FixedByteArrayOutputStream;
 import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
-import io.pravega.segmentstore.server.MetadataBuilder;
-import io.pravega.segmentstore.server.TestStorage;
-import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.ManualTimer;
+import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.TestStorage;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
@@ -27,6 +26,7 @@ import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.test.common.AssertExtensions;
@@ -55,13 +55,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the SegmentAggregator class.
@@ -81,6 +82,8 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
             .with(WriterConfig.MAX_FLUSH_SIZE_BYTES, 150)
             .with(WriterConfig.MIN_READ_TIMEOUT_MILLIS, 10L)
             .build();
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -14,20 +14,20 @@ import io.pravega.common.concurrent.ServiceShutdownListener;
 import io.pravega.common.segment.StreamSegmentNameUtils;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.server.ContainerMetadata;
+import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
+import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.TestStorage;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
-import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
-import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
-import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
-import io.pravega.segmentstore.server.DataCorruptionException;
-import io.pravega.segmentstore.server.EvictableMetadata;
-import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
+import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
 import io.pravega.segmentstore.server.logs.operations.TransactionMapOperation;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
@@ -52,11 +52,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the StorageWriter class.
@@ -78,7 +79,9 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             .with(WriterConfig.ERROR_SLEEP_MILLIS, 0L)
             .build();
 
-    private static final Duration TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -28,7 +28,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for BookKeeperLog. These require that a compiled BookKeeper distribution exists on the local
@@ -44,6 +46,8 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
 
     private static final AtomicReference<BookKeeperServiceRunner> BK_SERVICE = new AtomicReference<>();
     private static final AtomicInteger BK_PORT = new AtomicInteger();
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
     private final AtomicReference<BookKeeperConfig> config = new AtomicReference<>();
     private final AtomicReference<CuratorFramework> zkClient = new AtomicReference<>();
     private final AtomicReference<BookKeeperLogFactory> factory = new AtomicReference<>();
@@ -124,7 +128,7 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
         }
     }
 
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testCreateDefaultConfig() throws Exception {
         BookKeeperConfig bkConfig = BookKeeperConfig
                 .builder()

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ConcatOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ConcatOperationTests.java
@@ -19,7 +19,9 @@ import lombok.Cleanup;
 import lombok.val;
 import org.apache.hadoop.hdfs.protocol.AclException;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the ConcatOperation class.
@@ -28,12 +30,14 @@ public class ConcatOperationTests extends FileSystemOperationTestBase {
     private static final String TARGET_SEGMENT = "target" + FileSystemOperation.PART_SEPARATOR + "segment";
     private static final String SOURCE_SEGMENT = "source" + FileSystemOperation.PART_SEPARATOR + "segment#1234";
     private static final int WRITE_LENGTH = 100;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
     private final Random rnd = new Random(0);
 
     /**
      * Tests various combinations of bad input to the Concat command.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testInvalidInput() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -74,7 +78,7 @@ public class ConcatOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests a normal concatenation for single-file sources.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcatSingleFile() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -100,7 +104,7 @@ public class ConcatOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests a normal concatenation for empty source segment.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcatEmptySource() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -120,7 +124,7 @@ public class ConcatOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests a normal concatenation for empty target segment (files).
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcatEmptyTarget() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -139,7 +143,7 @@ public class ConcatOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests a normal concatenation for multi-file sources.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcatMultipleFiles() throws Exception {
         final int epochs = 50;
         @Cleanup

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperationTests.java
@@ -16,19 +16,23 @@ import lombok.val;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the CreateOperation class.
  */
 public class CreateOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests CreateOperation with no fencing involved. Verifies basic segment creation works, as well as rejection in
      * case the segment already exists.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNormalCall() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -53,7 +57,7 @@ public class CreateOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests CreateOperation with fencing resolution for lower-epoch creation.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testLowerEpochFencedOut() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -73,7 +77,7 @@ public class CreateOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests CreateOperation with fencing resolution for concurrent operations.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcurrentFencedOut() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/DeleteOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/DeleteOperationTests.java
@@ -16,7 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the DeleteOperation class.
@@ -24,11 +26,13 @@ import org.junit.Test;
 public class DeleteOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
     private static final int FILE_COUNT = 10;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests the ability to delete segments without outside interference.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNormalDelete() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -49,7 +53,7 @@ public class DeleteOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests the ability to delete segment when an outside interference happens.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcurrentDelete() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ExistsOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ExistsOperationTests.java
@@ -14,19 +14,23 @@ import lombok.Cleanup;
 import lombok.val;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests the ExistsOperation class.
  */
 public class ExistsOperationTests extends FileSystemOperationTestBase {
     // We introduce the separator into the name here, to make sure we can still extract the values correctly from there.
-    private static final String SEGMENT_NAME = "segment"+FileSystemOperation.PART_SEPARATOR+"segment";
+    private static final String SEGMENT_NAME = "segment" + FileSystemOperation.PART_SEPARATOR + "segment";
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests the ExistsOperation in various scenarios.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testExists() throws Exception {
         final int epoch = 1;
         final int offset = 0;

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/FileDescriptorTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/FileDescriptorTests.java
@@ -12,16 +12,21 @@ package io.pravega.segmentstore.storage.impl.hdfs;
 import io.pravega.test.common.AssertExtensions;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the FileDescriptor class.
  */
 public class FileDescriptorTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
+
     /**
      * Tests the ability to change read-only status and lengths.
      */
-    @Test(timeout = 10000)
+    @Test
     public void testMutators() {
         FileDescriptor fd = new FileDescriptor(new Path("foo"), 1, 2, 3, false);
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/FileSystemOperationTestBase.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/FileSystemOperationTestBase.java
@@ -22,8 +22,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
  * Base class for all tests for derived classes from FileSystemOperation.
  */
 abstract class FileSystemOperationTestBase {
-    protected static final int TEST_TIMEOUT_MILLIS = 30 * 1000;
-
+    protected static final int TIMEOUT_SECONDS = 30;
     static TestContext newContext(long epoch, MockFileSystem fileSystem) {
         return new TestContext(epoch, fileSystem);
     }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperationTests.java
@@ -16,7 +16,9 @@ import java.io.FileNotFoundException;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests the GetInfoOperation class.
@@ -24,11 +26,13 @@ import org.junit.Test;
 public class GetInfoOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
     private static final int WRITE_COUNT = 10;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests general GetInfoOperation behavior.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testGetInfo() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -64,7 +68,7 @@ public class GetInfoOperationTests extends FileSystemOperationTestBase {
     /**
      * Tests the behavior of the GetInfoOperation on a segment that is missing the first file.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testCorruptedSegment() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSSegmentHandleTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSSegmentHandleTests.java
@@ -14,12 +14,17 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.val;
 import org.apache.hadoop.fs.Path;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for HDFSSegmentHandle.
  */
 public class HDFSSegmentHandleTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
     /**
      * Tests the ability to replace files in a handle.
      */

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
@@ -14,8 +14,8 @@ import ch.qos.logback.classic.LoggerContext;
 import io.pravega.common.io.FileHelpers;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
-import io.pravega.segmentstore.storage.StorageTestBase;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.segmentstore.storage.StorageTestBase;
 import io.pravega.test.common.AssertExtensions;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.concurrent.Executor;
-
 import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.hadoop.conf.Configuration;
@@ -38,13 +37,17 @@ import org.apache.hadoop.util.Progressable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.LoggerFactory;
 
 /**
  * Unit tests for HDFSStorage.
  */
 public class HDFSStorageTest extends StorageTestBase {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
     private File baseDir = null;
     private MiniDFSCluster hdfsCluster = null;
     private HDFSStorageConfig adapterConfig;

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/OpenReadOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/OpenReadOperationTests.java
@@ -16,7 +16,9 @@ import java.util.List;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the OpenReadOperation class.
@@ -24,11 +26,13 @@ import org.junit.Test;
 public class OpenReadOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
     private static final int FILE_COUNT = 10;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests the OpenReadOperation.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testOpenRead() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/OpenWriteOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/OpenWriteOperationTests.java
@@ -17,19 +17,23 @@ import lombok.Cleanup;
 import lombok.val;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the OpenWriteOperation class
  */
 public class OpenWriteOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests the case when the last file has en epoch larger than ours.
      * Expected outcome: StorageNotPrimaryException and no side effects.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testLargerEpoch() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -51,7 +55,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the last file is read-only and sealed.
      * Expected outcome: Return a read-only handle and no side effects.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testReadOnlySealed() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -74,7 +78,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the last file is read only but not sealed.
      * Expected outcome: Create new read-write file; don't touch other files.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testReadOnlyNotSealed() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -96,7 +100,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the last file is not read only, but it has the same epoch as us.
      * Expected outcome: reuse last file and no side effects.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNotReadOnlySameEpoch() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -116,7 +120,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the last file is not read-only, and it has lower epoch than us.
      * Expected outcome: Make last file read-only and create new one.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNotReadOnlySmallerEpoch() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -131,7 +135,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * it was beaten to it by a higher epoch instance.
      * Expected outcome: StorageNotPrimaryException and no side effects (it should back off).
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcurrentFenceOutLower() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -159,7 +163,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * that a lower-epoch file was also created.
      * Expected outcome: succeed and delete the file.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testConcurrentFenceOutHigher() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -182,7 +186,7 @@ public class OpenWriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the OpenWriteOperation needs to consolidate multiple files of the same segment into fewer by
      * means of concatenation.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testMultiFileCoalescing() throws Exception {
         final int iterations = Byte.MAX_VALUE;
         final int emptyFileEvery = 10;

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ReadOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/ReadOperationTests.java
@@ -14,11 +14,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.util.Random;
-
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the ReadOperation class.
@@ -28,11 +29,13 @@ public class ReadOperationTests extends FileSystemOperationTestBase {
     private static final int FILE_COUNT = 10;
     private static final int WRITES_PER_FILE = 10;
     private static final int WRITE_SIZE = 100;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests a read scenario with no issues or failures.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNormalRead() throws Exception {
         // Write data.
         val rnd = new Random(0);
@@ -73,7 +76,7 @@ public class ReadOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the handle has become stale and needs refreshing (triggered by call to offset+length beyond
      * current known limits).
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testRefreshHandleOffset() throws Exception {
         val rnd = new Random(0);
         @Cleanup
@@ -115,7 +118,7 @@ public class ReadOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the handle has become stale due to the segment having been compacted externally. The read operation
      * should refresh the handle and continue working as expected.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testRefreshHandleMissingFile() throws Exception {
         val rnd = new Random(0);
         @Cleanup

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/SealOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/SealOperationTests.java
@@ -15,19 +15,23 @@ import java.io.ByteArrayInputStream;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the SealOperation class.
  */
 public class SealOperationTests extends FileSystemOperationTestBase {
     private static final String SEGMENT_NAME = "segment";
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests the case when the last file is non-empty non-read-only. This is a normal operation.
      * Expected outcome: Last file is made read-only and marked as 'sealed'.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testLastFileNonReadOnly() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -45,7 +49,7 @@ public class SealOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the last file is empty (read-only or not).
      * Expected outcome: Last file is deleted and previous one is set as sealed (except when only one file)
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testLastFileEmpty() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -79,7 +83,7 @@ public class SealOperationTests extends FileSystemOperationTestBase {
      * fenced out by a higher-epoch instance.
      * Expected outcome: StorageNotPrimaryException.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testLastFileEmptyNonReadOnlyFencedOut() throws Exception {
         final String emptySegment = SEGMENT_NAME;
         final String nonEmptySegment = SEGMENT_NAME + "nonempty";

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/WriteOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/WriteOperationTests.java
@@ -19,7 +19,9 @@ import java.util.Random;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the WriteOperation class.
@@ -29,11 +31,13 @@ public class WriteOperationTests extends FileSystemOperationTestBase {
     private static final int FILE_COUNT = 10;
     private static final int WRITES_PER_FILE = 10;
     private static final int WRITE_SIZE = 100;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
 
     /**
      * Tests a normal write across many epochs.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testNormalWrite() throws Exception {
         val rnd = new Random(0);
         @Cleanup
@@ -92,7 +96,7 @@ public class WriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the current file (previously empty) has disappeared due to it being fenced out.
      * Expected behavior: StorageNotPrimaryException with no side effects.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testFenceOutMissingFile() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();
@@ -116,7 +120,7 @@ public class WriteOperationTests extends FileSystemOperationTestBase {
      * Tests the case when the current file (non-empty) has been marked as read-only due to it being fenced out.
      * Expected behavior: StorageNotPrimaryException with no side effects.
      */
-    @Test (timeout = TEST_TIMEOUT_MILLIS)
+    @Test
     public void testFenceOutReadOnlyFile() throws Exception {
         @Cleanup
         val fs = new MockFileSystem();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheTests.java
@@ -9,19 +9,22 @@
  */
 package io.pravega.segmentstore.storage.impl.rocksdb;
 
+import com.google.common.io.Files;
 import io.pravega.segmentstore.storage.Cache;
 import io.pravega.segmentstore.storage.CacheTestBase;
-import com.google.common.io.Files;
 import java.io.File;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for RocksDBCache.
  */
 public class RocksDBCacheTests extends CacheTestBase {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
     private final AtomicReference<File> tempDir = new AtomicReference<>();
     private final AtomicReference<RocksDBConfig> config = new AtomicReference<>();
     private final AtomicReference<RocksDBCacheFactory> factory = new AtomicReference<>();

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
@@ -34,8 +34,7 @@ import org.junit.Test;
  * Base class for all tests for implementations of DurableDataLog.
  */
 public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
-    protected static final int TIMEOUT_MILLIS = 60 * 1000;
-    protected static final Duration TIMEOUT = Duration.ofMillis(TIMEOUT_MILLIS);
+    protected static final Duration TIMEOUT = Duration.ofMillis(60 * 1000);
     protected static final int WRITE_MIN_LENGTH = 20;
     protected static final int WRITE_MAX_LENGTH = 200;
     private final Random random = new Random(0);
@@ -47,7 +46,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testAppendSequence() throws Exception {
         try (DurableDataLog log = createDurableDataLog()) {
             // Check Append pre-initialization.
@@ -78,7 +77,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testAppendParallel() throws Exception {
         try (DurableDataLog log = createDurableDataLog()) {
             log.initialize(TIMEOUT);
@@ -90,7 +89,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
                 appendFutures.add(log.append(new ByteArraySegment(getWriteData()), TIMEOUT));
             }
 
-            val results = FutureHelpers.allOfWithResults(appendFutures).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            val results = FutureHelpers.allOfWithResults(appendFutures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             for (int i = 0; i < results.size(); i++) {
                 LogAddress address = results.get(i);
                 Assert.assertNotNull("No address returned from append() for index " + i, address);
@@ -107,7 +106,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testRead() throws Exception {
         TreeMap<LogAddress, byte[]> writeData;
         Object context = createSharedContext();
@@ -134,7 +133,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testTruncate() throws Exception {
         TreeMap<LogAddress, byte[]> writeData;
         ArrayList<LogAddress> addresses;
@@ -167,7 +166,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testConcurrentIterator() throws Exception {
         try (DurableDataLog log = createDurableDataLog()) {
             log.initialize(TIMEOUT);
@@ -194,7 +193,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If one got thrown.
      */
-    @Test(timeout = TIMEOUT_MILLIS)
+    @Test
     public void testOpenCloseClient() throws Exception {
         // This is a very repetitive test; and we only care about "recovery" from no client; all else is already tested.
         final int writeCount = 10;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -35,7 +35,7 @@ import static io.pravega.test.common.AssertExtensions.assertThrows;
 public abstract class StorageTestBase extends ThreadPooledTestSuite {
     //region General Test arguments
 
-    protected static final Duration TIMEOUT = Duration.ofSeconds(10);
+    protected static final Duration TIMEOUT = Duration.ofSeconds(30);
     protected static final long DEFAULT_EPOCH = 1;
     protected static final int APPENDS_PER_SEGMENT = 10;
     private static final int SEGMENT_COUNT = 4;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheTests.java
@@ -13,11 +13,15 @@ import io.pravega.segmentstore.storage.Cache;
 import io.pravega.segmentstore.storage.CacheTestBase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for InMemoryCache.
  */
 public class InMemoryCacheTests extends CacheTestBase {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
     private InMemoryCacheFactory factory;
 
     @Before

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
@@ -11,20 +11,24 @@ package io.pravega.segmentstore.storage.mocks;
 
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.storage.DurableDataLog;
-import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.DurableDataLogTestBase;
+import io.pravega.segmentstore.storage.LogAddress;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for InMemoryDurableDataLog.
  */
 public class InMemoryDurableDataLogTests extends DurableDataLogTestBase {
     private static final int WRITE_COUNT = 1000;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
     private final Supplier<Integer> nextContainerId = new AtomicInteger()::incrementAndGet;
     private InMemoryDurableDataLogFactory factory;
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageTests.java
@@ -13,9 +13,9 @@ import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.TruncateableStorage;
 import io.pravega.segmentstore.storage.TruncateableStorageTestBase;
-import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.test.common.AssertExtensions;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -27,12 +27,16 @@ import lombok.val;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for InMemoryStorage
  */
 public class InMemoryStorageTests extends TruncateableStorageTestBase {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
     private InMemoryStorageFactory factory;
 
     @Before


### PR DESCRIPTION
**Change log description**
Added unit tests for all SegmentStore unit tests that were missing that. Updated existing ones to be consistent.

**Purpose of the change**
Fixes #517.

**What the code does**
Same thing.

**How to verify it**
Build must pass.