### PR TITLE
Issue 1430: Add close to state synchronizer

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
@@ -12,7 +12,7 @@ package io.pravega.client.segment.impl;
 /**
  * A client for looking at and editing the metadata related to a specific segment.
  */
-public interface SegmentMetadataClient {
+public interface SegmentMetadataClient extends AutoCloseable {
     
     /**
      * Returns the length of the current segment. i.e. the total length of all data written to the segment.
@@ -37,5 +37,8 @@ public interface SegmentMetadataClient {
      * @return If the replacement occurred. (False if the attribute was not expectedValue)
      */
     abstract boolean compareAndSetAttribute(SegmentAttribute attribute, long expectedValue, long newValue);
+    
+    @Override
+    abstract void close();
     
 }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -15,6 +15,7 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.InvalidStreamException;
 import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.util.Retry;
 import io.pravega.common.util.Retry.RetryWithBackoff;
@@ -237,7 +238,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
     
     @Override
     public long fetchCurrentStreamLength() {
-        Preconditions.checkArgument(!closed.get(), "Already closed");
+        Exceptions.checkNotClosed(closed.get(), this);
         return RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class)
                              .throwingOn(InvalidStreamException.class)
                              .run(() -> {
@@ -268,7 +269,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
 
     @Override
     public void close() {
-        log.info("Closing segment metadata conncetion for {}", segmentId);
+        log.info("Closing segment metadata connection for {}", segmentId);
         if (closed.compareAndSet(false, true)) {
             closeConnection(new ConnectionClosedException());
         }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.client.segment.impl;
 
-import com.google.common.base.Preconditions;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.InvalidStreamException;
@@ -249,7 +248,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
     
     @Override
     public long fetchProperty(SegmentAttribute attribute) {
-        Preconditions.checkArgument(!closed.get(), "Already closed");
+        Exceptions.checkNotClosed(closed.get(), this);
         return RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class)
                 .throwingOn(InvalidStreamException.class)
                 .run(() -> {
@@ -259,7 +258,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
 
     @Override
     public boolean compareAndSetAttribute(SegmentAttribute attribute, long expectedValue, long newValue) {
-        Preconditions.checkArgument(!closed.get(), "Already closed");
+        Exceptions.checkNotClosed(closed.get(), this);
         return RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class)
                 .throwingOn(InvalidStreamException.class)
                 .run(() -> {

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -19,7 +19,7 @@ import java.util.Map.Entry;
  * A specific location can also be marked, which can also be updated with strong consistency. 
  * @param <T> The type of data written.
  */
-public interface RevisionedStreamClient<T> {
+public interface RevisionedStreamClient<T> extends AutoCloseable {
     
     /**
      * Returns the oldest revision than can be read.
@@ -74,5 +74,11 @@ public interface RevisionedStreamClient<T> {
      * @return true if it was successful. False if the mark was not the expected value.
      */
     boolean compareAndSetMark(Revision expected, Revision newLocation);
+    
+    /**
+     * @see java.lang.AutoCloseable#close()
+     */
+    @Override
+    abstract void close();
 
 }

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -76,6 +76,7 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
     boolean compareAndSetMark(Revision expected, Revision newLocation);
     
     /**
+     * Closes the client and frees any resources associated with it. (It may no longer be used)
      * @see java.lang.AutoCloseable#close()
      */
     @Override

--- a/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
+++ b/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
@@ -100,6 +100,7 @@ public interface StateSynchronizer<StateT extends Revisioned> extends AutoClosea
     
     
     /**
+     * Closes the StateSynchronizer and frees any resources associated with it. (It may no longer be used)
      * @see java.lang.AutoCloseable#close()
      */
     @Override

--- a/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
+++ b/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  * 
  * @param <StateT> The type of the object whose updates are being synchronized.
  */
-public interface StateSynchronizer<StateT extends Revisioned> {
+public interface StateSynchronizer<StateT extends Revisioned> extends AutoCloseable {
     
     /**
      * Gets the state object currently held in memory.
@@ -97,4 +97,11 @@ public interface StateSynchronizer<StateT extends Revisioned> {
      * @param compactor An generator of InitialUpdates given a state.
      */
     void compact(Function<StateT, InitialUpdate<StateT>> compactor);
+    
+    
+    /**
+     * @see java.lang.AutoCloseable#close()
+     */
+    @Override
+    abstract void close();
 }

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -171,4 +171,17 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
     public Revision fetchOldestRevision() {
         return new RevisionImpl(segment, 0, 0);
     }
+
+    @Override
+    public void close() {
+        synchronized (lock) {
+            try {
+                out.close();
+            } catch (SegmentSealedException e) {
+                log.warn("Error closing segment writer {}", out);
+            }
+            meta.close();
+            in.close();
+        }
+    }
 }

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -28,7 +28,7 @@ import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@ToString(of={"segment", "currentState"})
+@ToString(of = { "segment", "currentState" })
 public class StateSynchronizerImpl<StateT extends Revisioned>
         implements StateSynchronizer<StateT> {
 

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -23,10 +23,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Synchronized;
+import lombok.ToString;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@ToString(of={"segment", "currentState"})
 public class StateSynchronizerImpl<StateT extends Revisioned>
         implements StateSynchronizer<StateT> {
 
@@ -190,6 +192,12 @@ public class StateSynchronizerImpl<StateT extends Revisioned>
             log.trace("Updating new state to {} ", newValue.getRevision());
             currentState = newValue;
         }
+    }
+
+    @Override
+    public void close() {
+        log.info("Closing stateSynchronizer ", this);
+        client.close();
     }
 
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -213,6 +213,7 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
                     reader.close();
                 }
                 readers.clear();
+                groupState.close();
             }
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import lombok.Cleanup;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -62,6 +63,7 @@ public class ReaderGroupImpl implements ReaderGroup {
      */
     @VisibleForTesting
     public void initializeGroup(ReaderGroupConfig config, Set<String> streams) {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         Map<Segment, Long> segments = getSegmentsForStreams(streams);
         ReaderGroupStateManager.initializeReaderGroup(synchronizer, config, segments);
@@ -81,6 +83,7 @@ public class ReaderGroupImpl implements ReaderGroup {
 
     @Override
     public void readerOffline(String readerId, Position lastPosition) {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         ReaderGroupStateManager.readerShutdown(readerId, lastPosition, synchronizer);
     }
@@ -92,6 +95,7 @@ public class ReaderGroupImpl implements ReaderGroup {
 
     @Override
     public Set<String> getOnlineReaders() {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         synchronizer.fetchUpdates();
         return synchronizer.getState().getOnlineReaders();
@@ -99,6 +103,7 @@ public class ReaderGroupImpl implements ReaderGroup {
 
     @Override
     public CompletableFuture<Checkpoint> initiateCheckpoint(String checkpointName, ScheduledExecutorService backgroundExecutor) {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         synchronizer.updateStateUnconditionally(new CreateCheckpoint(checkpointName));
         AtomicBoolean checkpointPending = new AtomicBoolean(true);
@@ -128,6 +133,7 @@ public class ReaderGroupImpl implements ReaderGroup {
 
     @Override
     public void resetReadersToCheckpoint(Checkpoint checkpoint) {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         synchronizer.updateState(state -> {
             ReaderGroupConfig config = state.getConfig();
@@ -137,6 +143,7 @@ public class ReaderGroupImpl implements ReaderGroup {
 
     @Override
     public void alterConfig(ReaderGroupConfig config, Set<String> streamNames) {
+        @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         Map<Segment, Long> segments = getSegmentsForStreams(streamNames);
         synchronizer.updateStateUnconditionally(new ReaderGroupStateInit(config, segments));

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -144,6 +144,10 @@ public class ReaderGroupStateManager {
             return Collections.singletonList(new RemoveReader(readerId, lastPosition == null ? null : lastPosition.asImpl()));
         });
     }
+    
+    void close() {
+        sync.close();
+    }
 
     /**
      * Handles a segment being completed by calling the controller to gather all successors to the completed segment.

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -149,10 +149,14 @@ public class SynchronizerTest {
         public Revision fetchOldestRevision() {
             return new RevisionImpl(segment, 0, 0);
         }
+
+        @Override
+        public void close() { 
+        }
     }
 
     @Test(timeout = 20000)
-    public void testLocking() throws EndOfSegmentException {
+    public void testLocking() {
         String streamName = "streamName";
         String scope = "scope";
         Segment segment = new Segment(scope, streamName, 0);
@@ -162,6 +166,7 @@ public class SynchronizerTest {
 
         MockRevisionedStreamClient client = new MockRevisionedStreamClient();
         client.segment = segment;
+        @Cleanup
         StateSynchronizerImpl<RevisionedImpl> sync = new StateSynchronizerImpl<RevisionedImpl>(segment, client);
         client.init = new BlockingUpdate(0);
         client.updates = updates;

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -81,6 +81,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
                 streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                 new JavaSerializer<>(),
                 new JavaSerializer<>(),
@@ -122,6 +123,7 @@ public class ReaderGroupStateManagerTest {
         @Cleanup
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),
@@ -164,6 +166,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),
@@ -199,6 +202,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),
@@ -258,6 +262,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),
@@ -332,6 +337,7 @@ public class ReaderGroupStateManagerTest {
         @Cleanup
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),
@@ -430,6 +436,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
                                                             streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
         StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
                                                                                                       new JavaSerializer<>(),
                                                                                                       new JavaSerializer<>(),

--- a/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
@@ -97,8 +97,9 @@ public class StateSynchronizerTest {
         streamManager.createScope("scope");
         streamManager.createStream("scope", stateName, null);
         JavaSerializer<TestUpdate> serializer = new JavaSerializer<TestUpdate>();
-        
+        @Cleanup
         val a = streamManager.getClientFactory().createStateSynchronizer(stateName, serializer, serializer, SynchronizerConfig.builder().build());
+        @Cleanup
         val b = streamManager.getClientFactory().createStateSynchronizer(stateName, serializer, serializer, SynchronizerConfig.builder().build());
 
         a.initialize(new TestUpdate("init"));


### PR DESCRIPTION
**Change log description**
* Adds a close method to cleanup connections in RevisionedStreamClient and in StateSynchronizer on top of it. 
* Invokes these methods everywhere these classes are being used and the connections were not being cleaned up.

**Purpose of the change**
Fixes #1430 

**What the code does**
Adds a close method to StateSynchronizer and RevisionedStreamClient

**How to verify it**
Close calls were added to the tests using these classes. All tests pass.