### PR TITLE
Issue 1553: TxnSweeper should handle txnNotFound

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 @Data
 @AllArgsConstructor
 public class VersionedTransactionData {
-    public static final VersionedTransactionData NULL = new VersionedTransactionData(Integer.MIN_VALUE, new UUID(0, 0),
+    public static final VersionedTransactionData EMPTY = new VersionedTransactionData(Integer.MIN_VALUE, new UUID(0, 0),
             Integer.MIN_VALUE, TxnStatus.UNKNOWN, Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE);
 
     private final int epoch;

--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
@@ -20,6 +20,9 @@ import java.util.UUID;
 @Data
 @AllArgsConstructor
 public class VersionedTransactionData {
+    public static final VersionedTransactionData NULL = new VersionedTransactionData(Integer.MIN_VALUE, new UUID(0, 0),
+            Integer.MIN_VALUE, TxnStatus.UNKNOWN, Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE);
+
     private final int epoch;
     private final UUID id;
     private final int version;

--- a/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
@@ -128,7 +128,7 @@ public class TxnSweeper {
             if (e != null) {
                 if (ExceptionHelpers.getRealException(e) instanceof StoreException.DataNotFoundException) {
                     // transaction not found, which means it should already have completed. We will ignore such txns
-                    return VersionedTransactionData.NULL;
+                    return VersionedTransactionData.EMPTY;
                 } else {
                     throw new CompletionException(e);
                 }
@@ -146,6 +146,7 @@ public class TxnSweeper {
                 case COMMITTING:
                     return failOverCommittingTxn(failedHost, epoch, txn)
                             .handleAsync((v, e) -> new Result(txn, v, e), executor);
+                case UNKNOWN:
                 default:
                     return streamMetadataStore.removeTxnFromIndex(failedHost, txn, true)
                             .thenApply(x -> new Result(txn, null, null));

--- a/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
@@ -10,9 +10,12 @@
 package io.pravega.controller.task.Stream;
 
 import com.google.common.base.Preconditions;
+import io.pravega.common.ExceptionHelpers;
 import io.pravega.common.concurrent.FutureHelpers;
+import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.TxnStatus;
+import io.pravega.controller.store.stream.VersionedTransactionData;
 import io.pravega.controller.store.task.TxnResource;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +24,7 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -120,7 +124,17 @@ public class TxnSweeper {
         String stream = txn.getStream();
         UUID txnId = txn.getTxnId();
         log.debug("Host = {}, processing transaction {}/{}/{}", failedHost, scope, stream, txnId);
-        return streamMetadataStore.getTransactionData(scope, stream, txnId, null, executor).thenComposeAsync(txData -> {
+        return streamMetadataStore.getTransactionData(scope, stream, txnId, null, executor).handle((r, e) -> {
+            if (e != null) {
+                if (ExceptionHelpers.getRealException(e) instanceof StoreException.DataNotFoundException) {
+                    // transaction not found, which means it should already have completed. We will ignore such txns
+                    return VersionedTransactionData.NULL;
+                } else {
+                    throw new CompletionException(e);
+                }
+            }
+            return r;
+        }).thenComposeAsync(txData -> {
             int epoch = txData.getEpoch();
             switch (txData.getStatus()) {
                 case OPEN:
@@ -133,7 +147,8 @@ public class TxnSweeper {
                     return failOverCommittingTxn(failedHost, epoch, txn)
                             .handleAsync((v, e) -> new Result(txn, v, e), executor);
                 default:
-                    return CompletableFuture.completedFuture(new Result(txn, null, null));
+                    return streamMetadataStore.removeTxnFromIndex(failedHost, txn, true)
+                            .thenApply(x -> new Result(txn, null, null));
             }
         }, executor).whenComplete((v, e) ->
                 log.debug("Host = {}, processing transaction {}/{}/{} complete", failedHost, scope, stream, txnId));


### PR DESCRIPTION
**Change log description**
A txn in host index may still be present while the actual txn may have completed and hence removed.
Since txnSweeper simply tries to read txn data, it may get DataNotFoundException.
It should gracefully handle such exceptions and ignore txn ownership transfer in such cases.


**Purpose of the change**
TxnSweeper calls getTxnData for all txns found in the host index.
GetTxnData can throw TxnNotFound which this should handle gracefully.

**What the code does**
It captures DataNotFound exceptions and in such cases cleans up host index (removeTxnFromIndex)

Fixes #1553 

**How to verify it**
all unit tests should pass