### PR TITLE
Issue 1574: Move IdempotentStorageTestBase and update comment.

### DIFF
--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/IdempotentStorageTestBase.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/IdempotentStorageTestBase.java
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.pravega.segmentstore.storage.impl.filesystem;
+package io.pravega.segmentstore.storage.impl;
 
 import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
@@ -26,7 +26,7 @@ import static io.pravega.test.common.AssertExtensions.assertMayThrow;
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 
 /**
- * Unit tests for FileSystemStorage.
+ * Common Unit tests for FileSystemStorage and ExtendedS3Storage.
  */
 public abstract class IdempotentStorageTestBase extends StorageTestBase {
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
@@ -15,7 +15,7 @@ import com.emc.object.s3.jersey.S3JerseyClient;
 import com.emc.object.s3.request.DeleteObjectsRequest;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
-import io.pravega.segmentstore.storage.impl.filesystem.IdempotentStorageTestBase;
+import io.pravega.segmentstore.storage.impl.IdempotentStorageTestBase;
 import io.pravega.test.common.TestUtils;
 import java.net.URI;
 import java.nio.channels.FileChannel;

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorageTest.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.storage.impl.filesystem;
 import io.pravega.common.io.FileHelpers;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.impl.IdempotentStorageTestBase;
 import org.junit.After;
 import org.junit.Before;
 


### PR DESCRIPTION
**Change log description**
* Moves `IdempotentStorageTestBase` to under `imply` from under `filesystem`.

* Rewords the comment on top of the `IdempotentStorageTestBase` class.

**Purpose of the change**
Fixes #1574 

**What the code does**
Moves IdempotentStorageTestBase and rewords comment.

**How to verify it**
Visual inspection