### PR TITLE
Issue 1601: Bugfix for error handling

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -21,6 +21,7 @@ import io.pravega.common.util.Retry.RetryWithBackoff;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.FailingReplyProcessor;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
+import io.pravega.shared.protocol.netty.WireCommand;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentAttributeUpdated;
 import io.pravega.shared.protocol.netty.WireCommands.StreamSegmentInfo;
@@ -30,18 +31,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
 class SegmentMetadataClientImpl implements SegmentMetadataClient {
-    private static final RetryWithBackoff RETRY_SCHEDULE = Retry.withExpBackoff(1, 10, 5);
+    private static final RetryWithBackoff RETRY_SCHEDULE = Retry.withExpBackoff(1, 10, 6);
 
     private final Segment segmentId;
     private final Controller controller;
@@ -119,7 +120,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         }
     }
 
-    private void closeConnection(Exception exceptionToInflightRequests) {
+    private void closeConnection(Throwable exceptionToInflightRequests) {
         log.info("Closing connection with exception: {}", exceptionToInflightRequests.getMessage());
         CompletableFuture<ClientConnection> c;
         synchronized (lock) {
@@ -136,7 +137,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         failAllInflight(exceptionToInflightRequests);
     }
     
-    private void failAllInflight(Exception e) {
+    private void failAllInflight(Throwable e) {
         log.info("SegmentMetadata connection failed due to a {}.", e.getMessage());
         List<CompletableFuture<StreamSegmentInfo>> infoRequestsToFail;
         List<CompletableFuture<WireCommands.SegmentAttribute>> getAttributeRequestsToFail;
@@ -184,17 +185,19 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         synchronized (lock) {
             infoRequests.put(requestId, result);
         }
-        FutureHelpers.exceptionListener(getConnection().thenAccept(c -> {
-            try {
-                log.debug("Getting segment info for segment: {}", segmentId);
-                c.send(new WireCommands.GetStreamSegmentInfo(requestId, segmentId.getScopedName()));
-            } catch (ConnectionFailedException e) {
-                closeConnection(e);
-            }
-        }), e -> {
-            result.completeExceptionally(new CompletionException(e));
+        getConnection().thenAccept(c -> {
+            log.debug("Getting segment info for segment: {}", segmentId);
+            send(c, new WireCommands.GetStreamSegmentInfo(requestId, segmentId.getScopedName()));
+        }).exceptionally(e -> {
+            closeConnection(e);
+            return null;
         });
         return result;
+    }
+    
+    @SneakyThrows(ConnectionFailedException.class)
+    private void send(ClientConnection c, WireCommand cmd) {
+        c.send(cmd);
     }
     
     private CompletableFuture<WireCommands.SegmentAttribute> getPropertyAsync(UUID attributeId) {
@@ -203,15 +206,12 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         synchronized (lock) {
             getAttributeRequests.put(requestId, result);
         }
-        FutureHelpers.exceptionListener(getConnection().thenAccept(c -> {
-            try {
-                log.debug("Getting segment attribute: {}", attributeId);
-                c.send(new WireCommands.GetSegmentAttribute(requestId, segmentId.getScopedName(), attributeId));
-            } catch (ConnectionFailedException e) {
-                closeConnection(e);
-            }
-        }), e -> {
-            result.completeExceptionally(new CompletionException(e));
+        getConnection().thenAccept(c -> {
+            log.debug("Getting segment attribute: {}", attributeId);
+            send(c, new WireCommands.GetSegmentAttribute(requestId, segmentId.getScopedName(), attributeId));
+        }).exceptionally(e -> {
+            closeConnection(e);
+            return null;
         });
         return result;
     }
@@ -222,15 +222,12 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         synchronized (lock) {
             setAttributeRequests.put(requestId, result);
         }
-        FutureHelpers.exceptionListener(getConnection().thenAccept(c -> {
-            try {
-                log.trace("Updating segment attribute: {}", attributeId);
-                c.send(new WireCommands.UpdateSegmentAttribute(requestId, segmentId.getScopedName(), attributeId, value, expected));
-            } catch (ConnectionFailedException e) {
-                closeConnection(e);
-            }
-        }), e -> {
-            result.completeExceptionally(new CompletionException(e));
+        getConnection().thenAccept(c -> {
+            log.trace("Updating segment attribute: {}", attributeId);
+            send(c, new WireCommands.UpdateSegmentAttribute(requestId, segmentId.getScopedName(), attributeId, value, expected));
+        }).exceptionally(e -> {
+            closeConnection(e);
+            return null;
         });
         return result;
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -421,7 +421,12 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             ClientConnection connection = getAndHandleExceptions(newConnection, ConnectionFailedException::new);
             state.newConnection(connection);
             SetupAppend cmd = new SetupAppend(requestIdGenerator.get(), writerId, segmentName);
-            connection.send(cmd);
+            try {
+                connection.send(cmd);
+            } catch (ConnectionFailedException e) {
+                state.failConnection(e);
+                throw e;
+            }
         }
     }
 

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -423,7 +423,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             SetupAppend cmd = new SetupAppend(requestIdGenerator.get(), writerId, segmentName);
             try {
                 connection.send(cmd);
-            } catch (ConnectionFailedException e) {
+            } catch (Exception e) {
                 state.failConnection(e);
                 throw e;
             }
@@ -461,7 +461,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                              ClientConnection connection = getConnection();
                              try {
                                  connection.send(new KeepAlive());
-                             } catch (ConnectionFailedException e) {
+                             } catch (Exception e) {
                                  state.failConnection(e);
                                  throw e;
                              }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -459,7 +459,12 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          .throwingOn(SegmentSealedException.class)
                          .run(() -> {
                              ClientConnection connection = getConnection();
-                             connection.send(new KeepAlive());
+                             try {
+                                 connection.send(new KeepAlive());
+                             } catch (ConnectionFailedException e) {
+                                 state.failConnection(e);
+                                 throw e;
+                             }
                              FutureHelpers.<Void, ConnectionFailedException, SegmentSealedException, RuntimeException>getThrowingException(state.getEmptyInflightFuture());
                              return null;
                          });

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -10,14 +10,19 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.client.netty.impl.ClientConnection;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
+import io.pravega.common.concurrent.FutureHelpers;
+import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentAttributeUpdated;
 import io.pravega.shared.protocol.netty.WireCommands.StreamSegmentInfo;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -133,6 +138,48 @@ public class SegmentMetadataClientTest {
         order.verify(connection).send(getSegmentInfo1);
         order.verify(cf).establishConnection(endpoint, processor);
         order.verify(connection).send(getSegmentInfo2);
+        order.verifyNoMoreInteractions();
+        assertEquals(123, length);
+    }
+    
+    @Test(timeout = 10000)
+    public void testExceptionOnSend() throws Exception {
+        Segment segment = new Segment("scope", "testRetry", 4);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 0);
+        ConnectionFactory cf = Mockito.mock(ConnectionFactory.class);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        ClientConnection connection1 = mock(ClientConnection.class);
+        ClientConnection connection2 = mock(ClientConnection.class);
+        AtomicReference<ReplyProcessor> processor = new AtomicReference<>();
+        Mockito.when(cf.establishConnection(Mockito.eq(endpoint), Mockito.any()))
+               .thenReturn(FutureHelpers.failedFuture(new ConnectionFailedException()))
+               .thenReturn(CompletableFuture.completedFuture(connection1))
+               .thenAnswer(new Answer<CompletableFuture<ClientConnection>>() {
+                   @Override
+                   public CompletableFuture<ClientConnection> answer(InvocationOnMock invocation) throws Throwable {
+                       processor.set(invocation.getArgument(1));
+                       return CompletableFuture.completedFuture(connection2);
+                   }
+               });
+        WireCommands.GetStreamSegmentInfo getSegmentInfo1 = new WireCommands.GetStreamSegmentInfo(2, segment.getScopedName());
+        Mockito.doThrow(new ConnectionFailedException()).when(connection1).send(getSegmentInfo1);
+        WireCommands.GetStreamSegmentInfo getSegmentInfo2 = new WireCommands.GetStreamSegmentInfo(3, segment.getScopedName());
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                processor.get().streamSegmentInfo(new StreamSegmentInfo(3, segment.getScopedName(), true, false, false, 0,
+                                                                  123));
+                return null;
+            }
+        }).when(connection2).send(getSegmentInfo2);
+        SegmentMetadataClientImpl client = new SegmentMetadataClientImpl(segment, controller, cf);
+        InOrder order = Mockito.inOrder(connection1, connection2, cf);
+        long length = client.fetchCurrentStreamLength();
+        order.verify(cf, Mockito.times(2)).establishConnection(Mockito.eq(endpoint), Mockito.any());
+        order.verify(connection1).send(getSegmentInfo1);
+        order.verify(connection1).close();
+        order.verify(cf).establishConnection(Mockito.eq(endpoint), Mockito.any());
+        order.verify(connection2).send(getSegmentInfo2);
         order.verifyNoMoreInteractions();
         assertEquals(123, length);
     }

--- a/common/src/main/java/io/pravega/common/ExceptionHelpers.java
+++ b/common/src/main/java/io/pravega/common/ExceptionHelpers.java
@@ -30,7 +30,7 @@ public class ExceptionHelpers {
     /**
      * If the provided exception is a CompletionException or ExecutionException which need be unwraped.
      *
-     * @param e The exception to be unwrapped.
+     * @param ex The exception to be unwrapped.
      * @return The cause or the exception provided.
      */
     public static Throwable getRealException(Throwable ex) {

--- a/common/src/main/java/io/pravega/common/ExceptionHelpers.java
+++ b/common/src/main/java/io/pravega/common/ExceptionHelpers.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.common;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
@@ -29,10 +28,10 @@ public class ExceptionHelpers {
     }
 
     /**
-     * Extracts the inner exception from any Exception that may have an inner exception.
+     * If the provided exception is a CompletionException or ExecutionException which need be unwraped.
      *
-     * @param ex The exception to query.
-     * @return Throwable corresponding to the inner exception.
+     * @param e The exception to be unwrapped.
+     * @return The cause or the exception provided.
      */
     public static Throwable getRealException(Throwable ex) {
         if (canInspectCause(ex)) {
@@ -54,21 +53,9 @@ public class ExceptionHelpers {
         return c.equals(CompletionException.class) || c.equals(ExecutionException.class);
     }
     
-    /**
-     * If the provided exception is a CompletionException or ExecutionException which need be unwraped.
-     * @param e The exception to be unwrapped.
-     * @return The cause or the exception provided.
-     */
-    public static Throwable unwrapIfRequired(Throwable e) {
-        while ((e instanceof CompletionException || e instanceof ExecutionException) && e.getCause() != null) {
-            e = e.getCause();
-        }
-        return e;
-    }
     
     private static boolean canInspectCause(Throwable ex) {
         return ex instanceof CompletionException
-                || ex instanceof ExecutionException
-                || ex instanceof IOException;
+                || ex instanceof ExecutionException;
     }
 }

--- a/common/src/main/java/io/pravega/common/ExceptionHelpers.java
+++ b/common/src/main/java/io/pravega/common/ExceptionHelpers.java
@@ -60,8 +60,8 @@ public class ExceptionHelpers {
      * @return The cause or the exception provided.
      */
     public static Throwable unwrapIfRequired(Throwable e) {
-        if ((e instanceof CompletionException || e instanceof ExecutionException) && e.getCause() != null) {
-            return e.getCause();
+        while ((e instanceof CompletionException || e instanceof ExecutionException) && e.getCause() != null) {
+            e = e.getCause();
         }
         return e;
     }

--- a/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
@@ -140,7 +140,7 @@ public final class FutureHelpers {
             Thread.currentThread().interrupt();
             throw Lombok.sneakyThrow(e);
         } catch (Exception e) {
-            throw Lombok.sneakyThrow(ExceptionHelpers.unwrapIfRequired(e));
+            throw Lombok.sneakyThrow(ExceptionHelpers.getRealException(e));
         }
     }
 

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -270,7 +270,7 @@ public final class Retry {
             if (ExceptionHelpers.shouldUnwrap(retryType) || ExceptionHelpers.shouldUnwrap(throwType)) {
                 return e.getClass();
             } else {
-                return ExceptionHelpers.unwrapIfRequired(e).getClass();
+                return ExceptionHelpers.getRealException(e).getClass();
             }
         }
     }


### PR DESCRIPTION
**Change log description**
Upon error clear the connection before re-connecting so that any retries have the opportunity to go to a different host.

**Purpose of the change**
Fixes #1601. There was a case where ConnectionFailedException was being set on the future for the connection establishment, but the connection was not replaced when getConnection() was retried.

**What the code does**
Rather than only catching known exceptions and assuming that exceptions are only wrapped once, it makes sure that all possible exception paths result in connectionClose being called. 

**How to verify it**
Run the System tests.