### PR TITLE
Issue 1596: Fix use of negative in modulo operation.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
@@ -9,18 +9,27 @@
  */
 package io.pravega.client.stream.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.segment.impl.SegmentInputStream;
 import io.pravega.common.MathHelpers;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Used to select which event should go next when consuming from multiple segments.
  *
  */
+@RequiredArgsConstructor
 public class Orderer {
     private final AtomicInteger counter = new AtomicInteger(0);
 
+    @VisibleForTesting
+    Orderer(int initialCount) {
+        this();
+        counter.set(initialCount);
+    }
+    
     /**
      * Given a list of segments this reader owns, (which contain their positions) returns the one that should
      * be read from next. This is done in way to minimize blocking and ensure fairness.
@@ -28,12 +37,12 @@ public class Orderer {
      * @param segments The logs to get the next reader for.
      * @return A segment that this reader should read from next.
      */
-    SegmentInputStream nextSegment(List<SegmentInputStream> segments) {
+    <T extends SegmentInputStream> T nextSegment(List<T> segments) {
         if (segments.isEmpty()) {
             return null;
         }
         for (int i = 0; i < segments.size(); i++) {
-            SegmentInputStream inputStream = segments.get(MathHelpers.abs(counter.incrementAndGet()) % segments.size());
+            T inputStream = segments.get(MathHelpers.abs(counter.incrementAndGet()) % segments.size());
             if (inputStream.canReadWithoutBlocking()) {
                 return inputStream;
             } else {

--- a/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
@@ -10,6 +10,7 @@
 package io.pravega.client.stream.impl;
 
 import io.pravega.client.segment.impl.SegmentInputStream;
+import io.pravega.common.MathHelpers;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,13 +33,13 @@ public class Orderer {
             return null;
         }
         for (int i = 0; i < segments.size(); i++) {
-            SegmentInputStream inputStream = segments.get(counter.incrementAndGet() % segments.size());
+            SegmentInputStream inputStream = segments.get(MathHelpers.abs(counter.incrementAndGet()) % segments.size());
             if (inputStream.canReadWithoutBlocking()) {
                 return inputStream;
             } else {
                 inputStream.fillBuffer();
             }
         }
-        return segments.get(counter.incrementAndGet() % segments.size());
+        return segments.get(MathHelpers.abs(counter.incrementAndGet()) % segments.size());
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -1,11 +1,10 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.client.stream.impl;
 
@@ -22,13 +21,13 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class OrdererTest {
-    
+
     @Data
     private class StubSegmentInputStream implements SegmentInputStream {
         final int number;
         boolean canReadWithoutBlocking = true;
         long offset = 0;
-        
+
         @Override
         public Segment getSegmentId() {
             return null;
@@ -52,20 +51,20 @@ public class OrdererTest {
             return canReadWithoutBlocking;
         }
     };
-    
+
     @Test
     public void testChangingLogs() {
         List<StubSegmentInputStream> streams = createInputStreams(10);
         Orderer o = new Orderer();
         int[] totals = new int[streams.size()];
-        for (int i=0;i<streams.size()*10;i++) {
+        for (int i = 0; i < streams.size() * 10; i++) {
             StubSegmentInputStream chosen = o.nextSegment(streams);
             totals[chosen.getNumber()]++;
         }
-        for (int i=0;i<10;i++) {
+        for (int i = 0; i < 10; i++) {
             o.nextSegment(createInputStreams(1));
         }
-        for (int i=0;i<streams.size()*10;i++) {
+        for (int i = 0; i < streams.size() * 10; i++) {
             StubSegmentInputStream chosen = o.nextSegment(streams);
             totals[chosen.getNumber()]++;
         }
@@ -73,13 +72,13 @@ public class OrdererTest {
             assertEquals(20, value);
         }
     }
-    
+
     @Test
     public void testFair() {
         List<StubSegmentInputStream> streams = createInputStreams(7);
         Orderer o = new Orderer();
         int[] totals = new int[streams.size()];
-        for (int i=0;i<streams.size()*100;i++) {
+        for (int i = 0; i < streams.size() * 100; i++) {
             StubSegmentInputStream chosen = o.nextSegment(streams);
             totals[chosen.getNumber()]++;
         }
@@ -87,7 +86,7 @@ public class OrdererTest {
             assertEquals(100, value);
         }
     }
-    
+
     @Test
     public void testFindsNonblocking() {
         List<StubSegmentInputStream> streams = createInputStreams(13);
@@ -99,13 +98,13 @@ public class OrdererTest {
         StubSegmentInputStream chosen = o.nextSegment(streams);
         assertEquals(7, chosen.getNumber());
     }
-    
+
     @Test
     public void testIntWrap() {
         List<StubSegmentInputStream> streams = createInputStreams(10);
         Orderer o = new Orderer(Integer.MAX_VALUE - 5);
         int[] totals = new int[streams.size()];
-        for (int i=0;i<streams.size()*2;i++) {
+        for (int i = 0; i < streams.size() * 2; i++) {
             StubSegmentInputStream chosen = o.nextSegment(streams);
             assertNotNull(chosen);
             totals[chosen.getNumber()]++;
@@ -114,11 +113,11 @@ public class OrdererTest {
             assertTrue(value >= 1);
         }
     }
-    
+
     private List<StubSegmentInputStream> createInputStreams(int num) {
         Builder<StubSegmentInputStream> builder = ImmutableList.builder();
-        for (int i=0;i<num;i++) {
-        builder.add(new StubSegmentInputStream(i));
+        for (int i = 0; i < num; i++) {
+            builder.add(new StubSegmentInputStream(i));
         }
         return builder.build();
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -9,31 +9,118 @@
  */
 package io.pravega.client.stream.impl;
 
-import org.junit.Ignore;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import io.pravega.client.segment.impl.EndOfSegmentException;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentInputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import lombok.Data;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
-@Ignore
 public class OrdererTest {
+    
+    @Data
+    private class StubSegmentInputStream implements SegmentInputStream {
+        final int number;
+        boolean canReadWithoutBlocking = true;
+        long offset = 0;
+        
+        @Override
+        public Segment getSegmentId() {
+            return null;
+        }
+
+        @Override
+        public ByteBuffer read(long firstByteTimeout) throws EndOfSegmentException {
+            return null;
+        }
+
+        @Override
+        public void fillBuffer() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean canReadWithoutBlocking() {
+            return canReadWithoutBlocking;
+        }
+    };
+    
     @Test
     public void testChangingLogs() {
-        fail();
+        List<StubSegmentInputStream> streams = createInputStreams(10);
+        Orderer o = new Orderer();
+        int[] totals = new int[streams.size()];
+        for (int i=0;i<streams.size()*10;i++) {
+            StubSegmentInputStream chosen = o.nextSegment(streams);
+            totals[chosen.getNumber()]++;
+        }
+        for (int i=0;i<10;i++) {
+            o.nextSegment(createInputStreams(1));
+        }
+        for (int i=0;i<streams.size()*10;i++) {
+            StubSegmentInputStream chosen = o.nextSegment(streams);
+            totals[chosen.getNumber()]++;
+        }
+        for (int value : totals) {
+            assertEquals(20, value);
+        }
     }
-
+    
     @Test
-    public void testOneLogSealed() {
-        fail();
+    public void testFair() {
+        List<StubSegmentInputStream> streams = createInputStreams(7);
+        Orderer o = new Orderer();
+        int[] totals = new int[streams.size()];
+        for (int i=0;i<streams.size()*100;i++) {
+            StubSegmentInputStream chosen = o.nextSegment(streams);
+            totals[chosen.getNumber()]++;
+        }
+        for (int value : totals) {
+            assertEquals(100, value);
+        }
     }
-
+    
     @Test
-    public void testLogSealedButNotKnown() {
-        fail();
+    public void testFindsNonblocking() {
+        List<StubSegmentInputStream> streams = createInputStreams(13);
+        for (StubSegmentInputStream stream : streams) {
+            if (stream.getNumber() != 7)
+                stream.setCanReadWithoutBlocking(false);
+        }
+        Orderer o = new Orderer();
+        StubSegmentInputStream chosen = o.nextSegment(streams);
+        assertEquals(7, chosen.getNumber());
     }
-
+    
     @Test
-    public void testOrderConsistentAtTail() {
-        fail();
+    public void testIntWrap() {
+        List<StubSegmentInputStream> streams = createInputStreams(10);
+        Orderer o = new Orderer(Integer.MAX_VALUE - 5);
+        int[] totals = new int[streams.size()];
+        for (int i=0;i<streams.size()*2;i++) {
+            StubSegmentInputStream chosen = o.nextSegment(streams);
+            assertNotNull(chosen);
+            totals[chosen.getNumber()]++;
+        }
+        for (int value : totals) {
+            assertTrue(value >= 1);
+        }
+    }
+    
+    private List<StubSegmentInputStream> createInputStreams(int num) {
+        Builder<StubSegmentInputStream> builder = ImmutableList.builder();
+        for (int i=0;i<num;i++) {
+        builder.add(new StubSegmentInputStream(i));
+        }
+        return builder.build();
     }
 
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -50,7 +50,7 @@ public class OrdererTest {
         public boolean canReadWithoutBlocking() {
             return canReadWithoutBlocking;
         }
-    };
+    }
 
     @Test
     public void testChangingLogs() {
@@ -91,8 +91,9 @@ public class OrdererTest {
     public void testFindsNonblocking() {
         List<StubSegmentInputStream> streams = createInputStreams(13);
         for (StubSegmentInputStream stream : streams) {
-            if (stream.getNumber() != 7)
+            if (stream.getNumber() != 7) {
                 stream.setCanReadWithoutBlocking(false);
+            }
         }
         Orderer o = new Orderer();
         StubSegmentInputStream chosen = o.nextSegment(streams);


### PR DESCRIPTION
**Change log description**
 Fix use of negative in modulo operation.

**Purpose of the change**
Fixes #1596. Operator was returning values in a round-robin manner. This was done with a counter and a modulo operator. This broke when the integer wrapped around and the result became negative. 

**What the code does**
Uses MathHelpers.abs to avoid the negative value. 

**How to verify it**
The stress tests should no longer fail with ArrayIndexOutOfBounds 