### PR TITLE
Issue 1361: GetScalingEvents REST API

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApi.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApi.java
@@ -11,6 +11,7 @@ import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
 import io.pravega.controller.server.rest.generated.model.ScopeProperty;
 import io.pravega.controller.server.rest.generated.model.CreateStreamRequest;
 import io.pravega.controller.server.rest.generated.model.StreamProperty;
+import io.pravega.controller.server.rest.generated.model.ScalingEventList;
 import io.pravega.controller.server.rest.generated.model.ScopesList;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
@@ -108,6 +109,25 @@ public class ScopesApi  {
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteStream(scopeName,streamName,securityContext);
+    }
+    @GET
+    @Path("/{scopeName}/streams/{streamName}/scaling-events")
+    
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "", notes = "Get scaling events for a given datetime period.", response = ScalingEventList.class, tags={  })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "List of scaling events", response = ScalingEventList.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Scope/Stream not found", response = ScalingEventList.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server error", response = ScalingEventList.class) })
+    public Response getScalingEvents(@ApiParam(value = "Scope name",required=true) @PathParam("scopeName") String scopeName
+,@ApiParam(value = "Stream name",required=true) @PathParam("streamName") String streamName
+,@ApiParam(value = "Parameter to display scaling events from that particular datetime. Input should be milliseconds from Jan 1 1970.",required=true) @QueryParam("from") Long from
+,@ApiParam(value = "Parameter to display scaling events to that particular datetime. Input should be milliseconds from Jan 1 1970.",required=true) @QueryParam("to") Long to
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.getScalingEvents(scopeName,streamName,from,to,securityContext);
     }
     @GET
     @Path("/{scopeName}")

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApiService.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApiService.java
@@ -9,6 +9,7 @@ import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
 import io.pravega.controller.server.rest.generated.model.ScopeProperty;
 import io.pravega.controller.server.rest.generated.model.CreateStreamRequest;
 import io.pravega.controller.server.rest.generated.model.StreamProperty;
+import io.pravega.controller.server.rest.generated.model.ScalingEventList;
 import io.pravega.controller.server.rest.generated.model.ScopesList;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
@@ -28,6 +29,7 @@ public abstract class ScopesApiService {
     public abstract Response createStream(String scopeName,CreateStreamRequest createStreamRequest,SecurityContext securityContext) throws NotFoundException;
     public abstract Response deleteScope(String scopeName,SecurityContext securityContext) throws NotFoundException;
     public abstract Response deleteStream(String scopeName,String streamName,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response getScalingEvents(String scopeName,String streamName,Long from,Long to,SecurityContext securityContext) throws NotFoundException;
     public abstract Response getScope(String scopeName,SecurityContext securityContext) throws NotFoundException;
     public abstract Response getStream(String scopeName,String streamName,SecurityContext securityContext) throws NotFoundException;
     public abstract Response listScopes(SecurityContext securityContext) throws NotFoundException;

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/api/impl/ScopesApiServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/api/impl/ScopesApiServiceImpl.java
@@ -7,6 +7,7 @@ import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
 import io.pravega.controller.server.rest.generated.model.ScopeProperty;
 import io.pravega.controller.server.rest.generated.model.CreateStreamRequest;
 import io.pravega.controller.server.rest.generated.model.StreamProperty;
+import io.pravega.controller.server.rest.generated.model.ScalingEventList;
 import io.pravega.controller.server.rest.generated.model.ScopesList;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
@@ -41,6 +42,11 @@ public class ScopesApiServiceImpl extends ScopesApiService {
     }
     @Override
     public Response deleteStream(String scopeName, String streamName, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
+    public Response getScalingEvents(String scopeName, String streamName, Long from, Long to, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/model/ScaleMetadata.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/model/ScaleMetadata.java
@@ -1,0 +1,106 @@
+package io.pravega.controller.server.rest.generated.model;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.pravega.controller.server.rest.generated.model.Segment;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+
+/**
+ * ScaleMetadata
+ */
+
+public class ScaleMetadata   {
+  private Long timestamp = null;
+
+  private List<Segment> segmentList = new ArrayList<Segment>();
+
+  public ScaleMetadata timestamp(Long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+   /**
+   * Get timestamp
+   * @return timestamp
+  **/
+  @ApiModelProperty(value = "")
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public ScaleMetadata segmentList(List<Segment> segmentList) {
+    this.segmentList = segmentList;
+    return this;
+  }
+
+  public ScaleMetadata addSegmentListItem(Segment segmentListItem) {
+    this.segmentList.add(segmentListItem);
+    return this;
+  }
+
+   /**
+   * Get segmentList
+   * @return segmentList
+  **/
+  @ApiModelProperty(value = "")
+  public List<Segment> getSegmentList() {
+    return segmentList;
+  }
+
+  public void setSegmentList(List<Segment> segmentList) {
+    this.segmentList = segmentList;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ScaleMetadata scaleMetadata = (ScaleMetadata) o;
+    return Objects.equals(this.timestamp, scaleMetadata.timestamp) &&
+        Objects.equals(this.segmentList, scaleMetadata.segmentList);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(timestamp, segmentList);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ScaleMetadata {\n");
+    
+    sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    segmentList: ").append(toIndentedString(segmentList)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/model/ScalingEventList.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/model/ScalingEventList.java
@@ -1,0 +1,84 @@
+package io.pravega.controller.server.rest.generated.model;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.pravega.controller.server.rest.generated.model.ScaleMetadata;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+
+/**
+ * ScalingEventList
+ */
+
+public class ScalingEventList   {
+  private List<ScaleMetadata> scalingEvents = new ArrayList<ScaleMetadata>();
+
+  public ScalingEventList scalingEvents(List<ScaleMetadata> scalingEvents) {
+    this.scalingEvents = scalingEvents;
+    return this;
+  }
+
+  public ScalingEventList addScalingEventsItem(ScaleMetadata scalingEventsItem) {
+    this.scalingEvents.add(scalingEventsItem);
+    return this;
+  }
+
+   /**
+   * Get scalingEvents
+   * @return scalingEvents
+  **/
+  @ApiModelProperty(value = "")
+  public List<ScaleMetadata> getScalingEvents() {
+    return scalingEvents;
+  }
+
+  public void setScalingEvents(List<ScaleMetadata> scalingEvents) {
+    this.scalingEvents = scalingEvents;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ScalingEventList scalingEventList = (ScalingEventList) o;
+    return Objects.equals(this.scalingEvents, scalingEventList.scalingEvents);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scalingEvents);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ScalingEventList {\n");
+    
+    sb.append("    scalingEvents: ").append(toIndentedString(scalingEvents)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/model/Segment.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/model/Segment.java
@@ -16,7 +16,7 @@ import io.swagger.annotations.ApiModelProperty;
 public class Segment   {
   private Integer number = null;
 
-  private Long start = null;
+  private Long startTime = null;
 
   private Integer keyStart = null;
 
@@ -40,22 +40,22 @@ public class Segment   {
     this.number = number;
   }
 
-  public Segment start(Long start) {
-    this.start = start;
+  public Segment startTime(Long startTime) {
+    this.startTime = startTime;
     return this;
   }
 
    /**
-   * Get start
-   * @return start
+   * Get startTime
+   * @return startTime
   **/
   @ApiModelProperty(value = "")
-  public Long getStart() {
-    return start;
+  public Long getStartTime() {
+    return startTime;
   }
 
-  public void setStart(Long start) {
-    this.start = start;
+  public void setStartTime(Long startTime) {
+    this.startTime = startTime;
   }
 
   public Segment keyStart(Integer keyStart) {
@@ -105,14 +105,14 @@ public class Segment   {
     }
     Segment segment = (Segment) o;
     return Objects.equals(this.number, segment.number) &&
-        Objects.equals(this.start, segment.start) &&
+        Objects.equals(this.startTime, segment.startTime) &&
         Objects.equals(this.keyStart, segment.keyStart) &&
         Objects.equals(this.keyEnd, segment.keyEnd);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(number, start, keyStart, keyEnd);
+    return Objects.hash(number, startTime, keyStart, keyEnd);
   }
 
   @Override
@@ -121,7 +121,7 @@ public class Segment   {
     sb.append("class Segment {\n");
     
     sb.append("    number: ").append(toIndentedString(number)).append("\n");
-    sb.append("    start: ").append(toIndentedString(start)).append("\n");
+    sb.append("    startTime: ").append(toIndentedString(startTime)).append("\n");
     sb.append("    keyStart: ").append(toIndentedString(keyStart)).append("\n");
     sb.append("    keyEnd: ").append(toIndentedString(keyEnd)).append("\n");
     sb.append("}");

--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/model/Segment.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/model/Segment.java
@@ -1,0 +1,142 @@
+package io.pravega.controller.server.rest.generated.model;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+
+
+
+/**
+ * Segment
+ */
+
+public class Segment   {
+  private Integer number = null;
+
+  private Long start = null;
+
+  private Integer keyStart = null;
+
+  private Integer keyEnd = null;
+
+  public Segment number(Integer number) {
+    this.number = number;
+    return this;
+  }
+
+   /**
+   * Get number
+   * @return number
+  **/
+  @ApiModelProperty(value = "")
+  public Integer getNumber() {
+    return number;
+  }
+
+  public void setNumber(Integer number) {
+    this.number = number;
+  }
+
+  public Segment start(Long start) {
+    this.start = start;
+    return this;
+  }
+
+   /**
+   * Get start
+   * @return start
+  **/
+  @ApiModelProperty(value = "")
+  public Long getStart() {
+    return start;
+  }
+
+  public void setStart(Long start) {
+    this.start = start;
+  }
+
+  public Segment keyStart(Integer keyStart) {
+    this.keyStart = keyStart;
+    return this;
+  }
+
+   /**
+   * Get keyStart
+   * @return keyStart
+  **/
+  @ApiModelProperty(value = "")
+  public Integer getKeyStart() {
+    return keyStart;
+  }
+
+  public void setKeyStart(Integer keyStart) {
+    this.keyStart = keyStart;
+  }
+
+  public Segment keyEnd(Integer keyEnd) {
+    this.keyEnd = keyEnd;
+    return this;
+  }
+
+   /**
+   * Get keyEnd
+   * @return keyEnd
+  **/
+  @ApiModelProperty(value = "")
+  public Integer getKeyEnd() {
+    return keyEnd;
+  }
+
+  public void setKeyEnd(Integer keyEnd) {
+    this.keyEnd = keyEnd;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Segment segment = (Segment) o;
+    return Objects.equals(this.number, segment.number) &&
+        Objects.equals(this.start, segment.start) &&
+        Objects.equals(this.keyStart, segment.keyStart) &&
+        Objects.equals(this.keyEnd, segment.keyEnd);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(number, start, keyStart, keyEnd);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Segment {\n");
+    
+    sb.append("    number: ").append(toIndentedString(number)).append("\n");
+    sb.append("    start: ").append(toIndentedString(start)).append("\n");
+    sb.append("    keyStart: ").append(toIndentedString(keyStart)).append("\n");
+    sb.append("    keyEnd: ").append(toIndentedString(keyEnd)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -444,7 +444,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                 ScaleMetadata scaleMetadata = metadataIterator.next();
                 if (scaleMetadata.getTimestamp() >= from && scaleMetadata.getTimestamp() <= to) {
                     finalScaleMetadataList.add(scaleMetadata);
-                } else if (scaleMetadata.getTimestamp() < from && scaleMetadata.getTimestamp() < to) {
+                } else if (scaleMetadata.getTimestamp() < from) {
                     // This check is required to store a reference event i.e. an event before the 'from' datetime
                     referenceEvent = scaleMetadata;
                 } else {

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -440,6 +440,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
 
             // referenceEvent is the Event used as reference for the events between 'from' and 'to'.
             ScaleMetadata referenceEvent = null;
+
             while (metadataIterator.hasNext()) {
                 ScaleMetadata scaleMetadata = metadataIterator.next();
                 if (scaleMetadata.getTimestamp() >= from && scaleMetadata.getTimestamp() <= to) {
@@ -451,7 +452,10 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                     break;
                 }
             }
-            finalScaleMetadataList.add(0, referenceEvent);
+
+            if (referenceEvent != null) {
+                finalScaleMetadataList.add(0, referenceEvent);
+            }
             log.info("Successfully fetched required scaling events for scope: {}, stream: {}", scopeName, streamName);
             return Response.status(Status.OK).entity(finalScaleMetadataList).build();
         }).exceptionally(exception -> {

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -431,6 +431,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         if (from < 0 || to < 0 || from > to) {
             log.warn("Received invalid request from client for scopeName/streamName: {}/{} ", scopeName, streamName);
             asyncResponse.resume(Response.status(Status.BAD_REQUEST).build());
+            LoggerHelpers.traceLeave(log, "getScalingEvents", traceId);
             return;
         }
 

--- a/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server.rest.v1;
 
 import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
 import io.pravega.controller.server.rest.generated.model.CreateStreamRequest;
+import io.pravega.controller.server.rest.generated.model.ScalingEventList;
 import io.pravega.controller.server.rest.generated.model.ScopeProperty;
 import io.pravega.controller.server.rest.generated.model.ScopesList;
 import io.pravega.controller.server.rest.generated.model.StreamProperty;
@@ -242,5 +243,29 @@ public final class ApiV1 {
                 @ApiParam(value = "Stream name", required = true) @PathParam("streamName") String streamName,
                 @ApiParam(value = "The state info to be updated", required = true) StreamState updateStreamStateRequest,
                 @Context SecurityContext securityContext, @Suspended final AsyncResponse asyncResponse);
+
+        @GET
+        @Path("/{scopeName}/streams/{streamName}/scaling-events")
+        @Produces({ "application/json" })
+        @io.swagger.annotations.ApiOperation(value = "", notes = "Get scaling events for a given datetime period.",
+                response = ScalingEventList.class, tags = {  })
+        @io.swagger.annotations.ApiResponses(value = {
+                @io.swagger.annotations.ApiResponse(code = 200, message = "List of scaling events",
+                        response = ScalingEventList.class),
+
+                @io.swagger.annotations.ApiResponse(code = 404, message = "Scope/Stream not found",
+                        response = ScalingEventList.class),
+
+                @io.swagger.annotations.ApiResponse(code = 500, message = "Server error",
+                        response = ScalingEventList.class) })
+        void getScalingEvents(@ApiParam(value = "Scope name", required = true) @PathParam("scopeName") String scopeName,
+                              @ApiParam(value = "Stream name", required = true) @PathParam("streamName") String streamName,
+                              @ApiParam(value = "Parameter to display scaling events from that particular datetime. " +
+                "Input should be milliseconds from Jan 1 1970.", required = true)
+                              @QueryParam("from") Long from,
+                              @ApiParam(value = "Parameter to display scaling events to that particular datetime. " +
+                "Input should be milliseconds from Jan 1 1970.", required = true)
+                              @QueryParam("to") Long to,
+                              @Context SecurityContext securityContext, @Suspended final AsyncResponse asyncResponse);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -672,7 +672,7 @@ public class StreamMetaDataTests {
                 queryParam("to", toDateTime).request().buildGet().invoke();
         assertEquals("Get Scaling Events response code", 200, response.getStatus());
         final List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(List.class);
-        assertEquals("List Size", 3, scaleMetadataListResponse.size());
+        assertEquals("List Size", 2, scaleMetadataListResponse.size());
 
         // Test for getScalingEvents for invalid scope.
         final CompletableFuture<List<ScaleMetadata>> completableFuture1 = new CompletableFuture<>();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -682,6 +682,14 @@ public class StreamMetaDataTests {
                 queryParam("to", toDateTime).request().buildGet().invoke();
         assertEquals("Get Scaling Events response code", 404, response.getStatus());
 
+        // Test for getScalingEvents for bad request.
+        // from > to is tested here
+        when(mockControllerService.getScaleRecords("scope1", "stream1")).
+                thenReturn(CompletableFuture.completedFuture(scaleMetadataList));
+        response = client.target(resourceURI).queryParam("from", fromDateTime * 2).
+                queryParam("to", fromDateTime).request().buildGet().invoke();
+        assertEquals("Get Scaling Events response code", 400, response.getStatus());
+
         // Test for getScalingEvents failure.
         final CompletableFuture<List<ScaleMetadata>> completableFuture = new CompletableFuture<>();
         completableFuture.completeExceptionally(new Exception());

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -37,6 +37,7 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -649,22 +650,45 @@ public class StreamMetaDataTests {
      */
     @Test
     public void testGetScalingEvents() throws Exception {
-        final String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1/scaling-events";
+        String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1/scaling-events";
+        List<ScaleMetadata> scaleMetadataList = new ArrayList<>();
 
-        long fromDateTime = System.currentTimeMillis();
-        // test to get scaling events
+        /* Test to get scaling events
+
+        There are 4 scale events in final list.
+        Filter 'from' and 'to' is also tested here.
+        Event1 is before 'from'
+        Event2 and Event3 are between 'from' and 'to'
+        Event4 is after 'to'
+        Response contains 3 events : Event1 acts as reference event. Event2 and Event3 fall between 'from' and 'to'.
+         */
         Segment segment1 = new Segment(0, System.currentTimeMillis(), 0.00, 0.50);
         Segment segment2 = new Segment(1, System.currentTimeMillis(), 0.50, 1.00);
         List<Segment> segmentList1 = Arrays.asList(segment1, segment2);
+        ScaleMetadata scaleMetadata1 = new ScaleMetadata(System.currentTimeMillis() / 2, segmentList1);
+        scaleMetadataList.add(scaleMetadata1);
 
-        Segment segment3 = new Segment(0, System.currentTimeMillis(), 0.00, 0.25);
-        Segment segment4 = new Segment(1, System.currentTimeMillis(), 0.25, 1.00);
+        long fromDateTime = System.currentTimeMillis();
+
+        Segment segment3 = new Segment(0, System.currentTimeMillis(), 0.00, 0.50);
+        Segment segment4 = new Segment(1, System.currentTimeMillis(), 0.50, 1.00);
         List<Segment> segmentList2 = Arrays.asList(segment3, segment4);
-
-        ScaleMetadata scaleMetadata1 = new ScaleMetadata(System.currentTimeMillis(), segmentList1);
         ScaleMetadata scaleMetadata2 = new ScaleMetadata(System.currentTimeMillis(), segmentList2);
-        List<ScaleMetadata> scaleMetadataList = Arrays.asList(scaleMetadata1, scaleMetadata2);
+        scaleMetadataList.add(scaleMetadata2);
+
+        Segment segment5 = new Segment(0, System.currentTimeMillis(), 0.00, 0.25);
+        Segment segment6 = new Segment(1, System.currentTimeMillis(), 0.25, 1.00);
+        List<Segment> segmentList3 = Arrays.asList(segment5, segment6);
+        ScaleMetadata scaleMetadata3 = new ScaleMetadata(System.currentTimeMillis(), segmentList3);
+        scaleMetadataList.add(scaleMetadata3);
+
         long toDateTime = System.currentTimeMillis();
+
+        Segment segment7 = new Segment(0, System.currentTimeMillis(), 0.00, 0.40);
+        Segment segment8 = new Segment(0, System.currentTimeMillis(), 0.40, 1.00);
+        List<Segment> segmentList4 = Arrays.asList(segment7, segment8);
+        ScaleMetadata scaleMetadata4 = new ScaleMetadata(toDateTime * 2, segmentList4);
+        scaleMetadataList.add(scaleMetadata4);
 
         when(mockControllerService.getScaleRecords(scope1, stream1)).
                 thenReturn(CompletableFuture.completedFuture(scaleMetadataList));
@@ -672,9 +696,9 @@ public class StreamMetaDataTests {
                 queryParam("to", toDateTime).request().buildGet().invoke();
         assertEquals("Get Scaling Events response code", 200, response.getStatus());
         final List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(List.class);
-        assertEquals("List Size", 2, scaleMetadataListResponse.size());
+        assertEquals("List Size", 3, scaleMetadataListResponse.size());
 
-        // Test for getScalingEvents for invalid scope.
+        // Test for getScalingEvents for invalid scope/stream.
         final CompletableFuture<List<ScaleMetadata>> completableFuture1 = new CompletableFuture<>();
         completableFuture1.completeExceptionally(new DataNotFoundException(""));
         when(mockControllerService.getScaleRecords("scope1", "stream1")).thenReturn(completableFuture1);

--- a/docs/rest/restapis.md
+++ b/docs/rest/restapis.md
@@ -611,6 +611,74 @@ Delete a stream
 ```
 
 
+<a name="getscalingevents"></a>
+### GET /scopes/{scopeName}/streams/{streamName}/scaling-events
+
+#### Description
+Get scaling events for a given datetime period.
+
+
+#### Parameters
+
+|Type|Name|Description|Schema|
+|---|---|---|---|
+|**Path**|**scopeName**  <br>*required*|Scope name|string|
+|**Path**|**streamName**  <br>*required*|Stream name|string|
+|**Query**|**from**  <br>*required*|Parameter to display scaling events from that particular datetime. Input should be milliseconds from Jan 1 1970.|integer (int64)|
+|**Query**|**to**  <br>*required*|Parameter to display scaling events to that particular datetime. Input should be milliseconds from Jan 1 1970.|integer (int64)|
+
+
+#### Responses
+
+|HTTP Code|Description|Schema|
+|---|---|---|
+|**200**|Successfully fetched list of scaling events.|[ScalingEventList](#scalingeventlist)|
+|**404**|Scope/Stream not found.|No Content|
+|**500**|Internal Server error while fetching scaling events.|No Content|
+
+
+#### Produces
+
+* `application/json`
+
+
+#### Example HTTP request
+
+##### Request path
+```
+/scopes/string/streams/string/scaling-events
+```
+
+
+##### Request query
+```
+json :
+{
+  "from" : 0,
+  "to" : 0
+}
+```
+
+
+#### Example HTTP response
+
+##### Response 200
+```
+json :
+{
+  "scalingEvents" : [ {
+    "timestamp" : 0,
+    "segmentList" : [ {
+      "number" : 0,
+      "startTime" : 0,
+      "keyStart" : 0,
+      "keyEnd" : 0
+    } ]
+  } ]
+}
+```
+
+
 <a name="updatestreamstate"></a>
 ### PUT /scopes/{scopeName}/streams/{streamName}/state
 
@@ -693,6 +761,15 @@ json :
 |**value**  <br>*optional*|**Example** : `0`|integer (int64)|
 
 
+<a name="scalemetadata"></a>
+### ScaleMetadata
+
+|Name|Description|Schema|
+|---|---|---|
+|**segmentList**  <br>*optional*|**Example** : `[ "[segment](#segment)" ]`|< [Segment](#segment) > array|
+|**timestamp**  <br>*optional*|**Example** : `0`|integer (int64)|
+
+
 <a name="scalingconfig"></a>
 ### ScalingConfig
 
@@ -702,6 +779,14 @@ json :
 |**scaleFactor**  <br>*optional*|**Example** : `0`|integer (int32)|
 |**targetRate**  <br>*optional*|**Example** : `0`|integer (int32)|
 |**type**  <br>*optional*|**Example** : `"string"`|enum (FIXED_NUM_SEGMENTS, BY_RATE_IN_KBYTES_PER_SEC, BY_RATE_IN_EVENTS_PER_SEC)|
+
+
+<a name="scalingeventlist"></a>
+### ScalingEventList
+
+|Name|Description|Schema|
+|---|---|---|
+|**scalingEvents**  <br>*optional*|**Example** : `[ "[scalemetadata](#scalemetadata)" ]`|< [ScaleMetadata](#scalemetadata) > array|
 
 
 <a name="scopeproperty"></a>
@@ -718,6 +803,17 @@ json :
 |Name|Description|Schema|
 |---|---|---|
 |**scopes**  <br>*optional*|**Example** : `[ "[scopeproperty](#scopeproperty)" ]`|< [ScopeProperty](#scopeproperty) > array|
+
+
+<a name="segment"></a>
+### Segment
+
+|Name|Description|Schema|
+|---|---|---|
+|**keyEnd**  <br>*optional*|**Example** : `0`|integer (double)|
+|**keyStart**  <br>*optional*|**Example** : `0`|integer (double)|
+|**number**  <br>*optional*|**Example** : `0`|integer (int32)|
+|**startTime**  <br>*optional*|**Example** : `0`|integer (int64)|
 
 
 <a name="streamproperty"></a>

--- a/shared/controller-api/src/main/swagger/Controller.yaml
+++ b/shared/controller-api/src/main/swagger/Controller.yaml
@@ -316,13 +316,13 @@ paths:
         - application/json
       responses:
         200:
-          description: List of scaling events
+          description: Successfully fetched list of scaling events.
           schema:
             $ref: "#/definitions/ScalingEventList"
         404:
-          description: Scope/Stream not found
+          description: Scope/Stream not found.
         500:
-          description: Server error
+          description: Internal Server error while fetching scaling events.
 definitions:
   ScalingEventList:
     type: object

--- a/shared/controller-api/src/main/swagger/Controller.yaml
+++ b/shared/controller-api/src/main/swagger/Controller.yaml
@@ -375,8 +375,8 @@ definitions:
     properties:
       number:
         type: integer
-        format: int34
-      start:
+        format: int32
+      startTime:
         type: integer
         format: int64
       keyStart:

--- a/shared/controller-api/src/main/swagger/Controller.yaml
+++ b/shared/controller-api/src/main/swagger/Controller.yaml
@@ -247,8 +247,53 @@ paths:
           description: Scope or stream not found
         500:
           description: Server error
-
+  /scopes/{scopeName}/streams/{streamName}/scaling-events:
+    parameters:
+      - in: path
+        name: scopeName
+        description: Scope name
+        required: true
+        type: string
+      - in: path
+        name: streamName
+        description: Stream name
+        required: true
+        type: string
+    get:
+      parameters:
+        - in: query
+          name: from
+          description: Parameter to display scaling events from that particular datetime. Input should be milliseconds from Jan 1 1970.
+          required: true
+          type: integer
+          format: int64
+        - in: query
+          name: to
+          description: Parameter to display scaling events to that particular datetime. Input should be milliseconds from Jan 1 1970.
+          required: true
+          type: integer
+          format: int64
+      operationId: getScalingEvents
+      description: Get scaling events for a given datetime period.
+      produces:
+        - application/json
+      responses:
+        200:
+          description: List of scaling events
+          schema:
+            $ref: "#/definitions/ScalingEventList"
+        404:
+          description: Scope/Stream not found
+        500:
+          description: Server error
 definitions:
+  ScalingEventList:
+    type: object
+    properties:
+      scalingEvents:
+        type: array
+        items:
+          $ref: "#/definitions/ScaleMetadata"
   StreamsList:
     type: object
     properties:
@@ -315,3 +360,29 @@ definitions:
         type: string
         enum:
         - SEALED
+  ScaleMetadata:
+    type: object
+    properties:
+      timestamp:
+        type: integer
+        format: int64
+      segmentList:
+        type: array
+        items:
+          $ref: "#/definitions/Segment"
+  Segment:
+    type: object
+    properties:
+      number:
+        type: integer
+        format: int34
+      start:
+        type: integer
+        format: int64
+      keyStart:
+        type: integer
+        format: double
+      keyEnd:
+        type: integer
+        format: double
+


### PR DESCRIPTION
**Change log description**
Addition of new REST API - getScalingEvents. Returns a list of scaling events in desired period of time.

**Purpose of the change**
Fixes #1361

**What the code does**
Adds a new REST API implementation.

**How to verify it**
Unit Test/ Call the api using a rest client by starting standalone pravega cluster.

Note: Please do not review auto-generated files /rest/generated/*.