### PR TITLE
Issue 1428: Fix duplicate Segment Id bug

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -170,7 +170,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
         synchronized (this.lock) {
             validateNewMapping(streamSegmentName, streamSegmentId);
             StreamSegmentMetadata parentMetadata = this.metadataById.getOrDefault(parentStreamSegmentId, null);
-            Exceptions.checkArgument(parentMetadata != null, "parentStreamSegmentId", "Invalid Parent Stream Id.");
+            Exceptions.checkArgument(parentMetadata != null, "parentStreamSegmentId", "Invalid Parent Segment Id.");
             Exceptions.checkArgument(!parentMetadata.isTransaction(), "parentStreamSegmentId", "Cannot create a Transaction for another Transaction.");
 
             segmentMetadata = new StreamSegmentMetadata(streamSegmentName, streamSegmentId, parentStreamSegmentId, getContainerId());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -500,7 +500,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         // The ContainerMetadata.SequenceNumber is always guaranteed to be unique (it's monotonically strict increasing).
         // It can be safely used as a new unique Segment Id. If any clashes occur, just keep searching up until we find
         // a non-used one.
-        long segmentId = Math.max(this.realMetadata.getOperationSequenceNumber(), ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER);
+        long segmentId = this.realMetadata.getOperationSequenceNumber();
         while (this.newSegments.containsKey(segmentId) || this.baseMetadata.getStreamSegmentMetadata(segmentId) != null) {
             segmentId++;
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -129,6 +129,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
 
     @Override
     public long getOperationSequenceNumber() {
+        Preconditions.checkState(!isRecoveryMode(), "GetOperationSequenceNumber cannot be invoked in recovery mode.");
         return this.realMetadata.getOperationSequenceNumber();
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -114,13 +114,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         this.newTruncationPoints = new ArrayList<>();
         this.newSegments = new HashMap<>();
         this.newSegmentNames = new HashMap<>();
-        if (baseMetadata.isRecoveryMode()) {
-            this.newSequenceNumber = ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER;
-        } else {
-            this.newSequenceNumber = Long.MIN_VALUE;
-        }
-
         this.sealed = false;
+        resetNewSequenceNumber();
     }
 
     //endregion
@@ -134,7 +129,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
 
     @Override
     public long getOperationSequenceNumber() {
-        return this.newSequenceNumber;
+        return this.realMetadata.getOperationSequenceNumber();
     }
 
     @Override
@@ -197,11 +192,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         this.baseMetadata = baseMetadata;
         this.maximumActiveSegmentCount = baseMetadata.getMaximumActiveSegmentCount();
         this.baseActiveSegmentCount = baseMetadata.getActiveSegmentCount();
-        if (this.baseMetadata.isRecoveryMode()) {
-            this.newSequenceNumber = ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER;
-        } else {
-            this.newSequenceNumber = Long.MIN_VALUE;
-        }
+        resetNewSequenceNumber();
     }
 
     /**
@@ -219,8 +210,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 target.reset();
             }
 
-            // Reset cleaned up the Operation Sequence number. We need to reset it to whatever we have in our transaction.
-            // If we have nothing, we'll just set it to 0, which is what the default value was in the metadata too.
+            // RecoverableMetadata.reset() cleaned up the Operation Sequence number. We need to set it back to whatever
+            // we have in our UpdateTransaction. If we have nothing, we'll just set it to the default.
             assert this.newSequenceNumber >= ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER
                     : "Invalid Sequence Number " + this.newSequenceNumber;
             target.setOperationSequenceNumber(this.newSequenceNumber);
@@ -260,6 +251,10 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         this.newSegmentNames.clear();
         this.newTruncationPoints.clear();
         this.processedCheckpoint = false;
+        resetNewSequenceNumber();
+    }
+
+    private void resetNewSequenceNumber() {
         if (this.baseMetadata.isRecoveryMode()) {
             this.newSequenceNumber = ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER;
         } else {
@@ -505,11 +500,12 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         // The ContainerMetadata.SequenceNumber is always guaranteed to be unique (it's monotonically strict increasing).
         // It can be safely used as a new unique Segment Id. If any clashes occur, just keep searching up until we find
         // a non-used one.
-        long segmentId = Math.max(this.baseMetadata.getOperationSequenceNumber(), ContainerMetadata.NO_STREAM_SEGMENT_ID + 1);
+        long segmentId = Math.max(this.realMetadata.getOperationSequenceNumber(), ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER);
         while (this.newSegments.containsKey(segmentId) || this.baseMetadata.getStreamSegmentMetadata(segmentId) != null) {
             segmentId++;
         }
 
+        assert segmentId >= ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER : "Invalid generated SegmentId";
         return segmentId;
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -15,8 +15,8 @@ import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.server.ContainerMetadata;
+import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
-import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -161,7 +161,7 @@ public class OperationMetadataUpdaterTests {
      */
     @Test
     public void testRollback() throws Exception {
-        // 2 out of 3 transactions are failed (to verify multi-failure).
+        // 2 out of 3 UpdateTransactions are failed (to verify multi-failure).
         // Commit the rest and verify final metadata is as it should.
         final int failEvery = 3;
         Predicate<Integer> isIgnored = index -> index % failEvery > 0;
@@ -267,10 +267,11 @@ public class OperationMetadataUpdaterTests {
             // Seal&Merge the transaction created in the previous UpdateTransaction
             sealSegment(lastSegmentTxnId.get(), updater, referenceMetadata);
             mergeTransaction(lastSegmentTxnId.get(), updater, referenceMetadata);
+            lastSegmentTxnId.set(-1); // Txn has been merged - so it doesn't exist anymore.
         }
 
         if (referenceMetadata != null) {
-            // Don't remember these segment ids if we're going to be tossing them away.
+            // Don't remember any of these changes if we're going to be tossing them away.
             lastSegmentId.set(segmentId);
             lastSegmentTxnId.set(txnId);
         }
@@ -282,28 +283,18 @@ public class OperationMetadataUpdaterTests {
 
     private UpdateableContainerMetadata clone(ContainerMetadata base) {
         val metadata = createBlankMetadata();
-        for (long segmentId : base.getAllStreamSegmentIds()) {
-            val bsm = base.getStreamSegmentMetadata(segmentId);
-            UpdateableSegmentMetadata nsm;
-            if (bsm.isTransaction()) {
-                nsm = metadata.mapStreamSegmentId(bsm.getName(), bsm.getId(), bsm.getParentId());
-            } else {
-                nsm = metadata.mapStreamSegmentId(bsm.getName(), bsm.getId());
-            }
 
-            nsm.setDurableLogLength(bsm.getDurableLogLength());
-            nsm.setStorageLength(bsm.getStorageLength());
-            nsm.updateAttributes(bsm.getAttributes());
-            if (bsm.isSealed()) {
-                nsm.markSealed();
-            }
-            if (bsm.isMerged()) {
-                nsm.markMerged();
-            }
-            if (bsm.isSealedInStorage()) {
-                nsm.markSealedInStorage();
-            }
-        }
+        // First clone stand-alone (parent) Segments (since there may be Transactions mapped to them).
+        base.getAllStreamSegmentIds().stream()
+            .map(base::getStreamSegmentMetadata)
+            .filter(sm -> !sm.isTransaction())
+            .forEach(bsm -> metadata.mapStreamSegmentId(bsm.getName(), bsm.getId()).copyFrom(bsm));
+
+        // Then clone transactions.
+        base.getAllStreamSegmentIds().stream()
+            .map(base::getStreamSegmentMetadata)
+            .filter(SegmentMetadata::isTransaction)
+            .forEach(bsm -> metadata.mapStreamSegmentId(bsm.getName(), bsm.getId(), bsm.getParentId()).copyFrom(bsm));
 
         return metadata;
     }


### PR DESCRIPTION
**Change log description**
Fixed a bug in the ContainerMetadataUpdateTransaction that could potentially create duplicate Segment Ids. SegmentIds should be generated starting from the current Operation Sequence number (which guarantees a unique id to begin with), however due to a bug in the code, this was being generated off the newly assigned sequence number (which would only be set during recovery, and always starts off at `Long.MIN_VALUE`). This has been fixed to work as before.

**Purpose of the change**
Fixes #1428. Please refer to this issue's comments for the complete steps to repro the problem.

**What the code does**
Fixes a bug introduced by #1330 / #1391.

**How to verify it**
Look at the code, make sure unit tests pass. New assertion has been introduced to validate new segment id is a positive number.