### PR TITLE
Issue 1299: Delete default AWS region in pravega installer

### DIFF
--- a/deployment/aws/variable.tf
+++ b/deployment/aws/variable.tf
@@ -18,7 +18,6 @@ variable "aws_secret_key" {
 
 variable "aws_region" {
   description = "AWS Region to launch configuration in"
-  default = "us-east-1"
 }
 
 variable "aws_key_name" {


### PR DESCRIPTION
**Change log description**
Delete default AWS region
**Purpose of the change**
Enter by user would be a better choice, and also align with installation menu.
**What the code does**

**How to verify it**
sudo terraform apply