### PR TITLE
Manual scale should return to caller in timebound fashion #1594

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -282,7 +282,7 @@ public class ControllerImpl implements Controller {
                         + stream);
             case TIMEDOUT:
                 log.warn("Controller failed to complete scale within stipulated time: {}", stream.getStreamName());
-                throw new ControllerFailureException("Controller failed scale stream and timed out: "
+                throw new ControllerFailureException("Controller failed to scale stream within desired time: "
                         + stream);
             case UNRECOGNIZED:
             default:

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -280,6 +280,10 @@ public class ControllerImpl implements Controller {
                 log.warn("Controller failed to properly abort transactions on stream: {}", stream.getStreamName());
                 throw new ControllerFailureException("Controller failed to properly abort transactions on stream: "
                         + stream);
+            case TIMEDOUT:
+                log.warn("Controller failed to complete scale within stipulated time: {}", stream.getStreamName());
+                throw new ControllerFailureException("Controller failed scale stream and timed out: "
+                        + stream);
             case UNRECOGNIZED:
             default:
                 throw new ControllerFailureException("Unknown return status scaling stream " + stream

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -179,6 +179,9 @@ public class LocalController implements Controller {
                         return false;
                     case SUCCESS:
                         return true;
+                    case TIMEDOUT:
+                        throw new ControllerFailureException("Controller failed scale stream and timed out: "
+                                + stream);
                     case TXN_CONFLICT:
                         throw new ControllerFailureException("Controller failed to properly abort transactions on stream: "
                                 + stream);

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -180,7 +180,7 @@ public class LocalController implements Controller {
                     case SUCCESS:
                         return true;
                     case TIMEDOUT:
-                        throw new ControllerFailureException("Controller failed scale stream and timed out: "
+                        throw new ControllerFailureException("Controller failed to scale stream within desired time: "
                                 + stream);
                     case TXN_CONFLICT:
                         throw new ControllerFailureException("Controller failed to properly abort transactions on stream: "

--- a/controller/src/main/java/io/pravega/controller/store/stream/ScaleOperationExceptions.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ScaleOperationExceptions.java
@@ -31,6 +31,9 @@ public class ScaleOperationExceptions {
     public static class ScalePostException extends ScaleOperationException implements RetryableException {
     }
 
+    public static class ManualScaleTimedOut extends ScaleOperationException {
+    }
+
     public static class ScaleRequestNotEnabledException extends ScaleOperationException {
     }
 }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -43,12 +43,12 @@ import io.pravega.shared.controller.event.ControllerEvent;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -65,6 +65,7 @@ import static io.pravega.controller.task.Stream.TaskStepsRetryHelper.withRetries
 @Slf4j
 public class StreamMetadataTasks extends TaskBase {
 
+    private static final long TIMEOUT = Duration.ofMinutes(2).toMillis();
     private final StreamMetadataStore streamMetadataStore;
     private final HostControllerStore hostControllerStore;
     private final ConnectionFactory connectionFactory;
@@ -190,10 +191,19 @@ public class StreamMetadataTasks extends TaskBase {
                         context, executor)
                         .thenComposeAsync(startScaleResponse -> {
                             int activeEpoch = startScaleResponse.getActiveEpoch();
-                            AtomicBoolean scaling = new AtomicBoolean(true);
-                            return FutureHelpers.loop(scaling::get, () -> FutureHelpers.delayedFuture(() ->
+                            long startTime = System.currentTimeMillis();
+                            final CompletableFuture<Void> done = new CompletableFuture<>();
+                            return FutureHelpers.loop(() -> !done.isDone(), () -> FutureHelpers.delayedFuture(() ->
                                             streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor)
-                                                    .thenAccept(state -> scaling.set(state.getKey() == activeEpoch)),
+                                                    .thenAccept(state -> {
+                                                        if (state.getKey() == activeEpoch) {
+                                                            if (startTime + TIMEOUT < System.currentTimeMillis()) {
+                                                                done.completeExceptionally(new ScaleOperationExceptions.ManualScaleTimedOut());
+                                                            }
+                                                        } else {
+                                                            done.complete(null);
+                                                        }
+                                                    }),
                                     1000, executor), executor)
                                     .thenApply(r -> startScaleResponse);
                         })
@@ -204,6 +214,12 @@ public class StreamMetadataTasks extends TaskBase {
                                 Throwable cause = ExceptionHelpers.getRealException(e);
                                 if (cause instanceof ScaleOperationExceptions.ScalePreConditionFailureException) {
                                     response.setStatus(ScaleResponse.ScaleStreamStatus.PRECONDITION_FAILED);
+                                } else if (cause instanceof ScaleOperationExceptions.ManualScaleTimedOut) {
+                                    // Note: timedout does not mean the scale operation failed. In fact scale operation once started,
+                                    // is guaranteed to be retried on all retryable failures ad infinitum.
+                                    // We return this so that we do not block the grpc call if scale fails to complete within stipulated time.
+                                    // If a client gets timedout, it means scale was started, and should eventually complete.
+                                    response.setStatus(ScaleResponse.ScaleStreamStatus.TIMEDOUT);
                                 } else {
                                     response.setStatus(ScaleResponse.ScaleStreamStatus.FAILURE);
                                 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -41,6 +41,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -179,4 +180,21 @@ public class StreamMetadataTasksTest {
         // scaling operation fails once a stream is sealed.
         assertEquals(ScaleStreamStatus.SUCCESS, scaleOpResult.getStatus());
     }
+
+    @Test
+    public void manualScaleTest() throws Exception {
+        //scale operation on the sealed stream.
+        AbstractMap.SimpleEntry<Double, Double> segment3 = new AbstractMap.SimpleEntry<>(0.0, 0.2);
+        AbstractMap.SimpleEntry<Double, Double> segment4 = new AbstractMap.SimpleEntry<>(0.2, 0.4);
+        AbstractMap.SimpleEntry<Double, Double> segment5 = new AbstractMap.SimpleEntry<>(0.4, 0.5);
+
+        streamMetadataTasks.setRequestEventWriter(new EventStreamWriterMock());
+        streamMetadataTasks.setScaleRequestTimeout(Duration.ofSeconds(1));
+        ScaleResponse scaleOpResult = streamMetadataTasks.manualScale(SCOPE, stream1, Collections.singletonList(0),
+                Arrays.asList(segment3, segment4, segment5), 30, null).get();
+
+        // scaling operation fails once a stream is sealed.
+        assertEquals(ScaleStreamStatus.TIMEDOUT, scaleOpResult.getStatus());
+    }
+
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -193,7 +193,7 @@ public class StreamMetadataTasksTest {
         ScaleResponse scaleOpResult = streamMetadataTasks.manualScale(SCOPE, stream1, Collections.singletonList(0),
                 Arrays.asList(segment3, segment4, segment5), 30, null).get();
 
-        // scaling operation fails once a stream is sealed.
+        // scaling operation should timeout as we dont have an actual writer to write to the stream.
         assertEquals(ScaleStreamStatus.TIMEDOUT, scaleOpResult.getStatus());
     }
 

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -241,6 +241,7 @@ message ScaleResponse {
         FAILURE = 1;
         PRECONDITION_FAILED = 2;
         TXN_CONFLICT = 3;
+        TIMEDOUT = 4;
     }
     ScaleStreamStatus status = 1;
     repeated SegmentRange segments = 2;


### PR DESCRIPTION
**Change log description**
Currently manual scale can take as long to reply as the scale operation takes (once started).
Scale operation can go on indefinitely if hosts fail or if event processors fail repeatedly.
Which means manual scale rpc may never return to the caller. 

**Purpose of the change**
Completes manual scale rpc call in a time bound manner. 

**What the code does**
Instead of stalling the response to the caller, we complete manual scale request with timeout after 2 minutes.
This will ensure that we tell the caller we have started the scale but we are not able to finish it in the given time. 
It is important to note that timedout guarantees that the scale was started and will eventually be completed. But the control is returned to the caller and we dont stall the caller forever.

Look at changes in StreamMetadataTasks.java under manualScale method. 
**How to verify it**
All existing tests should pass. 