### PR TITLE
Issue 1551: Active Txn path does not have scope

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -34,7 +34,8 @@ public class ZKStoreHelper {
     private static final String SCOPE_TX_ROOT = ACTIVE_TX_ROOT_PATH + "/%s";
     static final String STREAM_TX_ROOT = SCOPE_TX_ROOT + "/%s";
     private static final String COMPLETED_TX_ROOT_PATH = TRANSACTION_ROOT_PATH + "/completedTx";
-    static final String COMPLETED_TX_PATH = COMPLETED_TX_ROOT_PATH + "/%s";
+    static final String SCOPE_COMPLETED_TX_PATH = COMPLETED_TX_ROOT_PATH + "/%s";
+    static final String COMPLETED_TX_PATH = SCOPE_COMPLETED_TX_PATH + "/%s";
 
     private final CuratorFramework client;
     private final Executor executor;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -28,13 +28,14 @@ import org.apache.zookeeper.KeeperException;
 
 @Slf4j
 public class ZKStoreHelper {
-    
+
     private static final String TRANSACTION_ROOT_PATH = "/transactions";
     private static final String ACTIVE_TX_ROOT_PATH = TRANSACTION_ROOT_PATH + "/activeTx";
-    static final String STREAM_TX_ROOT = ACTIVE_TX_ROOT_PATH + "/%s";
+    private static final String SCOPE_TX_ROOT = ACTIVE_TX_ROOT_PATH + "/%s";
+    static final String STREAM_TX_ROOT = SCOPE_TX_ROOT + "/%s";
     private static final String COMPLETED_TX_ROOT_PATH = TRANSACTION_ROOT_PATH + "/completedTx";
     static final String COMPLETED_TX_PATH = COMPLETED_TX_ROOT_PATH + "/%s";
-    
+
     private final CuratorFramework client;
     private final Executor executor;
     public ZKStoreHelper(final CuratorFramework cf, Executor executor) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -75,7 +75,7 @@ class ZKStream extends PersistentStreamBase<Integer> {
         segmentPath = String.format(SEGMENT_PATH, scopeName, streamName);
         historyPath = String.format(HISTORY_PATH, scopeName, streamName);
         indexPath = String.format(INDEX_PATH, scopeName, streamName);
-        activeTxRoot = String.format(ZKStoreHelper.STREAM_TX_ROOT, streamName);
+        activeTxRoot = String.format(ZKStoreHelper.STREAM_TX_ROOT, scopeName, streamName);
         completedTxPath = String.format(ZKStoreHelper.COMPLETED_TX_PATH, streamName);
         markerPath = String.format(MARKER_PATH, scopeName, streamName);
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -76,7 +76,7 @@ class ZKStream extends PersistentStreamBase<Integer> {
         historyPath = String.format(HISTORY_PATH, scopeName, streamName);
         indexPath = String.format(INDEX_PATH, scopeName, streamName);
         activeTxRoot = String.format(ZKStoreHelper.STREAM_TX_ROOT, scopeName, streamName);
-        completedTxPath = String.format(ZKStoreHelper.COMPLETED_TX_PATH, streamName);
+        completedTxPath = String.format(ZKStoreHelper.COMPLETED_TX_PATH, scopeName, streamName);
         markerPath = String.format(MARKER_PATH, scopeName, streamName);
 
         cache = new Cache<>(store::getData);


### PR DESCRIPTION
**Change log description**
* Corrects the definition of `activeTxRoot` to include scope.

**Purpose of the change**
A txn is created in the following path: `<active-tx-path>/<active-epoch>/<txn-metadata>`
In the case two different scopes both have a stream with the same name, then without this fix, their txns will get mixed up and epoch deletion logic will be affected. Txns on one stream might end up stalling scale on a different stream

**What the code does**
Adds scope to active txn path for the stream. 

Fixes #1551.

**How to verify it**
all tests should pass