### PR TITLE
Issue 1640: Ensuring that partially created txns are aborted on lease expiry

### DIFF
--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -53,32 +53,32 @@ public class SegmentHelperMock {
         return helper;
     }
 
-    public static SegmentHelper getFailingTxnOpsSegmentHelperMock() {
+    public static SegmentHelper getFailingSegmentHelperMock() {
         SegmentHelper helper = spy(new SegmentHelper());
 
         doReturn(NodeUri.newBuilder().setEndpoint("localhost").setPort(SERVICE_PORT).build()).when(helper).getSegmentUri(
                 anyString(), anyString(), anyInt(), any());
 
-        doReturn(CompletableFuture.completedFuture(true)).when(helper).sealSegment(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).sealSegment(
                 anyString(), anyString(), anyInt(), any(), any());
 
-        doReturn(CompletableFuture.completedFuture(true)).when(helper).createSegment(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).createSegment(
                 anyString(), anyString(), anyInt(), any(), any(), any());
 
-        doReturn(CompletableFuture.completedFuture(true)).when(helper).deleteSegment(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).deleteSegment(
                 anyString(), anyString(), anyInt(), any(), any());
 
-        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).abortTransaction(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).createTransaction(
                 anyString(), anyString(), anyInt(), any(), any(), any());
 
-        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).commitTransaction(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).abortTransaction(
                 anyString(), anyString(), anyInt(), any(), any(), any());
 
-        doReturn(CompletableFuture.completedFuture(true)).when(helper).updatePolicy(
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).commitTransaction(
+                anyString(), anyString(), anyInt(), any(), any(), any());
+
+        doReturn(FutureHelpers.failedFuture(new RuntimeException())).when(helper).updatePolicy(
                 anyString(), anyString(), any(), anyInt(), any(), any());
-
-        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).createTransaction(
-                anyString(), anyString(), anyInt(), any(), any(), any());
 
         return helper;
     }

--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.mocks;
 
+import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.stream.api.grpc.v1.Controller.NodeUri;
 
@@ -49,6 +50,36 @@ public class SegmentHelperMock {
 
         doReturn(CompletableFuture.completedFuture(true)).when(helper).updatePolicy(
                 anyString(), anyString(), any(), anyInt(), any(), any());
+        return helper;
+    }
+
+    public static SegmentHelper getFailingTxnOpsSegmentHelperMock() {
+        SegmentHelper helper = spy(new SegmentHelper());
+
+        doReturn(NodeUri.newBuilder().setEndpoint("localhost").setPort(SERVICE_PORT).build()).when(helper).getSegmentUri(
+                anyString(), anyString(), anyInt(), any());
+
+        doReturn(CompletableFuture.completedFuture(true)).when(helper).sealSegment(
+                anyString(), anyString(), anyInt(), any(), any());
+
+        doReturn(CompletableFuture.completedFuture(true)).when(helper).createSegment(
+                anyString(), anyString(), anyInt(), any(), any(), any());
+
+        doReturn(CompletableFuture.completedFuture(true)).when(helper).deleteSegment(
+                anyString(), anyString(), anyInt(), any(), any());
+
+        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).abortTransaction(
+                anyString(), anyString(), anyInt(), any(), any(), any());
+
+        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).commitTransaction(
+                anyString(), anyString(), anyInt(), any(), any(), any());
+
+        doReturn(CompletableFuture.completedFuture(true)).when(helper).updatePolicy(
+                anyString(), anyString(), any(), anyInt(), any(), any());
+
+        doReturn(FutureHelpers.failedFuture(new IllegalStateException())).when(helper).createTransaction(
+                anyString(), anyString(), anyInt(), any(), any(), any());
+
         return helper;
     }
 }


### PR DESCRIPTION
**Change log description**
Currently, after creating a transaction record in controller's metadata, if the subsequent step of creating transaction segments fails, the new transaction does not get added to timeout service. This may cause the transaction to not abort on its timeout expiry. Modified the transaction creation method to ensure that partially created transactions get added to in-memory timeout service.

**Purpose of the change**
Fixes #1640 

**What the code does**
Adds a newly created transaction to in-memory timeout service even if creation of few transaction segments fails.

**How to verify it**
All existing test cases should succeed. Added a new test case to test whether partially created transactions are added to timeout service.