### PR TITLE
Issue 1566:Change marathon app names

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -99,7 +99,7 @@ public class MultiReaderWriterWithFailOverTest {
         log.debug("Bookkeeper service details: {}", bkUris);
 
         //3. start 3 instances of pravega controller
-        Service conService = new PravegaControllerService("controllerFailover1", zkUri);
+        Service conService = new PravegaControllerService("controller", zkUri);
         if (!conService.isRunning()) {
             conService.start(true);
         }
@@ -115,7 +115,7 @@ public class MultiReaderWriterWithFailOverTest {
         log.info("Controller Service direct URI: {}", controllerURI);
 
         //4.start 3 instances of pravega segmentstore
-        Service segService = new PravegaSegmentStoreService("segmentstoreFailover1", zkUri, controllerURI);
+        Service segService = new PravegaSegmentStoreService("segmentstore", zkUri, controllerURI);
         if (!segService.isRunning()) {
             segService.start(true);
         }
@@ -136,7 +136,7 @@ public class MultiReaderWriterWithFailOverTest {
         URI zkUri = zkUris.get(0);
 
         // Verify controller is running.
-        controllerInstance = new PravegaControllerService("controllerFailover1", zkUri);
+        controllerInstance = new PravegaControllerService("controller", zkUri);
         assertTrue(controllerInstance.isRunning());
         List<URI> conURIs = controllerInstance.getServiceDetails();
         log.info("Pravega Controller service instance details: {}", conURIs);
@@ -149,7 +149,7 @@ public class MultiReaderWriterWithFailOverTest {
         log.info("Controller Service direct URI: {}", controllerURIDirect);
 
         // Verify segment store is running.
-        segmentStoreInstance = new PravegaSegmentStoreService("segmentstoreFailover1", zkUri, controllerURIDirect);
+        segmentStoreInstance = new PravegaSegmentStoreService("segmentstore", zkUri, controllerURIDirect);
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
 
@@ -158,12 +158,8 @@ public class MultiReaderWriterWithFailOverTest {
 
     @After
     public void tearDown() {
-        if (controllerInstance != null && controllerInstance.isRunning()) {
-            controllerInstance.stop();
-        }
-        if (segmentStoreInstance != null && segmentStoreInstance.isRunning()) {
-            segmentStoreInstance.stop();
-        }
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
         executorService.shutdownNow();
     }
 


### PR DESCRIPTION
**Change log description**
Changing the marathon app names used in multireaderwriterfailover test to match with the names used in other system tests.
**Purpose of the change**
Currently, we are using `controllerfailover1` and `segmentstorefailover1`.
**What the code does**
Fixes #1566 
**How to verify it**
Run system tests