### PR TITLE
Issue 1638: Implement put-if-absent for ExtendedS3Storage which can be overridden with a config

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
@@ -293,7 +293,13 @@ public class ExtendedS3Storage implements Storage {
          * But this does not work. Currently all the calls to putObject API fail if made with reqest.setIfNoneMatch("*").
          * once the issue with extended S3 API is fixed, addition of this one line will ensure put-if-absent semantics.
          * See: https://github.com/pravega/pravega/issues/1564
+         *
+         * This issue is fixed in some versions of extended S3 implementation. The following code sets the IfNoneMatch
+         * flag based on configuration.
          */
+        if (config.isIfNoneMatchWorks()) {
+            request.setIfNoneMatch("*");
+        }
         client.putObject(request);
 
         LoggerHelpers.traceLeave(log, "create", traceId);

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
@@ -281,7 +281,7 @@ public class ExtendedS3Storage implements Storage {
         });
         request.setAcl(acl);
 
-        /* TODO: Default behavior of putObject is to overwrite an existing object. This behavior can cause data loss.
+        /* Default behavior of putObject is to overwrite an existing object. This behavior can cause data loss.
          * Here is one of the scenarios in which data loss is observed:
          * 1. Host A owns the container and gets a create operation. It has not executed the putObject operation yet.
          * 2. Ownership changes and host B becomes the owner of the container. It picks up putObject from the queue, executes it.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
@@ -297,7 +297,7 @@ public class ExtendedS3Storage implements Storage {
          * This issue is fixed in some versions of extended S3 implementation. The following code sets the IfNoneMatch
          * flag based on configuration.
          */
-        if (config.isIfNoneMatchWorks()) {
+        if (config.isUseNoneMatch()) {
             request.setIfNoneMatch("*");
         }
         client.putObject(request);

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
@@ -30,7 +30,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<String> URI = Property.named("url", "");
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> NAMESPACE = Property.named("namespace", ""); // use default namespace
-    private static final Property<Boolean> IFNONEMATCHWORKS = Property.named("ifnonematchworks", false);
+    public static final Property<Boolean> IFNONEMATCHWORKS = Property.named("ifnonematchworks", false);
 
     private static final String COMPONENT_CODE = "extendeds3";
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
@@ -30,6 +30,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<String> URI = Property.named("url", "");
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> NAMESPACE = Property.named("namespace", ""); // use default namespace
+    private static final Property<Boolean> IFNONEMATCHWORKS = Property.named("ifnonematchworks", false);
 
     private static final String COMPONENT_CODE = "extendeds3";
 
@@ -74,6 +75,12 @@ public class ExtendedS3StorageConfig {
     @Getter
     private final String namespace;
 
+    /**
+     *
+     */
+    @Getter
+    private final boolean ifNoneMatchWorks;
+
     //endregion
 
     //region Constructor
@@ -90,6 +97,7 @@ public class ExtendedS3StorageConfig {
         this.url = java.net.URI.create(properties.get(URI));
         this.bucket = properties.get(BUCKET);
         this.namespace = properties.get(NAMESPACE);
+        this.ifNoneMatchWorks = properties.getBoolean(IFNONEMATCHWORKS);
     }
 
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageConfig.java
@@ -30,7 +30,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<String> URI = Property.named("url", "");
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> NAMESPACE = Property.named("namespace", ""); // use default namespace
-    public static final Property<Boolean> IFNONEMATCHWORKS = Property.named("ifnonematchworks", false);
+    public static final Property<Boolean> USENONEMATCH = Property.named("useNoneMatch", false);
 
     private static final String COMPONENT_CODE = "extendeds3";
 
@@ -79,7 +79,7 @@ public class ExtendedS3StorageConfig {
      *
      */
     @Getter
-    private final boolean ifNoneMatchWorks;
+    private final boolean useNoneMatch;
 
     //endregion
 
@@ -97,7 +97,7 @@ public class ExtendedS3StorageConfig {
         this.url = java.net.URI.create(properties.get(URI));
         this.bucket = properties.get(BUCKET);
         this.namespace = properties.get(NAMESPACE);
-        this.ifNoneMatchWorks = properties.getBoolean(IFNONEMATCHWORKS);
+        this.useNoneMatch = properties.getBoolean(USENONEMATCH);
     }
 
     /**

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
@@ -13,6 +13,7 @@ import com.emc.object.s3.S3Config;
 import com.emc.object.s3.bean.ObjectKey;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.emc.object.s3.request.DeleteObjectsRequest;
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.impl.IdempotentStorageTestBase;
@@ -25,6 +26,9 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 
 /**
  * Unit tests for ExtendedS3Storage.
@@ -73,6 +77,30 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
         s3Proxy.stop();
     }
 
+    //region If-none-match test
+    /**
+     * Tests the create() method with if-none-match set.
+     */
+    @Test
+    public void testCreateIfNoneMatch() {
+        adapterConfig = ExtendedS3StorageConfig.builder()
+                                               .with(ExtendedS3StorageConfig.BUCKET, adapterConfig.getBucket())
+                                               .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
+                                               .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
+                                               .with(ExtendedS3StorageConfig.ROOT, "test")
+                                               .with(ExtendedS3StorageConfig.URI, endpoint)
+                                               .with(ExtendedS3StorageConfig.IFNONEMATCHWORKS, true)
+                                               .build();
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            s.create(segmentName, null).join();
+            assertThrows("create() did not throw for existing StreamSegment.",
+                    s.create(segmentName, null),
+                    ex -> ex instanceof StreamSegmentExistsException);
+        }
+    }
+    //endregion
     @Override
     protected Storage createStorage() {
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
@@ -101,6 +101,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
         }
     }
     //endregion
+
     @Override
     protected Storage createStorage() {
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
@@ -89,7 +89,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
                                                .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
                                                .with(ExtendedS3StorageConfig.ROOT, "test")
                                                .with(ExtendedS3StorageConfig.URI, endpoint)
-                                               .with(ExtendedS3StorageConfig.IFNONEMATCHWORKS, true)
+                                               .with(ExtendedS3StorageConfig.USENONEMATCH, true)
                                                .build();
         String segmentName = "foo_open";
         try (Storage s = createStorage()) {


### PR DESCRIPTION
**Change log description**
- Add code for put-if-absent based on a config setting.

**Purpose of the change**
This fixes #1638. 

**What the code does**
Adds `setIfNoneMatch` to the `putObject` header, based on a config value.

**How to verify it**
