### PR TITLE
Issue 1375: Changes to TimeoutServiceTest.testPingFailureMaxExecutionTimeExceeded

### DIFF
--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -322,6 +322,7 @@ public class TimeoutServiceTest {
         TxnStatus status = streamStore.transactionStatus(SCOPE, STREAM, txData.getId(), null, executor).join();
         Assert.assertEquals(TxnStatus.OPEN, status);
 
+        // 3 * LEASE > MAX_EXECUTION_TIME
         PingTxnStatus pingStatus = timeoutService.pingTxn(SCOPE, STREAM, txData.getId(), 3 * LEASE);
         Assert.assertEquals(PingTxnStatus.Status.MAX_EXECUTION_TIME_EXCEEDED, pingStatus.getStatus());
 
@@ -338,6 +339,7 @@ public class TimeoutServiceTest {
         TxnState txnState = controllerService.checkTransactionStatus(SCOPE, STREAM, txnId).join();
         Assert.assertEquals(TxnState.State.OPEN, txnState.getState());
 
+        // 3 * LEASE > MAX_EXECUTION_TIME
         PingTxnStatus pingStatus = controllerService.pingTransaction(SCOPE, STREAM, txnId, 3 * LEASE).join();
         Assert.assertEquals(PingTxnStatus.Status.MAX_EXECUTION_TIME_EXCEEDED, pingStatus.getStatus());
 


### PR DESCRIPTION
**Change log description**
Existing TimeoutServiceTest.testPingFailureMaxExecutionTimeExceeded attempts to fail lease renewal by supplying a lease value to pingTxn API that exceeds maxExecutionTime by 1ms. This test fails intermittently if pingTxn API gets executed 1ms before expectation. Fixing this problem by supplying a lease value that exceeds maxExecutionTime by much more than 1ms.

**Purpose of the change**
Fixes #1375 

**What the code does**
As described above.

**How to verify it**
Test cases in TimeoutServiceTest.