### PR TITLE
Issue 1486: Having consistent string representing storagetype enum and env variable

### DIFF
--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -68,7 +68,7 @@ services:
     privileged: true
     environment:
       WAIT_FOR: bookie1:3181,bookie2:3182,bookie3:3183
-      TIER2_STORAGE: "FS"
+      TIER2_STORAGE: "FILESYSTEM"
       MOUNT_IN_CONTAINER: "true"
       NFS_SERVER: ${NFS_IP}:${NFS_PATH}
       NFS_MOUNT: /nfs

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -76,7 +76,7 @@ services:
       - nfs:/nfs/
     environment:
       WAIT_FOR: bookie1:3181,bookie2:3182,bookie3:3183
-      TIER2_STORAGE: "FS"
+      TIER2_STORAGE: "FILESYSTEM"
       NFS_MOUNT: /nfs
       HDFS_REPLICATION: 1
       HDFS_URL: ${HOST_IP}:8020

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -30,7 +30,7 @@ configure_tier2() {
     add_system_property "pravegaservice.storageImplementation" "${TIER2_STORAGE}"
 
     echo "Checking whether NFS mounting is required"
-    if [ "${TIER2_STORAGE}" = "FS" ] && [ "${MOUNT_IN_CONTAINER}"  = "true" ]; then
+    if [ "${TIER2_STORAGE}" = "FILESYSTEM" ] && [ "${MOUNT_IN_CONTAINER}"  = "true" ]; then
         while [ -z ${NFS_SERVER} ]
         do
             echo "NFS_SERVER not set. Looping till the container is restarted with NFS_SERVER set."

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -43,7 +43,7 @@ public class ServiceConfig {
     //endregion
     public enum StorageTypes {
         HDFS("HDFS"),
-        FILESYSTEM("FS"),
+        FILESYSTEM("FILESYSTEM"),
         INMEMORY("INMEMORY");
 
         private final String type;


### PR DESCRIPTION
**Change log description**
The segment store container was failing to start because the entrypoint script requires the value to be set as FS but the ServiceStarter is attempting to convert the string to an enumeration that expects FILESYSTEM. With this change, the string storagetype and env variable are same.

**Purpose of the change**
Fixes #1486.

**What the code does**
Changes the env value that is checked to "FILESYSTEM" from "FS". Replaces the enumeration FILESYSTEM("FS") with FILESYSTEM("FILESYSTEM").

**How to verify it**
Change the env value and start the docker container.