### PR TITLE
Issue 1366: Remove usage of blocking ZK APIs

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
@@ -42,7 +42,7 @@ public class ZKScope implements Scope {
 
     @Override
     public CompletableFuture<List<String>> listStreamsInScope() {
-        return store.getStreamsInPath(scopePath);
+        return store.getChildren(scopePath);
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -99,7 +99,7 @@ public class ScaleRequestHandlerTest {
         // add a host in zk
         // mock pravega
         // create a stream
-        streamStore.createScope(scope);
+        streamStore.createScope(scope).get();
         streamMetadataTasks.createStream(scope, stream, config, createTimestamp).get();
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -71,9 +71,9 @@ public abstract class StreamMetadataStoreTest {
     public void testStreamMetadataStore() throws InterruptedException, ExecutionException {
 
         // region createStream
-        long start = System.currentTimeMillis();
         store.createScope(scope).get();
 
+        long start = System.currentTimeMillis();
         store.createStream(scope, stream1, configuration1, start + 5, null, executor).get();
         store.setState(scope, stream1, State.ACTIVE, null, executor).get();
         store.createStream(scope, stream2, configuration2, start + 5, null, executor).get();


### PR DESCRIPTION
**Change log description**
A few APIs in ZKStoreHelper was still using blocking ZK APIs.
Now replaced all of them with non-blocking equivalents using curator's inBackground() API.

**Purpose of the change**
Fixes #1366 

**What the code does**
Removes all blocking calls to ZK.

**How to verify it**
The APIs are covered in existing test cases and should pass.