### PR TITLE
Issue 1682: Fix race between flush and connection failure

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -278,10 +278,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 Retry.indefinitelyWithExpBackoff(retrySchedule.getInitialMillis(), retrySchedule.getMultiplier(),
                                                  retrySchedule.getMaxDelay(),
                                                  t -> log.error(writerId + " to invoke sealed callback: ", t))
-                     .runAsync(() -> {
+                     .runInExecutor(() -> {
                          log.debug("Invoking SealedSegment call back for {}", segmentIsSealed);
                          callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));
-                         return null;
                      }, connectionFactory.getInternalExecutor());
             }
         }


### PR DESCRIPTION
**Change log description**
Fixes a race in SegmentOutputStreamImpl where if the connection failed after flush was called but reconnected before the future was used flush could get stuck retrying the connection even though it is connected and there are no events inflight.

**Purpose of the change**
Fix #1682. This should allow the system tests to pass.

**What the code does**
Changes the CompletableFuture on empty inflight back to a reusable latch and does the reconnecting in the background thread pool. This simplifies the handling, and eliminates the possibility that there could be an exception left set on the future, as the latch is single purpose: tacking if their is anything inflight rather and trying to do two jobs as the future was.

**How to verify it**
Added a new test that reproduces the error observed in the system tests. Enhanced other tests to have more assertions. All pass.