### PR TITLE
Issue 1538: Make updateStream's state update idempotent

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -760,7 +760,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
                     if (created) {
                         return future.get();
                     } else {
-                        throw new IllegalStateException("stream state not valid for the operation");
+                        throw new StoreException.IllegalStateException();
                     }
                 });
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -148,7 +148,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
         return verifyState(() -> updateState(State.UPDATING)
                 .thenApply(x -> setConfigurationData(configuration))
                 .thenApply(x -> true),
-                Lists.newArrayList(State.ACTIVE));
+                Lists.newArrayList(State.ACTIVE, State.UPDATING));
     }
 
     /**

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -366,13 +366,13 @@ public abstract class StreamMetadataStoreTest {
         AssertExtensions.assertThrows("", () ->
                         store.scaleNewSegmentsCreated(scope, stream, scale1SealedSegments, scale1SegmentsCreated,
                                 scale1ActiveEpoch, scaleTs, null, executor).join(),
-                e -> ExceptionHelpers.getRealException(e) instanceof IllegalStateException);
+                e -> ExceptionHelpers.getRealException(e) instanceof StoreException.IllegalStateException);
 
         // rerun  -- illegal state exception
         AssertExtensions.assertThrows("", () ->
                         store.scaleSegmentsSealed(scope, stream, scale1SealedSegments, scale1SegmentsCreated,
                                 scale1ActiveEpoch, scaleTs, null, executor).join(),
-                e -> ExceptionHelpers.getRealException(e) instanceof IllegalStateException);
+                e -> ExceptionHelpers.getRealException(e) instanceof StoreException.IllegalStateException);
 
         // rerun start scale -- should fail with precondition failure
         AssertExtensions.assertThrows("", () ->


### PR DESCRIPTION
**Change log description**
We first set state to Updating following by updating the configuration.
If controller fails after setting the state but before updating the configuration, the setting of state to Updating is not idempotent as it checks and processes only if original state is Active.

**Purpose of the change**
Fixes #1538

**What the code does**
Allows `updateStream` to run if state is updating. 

**How to verify it**
unit test added