### PR TITLE
Issue1490: sporadic build failure because of ScaleRequestHandlerTest getting timedout

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -199,7 +199,11 @@ public class ScaleRequestHandlerTest {
         assertTrue(activeSegments.stream().anyMatch(z -> z.getNumber() == 5));
         assertTrue(activeSegments.size() == 3);
 
-        assertFalse(FutureHelpers.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(0, 1, 5),
+        // make it throw a non retryable failure so that test does not wait for number of retries.
+        // This will bring down the test duration drastically because a retryable failure can keep retrying for few seconds.
+        // And if someone changes retry durations and number of attempts in retry helper, it will impact this test's running time.
+        // hence sending incorrect segmentsToSeal list which will result in a non retryable failure and this will fail immediately
+        assertFalse(FutureHelpers.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(6),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), true, System.currentTimeMillis()))));
         assertTrue(activeSegments.stream().noneMatch(z -> z.getNumber() == 3));
         assertTrue(activeSegments.stream().noneMatch(z -> z.getNumber() == 4));

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -138,7 +138,7 @@ public class ScaleRequestHandlerTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 30000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -138,7 +138,7 @@ public class ScaleRequestHandlerTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -138,7 +138,7 @@ public class ScaleRequestHandlerTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 20000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);


### PR DESCRIPTION
**Change log description**
The core issue was, in the test we wanted to run a failure scenario where request handler would eventually fail the request. 
To achieve this we passed a request whose processing would result in retryable exception which would be retried several times before failing.

With several retries, this could go upto few seconds. 
We have also been changing our retry duration and number of attempts which has a side effect on the runtime of this test.. 
Its better to give an input that results in a non-retryable exception in which case we will observe processing failure as intended without spending too much time.

So changed the input which should result in non-retryable failure, hence the test will finish faster and will not be impacted if retry attempts are changed elsewhere. 

**Purpose of the change**
Removes possibility of a timeout failure for this test and ensures that changing retry constants in RetryHelper does not affect this test's running time. 
**What the code does**
Changes input for scale such that non-retryable exception is thrown
**How to verify it**
Unit test changed