### PR TITLE
Issue 1406: Adds Rest API link to the docs page.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,7 +26,7 @@ pages:
       - 'Pravega FAQ': 'faq.md'
   - Developing Pravega Applications:
       - 'Java API Reference': 'javadoc.md'
-      - 'REST API Reference': 'rest/restapis.md'
+      - 'REST API - Controller': 'rest/restapis.md'
       - 'Working with Reader and Writer': 'basic-reader-and-writer.md'
       - 'Working with State Synchronizer': 'state-synchronizer.md'
       - 'Working with Transactions': 'transactions.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,6 +26,7 @@ pages:
       - 'Pravega FAQ': 'faq.md'
   - Developing Pravega Applications:
       - 'Java API Reference': 'javadoc.md'
+      - 'REST API Reference': 'rest/restapis.md'
       - 'Working with Reader and Writer': 'basic-reader-and-writer.md'
       - 'Working with State Synchronizer': 'state-synchronizer.md'
       - 'Working with Transactions': 'transactions.md'


### PR DESCRIPTION
**Change log description**
- Added REST API documentation link to the docs menu

**Purpose of the change**
- Added REST API documentation link to the docs menu
- Fixes #1406

**How to verify it**
Checkout the docs after generating it using mkdocs