### PR TITLE
Issue 1448: (SegmentStore) Fixed ContainerMetadataUpdateTransaction.getActiveSegmentCount

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -998,6 +998,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         val segment0Info = segment0Activation.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("Unable to properly activate dormant segment (0).", segment0Info);
 
+        tryActivate(localContainer, segment1, segment3).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // At this point the active segments should be: 0, 1 and 3.
         Assert.assertNotNull("Pre-activated segment did not stay in metadata (3).",
                 localContainer.getStreamSegmentInfo(segment3, false, TIMEOUT).join());


### PR DESCRIPTION
**Change log description**
Fixed a bug in ContainerMetadataUpdateTransaction where the ActiveSegmentCount would not refresh for a transaction when the ContainerMetadata's value changes.

This was done by calculating this value by referring to the real metadata, to which are added the counts of all newly mapped segments in the current chain of transactions.

**Purpose of the change**
Fixes #1448.

**What the code does**
Fixed the bug, added a unit test to accurately reproduce it. Enhanced an existing unit test to reduce the likelihood of this happening again (since it needs to wait for some background async operations to complete which are opaque to the test).

**How to verify it**
New unit test added, existing unit test improved to reduce the likelihood of this hitting again.