### PR TITLE
Issue 1433: Modify Cluster interface to return specific exceptions

### DIFF
--- a/common/src/main/java/io/pravega/common/cluster/Cluster.java
+++ b/common/src/main/java/io/pravega/common/cluster/Cluster.java
@@ -36,25 +36,22 @@ public interface Cluster extends AutoCloseable {
      * Add Listeners.
      *
      * @param listener Cluster event listener.
-     * @throws Exception Error while adding ClusterListener.
      */
-    public void addListener(final ClusterListener listener) throws Exception;
+    public void addListener(final ClusterListener listener);
 
     /**
      * Add Listeners with an executor to run the listener on.
      *
      * @param listener Cluster event listener.
      * @param executor Executor to run listener on.
-     * @throws Exception Error while adding ClusterListener.
      */
-    public void addListener(final ClusterListener listener, final Executor executor) throws Exception;
+    public void addListener(final ClusterListener listener, final Executor executor);
 
     /**
      * Get the current cluster members.
      *
      * @return List of cluster members.
-     * @throws Exception Error while getting Cluster members.
      */
-    public Set<Host> getClusterMembers() throws Exception;
+    public Set<Host> getClusterMembers();
 
 }

--- a/common/src/main/java/io/pravega/common/cluster/ClusterException.java
+++ b/common/src/main/java/io/pravega/common/cluster/ClusterException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.cluster;
+
+public class ClusterException extends RuntimeException {
+
+    public enum Type {
+        METASTORE
+    }
+
+    final String message;
+
+    public ClusterException(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Factory method to construct Store exceptions.
+     *
+     * @param type Type of Exception.
+     * @param message Exception message
+     * @return Instance of ClusterException.
+     */
+    public static ClusterException create(Type type, String message) {
+        switch (type) {
+            case METASTORE:
+                return new MetaStoreException(message);
+            default:
+                throw new IllegalArgumentException("Invalid exception type");
+        }
+    }
+
+    public static class MetaStoreException extends ClusterException {
+        public MetaStoreException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/common/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/common/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -177,7 +177,8 @@ public class ClusterZKImpl implements Cluster {
         try {
             cache.get().start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
         } catch (Exception e) {
-            throw ClusterException.create(ClusterException.Type.METASTORE, "Failed to initialize ZooKeeper cache");
+            throw ClusterException.create(ClusterException.Type.METASTORE,
+                                          "Failed to initialize ZooKeeper cache: " + e.getMessage());
         }
     }
 

--- a/common/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/common/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -11,6 +11,7 @@ package io.pravega.common.cluster.zkImpl;
 
 import io.pravega.common.Exceptions;
 import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.ClusterException;
 import io.pravega.common.cluster.ClusterListener;
 import io.pravega.common.cluster.Host;
 import com.google.common.base.Preconditions;
@@ -107,11 +108,10 @@ public class ClusterZKImpl implements Cluster {
      * Add Listener to the cluster.
      *
      * @param listener Cluster event Listener.
-     * @throws Exception Error while communicating to Zookeeper.
      */
     @Override
     @Synchronized
-    public void addListener(ClusterListener listener) throws Exception {
+    public void addListener(ClusterListener listener) {
         Preconditions.checkNotNull(listener, "listener");
         if (!cache.isPresent()) {
             initializeCache();
@@ -124,11 +124,10 @@ public class ClusterZKImpl implements Cluster {
      *
      * @param listener Cluster event Listener.
      * @param executor Executor to run the listener on.
-     * @throws Exception Error while communicating to Zookeeper.
      */
     @Override
     @Synchronized
-    public void addListener(final ClusterListener listener, final Executor executor) throws Exception {
+    public void addListener(final ClusterListener listener, final Executor executor) {
         Preconditions.checkNotNull(listener, "listener");
         Preconditions.checkNotNull(executor, "executor");
         if (!cache.isPresent()) {
@@ -141,11 +140,10 @@ public class ClusterZKImpl implements Cluster {
      * Get the current cluster members.
      *
      * @return List of cluster members.
-     * @throws Exception Error while communicating to Zookeeper.
      */
     @Override
     @Synchronized
-    public Set<Host> getClusterMembers() throws Exception {
+    public Set<Host> getClusterMembers() {
         if (!cache.isPresent()) {
             initializeCache();
         }
@@ -174,9 +172,13 @@ public class ClusterZKImpl implements Cluster {
         }
     }
 
-    private void initializeCache() throws Exception {
+    private void initializeCache() throws ClusterException {
         cache = Optional.of(new PathChildrenCache(client, getPathPrefix(), true));
-        cache.get().start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+        try {
+            cache.get().start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+        } catch (Exception e) {
+            throw ClusterException.create(ClusterException.Type.METASTORE, "Failed to initialize ZooKeeper cache");
+        }
     }
 
     private PathChildrenCacheListener pathChildrenCacheListener(final ClusterListener listener) {

--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -11,6 +11,7 @@ package io.pravega.controller.fault;
 
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.ClusterException;
 import io.pravega.common.cluster.Host;
 import io.pravega.controller.server.eventProcessor.ControllerEventProcessors;
 import io.pravega.controller.task.Stream.TxnSweeper;
@@ -68,7 +69,7 @@ public class ControllerClusterListener extends AbstractIdleService {
     }
 
     @Override
-    protected void startUp() throws InterruptedException, Exception {
+    protected void startUp() throws InterruptedException {
         long traceId = LoggerHelpers.traceEnter(log, objectId, "startUp");
         try {
             log.info("Registering host {} with controller cluster", host);
@@ -120,7 +121,7 @@ public class ControllerClusterListener extends AbstractIdleService {
                             .stream()
                             .map(Host::getHostId)
                             .collect(Collectors.toSet());
-                } catch (Exception e) {
+                } catch (ClusterException e) {
                     log.error("error fetching cluster members {}", e);
                     throw new CompletionException(e);
                 }

--- a/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
+++ b/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.fault;
 
 import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.ClusterException;
 import io.pravega.common.cluster.ClusterType;
 import io.pravega.common.cluster.Host;
 import io.pravega.common.cluster.zkImpl.ClusterZKImpl;
@@ -184,7 +185,7 @@ class SegmentMonitorLeader implements LeaderSelectorListener {
             Map<Host, Set<Integer>> newMapping = segBalancer.rebalance(hostStore.getHostContainersMap(),
                     pravegaServiceCluster.getClusterMembers());
             hostStore.updateHostContainersMap(newMapping);
-        } catch (Exception e) {
+        } catch (ClusterException e) {
             throw new IOException(e);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server;
 
 import io.pravega.common.Exceptions;
 import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.ClusterException;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.ScaleMetadata;
@@ -79,7 +80,7 @@ public class ControllerService {
                 return cluster.getClusterMembers().stream()
                         .map(host -> NodeUri.newBuilder().setEndpoint(host.getIpAddr()).setPort(host.getPort()).build())
                         .collect(Collectors.toList());
-            } catch (Exception e) {
+            } catch (ClusterException e) {
                 // cluster implementation throws checked exceptions which cannot be thrown inside completable futures.
                 throw Lombok.sneakyThrow(e);
             }


### PR DESCRIPTION
**Change log description**

* Creates a `ClusterException` class to create a scope for the exceptions the `Cluster` interface throws.
* Makes `ClusterException` unchecked to follow the pattern used with `StoreException`.

**Purpose of the change**
Fixes #1433 

Address the comments here:
https://github.com/pravega/pravega/pull/1334#discussion_r121228541

**What the code does**
The implementation of cluster based on zookeeper has calls that throw a generic exception. This happens because the Curator lib throws a generic exception on errors. This pull request basically reduces the scope of the exception and transforms it into a `ClusterException`, which is a class created in this pull request.

As mentioned above, I have made `ClusterException` unchecked to follow the pattern used in `StoreException`, but I could be convinced to make it checked.

**How to verify it**
Run tests.