### PR TITLE
Issue 1464: Remove old autoRecoveryDaemonEnabled setting before adding new one

### DIFF
--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -38,6 +38,7 @@ sed -i 's|ledgerDirectories=/tmp/bk-data|ledgerDirectories='${BK_DIR}'/ledgers|'
 sed -i 's|indexDirectories=/tmp/data/bk/ledgers|indexDirectories='${BK_DIR}'/index|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 sed -i 's|# zkLedgersRootPath=/ledgers|zkLedgersRootPath='${BK_LEDGERS_PATH}'|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 
+sed -i '/autoRecoveryDaemonEnabled/d' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 echo autoRecoveryDaemonEnabled=${BK_AUTORECOVERY} >> /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
 
 echo "wait for zookeeper"


### PR DESCRIPTION
**Change log description**
Removes the old autoRecoveryDaemonEnabled setting from Bookkeeper configuration before adding new setting

**Purpose of the change**
Fix issue 1464 wereby the autoRecoveryDaemonEnabled was added to the end of the configuration when the entrypoint script was rerun

**What the code does**
Removes the old `autoRecoveryDaemonEnabled` setting from Bookkeeper configuration before adding the setting

**How to verify it**
Run entrypoint multiple times, check configuration to make sure only one `autoRecoveryDaemonEnabled` is in the configuration
