### PR TITLE
Issue 1565: ensure we pass the right scope to client factory

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -11,6 +11,7 @@ package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
@@ -145,7 +146,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         final AtomicLong eventReadCount = new AtomicLong(); // used by readers to maintain a count of events.
 
         @Cleanup
-        ClientFactory clientFactory = getClientFactory();
+        ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI()));
 
         //1. Start writing events to the Stream.
         CompletableFuture<Void> writer1 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -11,7 +11,6 @@ package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
@@ -64,8 +63,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SystemTestRunner.class)
 public class ReadWithAutoScaleTest extends AbstractScaleTests {
 
-    private final static String SCOPE = "testReadAutoScale" + new Random().nextInt(Integer.MAX_VALUE);
-    private final static String STREAM_NAME = "testScaleUp";
+    private final static String STREAM_NAME = "testTxnScaleUpWithRead";
     private final static String READER_GROUP_NAME = "testReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
 
     //Initial number of segments is 2.
@@ -146,7 +144,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         final AtomicLong eventReadCount = new AtomicLong(); // used by readers to maintain a count of events.
 
         @Cleanup
-        ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI()));
+        ClientFactory clientFactory = getClientFactory();
 
         //1. Start writing events to the Stream.
         CompletableFuture<Void> writer1 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);


### PR DESCRIPTION
**Change log description**
* Fixes an issue in `ReadWithAutoScaleTest`
* Ensures we pass the right scope to client factory. 
* Refactored the code to reuse the scope in AbstractScaleTests, but with a different stream name.

**Purpose of the change**
Fix the incorrect scope being passed to the client factory.

**What the code does**
Fixes #1565 

**How to verify it**
Tests should pass.
Update: System test passes with this change.