### PR TITLE
Issue 1659: (SegmentStore) BugFix for possible out-of order writes.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
@@ -23,10 +23,10 @@ public interface OperationLog extends Container {
      *
      * @param operation The Operation to append.
      * @param timeout   Timeout for the operation.
-     * @return A CompletableFuture that, when completed, will contain the Sequence for the Operation. If the entry failed to
-     * be added, this Future will complete with the appropriate exception.
+     * @return A CompletableFuture that, when completed, will indicate that the operation has been durably added. If the
+     * operation failed to be added, this Future will complete with the appropriate exception.
      */
-    CompletableFuture<Long> add(Operation operation, Duration timeout);
+    CompletableFuture<Void> add(Operation operation, Duration timeout);
 
     /**
      * Truncates the log up to the given sequence.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
@@ -46,6 +46,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -572,6 +573,7 @@ public class StreamSegmentMapper {
      * A pending request for a Segment Assignment, which keeps track of all queued callbacks.
      * Note that this class in itself is not thread safe, so the caller should take precautions to ensure thread safety.
      */
+    @NotThreadSafe
     private static class PendingRequest {
         private final ArrayList<QueuedCallback<?>> callbacks = new ArrayList<>();
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
@@ -128,10 +128,14 @@ public class StreamSegmentMapper {
         }
 
         TimeoutTimer timer = new TimeoutTimer(timeout);
-        return this.storage
+        CompletableFuture<Void> result = this.storage
                 .create(streamSegmentName, timer.getRemaining())
-                .thenComposeAsync(si -> this.stateStore.put(streamSegmentName, getState(si, attributes), timer.getRemaining()), this.executor)
-                .thenAccept(v -> LoggerHelpers.traceLeave(log, traceObjectId, "createNewStreamSegment", traceId, streamSegmentName));
+                .thenComposeAsync(si -> this.stateStore.put(streamSegmentName, getState(si, attributes), timer.getRemaining()), this.executor);
+        if (log.isTraceEnabled()) {
+            result.thenAccept(v -> LoggerHelpers.traceLeave(log, traceObjectId, "createNewStreamSegment", traceId, streamSegmentName));
+        }
+
+        return result;
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -210,7 +210,7 @@ public class DurableLog extends AbstractService implements OperationLog {
     //region OperationLog Implementation
 
     @Override
-    public CompletableFuture<Long> add(Operation operation, Duration timeout) {
+    public CompletableFuture<Void> add(Operation operation, Duration timeout) {
         ensureRunning();
         return this.operationProcessor.process(operation);
     }
@@ -288,8 +288,7 @@ public class DurableLog extends AbstractService implements OperationLog {
 
     @Override
     public CompletableFuture<Void> operationProcessingBarrier(Duration timeout) {
-        return FutureHelpers
-                .toVoid(add(new ProbeOperation(), timeout))
+        return add(new ProbeOperation(), timeout)
                 .whenComplete((r, ex) -> {
                     // We don't care if this operation completed successfully or not. The Operation Barrier needs to complete
                     // when all operations prior to it completed, regardless of outcome.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -171,8 +171,8 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
      * failed, it will contain the exception that caused the failure.
      * @throws IllegalContainerStateException If the OperationProcessor is not running.
      */
-    public CompletableFuture<Long> process(Operation operation) {
-        CompletableFuture<Long> result = new CompletableFuture<>();
+    public CompletableFuture<Void> process(Operation operation) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
         if (!isRunning()) {
             result.completeExceptionally(new IllegalContainerStateException("OperationProcessor is not running."));
         } else {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CompletableOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CompletableOperation.java
@@ -26,7 +26,7 @@ public class CompletableOperation {
 
     private final Operation operation;
     private final Consumer<Throwable> failureHandler;
-    private final Consumer<Long> successHandler;
+    private final Consumer<Void> successHandler;
     private boolean done;
 
     //endregion
@@ -41,7 +41,7 @@ public class CompletableOperation {
      *                       If successful, the CompletableFuture will contain the Sequence Number of the Operation as its payload.
      * @throws IllegalArgumentException If the given callbackFuture is already done.
      */
-    public CompletableOperation(Operation operation, CompletableFuture<Long> callbackFuture) {
+    public CompletableOperation(Operation operation, CompletableFuture<Void> callbackFuture) {
         this(operation, callbackFuture::complete, callbackFuture::completeExceptionally);
         Exceptions.checkArgument(!callbackFuture.isDone(), "callbackFuture", "CallbackFuture is already done.");
     }
@@ -54,7 +54,7 @@ public class CompletableOperation {
      * @param failureHandler A consumer that will be invoked if this operation failed. The argument provided is the causing Exception for the failure.
      * @throws NullPointerException If operation is null.
      */
-    public CompletableOperation(Operation operation, Consumer<Long> successHandler, Consumer<Throwable> failureHandler) {
+    public CompletableOperation(Operation operation, Consumer<Void> successHandler, Consumer<Throwable> failureHandler) {
         Preconditions.checkNotNull(operation, "operation");
         this.operation = operation;
         this.failureHandler = failureHandler;
@@ -82,7 +82,7 @@ public class CompletableOperation {
 
         this.done = true;
         if (this.successHandler != null) {
-            CallbackHelpers.invokeSafely(this.successHandler, seqNo, cex -> log.error("Success Callback invocation failure.", cex));
+            CallbackHelpers.invokeSafely(this.successHandler, null, cex -> log.error("Success Callback invocation failure.", cex));
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
@@ -9,9 +9,9 @@
  */
 package io.pravega.segmentstore.server.store;
 
+import com.google.common.base.Preconditions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.common.function.CallbackHelpers;
 import io.pravega.common.segment.SegmentToContainerMapper;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.ContainerNotFoundException;
@@ -20,14 +20,11 @@ import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
-import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 
 import static io.pravega.common.LoggerHelpers.traceLeave;
@@ -38,6 +35,7 @@ import static io.pravega.common.LoggerHelpers.traceLeave;
 @Slf4j
 public class StreamSegmentService implements StreamSegmentStore {
     //region Members
+
     private final SegmentContainerRegistry segmentContainerRegistry;
     private final SegmentToContainerMapper segmentToContainerMapper;
 
@@ -50,15 +48,10 @@ public class StreamSegmentService implements StreamSegmentStore {
      *
      * @param segmentContainerRegistry The SegmentContainerRegistry to route requests to.
      * @param segmentToContainerMapper The SegmentToContainerMapper to use to map StreamSegments to Containers.
-     * @throws NullPointerException If segmentContainerRegistry is null.
-     * @throws NullPointerException If segmentToContainerMapper is null.
      */
     public StreamSegmentService(SegmentContainerRegistry segmentContainerRegistry, SegmentToContainerMapper segmentToContainerMapper) {
-        Preconditions.checkNotNull(segmentContainerRegistry, "segmentContainerRegistry");
-        Preconditions.checkNotNull(segmentToContainerMapper, "segmentToContainerMapper");
-
-        this.segmentContainerRegistry = segmentContainerRegistry;
-        this.segmentToContainerMapper = segmentToContainerMapper;
+        this.segmentContainerRegistry = Preconditions.checkNotNull(segmentContainerRegistry, "segmentContainerRegistry");
+        this.segmentToContainerMapper = Preconditions.checkNotNull(segmentToContainerMapper, "segmentToContainerMapper");
     }
 
     //endregion
@@ -67,109 +60,116 @@ public class StreamSegmentService implements StreamSegmentStore {
 
     @Override
     public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "append", streamSegmentName, data.length, attributeUpdates, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName).thenCompose(container -> container.append(streamSegmentName, data, attributeUpdates, timeout)),
-                r -> traceLeave(log, "append", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.append(streamSegmentName, data, attributeUpdates, timeout),
+                "append", streamSegmentName, data.length, attributeUpdates);
     }
 
     @Override
     public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "appendWithOffset", streamSegmentName, offset, data.length, attributeUpdates, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName).thenCompose(container -> container.append(streamSegmentName, offset, data, attributeUpdates, timeout)),
-                r -> traceLeave(log, "appendWithOffset", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.append(streamSegmentName, offset, data, attributeUpdates, timeout),
+                "appendWithOffset", streamSegmentName, offset, data.length, attributeUpdates);
     }
 
     @Override
     public CompletableFuture<Void> updateAttributes(String streamSegmentName, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "updateAttributes", streamSegmentName, attributeUpdates, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName).thenCompose(container -> container.updateAttributes(streamSegmentName, attributeUpdates, timeout)),
-                r -> traceLeave(log, "updateAttributes", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.updateAttributes(streamSegmentName, attributeUpdates, timeout),
+                "updateAttributes", streamSegmentName, attributeUpdates);
     }
 
     @Override
     public CompletableFuture<ReadResult> read(String streamSegmentName, long offset, int maxLength, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "read", streamSegmentName, offset, maxLength, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName)
-                        .thenCompose(container -> container.read(streamSegmentName, offset, maxLength, timeout)),
-                r -> traceLeave(log, "read", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.read(streamSegmentName, offset, maxLength, timeout),
+                "read", streamSegmentName, offset, maxLength);
     }
 
     @Override
     public CompletableFuture<SegmentProperties> getStreamSegmentInfo(String streamSegmentName, boolean waitForPendingOps, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "getStreamSegmentInfo", streamSegmentName, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName)
-                        .thenCompose(container -> container.getStreamSegmentInfo(streamSegmentName, waitForPendingOps, timeout)),
-                r -> traceLeave(log, "getStreamSegmentInfo", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.getStreamSegmentInfo(streamSegmentName, waitForPendingOps, timeout),
+                "getStreamSegmentInfo", streamSegmentName, waitForPendingOps);
     }
 
     @Override
     public CompletableFuture<Void> createStreamSegment(String streamSegmentName, Collection<AttributeUpdate> attributes, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "createStreamSegment", streamSegmentName, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName)
-                        .thenCompose(container -> container.createStreamSegment(streamSegmentName, attributes, timeout)),
-                r -> traceLeave(log, "createStreamSegment", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.createStreamSegment(streamSegmentName, attributes, timeout),
+                "createStreamSegment", streamSegmentName, attributes);
     }
 
     @Override
     public CompletableFuture<String> createTransaction(String parentStreamSegmentName, UUID transactionId,
                                                        Collection<AttributeUpdate> attributes, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "createTransaction", parentStreamSegmentName, timeout);
-        return withCompletion(
-                () -> getContainer(parentStreamSegmentName)
-                        .thenCompose(container -> container.createTransaction(parentStreamSegmentName, transactionId, attributes, timeout)),
-                r -> traceLeave(log, "createTransaction", traceId, r));
+        return invoke(
+                parentStreamSegmentName,
+                container -> container.createTransaction(parentStreamSegmentName, transactionId, attributes, timeout),
+                "createTransaction", parentStreamSegmentName, transactionId, attributes);
     }
 
     @Override
     public CompletableFuture<Void> mergeTransaction(String transactionName, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "mergeTransaction", transactionName, timeout);
-        return withCompletion(
-                () -> getContainer(transactionName)
-                        .thenCompose(container -> container.mergeTransaction(transactionName, timeout)),
-                r -> traceLeave(log, "mergeTransaction", traceId, r));
+        return invoke(
+                transactionName,
+                container -> container.mergeTransaction(transactionName, timeout),
+                "mergeTransaction", transactionName);
     }
 
     @Override
     public CompletableFuture<Long> sealStreamSegment(String streamSegmentName, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "sealStreamSegment", streamSegmentName, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName)
-                        .thenCompose(container -> container.sealStreamSegment(streamSegmentName, timeout)),
-                r -> traceLeave(log, "sealStreamSegment", traceId, r));
+        return invoke(
+                streamSegmentName,
+                container -> container.sealStreamSegment(streamSegmentName, timeout),
+                "sealStreamSegment", streamSegmentName);
     }
 
     @Override
     public CompletableFuture<Void> deleteStreamSegment(String streamSegmentName, Duration timeout) {
-        long traceId = LoggerHelpers.traceEnter(log, "deleteStreamSegment", streamSegmentName, timeout);
-        return withCompletion(
-                () -> getContainer(streamSegmentName)
-                        .thenCompose(container -> container.deleteStreamSegment(streamSegmentName, timeout)),
-                r -> traceLeave(log, "deleteStreamSegment", traceId, r));
-    }
-
-    private <T> CompletableFuture<T> withCompletion(Supplier<CompletableFuture<T>> supplier, Consumer<T> leaveCallback) {
-        CompletableFuture<T> resultFuture = supplier.get();
-        resultFuture.thenAccept(r -> CallbackHelpers.invokeSafely(leaveCallback, r, null));
-        return resultFuture;
+        return invoke(
+                streamSegmentName,
+                container -> container.deleteStreamSegment(streamSegmentName, timeout),
+                "deleteStreamSegment", streamSegmentName);
     }
 
     //endregion
 
     //region Helpers
 
-    private CompletableFuture<SegmentContainer> getContainer(String streamSegmentName) {
-        int containerId = this.segmentToContainerMapper.getContainerId(streamSegmentName);
+    /**
+     * Executes the given Function on the SegmentContainer that the given Segment maps to.
+     *
+     * @param streamSegmentName The name of the StreamSegment to fetch the Container for.
+     * @param toInvoke          A Function that will be invoked on the Container.
+     * @param methodName        The name of the calling method (for logging purposes).
+     * @param logArgs           (Optional) A vararg array of items to be logged.
+     * @param <T>               Resulting type.
+     * @return Either the result of toInvoke or a CompletableFuture completed exceptionally with a ContainerNotFoundException
+     * in case the SegmentContainer that the Segment maps to does not exist in this StreamSegmentService.
+     */
+    private <T> CompletableFuture<T> invoke(String streamSegmentName, ContainerFunction<T> toInvoke, String methodName, Object... logArgs) {
+        long traceId = LoggerHelpers.traceEnter(log, methodName, logArgs);
+        SegmentContainer container;
         try {
-            return CompletableFuture.completedFuture(this.segmentContainerRegistry.getContainer(containerId));
+            int containerId = this.segmentToContainerMapper.getContainerId(streamSegmentName);
+            container = this.segmentContainerRegistry.getContainer(containerId);
         } catch (ContainerNotFoundException ex) {
             return FutureHelpers.failedFuture(ex);
         }
+
+        CompletableFuture<T> resultFuture = toInvoke.apply(container);
+        resultFuture.thenAccept(r -> traceLeave(log, methodName, traceId, r));
+        return resultFuture;
+    }
+
+    private interface ContainerFunction<T> extends Function<SegmentContainer, CompletableFuture<T>> {
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -1267,10 +1267,8 @@ public class DurableLogTests extends OperationLogTestBase {
 
             // Verify that the operations have been completed and assigned sequential Sequence Numbers.
             Operation expectedOp = oc.operation;
-            long currentSeqNo = oc.completion.join();
-            Assert.assertEquals("Operation and its corresponding Completion Future have different Sequence Numbers.", currentSeqNo, expectedOp.getSequenceNumber());
-            AssertExtensions.assertGreaterThan("Operations were not assigned sequential Sequence Numbers.", lastSeqNo, currentSeqNo);
-            lastSeqNo = currentSeqNo;
+            AssertExtensions.assertGreaterThan("Operations were not assigned sequential Sequence Numbers.", lastSeqNo, expectedOp.getSequenceNumber());
+            lastSeqNo = expectedOp.getSequenceNumber();
 
             // MemoryLog: verify that the operations match that of the expected list.
             Assert.assertTrue("No more items left to read from DurableLog. Expected: " + expectedOp, logIterator.hasNext());
@@ -1304,7 +1302,7 @@ public class DurableLogTests extends OperationLogTestBase {
         int index = 0;
         for (Operation o : operations) {
             index++;
-            CompletableFuture<Long> completionFuture;
+            CompletableFuture<Void> completionFuture;
             try {
                 completionFuture = durableLog.add(o, TIMEOUT);
             } catch (Exception ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -443,7 +443,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
     @RequiredArgsConstructor
     static class OperationWithCompletion {
         final Operation operation;
-        final CompletableFuture<Long> completion;
+        final CompletableFuture<Void> completion;
 
         @Override
         public String toString() {
@@ -454,7 +454,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
         }
 
         static CompletableFuture<Void> allOf(Collection<OperationWithCompletion> operations) {
-            List<CompletableFuture<Long>> futures = new ArrayList<>();
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
             operations.forEach(oc -> futures.add(oc.completion));
             return FutureHelpers.allOf(futures);
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -11,7 +11,6 @@ package io.pravega.segmentstore.server.logs;
 
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Service;
-import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.common.util.ArrayView;
 import io.pravega.common.util.CloseableIterator;
 import io.pravega.common.util.SequencedItemList;
@@ -23,6 +22,7 @@ import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.segmentstore.server.TestDurableDataLog;
 import io.pravega.segmentstore.server.TruncationMarkerRepository;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
@@ -573,10 +573,8 @@ public class OperationProcessorTests extends OperationLogTestBase {
 
             // Verify that the operations have been completed and assigned sequential Sequence Numbers.
             Operation expectedOp = oc.operation;
-            long currentSeqNo = oc.completion.join();
-            Assert.assertEquals("Operation and its corresponding Completion Future have different Sequence Numbers.", currentSeqNo, expectedOp.getSequenceNumber());
-            AssertExtensions.assertGreaterThan("Operations were not assigned sequential Sequence Numbers.", lastSeqNo, currentSeqNo);
-            lastSeqNo = currentSeqNo;
+            AssertExtensions.assertGreaterThan("Operations were not assigned sequential Sequence Numbers.", lastSeqNo, expectedOp.getSequenceNumber());
+            lastSeqNo = expectedOp.getSequenceNumber();
 
             // MemoryLog: verify that the operations match that of the expected list.
             Assert.assertTrue("No more items left to read from MemoryLog. Expected: " + expectedOp, memoryLogIterator.hasNext());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CompletableOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CompletableOperationTests.java
@@ -9,20 +9,16 @@
  */
 package io.pravega.segmentstore.server.logs.operations;
 
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
-
-import io.pravega.test.common.AssertExtensions;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Unit tests for CompletableOperation class.
  */
 public class CompletableOperationTests {
-    private static final long DEFAULT_SEQ_NO = Operation.NO_SEQUENCE_NUMBER;
     private static final long VALID_SEQ_NO = 1;
 
     /**
@@ -32,20 +28,20 @@ public class CompletableOperationTests {
     public void testComplete() {
         MetadataCheckpointOperation op = new MetadataCheckpointOperation();
 
-        AtomicLong callbackSeqNo = new AtomicLong(DEFAULT_SEQ_NO);
+        AtomicBoolean callback = new AtomicBoolean(false);
         AtomicBoolean failureCallbackCalled = new AtomicBoolean();
-        CompletableOperation co = new CompletableOperation(op, callbackSeqNo::set, ex -> failureCallbackCalled.set(true));
+        CompletableOperation co = new CompletableOperation(op, v -> callback.set(true), ex -> failureCallbackCalled.set(true));
 
         AssertExtensions.assertThrows("complete() succeeded even if Operation had no Sequence Number.",
                 co::complete,
                 ex -> ex instanceof IllegalStateException);
 
-        Assert.assertEquals("Success callback was invoked for illegal complete() call.", DEFAULT_SEQ_NO, callbackSeqNo.get());
+        Assert.assertFalse("Success callback was invoked for illegal complete() call.", callback.get());
         Assert.assertFalse("Failure callback was invoked for illegal complete() call.", failureCallbackCalled.get());
 
         op.setSequenceNumber(VALID_SEQ_NO);
         co.complete();
-        Assert.assertEquals("Success callback not invoked with the correct argument after valid complete() call.", VALID_SEQ_NO, callbackSeqNo.get());
+        Assert.assertTrue("Success callback not invoked after valid complete() call.", callback.get());
         Assert.assertFalse("Failure callback was invoked for valid complete() call.", failureCallbackCalled.get());
     }
 


### PR DESCRIPTION
**Change log description**
Fixed a bug in SegmentStore where it would be possible to write two or more events received in a short timespan, in a different order than received from the caller. Please refer to #1659 for more details.
- `StreamSegmentService`: refactored all calls so they synchronously invoke the underlying Container's code vs via a CompletableFuture callback.
- `StreamSegmentMapper`: properly queueing up pending requests in the correct order (in which they were received) and then invoking them in the same order. This makes the invocation order predictable and no longer keeps us at the mercy of the JVM scheduler.
- `OperationLog/DurableLog`: add() returns a CompletableFuture<Void> since nobody cared about the result anyway. This enabled the simplification of some calls, thus reducing the number of invoked callbacks.

**Purpose of the change**
Fixes #1659.

**What the code does**
Removing unnecessary use of async callbacks where sync code would do just fine, in order to guarantee execution order.

**How to verify it**
- New unit test added to verify correctness.
- Selftest (branch for issue #338) should pass when targeting SegmentStoreDirect with ProducerParallelism > 1