### PR TITLE
Issue 1346: Record event counts per segment

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -57,6 +57,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_BYTES;
+import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_EVENTS;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_LATENCY;
 import static io.pravega.shared.MetricsNames.nameFromSegment;
 
@@ -73,7 +74,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
-    static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);
+    private static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);
 
     private final StreamSegmentStore store;
     private final ServerConnection connection;
@@ -237,9 +238,10 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                     handleException(append.getWriterId(), append.getEventNumber(), append.getSegment(), "appending data", exception);
                 }
             } else {
-                DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
                 connection.send(new DataAppended(append.getWriterId(), append.getEventNumber()));
-      
+                DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
+                DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
+
                 if (statsRecorder != null) {
                     statsRecorder.record(append.getSegment(), append.getDataLength(), append.getEventCount());
                 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Metrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Metrics.java
@@ -20,6 +20,6 @@ import io.pravega.shared.metrics.StatsLogger;
  */
 final class Metrics {
     static final StatsLogger DURABLE_DATALOG_LOGGER = MetricsProvider.createStatsLogger("durablelog");
-    static final OpStatsLogger WRITE_LATENCY = DURABLE_DATALOG_LOGGER.createStats(MetricsNames.TIER1_WRITE_BYTES);
+    static final OpStatsLogger WRITE_LATENCY = DURABLE_DATALOG_LOGGER.createStats(MetricsNames.TIER1_WRITE_LATENCY);
     static final Counter WRITE_BYTES = DURABLE_DATALOG_LOGGER.createCounter(MetricsNames.TIER1_WRITE_BYTES);
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -17,7 +17,7 @@ public final class MetricsNames {
     public static final String SEGMENT_WRITE_LATENCY = "segment_write_latency_ms";   // Timer
     public static final String SEGMENT_READ_BYTES = "segmentstore.segment_read_bytes";            // Dynamic Counter
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
-    public static final String SEGMENT_WRITE_EVENTS = "segment_write_events";                     // Dynamic Counter
+    public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment_write_events";        // Dynamic Counter
 
     //hdfs stats
     public static final String HDFS_READ_LATENCY = "tier2_read_latency_ms";   // Timer

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -11,12 +11,13 @@ package io.pravega.shared;
 
 public final class MetricsNames {
     // Metrics in Segment Store Service
-    // host stats
+    // Segment-related stats
     public static final String SEGMENT_CREATE_LATENCY = "segment_create_latency_ms"; // Timer
     public static final String SEGMENT_READ_LATENCY = "segment_read_latency_ms";     // Timer
     public static final String SEGMENT_WRITE_LATENCY = "segment_write_latency_ms";   // Timer
     public static final String SEGMENT_READ_BYTES = "segmentstore.segment_read_bytes";            // Dynamic Counter
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
+    public static final String SEGMENT_WRITE_EVENTS = "segment_write_events";                     // Dynamic Counter
 
     //hdfs stats
     public static final String HDFS_READ_LATENCY = "tier2_read_latency_ms";   // Timer
@@ -25,7 +26,7 @@ public final class MetricsNames {
     public static final String HDFS_WRITE_BYTES = "tier2_write_bytes";        // Counter
 
     //DurableLog stats
-    public static final String TIER1_WRITE_LATENCY = "tier1_write_latency"; // Timer
+    public static final String TIER1_WRITE_LATENCY = "tier1_datalog_write_latency"; // Timer
     public static final String TIER1_WRITE_BYTES = "tier1_datalog_write_bytes";     // Counter
 
     // Metrics in Controller


### PR DESCRIPTION
**Change log description**

* Records the incoming event count per segment as a metric in the SegmentStore.
* Corrects the metric name for `WRITE_LATENCY`stats logger.

**Purpose of the change**
Fixes #1346.

**What the code does**
Records new metric. 
Fixes existing bug.

**How to verify it**
Run Pravega and verify metric is recorded.