### PR TITLE
Issue 1513: REST API for scaling events should report the last event before "from" timestamp

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -439,15 +439,18 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             // referenceEvent is the Event used as reference for the events between 'from' and 'to'.
             ScaleMetadata referenceEvent = null;
 
+            log.warn("### List scale metadata size: " + listScaleMetadata.size());
             while (metadataIterator.hasNext()) {
                 ScaleMetadata scaleMetadata = metadataIterator.next();
                 if (scaleMetadata.getTimestamp() >= from && scaleMetadata.getTimestamp() <= to) {
                     finalScaleMetadataList.add(scaleMetadata);
-                } else if (scaleMetadata.getTimestamp() < from) {
+                } else if ((scaleMetadata.getTimestamp() < from) &&
+                            !(referenceEvent != null && referenceEvent.getTimestamp() > scaleMetadata.getTimestamp())) {
                     // This check is required to store a reference event i.e. an event before the 'from' datetime
+                    scaleMetadata.getSegments().forEach( segment -> {
+                        log.warn("### Segment number: " + segment.getNumber());
+                    });
                     referenceEvent = scaleMetadata;
-                } else {
-                    break;
                 }
             }
 

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -439,7 +439,6 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             // referenceEvent is the Event used as reference for the events between 'from' and 'to'.
             ScaleMetadata referenceEvent = null;
 
-            log.warn("### List scale metadata size: " + listScaleMetadata.size());
             while (metadataIterator.hasNext()) {
                 ScaleMetadata scaleMetadata = metadataIterator.next();
                 if (scaleMetadata.getTimestamp() >= from && scaleMetadata.getTimestamp() <= to) {
@@ -447,9 +446,6 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                 } else if ((scaleMetadata.getTimestamp() < from) &&
                             !(referenceEvent != null && referenceEvent.getTimestamp() > scaleMetadata.getTimestamp())) {
                     // This check is required to store a reference event i.e. an event before the 'from' datetime
-                    scaleMetadata.getSegments().forEach( segment -> {
-                        log.warn("### Segment number: " + segment.getNumber());
-                    });
                     referenceEvent = scaleMetadata;
                 }
             }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.rest.v1;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.pravega.controller.server.rest.RESTServer;
 import io.pravega.controller.server.rest.RESTServerConfig;
 import io.pravega.controller.server.rest.impl.RESTServerConfigImpl;
@@ -46,9 +47,11 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import io.pravega.test.common.TestUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,6 +61,7 @@ import org.junit.rules.Timeout;
 import static io.pravega.controller.server.rest.generated.model.RetentionConfig.TypeEnum;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -66,6 +70,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for Stream metadata REST APIs.
  */
+@Slf4j
 public class StreamMetaDataTests {
 
     //Ensure each test completes within 30 seconds.
@@ -654,48 +659,67 @@ public class StreamMetaDataTests {
 
         /* Test to get scaling events
 
-        There are 4 scale events in final list.
+        There are 5 scale events in final list.
         Filter 'from' and 'to' is also tested here.
         Event1 is before 'from'
-        Event2 and Event3 are between 'from' and 'to'
-        Event4 is after 'to'
-        Response contains 3 events : Event1 acts as reference event. Event2 and Event3 fall between 'from' and 'to'.
+        Event2 is before 'from'
+        Event3 and Event4 are between 'from' and 'to'
+        Event5 is after 'to'
+        Response contains 3 events : Event2 acts as reference event. Event3 and Event4 fall between 'from' and 'to'.
          */
         Segment segment1 = new Segment(0, System.currentTimeMillis(), 0.00, 0.50);
         Segment segment2 = new Segment(1, System.currentTimeMillis(), 0.50, 1.00);
         List<Segment> segmentList1 = Arrays.asList(segment1, segment2);
         ScaleMetadata scaleMetadata1 = new ScaleMetadata(System.currentTimeMillis() / 2, segmentList1);
-        scaleMetadataList.add(scaleMetadata1);
+
+        Segment segment3 = new Segment(2, System.currentTimeMillis(), 0.00, 0.40);
+        Segment segment4 = new Segment(3, System.currentTimeMillis(), 0.40, 1.00);
+        List<Segment> segmentList2 = Arrays.asList(segment3, segment4);
+        ScaleMetadata scaleMetadata2 = new ScaleMetadata(1 + System.currentTimeMillis() / 2, segmentList2);
 
         long fromDateTime = System.currentTimeMillis();
 
-        Segment segment3 = new Segment(0, System.currentTimeMillis(), 0.00, 0.50);
-        Segment segment4 = new Segment(1, System.currentTimeMillis(), 0.50, 1.00);
-        List<Segment> segmentList2 = Arrays.asList(segment3, segment4);
-        ScaleMetadata scaleMetadata2 = new ScaleMetadata(System.currentTimeMillis(), segmentList2);
-        scaleMetadataList.add(scaleMetadata2);
-
-        Segment segment5 = new Segment(0, System.currentTimeMillis(), 0.00, 0.25);
-        Segment segment6 = new Segment(1, System.currentTimeMillis(), 0.25, 1.00);
+        Segment segment5 = new Segment(4, System.currentTimeMillis(), 0.00, 0.50);
+        Segment segment6 = new Segment(5, System.currentTimeMillis(), 0.50, 1.00);
         List<Segment> segmentList3 = Arrays.asList(segment5, segment6);
         ScaleMetadata scaleMetadata3 = new ScaleMetadata(System.currentTimeMillis(), segmentList3);
-        scaleMetadataList.add(scaleMetadata3);
+
+        Segment segment7 = new Segment(6, System.currentTimeMillis(), 0.00, 0.25);
+        Segment segment8 = new Segment(7, System.currentTimeMillis(), 0.25, 1.00);
+        List<Segment> segmentList4 = Arrays.asList(segment7, segment8);
+        ScaleMetadata scaleMetadata4 = new ScaleMetadata(System.currentTimeMillis(), segmentList4);
 
         long toDateTime = System.currentTimeMillis();
 
-        Segment segment7 = new Segment(0, System.currentTimeMillis(), 0.00, 0.40);
-        Segment segment8 = new Segment(0, System.currentTimeMillis(), 0.40, 1.00);
-        List<Segment> segmentList4 = Arrays.asList(segment7, segment8);
-        ScaleMetadata scaleMetadata4 = new ScaleMetadata(toDateTime * 2, segmentList4);
+        Segment segment9 = new Segment(8, System.currentTimeMillis(), 0.00, 0.40);
+        Segment segment10 = new Segment(9, System.currentTimeMillis(), 0.40, 1.00);
+        List<Segment> segmentList5 = Arrays.asList(segment9, segment10);
+        ScaleMetadata scaleMetadata5 = new ScaleMetadata(toDateTime * 2, segmentList5);
+
+        // HistoryRecords.readAllRecords returns a list of records in decreasing order
+        // so we add the elements in reverse order as well to simulate that behavior
+        scaleMetadataList.add(scaleMetadata5);
         scaleMetadataList.add(scaleMetadata4);
+        scaleMetadataList.add(scaleMetadata3);
+        scaleMetadataList.add(scaleMetadata2);
+        scaleMetadataList.add(scaleMetadata1);
+
+        log.warn("#### Scale metadata list size: " + scaleMetadataList.size());
 
         when(mockControllerService.getScaleRecords(scope1, stream1)).
                 thenReturn(CompletableFuture.completedFuture(scaleMetadataList));
         Response response = client.target(resourceURI).queryParam("from", fromDateTime).
                 queryParam("to", toDateTime).request().buildGet().invoke();
         assertEquals("Get Scaling Events response code", 200, response.getStatus());
-        final List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(List.class);
+        final List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(new GenericType<List<ScaleMetadata>>(){});
         assertEquals("List Size", 3, scaleMetadataListResponse.size());
+        scaleMetadataListResponse.forEach(data -> {
+            log.warn("Here");
+            data.getSegments().forEach( segment -> {
+                log.warn("### Segment number: " + segment.getNumber());
+               assertTrue("Event 1 shouldn't be included", segment.getNumber() != 0);
+            });
+        });
 
         // Test for getScalingEvents for invalid scope/stream.
         final CompletableFuture<List<ScaleMetadata>> completableFuture1 = new CompletableFuture<>();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -714,7 +714,7 @@ public class StreamMetaDataTests {
         scaleMetadataListResponse.forEach(data -> {
             log.warn("Here");
             data.getSegments().forEach( segment -> {
-                log.warn("### Segment number: " + segment.getNumber());
+               log.debug("Checking segment number: " + segment.getNumber());
                assertTrue("Event 1 shouldn't be included", segment.getNumber() != 0);
             });
         });

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -704,8 +704,6 @@ public class StreamMetaDataTests {
         scaleMetadataList.add(scaleMetadata2);
         scaleMetadataList.add(scaleMetadata1);
 
-        log.warn("#### Scale metadata list size: " + scaleMetadataList.size());
-
         when(mockControllerService.getScaleRecords(scope1, stream1)).
                 thenReturn(CompletableFuture.completedFuture(scaleMetadataList));
         Response response = client.target(resourceURI).queryParam("from", fromDateTime).


### PR DESCRIPTION
**Change log description**
* Fixes the logic in `StreamMetadataResourceImpl` to process the list of scale records in descending order.

* Fixes the test case in `StreamMetadataTests` for getting scale events accordingly. 

**Purpose of the change**
Fixes #1513 

**What the code does**
Fixes the bug reported in #1513 .

**How to verify it**
Run controller unit tests.