### PR TITLE
Issue 1540: Set pravegaservice.storageImplementation to HDFS

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -137,7 +137,8 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +
                 setSystemProperty("autoScale.controllerUri", conUri.toString()) +
                 setSystemProperty("log.level", "DEBUG") +
-                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000));
+                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)) +
+                setSystemProperty("pravegaservice.storageImplementation", "HDFS");
 
         Map<String, String> map = new HashMap<>();
         map.put("PRAVEGA_SEGMENTSTORE_OPTS", hostSystemProperties);


### PR DESCRIPTION
**Change log description**
TIer2 storage is by default set to In memory. Change it to HDFS.

**Purpose of the change**
To point TIER2_STORAGE to HDFS  in system tests.

**What the code does**
Fixes #1540 .

**How to verify it**
Run system tests.