### PR TITLE
Issue 1492: Renabling retryable trait for operation not allowed exception

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -145,8 +145,8 @@ public abstract class PersistentStreamBase<T> implements Stream {
                         return setStateData(new Data<>(SerializationUtils.serialize(state), currState.getVersion()))
                                 .thenApply(x -> true);
                     } else {
-                        return FutureHelpers.failedFuture(StoreException.create(StoreException.Type.ILLEGAL_STATE,
-                                state.name()));
+                        return FutureHelpers.failedFuture(StoreException.create(
+                                StoreException.Type.OPERATION_NOT_ALLOWED, state.name()));
                     }
                 });
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StoreException.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StoreException.java
@@ -29,6 +29,7 @@ public class StoreException extends RuntimeException {
         DATA_CONTAINS_ELEMENTS,
         WRITE_CONFLICT,
         ILLEGAL_STATE,
+        OPERATION_NOT_ALLOWED,
         CONNECTION_ERROR,
         UNKNOWN
     }
@@ -95,6 +96,9 @@ public class StoreException extends RuntimeException {
             case ILLEGAL_STATE:
                 exception = new IllegalStateException();
                 break;
+            case OPERATION_NOT_ALLOWED:
+                exception = new OperationNotAllowedException();
+                break;
             case CONNECTION_ERROR:
                 exception = new StoreConnectionException();
                 break;
@@ -149,6 +153,15 @@ public class StoreException extends RuntimeException {
     public static class IllegalStateException extends StoreException {
         public IllegalStateException() {
             super(Type.ILLEGAL_STATE);
+        }
+    }
+
+    /**
+     * Exception type when the attempted operation is currently not allowed.
+     */
+    public static class OperationNotAllowedException extends StoreException implements RetryableException {
+        public OperationNotAllowedException() {
+            super(Type.OPERATION_NOT_ALLOWED);
         }
     }
 


### PR DESCRIPTION
**Change log description**
The retry-able trait in OperationNotAllowed was lost due to PR merge #1382
Reintroduced the exception with the retry-able trait to prevent regression.

**Purpose of the change**
Fixes #1492 

**What the code does**
Reintroduced the exception with the retry-able trait to prevent regression.

**How to verify it**
Existing tests should pass