### PR TITLE
Issue 1477: Async read retries

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
@@ -42,8 +42,9 @@ public interface ClientConnection extends AutoCloseable {
      * Sends a wire command asynchronously.
      *
      * @param cmd The wire command to be sent.
+     * @throws ConnectionFailedException If sending fails for some reason.
      */
-    void sendAsync(WireCommand cmd);
+    void sendAsync(WireCommand cmd) throws ConnectionFailedException;
 
     /**
      * Sends the provided append commands.

--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
@@ -114,10 +114,14 @@ public class ClientConnectionInboundHandler extends ChannelInboundHandlerAdapter
     }
 
     @Override
-    public void sendAsync(WireCommand cmd) {
+    public void sendAsync(WireCommand cmd) throws ConnectionFailedException {
         recentMessage.set(true);
         Channel channel = getChannel();
-        channel.writeAndFlush(cmd, channel.voidPromise());
+        try {
+            channel.writeAndFlush(cmd, channel.voidPromise());
+        } catch (RuntimeException e) {
+            throw new ConnectionFailedException(e);
+        }
     }
     
     @Override

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -22,6 +22,7 @@ import io.pravega.common.Exceptions;
 import io.pravega.shared.protocol.netty.AppendBatchSizeTracker;
 import io.pravega.shared.protocol.netty.CommandDecoder;
 import io.pravega.shared.protocol.netty.CommandEncoder;
+import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.ExceptionLoggingHandler;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
@@ -121,12 +122,12 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                     if (future.isSuccess()) {
                         result.complete(handler);
                     } else {
-                        result.completeExceptionally(future.cause());
+                        result.completeExceptionally(new ConnectionFailedException(future.cause()));
                     }
                 }
             });
         } catch (Exception e) {
-            result.completeExceptionally(e);
+            result.completeExceptionally(new ConnectionFailedException(e));
         }
         return result;
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
+import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -21,25 +22,6 @@ abstract class AsyncSegmentInputStream implements AutoCloseable {
     @Getter
     protected final Segment segmentId;
 
-    public interface ReadFuture {
-        /**
-         * @return True if the read has completed and is successful.
-         */
-        boolean isSuccess();
-        
-        /**
-         * Waits for the provided future to be complete and returns true if it completed and false if it did not.
-         * 
-         * @param timeout The maximum number of milliseconds to block
-         */
-        boolean await(long timeout);
-    }
-    
-    /**
-     * Given an ongoing read request, blocks on its completion and returns its result.
-     */
-    public abstract SegmentRead getResult(ReadFuture ongoingRead);
-    
     /**
      * Reads from the Segment at the specified offset asynchronously.
      * 
@@ -47,9 +29,9 @@ abstract class AsyncSegmentInputStream implements AutoCloseable {
      * @param offset The offset in the segment to read from
      * @param length The suggested number of bytes to read. (Note the result may contain either more or less than this
      *            value.)
-     * @return A future for the result of the read call. The result can be obtained by calling {@link #getResult(ReadFuture)}
+     * @return A future for the result of the read call. 
      */
-    public abstract ReadFuture read(long offset, int length);
+    public abstract CompletableFuture<SegmentRead> read(long offset, int length);
 
     @Override
     public abstract void close();

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -132,7 +132,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         Exceptions.checkNotClosed(closed.get(), this);
         WireCommands.ReadSegment request = new WireCommands.ReadSegment(segmentId.getScopedName(), offset, length);
 
-        return backoffSchedule.retryingOn(ConnectionFailedException.class)
+        return backoffSchedule.retryingOn(Exception.class)
                               .throwingOn(ConnectionClosedException.class)
                               .runAsync(() -> {
                                   return getConnection().thenCompose(c -> sendRequestOverConnection(request, c));

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -145,7 +145,10 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         synchronized (lock) {
             outstandingRequests.put(request.getOffset(), result);
         }
-        log.debug("Sending read request {}", request);
+        if (closed.get()) {
+            throw new ConnectionClosedException();
+        }
+        log.trace("Sending read request {}", request);
         c.sendAsync(request);
         return result;
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -15,7 +15,6 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.common.Exceptions;
-import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.util.Retry;
 import io.pravega.common.util.Retry.RetryWithBackoff;
@@ -23,31 +22,29 @@ import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.FailingReplyProcessor;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.GuardedBy;
-import lombok.Data;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
 
-    private final RetryWithBackoff backoffSchedule = Retry.withExpBackoff(1, 10, 5);
+    private final RetryWithBackoff backoffSchedule = Retry.withExpBackoff(1, 10, 6);
     private final ConnectionFactory connectionFactory;
 
     private final Object lock = new Object();
     @GuardedBy("lock")
     private CompletableFuture<ClientConnection> connection = null;
     @GuardedBy("lock")
-    private final Map<Long, ReadFutureImpl> outstandingRequests = new HashMap<>();
+    private final Map<Long, CompletableFuture<WireCommands.SegmentRead>> outstandingRequests = new HashMap<>();
 
     private final ResponseProcessor responseProcessor = new ResponseProcessor();
     private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -74,7 +71,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         @Override
         public void segmentIsSealed(WireCommands.SegmentIsSealed segmentIsSealed) {
             checkSegment(segmentIsSealed.getSegment());
-            ReadFutureImpl future;
+            CompletableFuture<SegmentRead> future;
             synchronized (lock) {
                 future = outstandingRequests.remove(segmentIsSealed.getRequestId());
             }
@@ -91,7 +88,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         public void segmentRead(WireCommands.SegmentRead segmentRead) {
             checkSegment(segmentRead.getSegment());
             log.trace("Received read result {}", segmentRead);
-            ReadFutureImpl future;
+            CompletableFuture<SegmentRead> future;
             synchronized (lock) {
                 future = outstandingRequests.remove(segmentRead.getOffset());
             }
@@ -114,52 +111,6 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         }
     }
 
-    @Data
-    private static class ReadFutureImpl implements ReadFuture {
-        private final WireCommands.ReadSegment request;
-        private final AtomicReference<CompletableFuture<WireCommands.SegmentRead>> result;
-
-        ReadFutureImpl(WireCommands.ReadSegment request) {
-            Preconditions.checkNotNull(request);
-            this.request = request;
-            this.result = new AtomicReference<>(new CompletableFuture<>());
-        }
-
-        @Override
-        public boolean await(long timeout) {
-            FutureHelpers.await(result.get(), timeout);
-            return result.get().isDone();
-        }
-        
-        public boolean await() {
-            return FutureHelpers.await(result.get());
-        }
-
-        private WireCommands.SegmentRead get() throws ExecutionException {
-            return Exceptions.handleInterrupted(() -> result.get().get());
-        }
-
-        private void complete(WireCommands.SegmentRead r) {
-            result.get().complete(r);
-        }
-
-        public void completeExceptionally(Exception e) {
-            result.get().completeExceptionally(e);
-        }
-
-        private void reset() {
-            CompletableFuture<WireCommands.SegmentRead> old = result.getAndSet(new CompletableFuture<>());
-            if (!old.isDone()) {
-                old.completeExceptionally(new RuntimeException("Retry already in progress"));
-            }
-        }
-
-        @Override
-        public boolean isSuccess() {
-            return FutureHelpers.isSuccessful(result.get());
-        }
-    }
-
     public AsyncSegmentInputStreamImpl(Controller controller, ConnectionFactory connectionFactory, Segment segment) {
         super(segment);
         Preconditions.checkNotNull(controller);
@@ -177,22 +128,26 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
     }
 
     @Override
-    public ReadFuture read(long offset, int length) {
+    public CompletableFuture<SegmentRead> read(long offset, int length) {
         Exceptions.checkNotClosed(closed.get(), this);
         WireCommands.ReadSegment request = new WireCommands.ReadSegment(segmentId.getScopedName(), offset, length);
-        
-        ReadFutureImpl read = new ReadFutureImpl(request);
+
+        return backoffSchedule.retryingOn(ConnectionFailedException.class)
+                              .throwingOn(ConnectionClosedException.class)
+                              .runAsync(() -> {
+                                  return getConnection().thenCompose(c -> sendRequestOverConnection(request, c));
+                              }, connectionFactory.getInternalExecutor());
+    }
+    
+    @SneakyThrows(ConnectionFailedException.class)
+    private CompletableFuture<SegmentRead> sendRequestOverConnection(WireCommands.ReadSegment request, ClientConnection c) {
+        CompletableFuture<WireCommands.SegmentRead> result = new CompletableFuture<>();            
         synchronized (lock) {
-            outstandingRequests.put(read.request.getOffset(), read);
+            outstandingRequests.put(request.getOffset(), result);
         }
-        getConnection().thenAccept((ClientConnection c) -> {
-            log.debug("Sending read request {}", read);
-            c.sendAsync(read.request);
-        }).exceptionally(e -> {
-            read.completeExceptionally(new CompletionException(e));
-            return null;
-        });
-        return read;
+        log.debug("Sending read request {}", request);
+        c.sendAsync(request);
+        return result;
     }
 
     private void closeConnection(Exception exceptionToInflightRequests) {
@@ -231,36 +186,14 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
 
     private void failAllInflight(Exception e) {
         log.info("Connection failed due to a {}. Read requests will be retransmitted.", e.toString());
-        List<ReadFutureImpl> readsToFail;
+        List<CompletableFuture<WireCommands.SegmentRead>> readsToFail;
         synchronized (lock) {
             readsToFail = new ArrayList<>(outstandingRequests.values());
-            //outstanding requests are not removed as they may be retried.
+            outstandingRequests.clear();
         }
-        for (ReadFutureImpl read : readsToFail) {
+        for (CompletableFuture<WireCommands.SegmentRead> read : readsToFail) {
             read.completeExceptionally(e);
         }
     }
-
-    @Override
-    public WireCommands.SegmentRead getResult(ReadFuture ongoingRead) {
-        ReadFutureImpl read = (ReadFutureImpl) ongoingRead;
-        return backoffSchedule.retryingOn(ExecutionException.class).throwingOn(RuntimeException.class).run(() -> {
-            if (closed.get()) {
-                throw new ObjectClosedException(this);
-            }
-            if (!read.await()) {
-                log.debug("Retransmitting a read request {}", read.request);
-                read.reset();
-                ClientConnection c = Exceptions.handleInterrupted(() -> getConnection().get());
-                try {
-                    c.send(read.request);
-                } catch (ConnectionFailedException e) {
-                    closeConnection(e);
-                }
-            }
-            return Exceptions.<ExecutionException, WireCommands.SegmentRead>handleInterrupted(() -> read.get());
-        });
-    }
-
 
 }

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -88,7 +88,7 @@ public class AsyncSegmentInputStreamTest {
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment);
         ClientConnection c = mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, c);
-        in.getConnection().get();// Make sure connection is established.
+        in.getConnection().get(); // Make sure connection is established.
         CompletableFuture<SegmentRead> read = in.read(1234, 5678);
         assertFalse(read.isDone());
         in.close();

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -12,17 +12,24 @@ package io.pravega.client.segment.impl;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
+import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import io.pravega.test.common.Async;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,7 +38,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class AsyncSegmentInputStreamTest {
     private static final int SERVICE_PORT = 12345;
 
-    @Test(timeout = 20000)
+    @Test(timeout = 10000)
     public void testRetry() throws ConnectionFailedException {
         Segment segment = new Segment("scope", "testRetry", 4);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -40,20 +47,30 @@ public class AsyncSegmentInputStreamTest {
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment);
         ClientConnection c = mock(ClientConnection.class);
+        InOrder inOrder = Mockito.inOrder(c);
         connectionFactory.provideConnection(endpoint, c);
-        AsyncSegmentInputStream.ReadFuture readFuture = in.read(1234, 5678);
-        ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
-        processor.connectionDropped();
-        verify(c).close();
-        assertFalse(readFuture.isSuccess());
+        
         WireCommands.SegmentRead segmentRead = new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.allocate(0));
-        WireCommands.SegmentRead result = Async.testBlocking(() -> in.getResult(readFuture), () -> {
-            processor.segmentRead(segmentRead);
-        });
-        verify(c).send(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
-        assertTrue(readFuture.isSuccess());
-        assertEquals(segmentRead, result);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                connectionFactory.getProcessor(endpoint).connectionDropped();
+                return null;            
+            }
+        }).doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                connectionFactory.getProcessor(endpoint).segmentRead(segmentRead);
+                return null;
+            }
+        }).when(c).sendAsync(Mockito.any(ReadSegment.class));
+        
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+        assertEquals(segmentRead, readFuture.join());
+        assertTrue(FutureHelpers.isSuccessful(readFuture));
+        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
+        inOrder.verify(c).close();
+        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
         verifyNoMoreInteractions(c);
     }
 
@@ -68,19 +85,24 @@ public class AsyncSegmentInputStreamTest {
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment);
         ClientConnection c = mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, c);
-        AsyncSegmentInputStream.ReadFuture readFuture = in.read(1234, 5678);
-        ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
+        
         WireCommands.SegmentRead segmentRead = new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.allocate(0));
-        processor.segmentRead(segmentRead);
-        assertTrue(readFuture.isSuccess());
-        assertEquals(segmentRead, in.getResult(readFuture));
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+        Async.testBlocking(() -> readFuture.get(), () -> {
+            ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+            processor.segmentRead(segmentRead);            
+        });
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
+        assertTrue(FutureHelpers.isSuccessful(readFuture));
+        assertEquals(segmentRead, readFuture.join());
         verifyNoMoreInteractions(c);
     }
 
     @Test(timeout = 10000)
     public void testWrongOffsetReturned() throws ConnectionFailedException {
         Segment segment = new Segment("scope", "testWrongOffsetReturned", 0);
+        byte[] good = new byte[] { 0, 1, 2, 3, 4 };
+        byte[] bad = new byte[] { 9, 8, 7, 6 };
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
@@ -88,11 +110,15 @@ public class AsyncSegmentInputStreamTest {
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment);
         ClientConnection c = mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, c);
-        AsyncSegmentInputStream.ReadFuture readFuture = in.read(1234, 5678);
-        ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+        Async.testBlocking(() -> readFuture.get(), () -> {
+            ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+            processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.wrap(bad)));            
+            processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.wrap(good)));         
+        });
         verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678));
-        processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.allocate(0)));
-        assertFalse(readFuture.isSuccess());
+        assertTrue(FutureHelpers.isSuccessful(readFuture));
+        assertEquals(ByteBuffer.wrap(good), readFuture.join().getData());
         verifyNoMoreInteractions(c);
     }
 

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -47,23 +47,6 @@ public class SegmentInputStreamTest {
             }
         }
 
-//        @Data
-//        private class ReadFutureImpl implements ReadFuture {
-//            final int num;
-//            int attempt = 0;
-//
-//            @Override
-//            public boolean isSuccess() {
-//                return FutureHelpers.isSuccessful(readResults.get(num + attempt));
-//            }
-//
-//            @Override
-//            public boolean await(long timeout) {
-//                FutureHelpers.await(readResults.get(num + attempt), timeout);
-//                return readResults.get(num + attempt).isDone();
-//            }
-//        }
-
         @Override
         public CompletableFuture<SegmentRead> read(long offset, int length) {
             int i = readIndex.incrementAndGet();
@@ -82,18 +65,6 @@ public class SegmentInputStreamTest {
         public void close() {
             closed.set(true);
         }
-
-       // @Override
-//        public WireCommands.SegmentRead getResult(ReadFuture ongoingRead) {
-//            ReadFutureImpl read = (ReadFutureImpl) ongoingRead;
-//            CompletableFuture<WireCommands.SegmentRead> future = ;
-//            if (FutureHelpers.await(future)) {
-//                return future.getNow(null);
-//            } else {
-//                read.attempt++;
-//                return FutureHelpers.getAndHandleExceptions(future, RuntimeException::new);
-//            }
-//        }
     }
 
     private ByteBuffer createEventFromData(byte[] data) {

--- a/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
@@ -183,12 +183,11 @@ public final class FutureHelpers {
      * @param <ResultT>            Type of the result.
      * @param <ExceptionT>         Type of the Exception.
      * @throws ExceptionT       If thrown by the future.
-     * @throws TimeoutException If the timeout expired prior to the future completing.
-     * @return The result of calling future.get().
+     * @return The result of calling future.get() or null if the timeout expired prior to the future completing.
      */
     @SneakyThrows(InterruptedException.class)
     public static <ResultT, ExceptionT extends Exception> ResultT getAndHandleExceptions(Future<ResultT> future,
-                                                                                         Function<Throwable, ExceptionT> exceptionConstructor, long timeoutMillis) throws TimeoutException, ExceptionT {
+                                                                                         Function<Throwable, ExceptionT> exceptionConstructor, long timeoutMillis) throws ExceptionT {
         try {
             return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
@@ -201,6 +200,8 @@ public final class FutureHelpers {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw e;
+        } catch (TimeoutException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
**Change log description**
Change read requests to use the threadPool for retries rather than relying on the caller's thread.

**Purpose of the change**
Fixes #1477

**What the code does**
Switches from using a ReadFuture to a standard completablefuture. This simplifies the calling code and lets the connection library be explicit about failures on send.

**How to verify it**
Some of the unit tests needed changes to verify the new behaviour. All pass.