### PR TITLE
Issue 1584: Manual scale hammers store to check if scale has completed or not 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/CommitEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/CommitEventProcessor.java
@@ -90,7 +90,7 @@ public class CommitEventProcessor extends EventProcessor<CommitEvent> {
         OperationContext context = streamMetadataStore.createContext(scope, stream);
         log.debug("Committing transaction {} on stream {}/{}", event.getTxid(), event.getScope(), event.getStream());
 
-        streamMetadataStore.getActiveEpoch(scope, stream, context, executor).thenComposeAsync(pair -> {
+        streamMetadataStore.getActiveEpoch(scope, stream, context, false, executor).thenComposeAsync(pair -> {
             // Note, transaction's epoch either equals stream's current epoch or is one more than it,
             // because stream scale operation ensures that all transactions in current epoch are
             // complete before transitioning the stream to new epoch.

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -571,8 +571,9 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     public CompletableFuture<Pair<Integer, List<Integer>>>  getActiveEpoch(final String scope,
                                               final String stream,
                                               final OperationContext context,
+                                              final boolean ignoreCached,
                                               final Executor executor) {
-        return withCompletion(getStream(scope, stream, context).getActiveEpoch(), executor);
+        return withCompletion(getStream(scope, stream, context).getActiveEpoch(ignoreCached), executor);
     }
 
     protected Stream getStream(String scope, final String name, OperationContext context) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -717,8 +717,11 @@ public abstract class PersistentStreamBase<T> implements Stream {
     }
 
     @Override
-    public CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch() {
-        return getHistoryTable().thenApply(table -> TableHelper.getActiveEpoch(table.getData()));
+    public CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch(boolean ignoreCached) {
+        CompletableFuture<Data<T>> historyTableFuture = ignoreCached ? getHistoryTableFromStore() :
+                getHistoryTable();
+
+        return historyTableFuture.thenApply(table -> TableHelper.getActiveEpoch(table.getData()));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -308,9 +308,11 @@ interface Stream {
 
     /**
      * Returns the currently active stream epoch.
+     *
+     * @param ignoreCached if ignore cache is set to true then fetch the value from the store. 
      * @return currently active stream epoch.
      */
-    CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch(boolean forceFetch);
+    CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch(boolean ignoreCached);
 
     /**
      * Refresh the stream object. Typically to be used to invalidate any caches.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -310,7 +310,7 @@ interface Stream {
      * Returns the currently active stream epoch.
      * @return currently active stream epoch.
      */
-    CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch();
+    CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch(boolean forceFetch);
 
     /**
      * Refresh the stream object. Typically to be used to invalidate any caches.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -552,12 +552,14 @@ public interface StreamMetadataStore {
      * @param scope    scope.
      * @param stream   stream.
      * @param context  operation context
+     * @param ignoreCached  boolean indicating whether to use cached value or force fetch from underlying store.
      * @param executor callers executor
      * @return         pair containing currently active epoch of the stream, and active segments in current epoch.
      */
     CompletableFuture<Pair<Integer, List<Integer>>> getActiveEpoch(final String scope,
                                                                    final String stream,
                                                                    final OperationContext context,
+                                                                   final boolean ignoreCached,
                                                                    final Executor executor);
 
     /**

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -263,7 +263,7 @@ class ZKStream extends PersistentStreamBase<Integer> {
 
     @Override
     public CompletableFuture<Map<String, Data<Integer>>> getCurrentTxns() {
-        return getActiveEpoch()
+        return getActiveEpoch(false)
                 .thenCompose(epoch -> store.getChildren(getEpochPath(epoch.getKey()))
                         .thenCompose(txIds -> FutureHelpers.allOfWithResults(txIds.stream().collect(
                                 Collectors.toMap(txId -> txId, txId -> cache.getCachedData(getActiveTxPath(epoch.getKey(), txId))))


### PR DESCRIPTION
**Change log description**
Once rpc call for manual scale is received on ControllerService, it calls into streamMetadataTask.manual scale method. 
Following is how manual scale is performed by streamMetadataTasks:
1. post scale request in Request event-processor's stream. 
2. start scale by performing the "store.startScale" step where new segments are created in the segment table followed by new epoch created in the history table. It also sets the stream state to 'scaling'. 
3. rest of the steps of scale operation are performed by the event in the stream. 
4. now the manual scale thread checks the stream state to see when it changes from scaling. 

(4) is done in a tight loop using FutureHelpers.loop without any delays. 
This leads to hammering of the store. We also set operation context to null, which results in entire cache refresh for this stream which means effectively every call would end up going to the store. 
Also, the state check is theoretically unending -- scale operations can keep running in succession and everytime we check the state we may find it to be 'Scaling'. So the manual scale call may theoretically never end. 

**Purpose of the change**
Fixes #1584  

**What the code does**
Two things --
1. Uses FutureHelper.delayedFuture inside FutureHelper.loop which reduces the hammering and the check is made every one second. 
2. Instead of using state to determine if scale has completed, use epoch instead. If the epoch is different from the one we started with, then scale has definitely completed. 
Secondly, added a new api to getActiveEpoch(ignoreCached) and using the same operation context. This will ensure that we do not refresh the cached values for the stream but only history table for making this check. [Note: we need to get the latest value from store each time, we cant rely on cached value because scale operation may be performed on a different controller instance). 

**How to verify it**
All existing tests should pass.