### PR TITLE
Issue 1460: (SegmentStore) Sporadic UnitTest failure in DataFrameBuilderTests

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -152,18 +151,8 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
         val asyncInjector = new ErrorInjector<Exception>(count -> count >= failAt, IntentionalException::new);
         dataLog.setAppendErrorInjectors(null, asyncInjector);
 
-        // lastCommitIndex is an index inside the records array that indicate what we think we have committed so far.
-        // We may use the array index interchangeably with the LogItem.SequenceNumber. The only reason this works
-        // is because the array index equals the LogItem.SequenceNumber - this simplifies things a lot.
-        AtomicInteger lastCommitIndex = new AtomicInteger(-1);
         AtomicInteger failCount = new AtomicInteger();
         List<DataFrameBuilder.CommitArgs> successCommits = Collections.synchronizedList(new ArrayList<>());
-        Consumer<DataFrameBuilder.CommitArgs> commitCallback = cc -> {
-            successCommits.add(cc);
-            synchronized (lastCommitIndex) {
-                lastCommitIndex.set(Math.max(lastCommitIndex.get(), (int) cc.getLastFullySerializedSequenceNumber()));
-            }
-        };
 
         // Keep a reference to the builder (once created) so we can inspect its failure cause).
         val builderRef = new AtomicReference<DataFrameBuilder>();
@@ -187,7 +176,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
             failCount.incrementAndGet();
         };
 
-        val args = new DataFrameBuilder.Args(ca -> attemptCount.incrementAndGet(), commitCallback, errorCallback, executorService());
+        val args = new DataFrameBuilder.Args(ca -> attemptCount.incrementAndGet(), successCommits::add, errorCallback, executorService());
         try (DataFrameBuilder<TestLogItem> b = new DataFrameBuilder<>(dataLog, args)) {
             builderRef.set(b);
             try {
@@ -197,7 +186,6 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
 
                 b.close();
             } catch (ObjectClosedException ex) {
-                attemptCount.decrementAndGet();
                 await(() -> b.failureCause() != null, 20);
 
                 // If DataFrameBuilder is closed, then we must have had an exception thrown via the callback before.
@@ -216,7 +204,8 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
             readItems.add(readItem.getItem());
         }
 
-        val expectedItems = records.stream().filter(r -> r.getSequenceNumber() <= lastCommitIndex.get()).collect(Collectors.toList());
+        val lastCommitSeqNo = successCommits.stream().mapToLong(DataFrameBuilder.CommitArgs::getLastFullySerializedSequenceNumber).max().orElse(-1);
+        val expectedItems = records.stream().filter(r -> r.getSequenceNumber() <= lastCommitSeqNo).collect(Collectors.toList());
         AssertExtensions.assertListEquals("Items read back do not match expected values.", expectedItems, readItems, TestLogItem::equals);
 
         // Read all entries in the Log and interpret them as DataFrames, then verify the records can be reconstructed.


### PR DESCRIPTION
**Change log description**
Fixed a sporadically-failing unit test due to unit-test-related sync issues: in some cases the number of attempts was double-decremented when failed, which could lead to the test believing fewer than actual operations were committed.

**Purpose of the change**
Fixes #1460.

**What the code does**
Fixed unit test.

**How to verify it**
Unit test passes consistently.