### PR TITLE
Issue 1657: Bugfix - ensure EventStreamWriter retries on netty connection errors.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
@@ -59,6 +59,7 @@ public class ClientConnectionInboundHandler extends ChannelInboundHandlerAdapter
         super.channelRegistered(ctx);
         Channel c = ctx.channel();
         channel.set(c);
+        log.info("Connection established {} ", ctx);
         c.write(new WireCommands.Hello(WireCommands.WIRE_VERSION, WireCommands.OLDEST_COMPATABLE_VERSION), c.voidPromise());
         ScheduledFuture<?> old = keepAliveFuture.getAndSet(c.eventLoop().scheduleWithFixedDelay(new KeepAliveTask(), 20, 10, TimeUnit.SECONDS));
         if (old != null) {

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -162,7 +162,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
     }
 
     private void closeConnection(Exception exceptionToInflightRequests) {
-        log.info("Closing connection with exception: {}", exceptionToInflightRequests.toString());
+        log.info("Closing connection with exception: {}", exceptionToInflightRequests);
         CompletableFuture<ClientConnection> c;
         synchronized (lock) {
             c = connection;

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -70,6 +70,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         
         @Override
         public void segmentIsSealed(WireCommands.SegmentIsSealed segmentIsSealed) {
+            log.info("Received segmentSealed {}", segmentIsSealed);
             checkSegment(segmentIsSealed.getSegment());
             CompletableFuture<SegmentRead> future;
             synchronized (lock) {
@@ -161,7 +162,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
     }
 
     private void closeConnection(Exception exceptionToInflightRequests) {
-        log.trace("Closing connection with exception: {}", exceptionToInflightRequests.toString());
+        log.info("Closing connection with exception: {}", exceptionToInflightRequests.toString());
         CompletableFuture<ClientConnection> c;
         synchronized (lock) {
             c = connection;

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -64,7 +64,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         
         @Override
         public void streamSegmentInfo(StreamSegmentInfo streamInfo) {
-            log.trace("Received stream segment info {}", streamInfo);
+            log.debug("Received stream segment info {}", streamInfo);
             CompletableFuture<StreamSegmentInfo> future;
             synchronized (lock) {
                 future = infoRequests.remove(streamInfo.getRequestId());
@@ -76,7 +76,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
 
         @Override
         public void segmentAttribute(WireCommands.SegmentAttribute segmentAttribute) {
-            log.trace("Received stream segment attribute {}", segmentAttribute);
+            log.debug("Received stream segment attribute {}", segmentAttribute);
             CompletableFuture<WireCommands.SegmentAttribute> future;
             synchronized (lock) {
                 future = getAttributeRequests.remove(segmentAttribute.getRequestId());
@@ -88,7 +88,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         
         @Override
         public void segmentAttributeUpdated(SegmentAttributeUpdated segmentAttributeUpdated) {
-            log.trace("Received stream segment attribute update result {}", segmentAttributeUpdated);
+            log.debug("Received stream segment attribute update result {}", segmentAttributeUpdated);
             CompletableFuture<SegmentAttributeUpdated> future;
             synchronized (lock) {
                 future = setAttributeRequests.remove(segmentAttributeUpdated.getRequestId());

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -102,8 +102,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         private final ReusableLatch connectionSetup = new ReusableLatch();
         @GuardedBy("lock")
         private CompletableFuture<Void> emptyInflightFuture = null;
-        private AtomicBoolean sealEncountered = new AtomicBoolean();
-        private AtomicBoolean reconnecting = new AtomicBoolean();
+        private final AtomicBoolean sealEncountered = new AtomicBoolean();
+        private final AtomicBoolean reconnecting = new AtomicBoolean();
 
         /**
          * Returns a future that will complete successfully once all the inflight events are acked

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -392,7 +392,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             connection.send(new Append(segmentName, writerId, eventNumber, Unpooled.wrappedBuffer(event.getData()),
                                        event.getExpectedOffset()));
         } catch (ConnectionFailedException e) {
-            log.warn("Connection failed due to: ", e);
+            log.warn("Connection " + writerId + " failed due to: ", e);
             getConnection(); // As the messages is inflight, this will perform the retransmition.
         }
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -85,7 +85,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      * No calls to external classes occur. No network calls occur via any methods in this object.
      */
     @ToString(of = {"closed", "exception", "eventNumber"})
-    private static final class State {
+    private final class State {
         private final Object lock = new Object();
         @GuardedBy("lock")
         private boolean closed = false;
@@ -169,7 +169,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 oldConnection = connection;
                 connection = null;
                 if (!closed) {
-                    log.warn("Connection failed due to: {}", e.getMessage());
+                    log.warn("Connection for segment {} failed due to: {}", segmentName, e.getMessage());
                 }
                 if (emptyInflightFuture != null) {
                     emptyInflightFuture.completeExceptionally(exception);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -491,6 +491,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          } catch (ConnectionFailedException exception) {
                              throw Lombok.sneakyThrow(exception);
                          }
+                         state.reconnecting.set(false);
                      }
                  }, connectionFactory.getInternalExecutor());
         }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
@@ -22,13 +22,15 @@ import io.pravega.shared.protocol.netty.ReplyProcessor;
 import com.google.common.base.Preconditions;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.Synchronized;
 
 @RequiredArgsConstructor
 public class MockConnectionFactoryImpl implements ConnectionFactory {
     Map<PravegaNodeUri, ClientConnection> connections = new HashMap<>();
     Map<PravegaNodeUri, ReplyProcessor> processors = new HashMap<>();
-    final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5, new ThreadFactoryBuilder().setNameFormat("testClientInternal-%d").build());
+    @Setter
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(5, new ThreadFactoryBuilder().setNameFormat("testClientInternal-%d").build());
 
     @Override
     @Synchronized

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -101,13 +101,17 @@ public final class Retry {
      * Used to invoke {@link #retryingOn(Class)}. Note this object is reusable so this can be done more than once.
      */
     public static final class RetryWithBackoff {
-        @Getter @Wither
+        @Getter
+        @Wither
         private final long initialMillis;
-        @Getter @Wither
+        @Getter
+        @Wither
         private final int multiplier;
-        @Getter @Wither
+        @Getter
+        @Wither
         private final int attempts;
-        @Getter @Wither
+        @Getter
+        @Wither
         private final long maxDelay;
 
         private RetryWithBackoff(long initialMillis, int multiplier, int attempts, long maxDelay) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -18,6 +18,7 @@ import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
 import io.pravega.segmentstore.contracts.BadOffsetException;
+import io.pravega.segmentstore.contracts.ContainerNotFoundException;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
@@ -275,6 +276,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         } else if (u instanceof WrongHostException) {
             WrongHostException wrongHost = (WrongHostException) u;
             connection.send(new WrongHost(requestId, wrongHost.getStreamSegmentName(), wrongHost.getCorrectHost()));
+        } else if (u instanceof ContainerNotFoundException) {
+            connection.send(new WrongHost(requestId, segment, ""));
         } else if (u instanceof BadAttributeUpdateException) {
             connection.send(new InvalidEventNumber(writerId, requestId));
             connection.close();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -19,6 +19,7 @@ import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
+import io.pravega.segmentstore.contracts.ContainerNotFoundException;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
@@ -370,6 +371,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         } else if (u instanceof WrongHostException) {
             WrongHostException wrongHost = (WrongHostException) u;
             connection.send(new WrongHost(requestId, wrongHost.getStreamSegmentName(), wrongHost.getCorrectHost()));
+        }  else if (u instanceof ContainerNotFoundException) {
+            connection.send(new WrongHost(requestId, segment, ""));
         } else if (u instanceof CancellationException) {
             log.info("Closing connection due to: ", u.getMessage());
             connection.close();


### PR DESCRIPTION
**Change log description**
* Ensures SegmentOutputStream attempts to setup connection on netty connection errors.
* Additional logs to simplify debugging.
* Uses separate promises for each send on reconnect.  This ensures the caller will be notified on failure.
* Handles ContainerNotFoundException.

**Purpose of the change**
Fixes #1657
 
**What the code does**
In case of errors during the net connection, ensures EventStreamWriter/SegmentOutputStreamImpl attempts to re-connect.

**How to verify it**
Tests should pass.