### PR TITLE
Issue 1512: Fix segment splits and merges metrics

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -617,8 +617,10 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     private CompletableFuture<Pair<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor) {
         return getScaleMetadata(scopeName, streamName, null, executor).thenApply(scaleMetadataList -> {
             int size = scaleMetadataList.size();
-            long totalNumSplits = 0, totalNumMerges = 0;
-            List<Segment> segmentList1, segmentList2;
+            long totalNumSplits = 0;
+            long totalNumMerges = 0;
+            List<Segment> segmentList1;
+            List<Segment> segmentList2;
             boolean isDescendingOrder = (size > 1) ?
                     (scaleMetadataList.get(0).getTimestamp() < scaleMetadataList.get(1).getTimestamp()) : true;
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -619,17 +619,14 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
             int size = scaleMetadataList.size();
             long totalNumSplits = 0;
             List<Segment> segmentList1, segmentList2;
+            boolean isDescendingOrder = isDescendingOrder(scaleMetadataList);
 
-            if (isDescendingOrder(scaleMetadataList)) {
-                for (int i = size; i > 1; i--) {
-                    segmentList1 = scaleMetadataList.get(i).getSegments();
-                    segmentList2 = scaleMetadataList.get(i-1).getSegments();
-                    totalNumSplits += findSegmentSplitsMerges(segmentList1, segmentList2);
-                }
-            } else {
-                for (int i = 0; i < size - 1; i++) {
-                    segmentList1 = scaleMetadataList.get(i).getSegments();
-                    segmentList2 = scaleMetadataList.get(i+1).getSegments();
+            for (int i = 0; i < size - 1; i++) {
+                segmentList1 = scaleMetadataList.get(i).getSegments();
+                segmentList2 = scaleMetadataList.get(i+1).getSegments();
+                if (isDescendingOrder) {
+                    totalNumSplits += findSegmentSplitsMerges(segmentList2, segmentList1);
+                } else {
                     totalNumSplits += findSegmentSplitsMerges(segmentList1, segmentList2);
                 }
             }
@@ -643,17 +640,14 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
             int size = scaleMetadataList.size();
             long totalNumMerges = 0;
             List<Segment> segmentList1, segmentList2;
+            boolean isDescendingOrder = isDescendingOrder(scaleMetadataList);
 
-            if (isDescendingOrder(scaleMetadataList)) {
-                for (int i = size; i > 1; i--) {
-                    segmentList1 = scaleMetadataList.get(i).getSegments();
-                    segmentList2 = scaleMetadataList.get(i-1).getSegments();
-                    totalNumMerges += findSegmentSplitsMerges(segmentList2, segmentList1);
-                }
-            } else {
-                for (int i = 0; i < size - 1; i++) {
-                    segmentList1 = scaleMetadataList.get(i).getSegments();
-                    segmentList2 = scaleMetadataList.get(i+1).getSegments();
+            for (int i = 0; i < size - 1; i++) {
+                segmentList1 = scaleMetadataList.get(i).getSegments();
+                segmentList2 = scaleMetadataList.get(i+1).getSegments();
+                if (isDescendingOrder) {
+                    totalNumMerges += findSegmentSplitsMerges(segmentList1, segmentList2);
+                } else {
                     totalNumMerges += findSegmentSplitsMerges(segmentList2, segmentList1);
                 }
             }

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -614,7 +614,8 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
         return result;
     }
 
-    private CompletableFuture<Pair<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor) {
+    @Override
+    public CompletableFuture<Pair<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor) {
         return getScaleMetadata(scopeName, streamName, null, executor).thenApply(scaleMetadataList -> {
             int size = scaleMetadataList.size();
             long totalNumSplits = 0;
@@ -622,7 +623,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
             List<Segment> segmentList1;
             List<Segment> segmentList2;
             boolean isDescendingOrder = (size > 1) ?
-                    (scaleMetadataList.get(0).getTimestamp() < scaleMetadataList.get(1).getTimestamp()) : true;
+                    (scaleMetadataList.get(0).getTimestamp() > scaleMetadataList.get(1).getTimestamp()) : true;
 
             for (int i = 0; i < size - 1; i++) {
                 segmentList1 = scaleMetadataList.get(i).getSegments();
@@ -640,11 +641,11 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
         });
     }
 
-    private int findSegmentSplitsMerges(List<Segment> segmentsList1, List<Segment> segmentsList2) {
+    private int findSegmentSplitsMerges(List<Segment> referenceSegmentsList, List<Segment> targetSegmentsList) {
         int count = 0;
-        for (Segment segment1 : segmentsList1 ) {
+        for (Segment segment1 : referenceSegmentsList ) {
             int overlaps = 0;
-            for (Segment segment2 : segmentsList2) {
+            for (Segment segment2 : targetSegmentsList) {
                 if (segment1.overlaps(segment2)) {
                     overlaps++;
                 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -614,8 +614,8 @@ public interface StreamMetadataStore {
      * @param scopeName     stream scope
      * @param streamName    stream name
      * @param executor      callers executor
-     * @return              Pair, number of splits and merges
+     * @return              SimpleEntry, number of splits as Key and number of merges as value
      */
-    CompletableFuture<Pair<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor);
+    CompletableFuture<SimpleEntry<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor);
 
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -608,4 +608,14 @@ public interface StreamMetadataStore {
      */
     CompletableFuture<List<ScaleMetadata>> getScaleMetadata(final String scope, final String name, final OperationContext context, final Executor executor);
 
+    /**
+     * Method to count number of splits and merges.
+     *
+     * @param scopeName     stream scope
+     * @param streamName    stream name
+     * @param executor      callers executor
+     * @return              Pair, number of splits and merges
+     */
+    CompletableFuture<Pair<Long, Long>> findNumSplitsMerges(String scopeName, String streamName, Executor executor);
+
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -22,7 +22,7 @@ import org.apache.curator.test.TestingServer;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -121,9 +121,9 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
         String stream = "testStreamScale";
         ScalingPolicy policy = ScalingPolicy.fixed(3);
         StreamConfiguration configuration = StreamConfiguration.builder().scope(scope).streamName(stream).scalingPolicy(policy).build();
-        AbstractMap.SimpleEntry<Double, Double> segment1 = new AbstractMap.SimpleEntry<>(0.0, 0.5);
-        AbstractMap.SimpleEntry<Double, Double> segment2 = new AbstractMap.SimpleEntry<>(0.5, 1.0);
-        List<java.util.AbstractMap.SimpleEntry<Double, Double>> newRanges = Arrays.asList(segment1, segment2);
+        SimpleEntry<Double, Double> segment1 = new SimpleEntry<>(0.0, 0.5);
+        SimpleEntry<Double, Double> segment2 = new SimpleEntry<>(0.5, 1.0);
+        List<SimpleEntry<Double, Double>> newRanges = Arrays.asList(segment1, segment2);
 
         store.createScope(scope).get();
         store.createStream(scope, stream, configuration, System.currentTimeMillis(), null, executor).get();
@@ -160,7 +160,8 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
         String scope = "testScopeScale";
         String stream = "testStreamScale";
         ScalingPolicy policy = ScalingPolicy.fixed(2);
-        StreamConfiguration configuration = StreamConfiguration.builder().scope(scope).streamName(stream).scalingPolicy(policy).build();
+        StreamConfiguration configuration = StreamConfiguration.builder().
+                scope(scope).streamName(stream).scalingPolicy(policy).build();
 
         store.createScope(scope).get();
         store.createStream(scope, stream, configuration, System.currentTimeMillis(), null, executor).get();
@@ -168,63 +169,65 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
 
         // Case: Initial state, splits = 0, merges = 0
         // time t0, total segments 2, S0 {0.0 - 0.5} S1 {0.5 - 1.0}
-        List<ScaleMetadata> scaleIncidents = store.getScaleMetadata(scope, stream, null, executor).get();
-        assertTrue(scaleIncidents.size() == 1);
-        org.apache.commons.lang3.tuple.Pair<Long, Long> pairSplitsMerges = store.findNumSplitsMerges(scope, stream, executor).get();
-        assertEquals("Number of splits ", new Long(0), pairSplitsMerges.getLeft());
-        assertEquals("Number of merges", new Long(0), pairSplitsMerges.getLeft());
+        List<ScaleMetadata> scaleRecords = store.getScaleMetadata(scope, stream, null, executor).get();
+        assertTrue(scaleRecords.size() == 1);
+        SimpleEntry<Long, Long> simpleEntrySplitsMerges = store.findNumSplitsMerges(scope, stream, executor).get();
+        assertEquals("Number of splits ", new Long(0), simpleEntrySplitsMerges.getKey());
+        assertEquals("Number of merges", new Long(0), simpleEntrySplitsMerges.getValue());
 
         // Case: Only splits, S0 split into S2, S3, S4 and S1 split into S5, S6,
         //  total splits = 2, total merges = 3
         // time t1, total segments 5, S2 {0.0, 0.2}, S3 {0.2, 0.4}, S4 {0.4, 0.5}, S5 {0.5, 0.7}, S6 {0.7, 1.0}
-        AbstractMap.SimpleEntry<Double, Double> segment2 = new AbstractMap.SimpleEntry<>(0.0, 0.2);
-        AbstractMap.SimpleEntry<Double, Double> segment3 = new AbstractMap.SimpleEntry<>(0.2, 0.4);
-        AbstractMap.SimpleEntry<Double, Double> segment4 = new AbstractMap.SimpleEntry<>(0.4, 0.5);
-        AbstractMap.SimpleEntry<Double, Double> segment5 = new AbstractMap.SimpleEntry<>(0.5, 0.7);
-        AbstractMap.SimpleEntry<Double, Double> segment6 = new AbstractMap.SimpleEntry<>(0.7, 1.0);
-        List<java.util.AbstractMap.SimpleEntry<Double, Double>> newRanges1 = Arrays.asList(segment2, segment3, segment4, segment5, segment6);
-        scale(scope, stream, scaleIncidents.get(0).getSegments(), newRanges1);
-        scaleIncidents = store.getScaleMetadata(scope, stream, null, executor).get();
-        assertTrue(scaleIncidents.size() == 2);
-        org.apache.commons.lang3.tuple.Pair<Long, Long> pairSplitsMerges1 = store.findNumSplitsMerges(scope, stream, executor).get();
-        assertEquals("Number of splits ", new Long(2), pairSplitsMerges1.getLeft());
-        assertEquals("Number of merges", new Long(0), pairSplitsMerges1.getRight());
+        SimpleEntry<Double, Double> segment2 = new SimpleEntry<>(0.0, 0.2);
+        SimpleEntry<Double, Double> segment3 = new SimpleEntry<>(0.2, 0.4);
+        SimpleEntry<Double, Double> segment4 = new SimpleEntry<>(0.4, 0.5);
+        SimpleEntry<Double, Double> segment5 = new SimpleEntry<>(0.5, 0.7);
+        SimpleEntry<Double, Double> segment6 = new SimpleEntry<>(0.7, 1.0);
+        List<SimpleEntry<Double, Double>> newRanges1 = Arrays.asList(segment2, segment3, segment4, segment5, segment6);
+        scale(scope, stream, scaleRecords.get(0).getSegments(), newRanges1);
+        scaleRecords = store.getScaleMetadata(scope, stream, null, executor).get();
+        assertTrue(scaleRecords.size() == 2);
+        SimpleEntry<Long, Long> simpleEntrySplitsMerges1 = store.findNumSplitsMerges(scope, stream, executor).get();
+        assertEquals("Number of splits ", new Long(2), simpleEntrySplitsMerges1.getKey());
+        assertEquals("Number of merges", new Long(0), simpleEntrySplitsMerges1.getValue());
 
         // Case: Splits and merges both, S2 and S3 merged to S7,  S4 and S5 merged to S8,  S6 split to S9 and S10
         // total splits = 3, total merges = 2
         // time t2, total segments 4, S7 {0.0, 0.4}, S8 {0.4, 0.7}, S9 {0.7, 0.8}, S10 {0.8, 1.0}
-        AbstractMap.SimpleEntry<Double, Double> segment7 = new AbstractMap.SimpleEntry<>(0.0, 0.4);
-        AbstractMap.SimpleEntry<Double, Double> segment8 = new AbstractMap.SimpleEntry<>(0.4, 0.7);
-        AbstractMap.SimpleEntry<Double, Double> segment9 = new AbstractMap.SimpleEntry<>(0.7, 0.8);
-        AbstractMap.SimpleEntry<Double, Double> segment10 = new AbstractMap.SimpleEntry<>(0.8, 1.0);
-        List<java.util.AbstractMap.SimpleEntry<Double, Double>> newRanges2 = Arrays.asList(segment7, segment8, segment9, segment10);
-        scale(scope, stream, scaleIncidents.get(0).getSegments(), newRanges2);
-        scaleIncidents = store.getScaleMetadata(scope, stream, null, executor).get();
-        org.apache.commons.lang3.tuple.Pair<Long, Long> pairSplitsMerges2 = store.findNumSplitsMerges(scope, stream, executor).get();
-        assertEquals("Number of splits ", new Long(3), pairSplitsMerges2.getLeft());
-        assertEquals("Number of merges", new Long(2), pairSplitsMerges2.getRight());
+        SimpleEntry<Double, Double> segment7 = new SimpleEntry<>(0.0, 0.4);
+        SimpleEntry<Double, Double> segment8 = new SimpleEntry<>(0.4, 0.7);
+        SimpleEntry<Double, Double> segment9 = new SimpleEntry<>(0.7, 0.8);
+        SimpleEntry<Double, Double> segment10 = new SimpleEntry<>(0.8, 1.0);
+        List<SimpleEntry<Double, Double>> newRanges2 = Arrays.asList(segment7, segment8, segment9, segment10);
+        scale(scope, stream, scaleRecords.get(0).getSegments(), newRanges2);
+        scaleRecords = store.getScaleMetadata(scope, stream, null, executor).get();
+        SimpleEntry<Long, Long> simpleEntrySplitsMerges2 = store.findNumSplitsMerges(scope, stream, executor).get();
+        assertEquals("Number of splits ", new Long(3), simpleEntrySplitsMerges2.getKey());
+        assertEquals("Number of merges", new Long(2), simpleEntrySplitsMerges2.getValue());
 
         // Case: Only merges , S7 and S8 merged to S11,  S9 and S10 merged to S12
         // total splits = 3, total merges = 4
         // time t3, total segments 2, S11 {0.0, 0.7}, S12 {0.7, 1.0}
-        AbstractMap.SimpleEntry<Double, Double> segment11 = new AbstractMap.SimpleEntry<>(0.0, 0.7);
-        AbstractMap.SimpleEntry<Double, Double> segment12 = new AbstractMap.SimpleEntry<>(0.7, 1.0);
-        List<java.util.AbstractMap.SimpleEntry<Double, Double>> newRanges3 = Arrays.asList(segment11, segment12);
-        scale(scope, stream, scaleIncidents.get(0).getSegments(), newRanges3);
-        org.apache.commons.lang3.tuple.Pair<Long, Long> pairSplitsMerges3 = store.findNumSplitsMerges(scope, stream, executor).get();
-        assertEquals("Number of splits ", new Long(3), pairSplitsMerges3.getLeft());
-        assertEquals("Number of merges", new Long(4), pairSplitsMerges3.getRight());
+        SimpleEntry<Double, Double> segment11 = new SimpleEntry<>(0.0, 0.7);
+        SimpleEntry<Double, Double> segment12 = new SimpleEntry<>(0.7, 1.0);
+        List<SimpleEntry<Double, Double>> newRanges3 = Arrays.asList(segment11, segment12);
+        scale(scope, stream, scaleRecords.get(0).getSegments(), newRanges3);
+        SimpleEntry<Long, Long> simpleEntrySplitsMerges3 = store.findNumSplitsMerges(scope, stream, executor).get();
+        assertEquals("Number of splits ", new Long(3), simpleEntrySplitsMerges3.getKey());
+        assertEquals("Number of merges", new Long(4), simpleEntrySplitsMerges3.getValue());
     }
 
     private void scale(String scope, String stream, List<Segment> segments,
-                       List<java.util.AbstractMap.SimpleEntry<Double, Double>> newRanges) {
+                       List<SimpleEntry<Double, Double>> newRanges) {
 
         long scaleTimestamp = System.currentTimeMillis();
         List<Integer> existingSegments = segments.stream().map(Segment::getNumber).collect(Collectors.toList());
         StartScaleResponse response = store.startScale(scope, stream, existingSegments, newRanges,
                 scaleTimestamp, false, null, executor).join();
         List<Segment> segmentsCreated = response.getSegmentsCreated();
-         store.scaleNewSegmentsCreated(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(), scaleTimestamp, null, executor).join();
-        store.scaleSegmentsSealed(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(), scaleTimestamp, null, executor).join();
+        store.scaleNewSegmentsCreated(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(),
+                scaleTimestamp, null, executor).join();
+        store.scaleSegmentsSealed(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(),
+                scaleTimestamp, null, executor).join();
     }
 }


### PR DESCRIPTION
**Change log description**
Corrects reporting of segment splits and merges metrics.

**Purpose of the change**
Fixes #1512 

**What the code does**
Doesn't assume the reporting order of underlying controller API and counts splits/merges.

**How to verify it**
./gradlew startStandalone task generates few metrics in /tmp/csv folder 
