### PR TITLE
Issue 1536: (SegmentStore) Container de-registration sporadic issues.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
@@ -20,9 +20,9 @@ import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
 import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -41,7 +41,7 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     //region Members
 
     private final SegmentContainerFactory factory;
-    private final AbstractMap<Integer, ContainerWithHandle> containers;
+    private final Map<Integer, ContainerWithHandle> containers;
     private final Executor executor;
     private final AtomicBoolean closed;
 
@@ -111,27 +111,20 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
         Exceptions.checkNotClosed(this.closed.get(), this);
 
         // Check if container exists
-        Exceptions.checkArgument(!this.containers.containsKey(containerId), "containerId", "Container %d is already registered.", containerId);
-
-        // If not, create one and register it.
-        ContainerWithHandle newContainer = new ContainerWithHandle(this.factory.createStreamSegmentContainer(containerId), new SegmentContainerHandle(containerId));
-        ContainerWithHandle existingContainer = this.containers.putIfAbsent(containerId, newContainer);
+        ContainerWithHandle existingContainer = this.containers.get(containerId);
         if (existingContainer != null) {
-            // We had a race and some other request beat us to it.
-            newContainer.container.close();
-            throw new IllegalArgumentException(String.format("Container %d is already registered.", containerId));
+            if (!isShutdown(existingContainer.container.state())) {
+                // Container is already registered and not in the process of shutting down.
+                throw new IllegalArgumentException(String.format("Container %d is already registered.", containerId));
+            }
+
+            // Wait for the container to shut down, and then start a new one.
+            return existingContainer.shutdownNotifier
+                                    .thenComposeAsync(v -> startContainerInternal(containerId), this.executor);
+        } else {
+            // Start the container right away.
+            return startContainerInternal(containerId);
         }
-
-        log.info("Registered SegmentContainer {}.", containerId);
-
-        // Attempt to Start the container, but first, attach a shutdown listener so we know to unregister it when it's stopped.
-        ServiceHelpers.onStop(
-                newContainer.container,
-                () -> unregisterContainer(newContainer),
-                ex -> handleContainerFailure(newContainer, ex),
-                this.executor);
-        return ServiceHelpers.startAsync(newContainer.container, this.executor)
-                .thenApply(v -> newContainer.handle);
     }
 
     @Override
@@ -149,6 +142,31 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     //endregion
 
     //region Helpers
+
+    private CompletableFuture<ContainerHandle> startContainerInternal(int containerId) {
+        // Create a new Container and attempt to register it. Be optimistic about it: create it first and then attempt
+        // to register it, which should prevent us from having to lock on this entire method. Creating new containers is
+        // cheap (we don't start them yet), so this operation should not take any extra resources.
+        ContainerWithHandle newContainer = new ContainerWithHandle(this.factory.createStreamSegmentContainer(containerId),
+                new SegmentContainerHandle(containerId));
+        ContainerWithHandle existingContainer = this.containers.putIfAbsent(containerId, newContainer);
+        if (existingContainer != null) {
+            // We had multiple concurrent calls to start this Container and some other request beat us to it.
+            newContainer.container.close();
+            throw new IllegalArgumentException(String.format("Container %d is already registered.", containerId));
+        }
+
+        log.info("Registered SegmentContainer {}.", containerId);
+
+        // Attempt to Start the container, but first, attach a shutdown listener so we know to unregister it when it's stopped.
+        ServiceHelpers.onStop(
+                newContainer.container,
+                () -> unregisterContainer(newContainer),
+                ex -> handleContainerFailure(newContainer, ex),
+                this.executor);
+        return ServiceHelpers.startAsync(newContainer.container, this.executor)
+                             .thenApply(v -> newContainer.handle);
+    }
 
     private void handleContainerFailure(ContainerWithHandle containerWithHandle, Throwable exception) {
         unregisterContainer(containerWithHandle);
@@ -168,6 +186,14 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
         // Notify the handle that the container is now in a Stopped state.
         containerWithHandle.handle.notifyContainerStopped();
         log.info("Unregistered SegmentContainer {}.", containerWithHandle.handle.getContainerId());
+
+        containerWithHandle.shutdownNotifier.complete(null);
+    }
+
+    private static boolean isShutdown(Service.State state) {
+        return state == Service.State.FAILED
+                || state == Service.State.STOPPING
+                || state == Service.State.TERMINATED;
     }
 
     //endregion
@@ -178,6 +204,7 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     private static class ContainerWithHandle {
         final SegmentContainer container;
         final SegmentContainerHandle handle;
+        final CompletableFuture<Void> shutdownNotifier = new CompletableFuture<>();
 
         @Override
         public String toString() {


### PR DESCRIPTION
**Change log description**
1. Fixed a bug in `StreamSegmentContainerRegistry` where it could erroneously fail a container registration request if that container has just been shut down. This was due to the fact that the internal de-registration happens in a callback which may be executed after the Future returned externally does. The solution provided handles all three possible cases: when a container fails during startup, when it shuts down (and results in failure or no failure) or when it fails while running.

2. Fixed a bug in `ServiceHelpers` where it could be possible that callbacks passed to onStop() would never execute in certain cases.

**Purpose of the change**
Fixes #1536.

**What the code does**
* `StreamSegmentContainerRegistry`: waits for a previous de-registration to happen before re-registering.
* `ServiceHelpers` handling a special case.

**How to verify it**
Unit tests added. Existing tests must pass.