### PR TITLE
Issue 1621: Increased gRPC client keepalive timeout to 6 minutes

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -77,7 +77,8 @@ import static io.pravega.common.concurrent.FutureHelpers.getAndHandleExceptions;
 public class ControllerImpl implements Controller {
 
     // The default keepalive interval for the gRPC transport to ensure long running RPCs are tested for connectivity.
-    private static final long DEFAULT_KEEPALIVE_TIME_SECONDS = 60;
+    // This value should be greater than the permissible value configured at the server which is by default 5 minutes.
+    private static final long DEFAULT_KEEPALIVE_TIME_MINUTES = 6;
 
     // The gRPC client for the Controller Service.
     private final ControllerServiceGrpc.ControllerServiceStub client;
@@ -95,7 +96,7 @@ public class ControllerImpl implements Controller {
         this(NettyChannelBuilder.forTarget(controllerURI.toString())
                 .nameResolverFactory(new ControllerResolverFactory())
                 .loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance())
-                .keepAliveTime(DEFAULT_KEEPALIVE_TIME_SECONDS, TimeUnit.SECONDS)
+                .keepAliveTime(DEFAULT_KEEPALIVE_TIME_MINUTES, TimeUnit.MINUTES)
                 .usePlaintext(true));
         log.info("Controller client connecting to server at {}", controllerURI.getAuthority());
     }


### PR DESCRIPTION
**Change log description**
Increased keepalive timeout to 6 minutes from 1 minute. The earlier 1 minute keep-alives were being rejected by the gRPC server since it was less than the permissible server keep-alive limit of 5 minutes. 

**Purpose of the change**
Fixes #1621 

**What the code does**
Increases keepalive timeout

**How to verify it**
Added test case to simulate long running RPC with different keep-alive timeout configuration