### PR TITLE
Issue 1505: (SegmentStore) Sporadic build failure due to StorageWriter/ReadIndex shutdown

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -575,6 +575,8 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      * @throws IllegalArgumentException If the parameters are invalid (offset, length or offset+length are not in the Segment's range).
      */
     InputStream readDirect(long startOffset, int length) {
+        Exceptions.checkNotClosed(this.closed, this);
+        Preconditions.checkState(!this.recoveryMode, "StreamSegmentReadIndex is in Recovery Mode.");
         Preconditions.checkArgument(length >= 0, "length must be a non-negative number");
         Preconditions.checkArgument(startOffset >= this.metadata.getStorageLength(), "startOffset must refer to an offset beyond the Segment's StorageLength offset.");
         Preconditions.checkArgument(startOffset + length <= this.metadata.getDurableLogLength(), "startOffset+length must be less than the length of the Segment.");


### PR DESCRIPTION
**Change log description**
Fixed a sporadic bug that would happen very rarely during the builds. This is not a "steady-state" bug, rather something that would happen due to various components shutting down asynchronously - so it may only happen upon container shutdown.
* Added proper checks to StreamSegmentReadIndex.readDirect (closed, not recovery). This will throw into the SegmentAggregator (at the readDirect's callsite), it will bubble all the way up to the StorageWriter, which will handle it appropriately.
* Updated StorageWriter to ignore ObjectClosedExceptions (along CancellationExceptions) if it's already shutting down.

**Purpose of the change**
Fixes #1505.

**What the code does**
Handles a special case.

**How to verify it**
Unfortunately I can't repro this with a unit test due to the async nature of things - a bunch of things have to happen very quickly in short succession in order to trigger it. Please look at the changes and verify that their addition are not likely to add other problems.