### PR TITLE
Issue 926: Streaming json responses for REST APIs to support APIs with large message body

### DIFF
--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -605,13 +605,13 @@ public class StreamMetaDataTests {
         response.close();
 
         // Test to list large number of streams.
-        streamsList = Collections.nCopies(1000, streamConfiguration1);
+        streamsList = Collections.nCopies(50000, streamConfiguration1);
         when(mockControllerService.listStreamsInScope("scope1")).thenReturn(CompletableFuture.completedFuture(streamsList));
         response = client.target(resourceURI).request().buildGet().invoke();
         assertEquals("List Streams response code", 200, response.getStatus());
         assertTrue(response.bufferEntity());
         final StreamsList streamsList2 = response.readEntity(StreamsList.class);
-        assertEquals("List count", 200, streamsList2.getStreams().size());
+        assertEquals("List count", 50000, streamsList2.getStreams().size());
         response.close();
     }
 
@@ -716,16 +716,28 @@ public class StreamMetaDataTests {
                 queryParam("to", toDateTime).request().buildGet().invoke();
         assertEquals("Get Scaling Events response code", 200, response.getStatus());
         assertTrue(response.bufferEntity());
-        final List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(
+        List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(
                 new GenericType<List<ScaleMetadata>>() { });
         assertEquals("List Size", 3, scaleMetadataListResponse.size());
         scaleMetadataListResponse.forEach(data -> {
-            log.warn("Here");
             data.getSegments().forEach( segment -> {
                log.debug("Checking segment number: " + segment.getNumber());
                assertTrue("Event 1 shouldn't be included", segment.getNumber() != 0);
             });
         });
+
+        // Test for large number of scaling events.
+        scaleMetadataList.clear();
+        scaleMetadataList.addAll(Collections.nCopies(10000, scaleMetadata3));
+        when(mockControllerService.getScaleRecords(scope1, stream1)).
+                thenReturn(CompletableFuture.completedFuture(scaleMetadataList));
+        response = client.target(resourceURI).queryParam("from", fromDateTime).
+                queryParam("to", toDateTime).request().buildGet().invoke();
+        assertEquals("Get Scaling Events response code", 200, response.getStatus());
+        assertTrue(response.bufferEntity());
+        scaleMetadataListResponse = response.readEntity(
+                new GenericType<List<ScaleMetadata>>() { });
+        assertEquals("List Size", 10000, scaleMetadataListResponse.size());
 
         // Test for getScalingEvents for invalid scope/stream.
         final CompletableFuture<List<ScaleMetadata>> completableFuture1 = new CompletableFuture<>();
@@ -811,14 +823,14 @@ public class StreamMetaDataTests {
         response.close();
 
         // Test to list large number of reader groups.
-        streamsList = Collections.nCopies(1000, readerGroup1);
+        streamsList = Collections.nCopies(10000, readerGroup1);
         when(mockControllerService.listStreamsInScope("scope1")).thenReturn(
                 CompletableFuture.completedFuture(streamsList));
         response = client.target(resourceURI).request().buildGet().invoke();
         assertEquals("List Reader Groups response code", 200, response.getStatus());
         assertTrue(response.bufferEntity());
         final ReaderGroupsList readerGroupsList = response.readEntity(ReaderGroupsList.class);
-        assertEquals("List count", 200, readerGroupsList.getReaderGroups().size());
+        assertEquals("List count", 10000, readerGroupsList.getReaderGroups().size());
         response.close();
     }
 


### PR DESCRIPTION
**Change log description**
Using Jersey's streaming support to send responses with large message body to prevent buffer overflows

**Purpose of the change**
Fixes #926 and #1517 

**What the code does**
Uses stream writer to send large json objects

**How to verify it**
Added test cases to send and receive large number of json objects (10000 to 50000) in a single REST API response.