### PR TITLE
Issue 1470: (SegmentStore) OperationProcessor shutdown bug

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -199,7 +199,7 @@ class DataFrameBuilder<T extends LogItem> implements AutoCloseable {
         // DataFrameBuilder cannot recover from this; as such it will close and will leave it to the caller to handle
         // the failure.
         ex = ExceptionHelpers.getRealException(ex);
-        if (!(ex instanceof ObjectClosedException) && !(ex instanceof CancellationException)) {
+        if (!isShutdownException(ex)) {
             // This is usually from a subsequent call. We want to store the actual failure cause.
             this.failureCause.compareAndSet(null, ex);
         }
@@ -207,6 +207,10 @@ class DataFrameBuilder<T extends LogItem> implements AutoCloseable {
         this.args.commitFailure.accept(ex, commitArgs);
         close();
         return null;
+    }
+
+    private boolean isShutdownException(Throwable ex) {
+        return ex instanceof ObjectClosedException || ex instanceof CancellationException;
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -378,10 +378,4 @@ public class OperationMetadataUpdaterTests {
         op.setSequenceNumber(updater.nextOperationSequenceNumber());
         updater.acceptOperation(op);
     }
-
-    private static class TestLogAddress extends LogAddress {
-        public TestLogAddress(long sequence) {
-            super(sequence);
-        }
-    }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -12,6 +12,8 @@ package io.pravega.segmentstore.server.logs;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Service;
 import io.pravega.common.concurrent.ServiceShutdownListener;
+import io.pravega.common.util.ArrayView;
+import io.pravega.common.util.CloseableIterator;
 import io.pravega.common.util.SequencedItemList;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
@@ -38,12 +40,14 @@ import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
 import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
+import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.mocks.InMemoryCacheFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ErrorInjector;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,10 +56,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import lombok.Cleanup;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -497,6 +506,46 @@ public class OperationProcessorTests extends OperationLogTestBase {
         operationProcessor.stopAsync().awaitTerminated();
     }
 
+    /**
+     * Tests a scenario where the OperationProcessor is shut down while a DataFrame is being processed and will eventually
+     * complete successfully - however its operation should be cancelled.
+     */
+    @Test
+    public void testConcurrentStopAndCommit() throws Exception {
+        @Cleanup
+        TestContext context = new TestContext();
+
+        // Generate some test data.
+        val segmentId = createStreamSegmentsInMetadata(1, context.metadata).stream().findFirst().orElse(-1L);
+        List<Operation> operations = Collections.singletonList(new StreamSegmentAppendOperation(segmentId, new byte[1], null));
+
+        CompletableFuture<LogAddress> appendCallback = new CompletableFuture<>();
+
+        // Setup an OperationProcessor with a custom DurableDataLog and start it.
+        @Cleanup
+        DurableDataLog dataLog = new ManualAppendOnlyDurableDataLog(() -> appendCallback);
+        dataLog.initialize(TIMEOUT);
+        @Cleanup
+        OperationProcessor operationProcessor = new OperationProcessor(context.metadata, context.stateUpdater,
+                dataLog, getNoOpCheckpointPolicy(), executorService());
+        operationProcessor.startAsync().awaitRunning();
+
+        // Process all generated operations.
+        OperationWithCompletion completionFuture = processOperations(operations, operationProcessor).stream().findFirst().orElse(null);
+        operationProcessor.stopAsync();
+        appendCallback.complete(new TestLogAddress(1));
+
+        // Stop the processor.
+        operationProcessor.awaitTerminated();
+
+        // Wait for the operation to complete. The operation should have been cancelled (due to the OperationProcessor
+        // shutting down) - no other exception (or successful completion is accepted).
+        AssertExtensions.assertThrows(
+                "Operation did not fail with the right exception.",
+                () -> completionFuture.completion,
+                ex -> ex instanceof CancellationException);
+    }
+
     private List<OperationWithCompletion> processOperations(Collection<Operation> operations, OperationProcessor operationProcessor) {
         List<OperationWithCompletion> completionFutures = new ArrayList<>();
         operations.forEach(op -> completionFutures.add(new OperationWithCompletion(op, operationProcessor.process(op))));
@@ -607,4 +656,58 @@ public class OperationProcessorTests extends OperationLogTestBase {
             this.cacheManager.close();
         }
     }
+
+
+    //region ManualAppendOnlyDurableDataLog
+
+    @RequiredArgsConstructor
+    private static class ManualAppendOnlyDurableDataLog implements DurableDataLog {
+        private final Supplier<CompletableFuture<LogAddress>> addImplementation;
+
+        @Override
+        public CompletableFuture<LogAddress> append(ArrayView data, Duration timeout) {
+            return this.addImplementation.get();
+        }
+
+        //region Not Implemented methods.
+
+        @Override
+        public void initialize(Duration timeout) throws DurableDataLogException {
+
+        }
+
+        @Override
+        public CompletableFuture<Void> truncate(LogAddress upToAddress, Duration timeout) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CloseableIterator<ReadItem, DurableDataLogException> getReader() throws DurableDataLogException {
+            return null;
+        }
+
+        @Override
+        public int getMaxAppendLength() {
+            return 1024 * 1024;
+        }
+
+        @Override
+        public long getEpoch() {
+            return 0;
+        }
+
+        @Override
+        public QueueStats getQueueStatistics() {
+            return QueueStats.DEFAULT;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        //endregion
+    }
+
+    //endregion
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogAddress.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogAddress.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.logs;
+
+import io.pravega.segmentstore.storage.LogAddress;
+
+/**
+ * Test implementation of LogAddress.
+ */
+class TestLogAddress extends LogAddress {
+    TestLogAddress(long sequence) {
+        super(sequence);
+    }
+}


### PR DESCRIPTION
**Change log description**
Fixed a bug in OperationProcessor where it could fail an operation with an incorrect exception (and hence shutdown with failure) if it shut down while a DataFrame is in flight. Please refer to Issue #1470 for steps to reproduce the problem.

**Purpose of the change**
Fixes #1470.

**What the code does**
Checks to see if the OperatioProcessor is shutting down when processing a commit from a DataFrame - if so, it aborts the callback, instead of throwing an AssertionError.

**How to verify it**
New unit test added to verify behavior.