### PR TITLE
Issue 1490: Sporadic test failure ScaleRequestHandlerTest > testScaleRequest 

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -138,7 +138,7 @@ public class ScaleRequestHandlerTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 30000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -138,7 +138,7 @@ public class ScaleRequestHandlerTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);


### PR DESCRIPTION
**Change log description**
The test, on local runs in the debugger seems to be taking 15 seconds on average.
Hence increasing the timeout to 30 seconds for travis as 20 seconds could be elapsing if travis vm is resource crunched during build. 
**Purpose of the change**
fixes #1490 
**What the code does**
increases timeout to 30 seconds
**How to verify it**
unit test should not timeout