### PR TITLE
Issue 1630: Remove unnecessary error level logging for all exceptions encountered by the StreamStore

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -605,7 +605,6 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 
         future.whenCompleteAsync((r, e) -> {
             if (e != null) {
-                log.error("AbstractStreamMetadataStore exception: {}", e);
                 result.completeExceptionally(e);
             } else {
                 result.complete(r);


### PR DESCRIPTION
**Change log description**
`AbstractStreammetadataStore` has a `withCompletion` method that employs visitor pattern for futures so that callers do not perform any processing on store's executor.
However, along with it, it also logs all exceptions at log level ERROR.
The log level error should be callers discretion because they know if the error is handled or not.


**Purpose of the change**
Remove unnecessary log.error level messages.

Fixes #1630 

**What the code does**
It removes logging of all errors in the store.. Logging is callers responsibility. 

**How to verify it**
All existing tests should pass
