### PR TITLE
Issue 1623: Use stateSynchronizer's consistency to enforce the consistency of checkpoints

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -37,12 +37,12 @@ public class CheckpointState {
     private final Map<String, Map<Segment, Long>> checkpointPositions = new HashMap<>();
     
     @Synchronized
-    void beginNewCheckpoint(String checkpointId, Set<String> currentReaders) {
+    void beginNewCheckpoint(String checkpointId, Set<String> currentReaders, Map<Segment, Long> knownPositions) {
         if (!checkpointPositions.containsKey(checkpointId)) {
             if (!currentReaders.isEmpty()) {
                 uncheckpointedHosts.put(checkpointId, new ArrayList<>(currentReaders));
             }
-            checkpointPositions.put(checkpointId, new HashMap<>());
+            checkpointPositions.put(checkpointId, knownPositions);
             checkpoints.add(checkpointId);
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -42,7 +42,7 @@ public class CheckpointState {
             if (!currentReaders.isEmpty()) {
                 uncheckpointedHosts.put(checkpointId, new ArrayList<>(currentReaders));
             }
-            checkpointPositions.put(checkpointId, knownPositions);
+            checkpointPositions.put(checkpointId, new HashMap<>(knownPositions));
             checkpoints.add(checkpointId);
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -191,7 +191,7 @@ class ReaderGroupState implements Revisioned {
     }
     
     @Synchronized
-    String getCheckpointsForReader(String readerName) {
+    String getCheckpointForReader(String readerName) {
         return checkpointState.getCheckpointForReader(readerName);
     }
     
@@ -451,7 +451,7 @@ class ReaderGroupState implements Revisioned {
          */
         @Override
         void update(ReaderGroupState state) {
-            state.checkpointState.beginNewCheckpoint(checkpointId, state.getOnlineReaders());
+            state.checkpointState.beginNewCheckpoint(checkpointId, state.getOnlineReaders(), state.getUnassignedSegments());
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -340,6 +340,7 @@ public class ReaderGroupStateManager {
     }
     
     String getCheckpoint() throws ReinitializationRequiredException {
+        fetchUpdatesIfNeeded();
         ReaderGroupState state = sync.getState();
         if (!state.isReaderOnline(readerId)) {
             throw new ReinitializationRequiredException();

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -27,14 +27,14 @@ public class CheckpointStateTest {
     @Test
     public void testCheckpointNoReaders() {
         CheckpointState state = new CheckpointState();
-        state.beginNewCheckpoint("foo", ImmutableSet.of());
+        state.beginNewCheckpoint("foo", ImmutableSet.of(), Collections.emptyMap());
         assertTrue(state.isCheckpointComplete("foo"));
     }
     
     @Test
     public void testCheckpointCompletes() {
         CheckpointState state = new CheckpointState();
-        state.beginNewCheckpoint("foo", ImmutableSet.of("a", "b"));
+        state.beginNewCheckpoint("foo", ImmutableSet.of("a", "b"), Collections.emptyMap());
         assertFalse(state.isCheckpointComplete("foo"));
         state.readerCheckpointed("foo", "a", ImmutableMap.of(getSegment("S1"), 1L));
         assertFalse(state.isCheckpointComplete("foo"));
@@ -49,7 +49,7 @@ public class CheckpointStateTest {
     @Test
     public void testGetCheckpointForReader() {
         CheckpointState state = new CheckpointState();
-        state.beginNewCheckpoint("foo", ImmutableSet.of("a", "b"));
+        state.beginNewCheckpoint("foo", ImmutableSet.of("a", "b"), Collections.emptyMap());
         assertEquals("foo", state.getCheckpointForReader("a"));
         assertEquals("foo", state.getCheckpointForReader("b"));
         assertEquals(null, state.getCheckpointForReader("c"));

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -122,9 +122,11 @@ public class EventStreamReaderTest {
         Assert.assertEquals(segment2, readers.get(1).getSegmentId());
 
         Mockito.when(groupState.getCheckpoint()).thenReturn("checkpoint");
+        assertTrue(reader.readNextEvent(0).isCheckpoint());
+        Mockito.when(groupState.getCheckpoint()).thenReturn(null);
         Mockito.when(groupState.findSegmentToReleaseIfRequired()).thenReturn(segment2);
-        reader.readNextEvent(0);
-        reader.readNextEvent(0);
+        Mockito.when(groupState.releaseSegment(Mockito.eq(segment2), Mockito.anyLong(), Mockito.anyLong())).thenReturn(true);
+        assertFalse(reader.readNextEvent(0).isCheckpoint());
         Mockito.verify(groupState).releaseSegment(Mockito.eq(segment2), Mockito.anyLong(), Mockito.anyLong());
         readers = reader.getReaders();
         assertEquals(1, readers.size());

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -28,6 +28,7 @@ import io.pravega.test.common.AssertExtensions;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
@@ -504,4 +505,71 @@ public class ReaderGroupStateManagerTest {
         assertEquals(segments, stateSynchronizer.getState().getPositionsForCompletedCheckpoint("CP1"));
     }
     
+    @Test(timeout = 10000)
+    public void testSegmentsCannotBeReleasedWithoutCheckpoint() throws ReinitializationRequiredException {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        Segment segment0 = new Segment(scope, stream, 0);
+        Segment segment1 = new Segment(scope, stream, 1);
+        Segment segment2 = new Segment(scope, stream, 2);
+        MockController controller = new MockControllerWithSuccessors(endpoint.getEndpoint(), endpoint.getPort(),
+                connectionFactory, new StreamSegmentsWithPredecessors(ImmutableMap.of()));
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
+                                                            streamFactory, streamFactory);
+        SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
+                                                                                                      new JavaSerializer<>(),
+                                                                                                      new JavaSerializer<>(),
+                                                                                                      config);
+        AtomicLong clock = new AtomicLong();
+        Map<Segment, Long> segments = ImmutableMap.of(segment0, 0L, segment1, 1L, segment2, 2L);
+        ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
+        val readerState1 = new ReaderGroupStateManager("reader1", stateSynchronizer, controller, clock::get);
+        readerState1.initializeReader(0);
+        val readerState2 = new ReaderGroupStateManager("reader2", stateSynchronizer, controller, clock::get);
+        readerState2.initializeReader(0);
+        
+        assertEquals(segments, stateSynchronizer.getState().getUnassignedSegments());
+        stateSynchronizer.updateStateUnconditionally(new CreateCheckpoint("CP1"));
+        stateSynchronizer.fetchUpdates();
+        assertEquals("CP1", readerState1.getCheckpoint());
+        assertEquals(Collections.emptyMap(), readerState1.acquireNewSegmentsIfNeeded(1));
+        assertEquals(Collections.emptyMap(), readerState2.acquireNewSegmentsIfNeeded(2));
+        assertEquals("CP1", readerState2.getCheckpoint());
+        readerState1.checkpoint("CP1", new PositionImpl(Collections.emptyMap()));
+        readerState2.checkpoint("CP1", new PositionImpl(Collections.emptyMap()));
+        assertEquals(segments, stateSynchronizer.getState().getPositionsForCompletedCheckpoint("CP1"));
+        Map<Segment, Long> segments1 = readerState1.acquireNewSegmentsIfNeeded(1);
+        Map<Segment, Long> segments2 = readerState2.acquireNewSegmentsIfNeeded(2);
+        assertFalse(segments1.isEmpty());
+        assertFalse(segments2.isEmpty());
+        assertEquals(0, stateSynchronizer.getState().getNumberOfUnassignedSegments());
+        
+        //Induce imbalance
+        for (Entry<Segment, Long> entry : segments1.entrySet()) {            
+            stateSynchronizer.updateStateUnconditionally(new ReaderGroupState.ReleaseSegment("reader1", entry.getKey(), entry.getValue()));
+            stateSynchronizer.updateStateUnconditionally(new ReaderGroupState.AcquireSegment("reader2", entry.getKey()));
+        }
+        stateSynchronizer.updateStateUnconditionally(new CreateCheckpoint("CP2"));
+        stateSynchronizer.fetchUpdates();
+        
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        assertNull(readerState1.findSegmentToReleaseIfRequired());
+        assertNull(readerState2.findSegmentToReleaseIfRequired());
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        assertFalse(readerState2.releaseSegment(segments2.keySet().iterator().next(), 20, 2));
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        readerState1.checkpoint("CP2", new PositionImpl(Collections.emptyMap()));
+        readerState2.checkpoint("CP2", new PositionImpl(segments));
+        assertEquals(segments, stateSynchronizer.getState().getPositionsForCompletedCheckpoint("CP2"));
+        Segment toRelease = readerState2.findSegmentToReleaseIfRequired();
+        assertNotNull(toRelease);
+        assertTrue(readerState2.releaseSegment(toRelease, 10, 1));
+        assertEquals(1, stateSynchronizer.getState().getNumberOfUnassignedSegments());
+    }
 }


### PR DESCRIPTION
**Change log description**
Fix a race condition, that could result in an inconsistent checkpoint.

**Purpose of the change**
Fixes #1623. It was previously possible to have a checkpoint be inconsistent as a result of a race condition with a concurrent rebalance operation, because the ReaderGroupStateManager did not use its ability to perform a compare and set to enforce the invariant. 

**What the code does**
ReaderGroupStateManager now performs checks when releasing and acquiring segments to make sure there is not a pending checkpoint for its reader. 

**How to verify it**
Two new tests were created that failed before the change and now pass. All existing tests should pass.
