### PR TITLE
Issue 1203: Remove jersey-netty dependency from test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,7 +393,6 @@ project('controller') {
         compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
         compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
         testCompile project(':test:testcommon')
-        testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-netty', version: jerseyVersion
         testCompile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
     }
 

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -36,7 +36,7 @@ public class PingTest {
 
     //Ensure each test completes within 30 seconds.
     @Rule
-    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+    public final Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
 
     private RESTServerConfig serverConfig;
     private RESTServer restServer;

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -9,32 +9,61 @@
  */
 package io.pravega.controller.rest.v1;
 
-import io.pravega.controller.server.rest.resources.PingImpl;
+import io.pravega.controller.server.ControllerService;
+import io.pravega.controller.server.rest.RESTServer;
+import io.pravega.controller.server.rest.RESTServerConfig;
+import io.pravega.controller.server.rest.impl.RESTServerConfigImpl;
 import io.pravega.test.common.TestUtils;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
-import javax.ws.rs.core.Application;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test for ping API.
  */
-public class PingTest extends JerseyTest {
+public class PingTest {
 
-    @Override
-    protected Application configure() {
-        this.forceSet(TestProperties.CONTAINER_PORT, String.valueOf(TestUtils.getAvailableListenPort()));
-        return new ResourceConfig(PingImpl.class);
+    //Ensure each test completes within 30 seconds.
+    @Rule
+    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+
+    private RESTServerConfig serverConfig;
+    private RESTServer restServer;
+    private Client client;
+
+    @Before
+    public void setup() {
+        ControllerService mockControllerService = mock(ControllerService.class);
+        serverConfig = RESTServerConfigImpl.builder().host("localhost").port(TestUtils.getAvailableListenPort())
+                .build();
+        restServer = new RESTServer(mockControllerService, serverConfig);
+        restServer.startAsync();
+        restServer.awaitRunning();
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
+        restServer.stopAsync();
+        restServer.awaitTerminated();
     }
 
     @Test
     public void test() {
-        final Response hello = target("/ping").request().get(Response.class);
-        assertEquals(200, hello.getStatus());
+        String streamResourceURI = "http://localhost:" + serverConfig.getPort() + "/ping";
+        Response response = client.target(streamResourceURI).request().buildGet().invoke();
+        assertEquals(200, response.getStatus());
     }
 }


### PR DESCRIPTION
**Change log description**
Updated the PingTest to remove unnecessary jersey-netty dependency

**Purpose of the change**
Fixes #1203 

**What the code does**
Update code to remove jersey-netty dependency

**How to verify it**
PingTest should continue to pass