### PR TITLE
Issue 1525: (SegmentStore) Fixed spurious ReadIndex merge bug

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -206,13 +206,15 @@ public class ContainerReadIndex implements ReadIndex {
                 if (getIndex(segmentId) == null) {
                     throw ex;
                 } else {
-                    log.debug("{}: triggerFutureReads: StreamSegmentId {} was skipped because it is no longer registered.", this.traceObjectId, segmentId);
+                    log.debug("{}: triggerFutureReads: StreamSegmentId {} was skipped because it is no longer registered.",
+                            this.traceObjectId, segmentId);
                 }
             }
         }
 
         // Throw any exception at the end - we want to make sure at least the ones that did have a valid index entry got triggered.
-        Exceptions.checkArgument(missingIds.size() == 0, "streamSegmentIds", "At least one StreamSegmentId does not exist in the metadata: %s", missingIds);
+        Exceptions.checkArgument(missingIds.size() == 0, "streamSegmentIds",
+                "At least one StreamSegmentId does not exist in the metadata: %s", missingIds);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.reading;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
+import io.pravega.common.ObjectClosedException;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.DataCorruptionException;
@@ -189,8 +190,24 @@ public class ContainerReadIndex implements ReadIndex {
                         missingIds.add(segmentId);
                     }
                 }
-            } else {
+                continue;
+            }
+
+            try {
                 index.triggerFutureReads();
+            } catch (ObjectClosedException ex) {
+                // It is possible that between the time we got the pointer to the StreamSegmentReadIndex and when we got
+                // to invoking triggerFutureReads, the StreamSegmentReadIndex has already been closed. If this is the case,
+                // ignore the error.
+                // This is possible in the following scenario: for a Transaction, we have an Append, followed by a Merge;
+                // the Append makes this index eligible for triggering future reads, and the Merge (once committed to Storage)
+                // will close it. If the StorageWriter is sufficiently fast in comparison to the OperationProcessor callbacks
+                // (which could be the case for in-memory unit tests), it may trigger this condition.
+                if (getIndex(segmentId) == null) {
+                    throw ex;
+                } else {
+                    log.debug("{}: triggerFutureReads: StreamSegmentId {} was skipped because it is no longer registered.", this.traceObjectId, segmentId);
+                }
             }
         }
 


### PR DESCRIPTION
**Change log description**
Fixed a bug in ContainerReadIndex where it would erroneously report ObjectClosedException in a corner case, thus failing an already committed operation.

Scenario:
- Consider a Transaction segment T1, with an Append/Seal and a Merge in the same batch of operations.
- These operations are written to Tier1, committed to in-memory metadata.
- Since an Append/Seal is involved, the ReadIndex will need to trigger future reads (if any) for T1
- However, if the Storage Writer is fast enough (which can happen in unit tests where everything is in memory), it could already process the merge, and thus close the ReadIndex for T1.
    - In this case, it is possible that a pointer to T1's ReadIndex is obtained prior to this merge, but triggerFutureReads() is invoked after the merge, hence the ObjectClosedException.

**Purpose of the change**
Fixes #1525.

**What the code does**
Explicitly handling `ObjectClosedException` during the call to `triggerFutureReads`.

**How to verify it**
Unfortunately this situation is nearly impossible to reproduce via unit test. As the description states, a number of things need to happen in the right order, most of which are beyond the control of a unit test (such as Java's thread scheduling).