### PR TITLE
Issue 1582: Update reader's error handling to handle failure to connect to Pravega node.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -23,10 +23,6 @@ import io.pravega.shared.protocol.netty.FailingReplyProcessor;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.concurrent.GuardedBy;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.concurrent.GuardedBy;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
@@ -190,8 +189,8 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
                 if (connection == null) {
                     connection = connectionFactory.establishConnection(uri, responseProcessor);
                 }
-                return connection; 
-            } 
+                return connection;
+            }
         });
     }
 


### PR DESCRIPTION
**Change log description**
AsyncSegmentInputStreamImpl closes ClientConnection in case of error based on the `ReplyProcessor` call backs.  It performs retries in case of exceptions during
* Fetching SegmentEndpoint from controller
* Establishing a connection to pravega node.
* Sending a read for the segment.

This change ensures we close the connection in case of error while establishing connection to pravega node, so that in the next retry we try to re-establish the connection to the pravega node (obtained from the controller)

**Purpose of the change**
Fixes #1582 

**What the code does**
Close the connection in case of errors while establishing connection to pravega node.

**How to verify it**
System tests should pass.
Update: With this change MultiReaderWriterWithFailOverTest passed on my jarvis cluster.