### PR TITLE
Issue 1457: Added autoRecoveryDaemonEnabled setting to Bookie entry point

### DIFF
--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -16,6 +16,7 @@ USE_MOUNT=${USE_MOUNT:-0}
 PRAVEGA_PATH=${PRAVEGA_PATH:-"pravega"}
 PRAVEGA_CLUSTER_NAME=${PRAVEGA_CLUSTER_NAME:-"pravega-cluster"}
 BK_CLUSTER_NAME=${BK_CLUSTER_NAME:-"bookkeeper"}
+BK_AUTORECOVERY=${BK_AUTORECOVERY:-"false"}
 
 BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}/ledgers"
 
@@ -36,6 +37,8 @@ sed -i 's|journalDirectory=/tmp/bk-txn|journalDirectory='${BK_DIR}'/journal|' /o
 sed -i 's|ledgerDirectories=/tmp/bk-data|ledgerDirectories='${BK_DIR}'/ledgers|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 sed -i 's|indexDirectories=/tmp/data/bk/ledgers|indexDirectories='${BK_DIR}'/index|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 sed -i 's|# zkLedgersRootPath=/ledgers|zkLedgersRootPath='${BK_LEDGERS_PATH}'|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
+
+echo autoRecoveryDaemonEnabled=${BK_AUTORECOVERY} >> /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 
 echo "wait for zookeeper"
 until /opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL ls /; do sleep 2; done


### PR DESCRIPTION
**Change log description**
Allow setting of the  `autoRecoveryDaemonEnabled` bookie setting that turns on the AutoRecovery daemons.

**Purpose of the change**
Fixes #1457

**What the code does**
Allows turning on the AutoRecovery Daemons which will make sure all Bookkeeper segments are kept at their correct replication levels should a bookie fail.

**How to verify it**
Deploy Bookie with environment variable `BK_AUTORECOVERY=true` and the bookie logs will show the Auto Recovery Auditor starting :

```
....
2017-06-20 11:34:38,277 - INFO  - [main:BookieServer@395] - Register shutdown hook successfully
2017-06-20 11:34:39,574 - INFO  - [AuditorElector-172.16.28.4:3181:RackawareEnsemblePlacementPolicy@330] - Initialize rackaware ensemble placement policy @ <Bookie:172.16.28.4:0> : org.apache.bookkeeper.net.ScriptBasedMapping.
2017-06-20 11:34:39,776 - INFO  - [main-EventThread:NetworkTopology@394] - Adding a new node: /default-rack/172.16.28.4:3181
2017-06-20 11:34:39,778 - INFO  - [AuditorElector-172.16.28.4:3181:Auditor@195] - I'm starting as Auditor Bookie. ID: 172.16.28.4:3181
2017-06-20 11:34:39,778 - INFO  - [AuditorElector-172.16.28.4:3181:Auditor@206] - Auditor periodic ledger checking enabled 'auditorPeriodicCheckInterval' 604800 seconds
2017-06-20 11:34:40,075 - INFO  - [AuditorElector-172.16.28.4:3181:Auditor@252] - Auditor periodic bookie checking enabled 'auditorPeriodicBookieCheckInterval' 86400 seconds
2017-06-20 11:34:42,715 - INFO  - [main-EventThread:NetworkTopology@394] - Adding a new node: /default-rack/172.16.28.15:3181
2017-06-20 11:34:42,717 - INFO  - [main-EventThread:NetworkTopology@394] - Adding a new node: /default-rack/172.16.28.15:3181
2017-06-20 11:34:56,269 - INFO  - [main-EventThread:NetworkTopology@394] - Adding a new node: /default-rack/172.16.28.11:3181
```