### PR TITLE
Issue1617: NullPointerExceptions from ControllerClusterListener

### DIFF
--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -20,6 +20,7 @@ import io.pravega.controller.util.RetryHelper;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -50,6 +51,7 @@ public class ControllerClusterListener extends AbstractIdleService {
         Preconditions.checkNotNull(host, "host");
         Preconditions.checkNotNull(cluster, "cluster");
         Preconditions.checkNotNull(executor, "executor");
+        Preconditions.checkArgument(sweepers.stream().noneMatch(Objects::isNull));
 
         this.objectId = "ControllerClusterListener";
         this.host = host;

--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -10,7 +10,6 @@
 package io.pravega.controller.fault;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractIdleService;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.cluster.Cluster;
@@ -47,7 +46,7 @@ public class ControllerClusterListener extends AbstractIdleService {
     private final List<FailoverSweeper> sweepers;
 
     public ControllerClusterListener(final Host host, final Cluster cluster,
-                                     final ScheduledExecutorService executor, final FailoverSweeper... sweepers) {
+                                     final ScheduledExecutorService executor, final List<FailoverSweeper> sweepers) {
         Preconditions.checkNotNull(host, "host");
         Preconditions.checkNotNull(cluster, "cluster");
         Preconditions.checkNotNull(executor, "executor");
@@ -56,7 +55,7 @@ public class ControllerClusterListener extends AbstractIdleService {
         this.host = host;
         this.cluster = cluster;
         this.executor = executor;
-        this.sweepers = Lists.newArrayList(sweepers);
+        this.sweepers = sweepers;
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.fault;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractIdleService;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.cluster.Cluster;
@@ -57,7 +58,7 @@ public class ControllerClusterListener extends AbstractIdleService {
         this.host = host;
         this.cluster = cluster;
         this.executor = executor;
-        this.sweepers = sweepers;
+        this.sweepers = Lists.newArrayList(sweepers);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -17,6 +17,7 @@ import io.pravega.common.cluster.ClusterType;
 import io.pravega.common.cluster.Host;
 import io.pravega.common.cluster.zkImpl.ClusterZKImpl;
 import io.pravega.controller.fault.ControllerClusterListener;
+import io.pravega.controller.fault.FailoverSweeper;
 import io.pravega.controller.fault.SegmentContainerMonitor;
 import io.pravega.controller.fault.UniformContainerBalancer;
 import io.pravega.controller.server.eventProcessor.ControllerEventProcessors;
@@ -45,6 +46,8 @@ import org.apache.curator.framework.CuratorFramework;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -156,16 +159,6 @@ public class ControllerServiceStarter extends AbstractIdleService {
             TxnSweeper txnSweeper = new TxnSweeper(streamStore, streamTransactionMetadataTasks,
                     serviceConfig.getTimeoutServiceConfig().getMaxLeaseValue(), controllerExecutor);
 
-            // Setup and start controller cluster listener.
-            if (serviceConfig.isControllerClusterListenerEnabled()) {
-                cluster = new ClusterZKImpl((CuratorFramework) storeClient.getClient(), ClusterType.CONTROLLER);
-                controllerClusterListener = new ControllerClusterListener(host, cluster, controllerExecutor,
-                        controllerEventProcessors, taskSweeper, txnSweeper);
-
-                log.info("Starting controller cluster listener");
-                controllerClusterListener.startAsync();
-            }
-
             controllerService = new ControllerService(streamStore, hostStore, streamMetadataTasks,
                     streamTransactionMetadataTasks, new SegmentHelper(), controllerExecutor, cluster);
 
@@ -182,6 +175,22 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 log.info("Starting event processors");
                 controllerEventProcessors.bootstrap(streamTransactionMetadataTasks, streamMetadataTasks)
                         .thenAcceptAsync(x -> controllerEventProcessors.startAsync(), controllerExecutor);
+            }
+
+            // Setup and start controller cluster listener after all sweepers have been initialized.
+            if (serviceConfig.isControllerClusterListenerEnabled()) {
+                cluster = new ClusterZKImpl((CuratorFramework) storeClient.getClient(), ClusterType.CONTROLLER);
+                List<FailoverSweeper> failoverSweepers = new ArrayList<>();
+                failoverSweepers.add(taskSweeper);
+                failoverSweepers.add(txnSweeper);
+                if (controllerEventProcessors != null) {
+                    failoverSweepers.add(controllerEventProcessors);
+                }
+
+                controllerClusterListener = new ControllerClusterListener(host, cluster, controllerExecutor, failoverSweepers);
+
+                log.info("Starting controller cluster listener");
+                controllerClusterListener.startAsync();
             }
 
             // Start RPC server.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -159,6 +159,10 @@ public class ControllerServiceStarter extends AbstractIdleService {
             TxnSweeper txnSweeper = new TxnSweeper(streamStore, streamTransactionMetadataTasks,
                     serviceConfig.getTimeoutServiceConfig().getMaxLeaseValue(), controllerExecutor);
 
+            if (serviceConfig.isControllerClusterListenerEnabled()) {
+                cluster = new ClusterZKImpl((CuratorFramework) storeClient.getClient(), ClusterType.CONTROLLER);
+            }
+
             controllerService = new ControllerService(streamStore, hostStore, streamMetadataTasks,
                     streamTransactionMetadataTasks, new SegmentHelper(), controllerExecutor, cluster);
 
@@ -179,7 +183,6 @@ public class ControllerServiceStarter extends AbstractIdleService {
 
             // Setup and start controller cluster listener after all sweepers have been initialized.
             if (serviceConfig.isControllerClusterListenerEnabled()) {
-                cluster = new ClusterZKImpl((CuratorFramework) storeClient.getClient(), ClusterType.CONTROLLER);
                 List<FailoverSweeper> failoverSweepers = new ArrayList<>();
                 failoverSweepers.add(taskSweeper);
                 failoverSweepers.add(txnSweeper);

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -183,7 +183,8 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 List<FailoverSweeper> failoverSweepers = new ArrayList<>();
                 failoverSweepers.add(taskSweeper);
                 failoverSweepers.add(txnSweeper);
-                if (controllerEventProcessors != null) {
+                if (serviceConfig.getEventProcessorConfig().isPresent()) {
+                    assert controllerEventProcessors != null;
                     failoverSweepers.add(controllerEventProcessors);
                 }
 

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.fault;
 
+import com.google.common.collect.Lists;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.common.cluster.ClusterType;
 import io.pravega.common.cluster.Host;
@@ -136,7 +137,8 @@ public class ControllerClusterListenerTest {
         TxnSweeper txnSweeper = new TxnSweeper(streamStore, txnTasks, 100, executor);
 
         // Create ControllerClusterListener.
-        ControllerClusterListener clusterListener =  new ControllerClusterListener(host, clusterZK, executor, taskSweeper, txnSweeper);
+        ControllerClusterListener clusterListener =  new ControllerClusterListener(host, clusterZK, executor,
+                Lists.newArrayList(taskSweeper, txnSweeper));
         clusterListener.startAsync();
 
         clusterListener.awaitRunning();
@@ -229,7 +231,7 @@ public class ControllerClusterListenerTest {
 
         // Create ControllerClusterListener.
         ControllerClusterListener clusterListener = new ControllerClusterListener(host, clusterZK, executor,
-                        taskSweeper, txnSweeper);
+                Lists.newArrayList(taskSweeper, txnSweeper));
 
         clusterListener.startAsync();
         clusterListener.awaitRunning();


### PR DESCRIPTION
**Change log description**
```
Caused by: java.lang.NullPointerException: null
	at io.pravega.controller.fault.ControllerClusterListener.lambda$null$10(ControllerClusterListener.java:136)
	at io.pravega.common.concurrent.FutureHelpers.lambda$delayedFuture$24(FutureHelpers.java:458)
	at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:952)
	... 10 common frames omitted
```

which is caused by a sweeper being null in this block of code:

```
    private CompletableFuture<Void> sweepAll(Supplier<Set<String>> processes) {
        return FutureHelpers.allOf(sweepers.stream().map(sweeper -> RetryHelper.withIndefiniteRetriesAsync(() -> {
            if (!sweeper.isReady()) {
                log.trace("sweeper not ready, retrying with exponential backoff");
                throw new RuntimeException("sweeper not ready");
            }
            return sweeper.sweepFailedProcesses(processes);
        }, e -> log.warn(e.getMessage(), e), executor)).collect(Collectors.toList()));
    }
```
**Purpose of the change**
Fixes #1617.
io.pravega.controller.server.ControllerServiceStarter is passing in 3 FailoverSweepers, and one is null:
https://github.com/pravega/pravega/blob/master/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java#L163
The controllerEventProcessors field is passed in as the first argument of this vararg and it is null, it is initialized later in the code (and only if certain conditions exist):
https://github.com/pravega/pravega/blob/master/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java#L177
**What the code does**

We move creation of controller cluster listener only after all sweepers are started (which includes eventprocessors). 

**How to verify it**
added preconditions and asserts to flag the issue. All existing tests should pass. 