### PR TITLE
Issue 1580:  System tests should follow the same path through entrypoint.sh as production deployment

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -132,7 +132,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         map.put("ZK_URL", zk);
         map.put("BK_ZK_URL", zk);
         map.put("HDFS_URL", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020");
-        map.put("CONTROLLER_URI", conUri.toString());
+        map.put("CONTROLLER_URL", conUri.toString());
         map.put("TIER2_STORAGE", "HDFS");
 
         //Properties set to override defaults for system tests

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -127,7 +127,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         //set env
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
 
-        //System properties to configure SS service.
+        //Environment variables to configure SS service.
         Map<String, String> map = new HashMap<>();
         map.put("ZK_URL", zk);
         map.put("BK_ZK_URL", zk);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -128,19 +128,19 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
 
         //System properties to configure SS service.
-        String hostSystemProperties = setSystemProperty("pravegaservice.zkURL", zk) +
-                setSystemProperty("bookkeeper.zkAddress", zk) +
-                setSystemProperty("hdfs.hdfsUrl", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020") +
-                setSystemProperty("autoScale.muteInSeconds", "120") +
+        String hostSystemProperties = setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +
-                setSystemProperty("autoScale.controllerUri", conUri.toString()) +
                 setSystemProperty("log.level", "DEBUG") +
-                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)) +
-                setSystemProperty("pravegaservice.storageImplementation", "HDFS");
+                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000));
 
         Map<String, String> map = new HashMap<>();
+        map.put("ZK_URL", zk);
+        map.put("BK_ZK_URL", zk);
+        map.put("HDFS_URL", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020");
+        map.put("CONTROLLER_URI", conUri.toString());
+        map.put("TIER2_STORAGE", "HDFS");
         map.put("PRAVEGA_SEGMENTSTORE_OPTS", hostSystemProperties);
         app.setEnv(map);
         app.setArgs(Arrays.asList("segmentstore"));

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -128,6 +128,14 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
 
         //System properties to configure SS service.
+        Map<String, String> map = new HashMap<>();
+        map.put("ZK_URL", zk);
+        map.put("BK_ZK_URL", zk);
+        map.put("HDFS_URL", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020");
+        map.put("CONTROLLER_URI", conUri.toString());
+        map.put("TIER2_STORAGE", "HDFS");
+
+        //Properties set to override defaults for system tests
         String hostSystemProperties = setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
@@ -135,12 +143,6 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
                 setSystemProperty("log.level", "DEBUG") +
                 setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000));
 
-        Map<String, String> map = new HashMap<>();
-        map.put("ZK_URL", zk);
-        map.put("BK_ZK_URL", zk);
-        map.put("HDFS_URL", "hdfs.marathon.containerip.dcos.thisdcos.directory:8020");
-        map.put("CONTROLLER_URI", conUri.toString());
-        map.put("TIER2_STORAGE", "HDFS");
         map.put("PRAVEGA_SEGMENTSTORE_OPTS", hostSystemProperties);
         app.setEnv(map);
         app.setArgs(Arrays.asList("segmentstore"));


### PR DESCRIPTION
**Change log description**
- Sets the configuration through environment variables as the script `entrypoint.sh` uses in production deployment.
- Overrides defaults using `PRAVEGA_SEGMENTSTORE_OPTS` as required  specifically for system tests.

**Purpose of the change**
To ensure system test runs resembles the production runs.
To ensure that system tests are able to mount NFS directory when the tested with filesystem as tier2.

**What the code does**
- Sets the configuration through environment variables as the script `entrypoint.sh` uses in production deployment.
- Overrides defaults using `PRAVEGA_SEGMENTSTORE_OPTS` as required  specifically for system tests.

**How to verify it**
Segmentstore comes up with the configured values.