### PR TITLE
Issue 1655: Correct the stream name in waitForScaling() of ReadWriteAndAutoScaleWithFailoverTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -54,8 +54,8 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 abstract class AbstractFailoverTests {
 
-    static final String STREAM = "testReadWriteAndAutoScaleStream";
-    static final String STREAM_NAME = "testReadWriteAndScaleStream";
+    static final String AUTO_SCALE_STREAM = "testReadWriteAndAutoScaleStream";
+    static final String SCALE_STREAM = "testReadWriteAndScaleStream";
     static final int ADD_NUM_WRITERS = 6;
     //Duration for which the system test waits for writes/reads to happen post failover.
     //10s (SessionTimeout) + 10s (RebalanceContainers) + 20s (For Container recovery + start) + NetworkDelays
@@ -207,10 +207,10 @@ abstract class AbstractFailoverTests {
 
     void cleanUp(String scope, String stream) throws InterruptedException, ExecutionException {
         CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, stream);
-        log.info("Sealing stream {}", STREAM_NAME);
+        log.info("Sealing stream {}", stream);
         assertTrue(sealStreamStatus.get());
         CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, stream);
-        log.info("Deleting stream {}", STREAM_NAME);
+        log.info("Deleting stream {}", stream);
         assertTrue(deleteStreamStatus.get());
         CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
         log.info("Deleting scope {}", scope);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -50,7 +50,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
-            .streamName(STREAM).scalingPolicy(scalingPolicy).build();
+            .streamName(AUTO_SCALE_STREAM).scalingPolicy(scalingPolicy).build();
 
 
     @Environment
@@ -107,13 +107,13 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @Test(timeout = 12 * 60 * 1000)
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
-        createScopeAndStream(scope, STREAM, config, controllerURIDirect);
+        createScopeAndStream(scope, AUTO_SCALE_STREAM, config, controllerURIDirect);
         log.info("Scope passed to client factory {}", scope);
         try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect)) {
 
-            createWriters(clientFactory, INIT_NUM_WRITERS, scope, STREAM);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM, NUM_READERS);
+            createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
 
             //run the failover test before scaling
             performFailoverTest();
@@ -123,7 +123,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
             segmentStoreInstance.scaleService(3, true);
             Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS);
 
-            addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, STREAM);
+            addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
 
             //run the failover test while scaling
             performFailoverTest();
@@ -141,12 +141,12 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
             stopReadersAndWriters(readerGroupManager, readerGroupName);
 
         }
-        cleanUp(scope, STREAM);
+        cleanUp(scope, AUTO_SCALE_STREAM);
         log.info("Test {} succeeds ", "ReadWriteAndAutoScaleWithFailover");
     }
 
     private void waitForScaling() throws InterruptedException, ExecutionException {
-        StreamSegments streamSegments = controller.getCurrentSegments(scope, STREAM_NAME).get();
+        StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
         for (int waitCounter = 0; waitCounter < 2; waitCounter++) {
             testState.currentNumOfSegments.set(streamSegments.getSegments().size());
             if (testState.currentNumOfSegments.get() == 2) {

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -146,8 +146,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     }
 
     private void waitForScaling() throws InterruptedException, ExecutionException {
-        StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
         for (int waitCounter = 0; waitCounter < 2; waitCounter++) {
+            StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
             testState.currentNumOfSegments.set(streamSegments.getSegments().size());
             if (testState.currentNumOfSegments.get() == 2) {
                 log.info("The current number of segments is equal to 2, ScaleOperation did not happen");

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -50,7 +50,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     private final String readerGroupName = "testReadWriteAndScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 1);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
-            .streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
+            .streamName(SCALE_STREAM).scalingPolicy(scalingPolicy).build();
 
     @Environment
     public static void initialize() throws InterruptedException, MarathonException, URISyntaxException {
@@ -104,14 +104,14 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
     @Test(timeout = 12 * 60 * 1000)
     public void readWriteAndScaleWithFailoverTest() throws Exception {
-        createScopeAndStream(scope, STREAM_NAME, config, controllerURIDirect);
+        createScopeAndStream(scope, SCALE_STREAM, config, controllerURIDirect);
 
         log.info("Scope passed to client factory {}", scope);
         try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect)) {
 
-            createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
+            createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
+            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
 
             //run the failover test before scaling
             performFailoverTest();
@@ -122,14 +122,14 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
             Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS);
 
             //scale manually
-            log.debug("Scale down stream starting segments:" + controller.getCurrentSegments(scope, STREAM_NAME)
+            log.debug("Scale down stream starting segments:" + controller.getCurrentSegments(scope, SCALE_STREAM)
                     .get().getSegments().size());
 
             Map<Double, Double> keyRanges = new HashMap<>();
             keyRanges.put(0.0, 0.5);
             keyRanges.put(0.5, 1.0);
 
-            CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, STREAM_NAME),
+            CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
                     Collections.singletonList(0),
                     keyRanges,
                     executorService).getFuture();
@@ -139,7 +139,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
             //do a get on scaleStatus
             scaleStatus.get();
-            log.debug("Scale down stream final segments:" + controller.getCurrentSegments(scope, STREAM_NAME)
+            log.debug("Scale down stream final segments:" + controller.getCurrentSegments(scope, SCALE_STREAM)
                     .get().getSegments().size());
 
             //bring the instances back to 3 before performing failover after scaling
@@ -152,7 +152,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
             stopReadersAndWriters(readerGroupManager, readerGroupName);
         }
-        cleanUp(scope, STREAM_NAME);
+        cleanUp(scope, SCALE_STREAM);
         log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");
     }
 }


### PR DESCRIPTION
**Change log description**
Passes the correct stream name to check if auto scaling is triggered.

**Purpose of the change**
getCurrentSegments is checked for wrong stream name in waitForScaling().

**What the code does**
Fixes #1655 

**How to verify it**
Run system tests