### PR TITLE
Issue 201: SegmentContainerMonitor: handle multiple host events

### DIFF
--- a/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
+++ b/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.controller.fault;
 
-import io.pravega.common.TimeoutTimer;
 import io.pravega.common.cluster.Cluster;
 import io.pravega.common.cluster.ClusterType;
 import io.pravega.common.cluster.Host;
@@ -45,9 +44,6 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
 
     //The pravega cluster which this host controller manages.
     private Cluster pravegaServiceCluster = null;
-
-    //The timer to ensure we maintain a minimum interval between expensive rebalance operations.
-    private TimeoutTimer timeoutTimer = null;
 
     //The minimum interval between any two rebalance operations. The minimum duration is not guaranteed when leadership
     //moves across controllers. Since this is uncommon and there are no significant side-effects to it, we don't
@@ -143,9 +139,9 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
                 }
 
                 hostsChange.acquire();
-                log.debug("Received rebalance event");
+                log.info("Received rebalance event");
 
-                //Wait here until the rebalance timer is zero so that we honor the minimum rebalance interval.
+                //Wait here so we can club multiple rebalance events into one.
                 waitForRebalance();
 
                 //Clear all events that has been received until this point.
@@ -171,14 +167,14 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
     }
 
     /**
-     * Blocks until the rebalance timer is zero so that we honor the minimum rebalance interval.
+     * Blocks until the rebalance interval. This wait serves multiple purposes:
+     * -- Ensure rebalance does not happen in quick succession since its a costly cluster level operation.
+     * -- Clubs multiple host events into one to reduce rebalance operations. For example:
+     *      Fresh cluster start, cluster/multi-host/host restarts, etc.
      */
     private void waitForRebalance() throws InterruptedException {
-        if (timeoutTimer != null && timeoutTimer.getRemaining().getSeconds() > 0) {
-            log.info("Waiting for {} seconds before attempting to rebalance",
-                    timeoutTimer.getRemaining().getSeconds());
-            Thread.sleep(timeoutTimer.getRemaining().getSeconds() * 1000);
-        }
+        log.info("Waiting for {} seconds before attempting to rebalance", minRebalanceInterval.getSeconds());
+        Thread.sleep(minRebalanceInterval.toMillis());
     }
 
     private void triggerRebalance() throws IOException {
@@ -189,9 +185,6 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
             hostStore.updateHostContainersMap(newMapping);
         } catch (Exception e) {
             throw new IOException(e);
-        } finally {
-            //Reset the rebalance timer.
-            timeoutTimer = new TimeoutTimer(minRebalanceInterval);
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
+++ b/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
@@ -141,10 +141,11 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
                 hostsChange.acquire();
                 log.info("Received rebalance event");
 
-                //Wait here so we can club multiple rebalance events into one.
+                // Wait here until rebalance can be performed.
                 waitForRebalance();
 
-                //Clear all events that has been received until this point.
+                // Clear all events that has been received until this point since this will be included in the current
+                // rebalance operation.
                 hostsChange.drainPermits();
                 triggerRebalance();
             } catch (InterruptedException e) {

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -124,7 +124,7 @@ public class SegmentContainerMonitorTest {
         }
 
         SegmentContainerMonitor monitor = new SegmentContainerMonitor(new MockHostControllerStore(), zkClient,
-                new UniformContainerBalancer(), 5);
+                new UniformContainerBalancer(), 2);
         monitor.startAsync().awaitRunning();
 
         assertEquals(hostStore.getContainerCount(), Config.HOST_STORE_CONTAINER_COUNT);


### PR DESCRIPTION
**Change log description**
Using timeout heuristics to club multiple host events which happen in quick succession into one rebalance operation. This handle cases like node restart, fresh cluster start, multi-host start/failures, etc.

**Purpose of the change**
Fixes #201 

**What the code does**
Uses the existing timeout values to wait for multi-host events before triggering rebalance operations.

**How to verify it**
Existing test cases present for handling host start/stop should succeed.
./gradlew test