### PR TITLE
Issue 1591: (SegmentStore) Fixed bug in StreamSegmentContainerRegistry.getContainer

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerRegistry.java
@@ -10,9 +10,7 @@
 package io.pravega.segmentstore.server;
 
 import io.pravega.segmentstore.contracts.ContainerNotFoundException;
-
 import java.time.Duration;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -23,11 +21,6 @@ public interface SegmentContainerRegistry extends AutoCloseable {
      * Gets the number of registered containers.
      */
     int getContainerCount();
-
-    /**
-     * Gets a read-only collection of registered container ids.
-     */
-    Collection<Integer> getRegisteredContainerIds();
 
     /**
      * Gets a reference to the SegmentContainer with given Id.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
@@ -21,7 +21,6 @@ import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -90,15 +89,10 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     }
 
     @Override
-    public Collection<Integer> getRegisteredContainerIds() {
-        return this.containers.keySet();
-    }
-
-    @Override
     public SegmentContainer getContainer(int containerId) throws ContainerNotFoundException {
         Exceptions.checkNotClosed(this.closed.get(), this);
         ContainerWithHandle result = this.containers.getOrDefault(containerId, null);
-        if (result == null) {
+        if (result == null || isShutdown(result.container.state())) {
             throw new ContainerNotFoundException(containerId);
         }
 


### PR DESCRIPTION
**Change log description**
- Fixed a bug in `StreamSegmentContainerRegistry.getContainer()` that could incorrectly not throw `ContainerNotFoundException` if invoked with a container id for a container that was just shut down. This was changed to check if the container is currently in the process of shutting down (or already terminated), in which case it simply throws the exception.
- Removed `getRegisteredContainerIds` from `SegmentContainerRegistry` (and its implementing class - this is not used.

**Purpose of the change**
Fixes #1591.

**What the code does**
Verifies if container is currently shutting down or shut down. If so, it throws an exception.

**How to verify it**
Unit test updated to verify this particular scenario.