### PR TITLE
Issue 674: Enabling retries in the controller RPC client

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ClientFactory.java
@@ -27,6 +27,8 @@ import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import java.net.URI;
+
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import lombok.val;
 
 /**
@@ -60,7 +62,8 @@ public interface ClientFactory extends AutoCloseable {
      */
     static ClientFactory withScope(String scope, URI controllerUri) {
         val connectionFactory = new ConnectionFactoryImpl(false);
-        return new ClientFactoryImpl(scope, new ControllerImpl(controllerUri), connectionFactory);
+        return new ClientFactoryImpl(scope, new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
+                connectionFactory.getInternalExecutor()), connectionFactory);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -22,6 +22,7 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.ReaderGroupImpl;
 import io.pravega.client.stream.impl.StreamImpl;
@@ -47,7 +48,8 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     public ReaderGroupManagerImpl(String scope, URI controllerUri, ConnectionFactory connectionFactory) {
         this.scope = scope;
-        this.controller = new ControllerImpl(controllerUri);
+        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
+                connectionFactory.getInternalExecutor());
         this.connectionFactory = connectionFactory;
         this.clientFactory = new ClientFactoryImpl(scope, this.controller, connectionFactory);
     }

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -14,6 +14,7 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.shared.NameUtils;
 import java.net.URI;
@@ -26,7 +27,7 @@ public class StreamManagerImpl implements StreamManager {
     private final Controller controller;
 
     public StreamManagerImpl(URI controllerUri) {
-        this.controller = new ControllerImpl(controllerUri);
+        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build());
     }
 
     @VisibleForTesting
@@ -81,10 +82,8 @@ public class StreamManagerImpl implements StreamManager {
                 RuntimeException::new);
     }
 
-
     @Override
     public void close() {
-        //Nothing to close
+        this.controller.close();
     }
-
 }

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -14,9 +14,9 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
-import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.shared.NameUtils;
+
 import java.net.URI;
 
 /**
@@ -26,13 +26,18 @@ public class StreamManagerImpl implements StreamManager {
 
     private final Controller controller;
 
+    // Flag to indicate whether we need to cleanup the controller instance on close().
+    private final boolean cleanupController;
+
     public StreamManagerImpl(URI controllerUri) {
-        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build());
+        this.controller = new ControllerImpl(controllerUri);
+        this.cleanupController = true;
     }
 
     @VisibleForTesting
     public StreamManagerImpl(Controller controller) {
         this.controller = controller;
+        this.cleanupController = false;
     }
 
     @Override
@@ -84,6 +89,8 @@ public class StreamManagerImpl implements StreamManager {
 
     @Override
     public void close() {
-        this.controller.close();
+        if (this.cleanupController) {
+            this.controller.close();
+        }
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Stream Controller APIs.
  */
-public interface Controller {
+public interface Controller extends AutoCloseable {
 
     // Controller Apis for administrative action for streams
 
@@ -254,4 +254,10 @@ public interface Controller {
      */
     CompletableFuture<PravegaNodeUri> getEndpointForSegment(final String qualifiedSegmentName);
 
+    /**
+     * Closes the controller client.
+     * @see java.lang.AutoCloseable#close()
+     */
+    @Override
+    void close();
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -12,6 +12,7 @@ package io.pravega.client.stream.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.RoundRobinLoadBalancerFactory;
@@ -25,6 +26,7 @@ import io.pravega.client.stream.TxnFailedException;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.concurrent.FutureHelpers;
+import io.pravega.common.util.Retry;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateScopeStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateStreamStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateTxnRequest;
@@ -65,8 +67,11 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
@@ -83,8 +88,46 @@ public class ControllerImpl implements Controller {
     // This value should be greater than the permissible value configured at the server which is by default 5 minutes.
     private static final long DEFAULT_KEEPALIVE_TIME_MINUTES = 6;
 
+    // The internal retry object to handle RPC failures.
+    private final Retry.RetryAndThrowExceptionally<StatusRuntimeException, Exception> retryConfig;
+
+    // The executor supplied by the appication to handle internal retries.
+    private final ScheduledExecutorService executor;
+
+    // The executor used when external executor is not supplied.
+    private final AtomicReference<ScheduledExecutorService> internalExecutor = new AtomicReference<>(null);
+
+    // Flag to indicate if the client is closed.
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
     // The gRPC client for the Controller Service.
     private final ControllerServiceGrpc.ControllerServiceStub client;
+
+    /**
+     * Creates a new instance of the Controller client class.
+     * @param controllerURI The controller rpc URI. This can be of 2 types
+     *                      1. tcp://ip1:port1,ip2:port2,...
+     *                          This is used if the controller endpoints are static and can be directly accessed.
+     *                      2. pravega://ip1:port1,ip2:port2,...
+     *                          This is used to autodiscovery the controller endpoints from an initial controller list.
+     */
+    public ControllerImpl(final URI controllerURI) {
+        this(controllerURI, ControllerImplConfig.builder().build());
+    }
+
+    /**
+     * Creates a new instance of the Controller client class.
+     * @param controllerURI The controller rpc URI. This can be of 2 types
+     *                      1. tcp://ip1:port1,ip2:port2,...
+     *                          This is used if the controller endpoints are static and can be directly accessed.
+     *                      2. pravega://ip1:port1,ip2:port2,...
+     *                          This is used to autodiscovery the controller endpoints from an initial controller list.
+     * @param config        The configuration for this client implementation.
+     */
+    public ControllerImpl(final URI controllerURI, final ControllerImplConfig config) {
+        this(controllerURI, config, Executors.newSingleThreadScheduledExecutor());
+        this.internalExecutor.set(this.executor);
+    }
 
     /**
      * Creates a new instance of the Controller client class.
@@ -94,13 +137,16 @@ public class ControllerImpl implements Controller {
      *                          This is used if the controller endpoints are static and can be directly accessed.
      *                      2. pravega://ip1:port1,ip2:port2,...
      *                          This is used to autodiscovery the controller endpoints from an initial controller list.
+     * @param config        The configuration for this client implementation.
+     * @param executor      The executor service to be used for handling retries.
      */
-    public ControllerImpl(final URI controllerURI) {
+    public ControllerImpl(final URI controllerURI, final ControllerImplConfig config,
+                          final ScheduledExecutorService executor) {
         this(NettyChannelBuilder.forTarget(controllerURI.toString())
                 .nameResolverFactory(new ControllerResolverFactory())
                 .loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance())
                 .keepAliveTime(DEFAULT_KEEPALIVE_TIME_MINUTES, TimeUnit.MINUTES)
-                .usePlaintext(true));
+                .usePlaintext(true), config, executor);
         log.info("Controller client connecting to server at {}", controllerURI.getAuthority());
     }
 
@@ -108,91 +154,110 @@ public class ControllerImpl implements Controller {
      * Creates a new instance of the Controller client class.
      *
      * @param channelBuilder The channel builder to connect to the service instance.
+     * @param config         The configuration for this client implementation.
+     * @param executor       The executor service to be used internally.
      */
     @VisibleForTesting
-    public ControllerImpl(ManagedChannelBuilder<?> channelBuilder) {
+    public ControllerImpl(ManagedChannelBuilder<?> channelBuilder, final ControllerImplConfig config,
+                          final ScheduledExecutorService executor) {
         Preconditions.checkNotNull(channelBuilder, "channelBuilder");
 
+        this.executor = executor;
+        this.retryConfig = Retry.withExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
+                config.getRetryAttempts(), config.getMaxBackoffMillis())
+                .retryingOn(StatusRuntimeException.class)
+                .throwingOn(Exception.class);
+
         // Create Async RPC client.
-        client = ControllerServiceGrpc.newStub(channelBuilder.build());
+        this.client = ControllerServiceGrpc.newStub(channelBuilder.build());
     }
 
     @Override
     public CompletableFuture<Boolean> createScope(final String scopeName) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "createScope", scopeName);
 
-        RPCAsyncCallback<CreateScopeStatus> callback = new RPCAsyncCallback<>();
-        client.createScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
-        return callback.getFuture()
-                .thenApply(x -> {
-                    switch (x.getStatus()) {
-                    case FAILURE:
-                        log.warn("Failed to create scope: {}", scopeName);
-                        throw new ControllerFailureException("Failed to create scope: " + scopeName);
-                    case INVALID_SCOPE_NAME:
-                        log.warn("Illegal scope name: {}", scopeName);
-                        throw new IllegalArgumentException("Illegal scope name: " + scopeName);
-                    case SCOPE_EXISTS:
-                        log.warn("Scope already exists: {}", scopeName);
-                        return false;
-                    case SUCCESS:
-                        log.info("Scope created successfully: {}", scopeName);
-                        return true;
-                    case UNRECOGNIZED:
-                    default:
-                        throw new ControllerFailureException("Unknown return status creating scope " + scopeName
-                                                             + " " + x.getStatus());
-                    }
-                }).whenComplete((x, e) -> {
-                    if (e != null) {
-                        log.warn("createScope failed: ", e);
-                    }
-                    LoggerHelpers.traceLeave(log, "createScope", traceId);
-                });
+        final CompletableFuture<CreateScopeStatus> result = this.retryConfig.runAsync(() -> {
+                RPCAsyncCallback<CreateScopeStatus> callback = new RPCAsyncCallback<>();
+                client.createScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
+                return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
+                switch (x.getStatus()) {
+                case FAILURE:
+                    log.warn("Failed to create scope: {}", scopeName);
+                    throw new ControllerFailureException("Failed to create scope: " + scopeName);
+                case INVALID_SCOPE_NAME:
+                    log.warn("Illegal scope name: {}", scopeName);
+                    throw new IllegalArgumentException("Illegal scope name: " + scopeName);
+                case SCOPE_EXISTS:
+                    log.warn("Scope already exists: {}", scopeName);
+                    return false;
+                case SUCCESS:
+                    log.info("Scope created successfully: {}", scopeName);
+                    return true;
+                case UNRECOGNIZED:
+                default:
+                    throw new ControllerFailureException("Unknown return status creating scope " + scopeName
+                                                         + " " + x.getStatus());
+                }
+            }).whenComplete((x, e) -> {
+                if (e != null) {
+                    log.warn("createScope failed: ", e);
+                }
+                LoggerHelpers.traceLeave(log, "createScope", traceId);
+            });
     }
 
     @Override
     public CompletableFuture<Boolean> deleteScope(String scopeName) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "deleteScope", scopeName);
 
-        RPCAsyncCallback<DeleteScopeStatus> callback = new RPCAsyncCallback<>();
-        client.deleteScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
-        return callback.getFuture()
-                .thenApply(x -> {
-                    switch (x.getStatus()) {
-                    case FAILURE:
-                        log.warn("Failed to delete scope: {}", scopeName);
-                        throw new ControllerFailureException("Failed to delete scope: " + scopeName);
-                    case SCOPE_NOT_EMPTY:
-                        log.warn("Cannot delete non empty scope: {}", scopeName);
-                        throw new IllegalStateException("Scope "+ scopeName+ " is not empty.");
-                    case SCOPE_NOT_FOUND:
-                        log.warn("Scope not found: {}", scopeName);
-                        return false;
-                    case SUCCESS:
-                        log.info("Scope deleted successfully: {}", scopeName);
-                        return true;
-                    case UNRECOGNIZED:
-                    default:
-                        throw new ControllerFailureException("Unknown return status deleting scope " + scopeName
-                                                             + " " + x.getStatus());
-                    }
-                }).whenComplete((x, e) -> {
-                    if (e != null) {
-                        log.warn("deleteScope failed: ", e);
-                    }
-                    LoggerHelpers.traceLeave(log, "deleteScope", traceId);
-                });
+        final CompletableFuture<DeleteScopeStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<DeleteScopeStatus> callback = new RPCAsyncCallback<>();
+            client.deleteScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
+            switch (x.getStatus()) {
+                case FAILURE:
+                    log.warn("Failed to delete scope: {}", scopeName);
+                    throw new ControllerFailureException("Failed to delete scope: " + scopeName);
+                case SCOPE_NOT_EMPTY:
+                    log.warn("Cannot delete non empty scope: {}", scopeName);
+                    throw new IllegalStateException("Scope "+ scopeName+ " is not empty.");
+                case SCOPE_NOT_FOUND:
+                    log.warn("Scope not found: {}", scopeName);
+                    return false;
+                case SUCCESS:
+                    log.info("Scope deleted successfully: {}", scopeName);
+                    return true;
+                case UNRECOGNIZED:
+                default:
+                    throw new ControllerFailureException("Unknown return status deleting scope " + scopeName
+                                                         + " " + x.getStatus());
+                }
+            }).whenComplete((x, e) -> {
+                if (e != null) {
+                    log.warn("deleteScope failed: ", e);
+                }
+                LoggerHelpers.traceLeave(log, "deleteScope", traceId);
+            });
     }
 
     @Override
     public CompletableFuture<Boolean> createStream(final StreamConfiguration streamConfig) {
-        long traceId = LoggerHelpers.traceEnter(log, "createStream", streamConfig);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(streamConfig, "streamConfig");
+        long traceId = LoggerHelpers.traceEnter(log, "createStream", streamConfig);
 
-        RPCAsyncCallback<CreateStreamStatus> callback = new RPCAsyncCallback<>();
-        client.createStream(ModelHelper.decode(streamConfig), callback);
-        return callback.getFuture().thenApply(x -> {
+        final CompletableFuture<CreateStreamStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<CreateStreamStatus> callback = new RPCAsyncCallback<>();
+            client.createStream(ModelHelper.decode(streamConfig), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
                 log.warn("Failed to create stream: {}", streamConfig.getStreamName());
@@ -224,12 +289,16 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Boolean> updateStream(final StreamConfiguration streamConfig) {
-        long traceId = LoggerHelpers.traceEnter(log, "updateStream", streamConfig);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(streamConfig, "streamConfig");
+        long traceId = LoggerHelpers.traceEnter(log, "updateStream", streamConfig);
 
-        RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>();
-        client.updateStream(ModelHelper.decode(streamConfig), callback);
-        return callback.getFuture().thenApply(x -> {
+        final CompletableFuture<UpdateStreamStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>();
+            client.updateStream(ModelHelper.decode(streamConfig), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
                 log.warn("Failed to update stream: {}", streamConfig.getStreamName());
@@ -260,6 +329,7 @@ public class ControllerImpl implements Controller {
     public CancellableRequest<Boolean> scaleStream(final Stream stream, final List<Integer> sealedSegments,
                                                   final Map<Double, Double> newKeyRanges,
                                                   final ScheduledExecutorService executor) {
+        Exceptions.checkNotClosed(closed.get(), this);
         CancellableRequest<Boolean> cancellableRequest = new CancellableRequest<>();
 
         startScaleInternal(stream, sealedSegments, newKeyRanges)
@@ -285,6 +355,7 @@ public class ControllerImpl implements Controller {
     @Override
     public CompletableFuture<Boolean> startScale(final Stream stream, final List<Integer> sealedSegments,
                                                   final Map<Double, Double> newKeyRanges) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "scaleStream", stream);
         return startScaleInternal(stream, sealedSegments, newKeyRanges).thenApply(x -> {
             switch (x.getStatus()) {
@@ -312,16 +383,21 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Boolean> checkScaleStatus(final Stream stream, final int scaleEpoch) {
-        long traceId = LoggerHelpers.traceEnter(log, "checkScale", stream);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkArgument(scaleEpoch >= 0);
-        RPCAsyncCallback<ScaleStatusResponse> callback = new RPCAsyncCallback<>();
-        client.checkScale(ScaleStatusRequest.newBuilder()
-                        .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
-                        .setEpoch(scaleEpoch)
-                        .build(),
-                callback);
-        return callback.getFuture().thenApply(response -> {
+
+        long traceId = LoggerHelpers.traceEnter(log, "checkScale", stream);
+        final CompletableFuture<ScaleStatusResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<ScaleStatusResponse> callback = new RPCAsyncCallback<>();
+            client.checkScale(ScaleStatusRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
+                            .setEpoch(scaleEpoch)
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(response -> {
             switch (response.getStatus()) {
                 case IN_PROGRESS:
                     return false;
@@ -347,29 +423,36 @@ public class ControllerImpl implements Controller {
         Preconditions.checkNotNull(sealedSegments, "sealedSegments");
         Preconditions.checkNotNull(newKeyRanges, "newKeyRanges");
 
-        RPCAsyncCallback<ScaleResponse> callback = new RPCAsyncCallback<>();
-        client.scale(ScaleRequest.newBuilder()
-                        .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
-                        .addAllSealedSegments(sealedSegments)
-                        .addAllNewKeyRanges(newKeyRanges.entrySet().stream()
-                                .map(x -> ScaleRequest.KeyRangeEntry.newBuilder()
-                                        .setStart(x.getKey()).setEnd(x.getValue()).build())
-                                .collect(Collectors.toList()))
-                        .setScaleTimestamp(System.currentTimeMillis())
-                        .build(),
-                callback);
-        return callback.getFuture();
+        final CompletableFuture<ScaleResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<ScaleResponse> callback = new RPCAsyncCallback<>();
+            client.scale(ScaleRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
+                            .addAllSealedSegments(sealedSegments)
+                            .addAllNewKeyRanges(newKeyRanges.entrySet().stream()
+                                    .map(x -> ScaleRequest.KeyRangeEntry.newBuilder()
+                                            .setStart(x.getKey()).setEnd(x.getValue()).build())
+                                    .collect(Collectors.toList()))
+                            .setScaleTimestamp(System.currentTimeMillis())
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result;
     }
 
     @Override
     public CompletableFuture<Boolean> sealStream(final String scope, final String streamName) {
-        long traceId = LoggerHelpers.traceEnter(log, "sealStream", scope, streamName);
+        Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(streamName, "streamName");
+        long traceId = LoggerHelpers.traceEnter(log, "sealStream", scope, streamName);
 
-        RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>();
-        client.sealStream(ModelHelper.createStreamInfo(scope, streamName), callback);
-        return callback.getFuture().thenApply(x -> {
+        final CompletableFuture<UpdateStreamStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>();
+            client.sealStream(ModelHelper.createStreamInfo(scope, streamName), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
                 log.warn("Failed to seal stream: {}", streamName);
@@ -398,13 +481,17 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Boolean> deleteStream(final String scope, final String streamName) {
-        long traceId = LoggerHelpers.traceEnter(log, "deleteStream", scope, streamName);
+        Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(streamName, "streamName");
+        long traceId = LoggerHelpers.traceEnter(log, "deleteStream", scope, streamName);
 
-        RPCAsyncCallback<DeleteStreamStatus> callback = new RPCAsyncCallback<>();
-        client.deleteStream(ModelHelper.createStreamInfo(scope, streamName), callback);
-        return callback.getFuture().thenApply(x -> {
+        final CompletableFuture<DeleteStreamStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<DeleteStreamStatus> callback = new RPCAsyncCallback<>();
+            client.deleteStream(ModelHelper.createStreamInfo(scope, streamName), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(x -> {
             switch (x.getStatus()) {
             case FAILURE:
                 log.warn("Failed to delete stream: {}", streamName);
@@ -433,17 +520,21 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Map<Segment, Long>> getSegmentsAtTime(final Stream stream, final long timestamp) {
-        long traceId = LoggerHelpers.traceEnter(log, "getSegmentsAtTime", stream, timestamp);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
+        long traceId = LoggerHelpers.traceEnter(log, "getSegmentsAtTime", stream, timestamp);
 
-        RPCAsyncCallback<SegmentsAtTime> callback = new RPCAsyncCallback<>();
-        StreamInfo streamInfo = ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName());
-        GetSegmentsRequest request = GetSegmentsRequest.newBuilder()
-                                                       .setStreamInfo(streamInfo)
-                                                       .setTimestamp(timestamp)
-                                                       .build();
-        client.getSegments(request, callback);
-        return callback.getFuture().thenApply(segments -> {
+        final CompletableFuture<SegmentsAtTime> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<SegmentsAtTime> callback = new RPCAsyncCallback<>();
+            StreamInfo streamInfo = ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName());
+            GetSegmentsRequest request = GetSegmentsRequest.newBuilder()
+                    .setStreamInfo(streamInfo)
+                    .setTimestamp(timestamp)
+                    .build();
+            client.getSegments(request, callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(segments -> {
             log.debug("Received the following data from the controller {}", segments.getSegmentsList());
             return segments.getSegmentsList()
                            .stream()
@@ -459,11 +550,15 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors(Segment segment) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "getSuccessors", segment);
 
-        RPCAsyncCallback<SuccessorResponse> callback = new RPCAsyncCallback<>();
-        client.getSegmentsImmediatlyFollowing(ModelHelper.decode(segment), callback);
-        return callback.getFuture().thenApply(successors -> {
+        final CompletableFuture<SuccessorResponse> resultFuture = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<SuccessorResponse> callback = new RPCAsyncCallback<>();
+            client.getSegmentsImmediatlyFollowing(ModelHelper.decode(segment), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return resultFuture.thenApply(successors -> {
             log.debug("Received the following data from the controller {}", successors.getSegmentsList());
             Map<SegmentWithRange, List<Integer>> result = new HashMap<>();
             for (SuccessorResponse.SegmentEntry entry : successors.getSegmentsList()) {
@@ -480,6 +575,7 @@ public class ControllerImpl implements Controller {
     
     @Override
     public CompletableFuture<Set<Segment>> getSuccessors(StreamCut from) {
+        Exceptions.checkNotClosed(closed.get(), this);
         Stream stream = from.getStream();
         long traceId = LoggerHelpers.traceEnter(log, "getSuccessorsFromCut", stream);
         HashSet<Segment> unread = new HashSet<>(from.getPositions().keySet());
@@ -523,13 +619,17 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<StreamSegments> getCurrentSegments(final String scope, final String stream) {
-        long traceId = LoggerHelpers.traceEnter(log, "getCurrentSegments", scope, stream);
+        Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(stream, "stream");
+        long traceId = LoggerHelpers.traceEnter(log, "getCurrentSegments", scope, stream);
 
-        RPCAsyncCallback<SegmentRanges> callback = new RPCAsyncCallback<>();
-        client.getCurrentSegments(ModelHelper.createStreamInfo(scope, stream), callback);
-        return callback.getFuture().thenApply(ranges -> {
+        final CompletableFuture<SegmentRanges> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<SegmentRanges> callback = new RPCAsyncCallback<>();
+            client.getCurrentSegments(ModelHelper.createStreamInfo(scope, stream), callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(ranges -> {
                     log.debug("Received the following data from the controller {}", ranges.getSegmentRangesList());
                     NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
                     for (SegmentRange r : ranges.getSegmentRangesList()) {
@@ -547,16 +647,20 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<PravegaNodeUri> getEndpointForSegment(final String qualifiedSegmentName) {
-        long traceId = LoggerHelpers.traceEnter(log, "getEndpointForSegment", qualifiedSegmentName);
+        Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(qualifiedSegmentName, "qualifiedSegmentName");
+        long traceId = LoggerHelpers.traceEnter(log, "getEndpointForSegment", qualifiedSegmentName);
 
-        RPCAsyncCallback<NodeUri> callback = new RPCAsyncCallback<>();
-        Segment segment = Segment.fromScopedName(qualifiedSegmentName);
-        client.getURI(ModelHelper.createSegmentId(segment.getScope(),
-                                                  segment.getStreamName(),
-                                                  segment.getSegmentNumber()),
-                      callback);
-        return callback.getFuture().thenApply(ModelHelper::encode)
+        final CompletableFuture<NodeUri> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<NodeUri> callback = new RPCAsyncCallback<>();
+            Segment segment = Segment.fromScopedName(qualifiedSegmentName);
+            client.getURI(ModelHelper.createSegmentId(segment.getScope(),
+                    segment.getStreamName(),
+                    segment.getSegmentNumber()),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(ModelHelper::encode)
                 .whenComplete((x, e) -> {
                     if (e != null) {
                         log.warn("getEndpointForSegment failed: ", e);
@@ -567,13 +671,18 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Boolean> isSegmentOpen(final Segment segment) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "isSegmentOpen", segment);
-        RPCAsyncCallback<SegmentValidityResponse> callback = new RPCAsyncCallback<>();
-        client.isSegmentValid(ModelHelper.createSegmentId(segment.getScope(),
-                                                          segment.getStreamName(),
-                                                          segment.getSegmentNumber()),
-                              callback);
-        return callback.getFuture().thenApply(SegmentValidityResponse::getResponse)
+
+        final CompletableFuture<SegmentValidityResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<SegmentValidityResponse> callback = new RPCAsyncCallback<>();
+            client.isSegmentValid(ModelHelper.createSegmentId(segment.getScope(),
+                    segment.getStreamName(),
+                    segment.getSegmentNumber()),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(SegmentValidityResponse::getResponse)
                 .whenComplete((x, e) -> {
                     if (e != null) {
                         log.warn("isSegmentOpen failed: ", e);
@@ -585,18 +694,23 @@ public class ControllerImpl implements Controller {
     @Override
     public CompletableFuture<TxnSegments> createTransaction(final Stream stream, final long lease, final long maxExecutionTime,
                                                      final long scaleGracePeriod) {
-        long traceId = LoggerHelpers.traceEnter(log, "createTransaction", stream, lease, maxExecutionTime, scaleGracePeriod);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
-        RPCAsyncCallback<CreateTxnResponse> callback = new RPCAsyncCallback<>();
-        client.createTransaction(
-                CreateTxnRequest.newBuilder()
-                                .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
-                                .setLease(lease)
-                                .setMaxExecutionTime(maxExecutionTime)
-                                .setScaleGracePeriod(scaleGracePeriod)
-                                .build(),
-                callback);
-        return callback.getFuture().thenApply(this::convert)
+        long traceId = LoggerHelpers.traceEnter(log, "createTransaction", stream, lease, maxExecutionTime, scaleGracePeriod);
+
+        final CompletableFuture<CreateTxnResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<CreateTxnResponse> callback = new RPCAsyncCallback<>();
+            client.createTransaction(
+                    CreateTxnRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
+                            .setLease(lease)
+                            .setMaxExecutionTime(maxExecutionTime)
+                            .setScaleGracePeriod(scaleGracePeriod)
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(this::convert)
                 .whenComplete((x, e) -> {
                     if (e != null) {
                         log.warn("createTransaction failed: ", e);
@@ -617,15 +731,19 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Void> pingTransaction(Stream stream, UUID txId, long lease) {
+        Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "pingTransaction", stream, txId, lease);
 
-        RPCAsyncCallback<PingTxnStatus> callback = new RPCAsyncCallback<>();
-        client.pingTransaction(PingTxnRequest.newBuilder().setStreamInfo(
-                ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
-                                       .setTxnId(ModelHelper.decode(txId))
-                                       .setLease(lease).build(),
-                               callback);
-        return FutureHelpers.toVoidExpecting(callback.getFuture(),
+        final CompletableFuture<PingTxnStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<PingTxnStatus> callback = new RPCAsyncCallback<>();
+            client.pingTransaction(PingTxnRequest.newBuilder().setStreamInfo(
+                    ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
+                            .setTxnId(ModelHelper.decode(txId))
+                            .setLease(lease).build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return FutureHelpers.toVoidExpecting(result,
                                              PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build(),
                                              PingFailedException::new)
                 .whenComplete((x, e) -> {
@@ -638,19 +756,22 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Void> commitTransaction(final Stream stream, final UUID txId) {
-        long traceId = LoggerHelpers.traceEnter(log, "commitTransaction", stream, txId);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkNotNull(txId, "txId");
+        long traceId = LoggerHelpers.traceEnter(log, "commitTransaction", stream, txId);
 
-        RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>();
-        client.commitTransaction(TxnRequest.newBuilder()
-                                           .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
-                                                                                       stream.getStreamName()))
-                                           .setTxnId(ModelHelper.decode(txId))
-                                           .build(),
-                                 callback);
-
-        return FutureHelpers.toVoidExpecting(callback.getFuture(),
+        final CompletableFuture<TxnStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>();
+            client.commitTransaction(TxnRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
+                                    stream.getStreamName()))
+                            .setTxnId(ModelHelper.decode(txId))
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return FutureHelpers.toVoidExpecting(result,
                 TxnStatus.newBuilder().setStatus(TxnStatus.Status.SUCCESS).build(), TxnFailedException::new)
                 .whenComplete((x, e) -> {
                     if (e != null) {
@@ -662,18 +783,22 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Void> abortTransaction(final Stream stream, final UUID txId) {
-        long traceId = LoggerHelpers.traceEnter(log, "abortTransaction", stream, txId);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkNotNull(txId, "txId");
+        long traceId = LoggerHelpers.traceEnter(log, "abortTransaction", stream, txId);
 
-        RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>();
-        client.abortTransaction(TxnRequest.newBuilder()
-                                          .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
-                                                                                      stream.getStreamName()))
-                                          .setTxnId(ModelHelper.decode(txId))
-                                          .build(),
-                                callback);
-        return FutureHelpers.toVoidExpecting(callback.getFuture(),
+        final CompletableFuture<TxnStatus> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>();
+            client.abortTransaction(TxnRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
+                                    stream.getStreamName()))
+                            .setTxnId(ModelHelper.decode(txId))
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return FutureHelpers.toVoidExpecting(result,
                 TxnStatus.newBuilder().setStatus(TxnStatus.Status.SUCCESS).build(), TxnFailedException::new)
                 .whenComplete((x, e) -> {
                     if (e != null) {
@@ -685,25 +810,38 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Transaction.Status> checkTransactionStatus(final Stream stream, final UUID txId) {
-        long traceId = LoggerHelpers.traceEnter(log, "checkTransactionStatus", stream, txId);
+        Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkNotNull(txId, "txId");
+        long traceId = LoggerHelpers.traceEnter(log, "checkTransactionStatus", stream, txId);
 
-        RPCAsyncCallback<TxnState> callback = new RPCAsyncCallback<>();
-        client.checkTransactionState(TxnRequest.newBuilder()
-                                               .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
-                                                                                           stream.getStreamName()))
-                                               .setTxnId(ModelHelper.decode(txId))
-                                               .build(),
-                                     callback);
-        return callback.getFuture()
-                .thenApply(status -> ModelHelper.encode(status.getState(), stream + " " + txId))
+        final CompletableFuture<TxnState> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<TxnState> callback = new RPCAsyncCallback<>();
+            client.checkTransactionState(TxnRequest.newBuilder()
+                            .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
+                                    stream.getStreamName()))
+                            .setTxnId(ModelHelper.decode(txId))
+                            .build(),
+                    callback);
+            return callback.getFuture();
+        }, this.executor);
+        return result.thenApply(status -> ModelHelper.encode(status.getState(), stream + " " + txId))
                 .whenComplete((x, e) -> {
                     if (e != null) {
                         log.warn("checkTransactionStatus failed: ", e);
                     }
                     LoggerHelpers.traceLeave(log, "checkTransactionStatus", traceId);
                 });
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            final ScheduledExecutorService executorService = this.internalExecutor.getAndSet(null);
+            if (executorService != null) {
+                executorService.shutdownNow();
+            }
+        }
     }
 
     // Local callback definition to wrap gRPC responses in CompletableFutures used by the rest of our code.
@@ -733,5 +871,4 @@ public class ControllerImpl implements Controller {
             return future;
         }
     }
-
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+import java.io.Serializable;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ControllerImplConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final int initialBackoffMillis;
+    private final int maxBackoffMillis;
+    private final int retryAttempts;
+    private final int backoffMultiple;
+
+    public static final class ControllerImplConfigBuilder {
+        private int initialBackoffMillis = 1;
+        private int maxBackoffMillis = 20000;
+        private int retryAttempts = 10;
+        private int backoffMultiple = 10;
+    }
+}

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
@@ -117,8 +119,10 @@ public class ControllerImplLBTest {
         final int serverPort2 = testRPCServer2.getPort();
 
         // Use 2 servers to discover all the servers.
-        ControllerImpl controllerClient = new ControllerImpl(
-                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(
+                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
 
         // Verify we could reach all 3 controllers.
@@ -132,8 +136,10 @@ public class ControllerImplLBTest {
 
         // Use 2 servers to discover all the servers.
         String localIP = InetAddress.getLoopbackAddress().getHostAddress();
-        ControllerImpl controllerClient = new ControllerImpl(
-                URI.create("pravega://" + localIP + ":" + serverPort1 + "," + localIP + ":" + serverPort2));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(
+                URI.create("pravega://" + localIP + ":" + serverPort1 + "," + localIP + ":" + serverPort2),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
 
         // Verify we could reach all 3 controllers.
@@ -149,8 +155,10 @@ public class ControllerImplLBTest {
         testRPCServer1.shutdownNow();
         testRPCServer1.awaitTermination();
         Assert.assertTrue(testRPCServer1.isTerminated());
-        ControllerImpl controllerClient = new ControllerImpl(
-                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(
+                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
+                ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Verify that we can read from the 2 live servers.
         Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 2);
@@ -175,8 +183,10 @@ public class ControllerImplLBTest {
         testRPCServer3.shutdownNow();
         testRPCServer3.awaitTermination();
         Assert.assertTrue(testRPCServer3.isTerminated());
-        ControllerImpl client = new ControllerImpl(
-                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2));
+        @Cleanup
+        final ControllerImpl client = new ControllerImpl(
+                URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         AssertExtensions.assertThrows(ExecutionException.class, () -> client.getEndpointForSegment("a/b/0").get());
     }
 
@@ -187,8 +197,10 @@ public class ControllerImplLBTest {
         final int serverPort3 = testRPCServer3.getPort();
 
         // Directly use all 3 servers and verify.
-        ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1 + ",localhost:"
-                + serverPort2 + ",localhost:" + serverPort3));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1
+                + ",localhost:" + serverPort2 + ",localhost:" + serverPort3),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
         Assert.assertEquals(3, uris.size());
     }
@@ -201,8 +213,10 @@ public class ControllerImplLBTest {
 
         // Directly use all 3 servers and verify.
         String localIP = InetAddress.getLoopbackAddress().getHostAddress();
-        ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://" + localIP + ":" + serverPort1
-                + "," + localIP + ":" + serverPort2 + "," + localIP + ":" + serverPort3));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://" + localIP + ":" + serverPort1
+                + "," + localIP + ":" + serverPort2 + "," + localIP + ":" + serverPort3),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
         Assert.assertEquals(3, uris.size());
     }
@@ -218,8 +232,10 @@ public class ControllerImplLBTest {
         testRPCServer1.awaitTermination();
         Assert.assertTrue(testRPCServer1.isTerminated());
 
-        ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1 + ",localhost:"
-                + serverPort2 + ",localhost:" + serverPort3));
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1
+                + ",localhost:" + serverPort2 + ",localhost:" + serverPort3),
+                ControllerImplConfig.builder().retryAttempts(1).build());
         Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 2);
         Assert.assertEquals(2, uris.size());
         Assert.assertFalse(uris.contains(new PravegaNodeUri("localhost1", 1)));

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -20,7 +20,6 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
-import io.pravega.common.ExceptionHelpers;
 import io.pravega.common.Exceptions;
 import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.controller.stream.api.grpc.v1.Controller;

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -11,7 +11,6 @@ package io.pravega.client.stream.impl;
 
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.internal.ServerImpl;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -608,8 +607,8 @@ public class ControllerImplTest {
                 .scope("scope1")
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build());
-        AssertExtensions.assertThrows("Should throw Exception", createStreamStatus,
-                throwable -> ExceptionHelpers.getRealException(throwable.getCause()) instanceof StatusRuntimeException);
+        AssertExtensions.assertThrows("Should throw RetriesExhaustedException", createStreamStatus,
+                throwable -> throwable instanceof RetriesExhaustedException);
 
         // Verify that the same RPC with permissible keepalive time succeeds.
         int serverPort2 = TestUtils.getAvailableListenPort();

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -21,7 +21,9 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
+import io.pravega.common.ExceptionHelpers;
 import io.pravega.common.Exceptions;
+import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleStatusRequest;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleStatusResponse;
@@ -69,8 +71,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.pravega.test.common.TestUtils;
+import lombok.Cleanup;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -94,6 +98,9 @@ public class ControllerImplTest {
 
     @Rule
     public final Timeout globalTimeout = new Timeout(120, TimeUnit.SECONDS);
+
+    // Global variable to track number of attempts to verify retries.
+    private final AtomicInteger retryAttempts = new AtomicInteger(0);
 
     // Test implementation for simulating the server responses.
     private ControllerServiceImplBase testServerImpl;
@@ -155,6 +162,17 @@ public class ControllerImplTest {
                             .setStatus(CreateStreamStatus.Status.SUCCESS)
                             .build());
                     responseObserver.onCompleted();
+                } else if (request.getStreamInfo().getStream().equals("streamretryfailure")) {
+                    responseObserver.onError(Status.UNKNOWN.withDescription("Transport error").asRuntimeException());
+                } else if (request.getStreamInfo().getStream().equals("streamretrysuccess")) {
+                    if (retryAttempts.incrementAndGet() > 3) {
+                        responseObserver.onNext(CreateStreamStatus.newBuilder()
+                                .setStatus(CreateStreamStatus.Status.SUCCESS)
+                                .build());
+                        responseObserver.onCompleted();
+                    } else {
+                        responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
+                    }
                 } else {
                     responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
                 }
@@ -566,8 +584,9 @@ public class ControllerImplTest {
                 .addService(testServerImpl)
                 .build()
                 .start();
-        controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort));
         executor = Executors.newSingleThreadScheduledExecutor();
+        controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
+                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
     }
 
     @After
@@ -580,15 +599,17 @@ public class ControllerImplTest {
     public void testKeepAlive() throws IOException, ExecutionException, InterruptedException {
 
         // Verify that keep-alive timeout less than permissible by the server results in a failure.
-        ControllerImpl controller = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort)
-                .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true));
+        @Cleanup
+        final ControllerImpl controller = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort)
+                .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true),
+                ControllerImplConfig.builder().retryAttempts(1).build(), this.executor);
         CompletableFuture<Boolean> createStreamStatus = controller.createStream(StreamConfiguration.builder()
                 .streamName("streamdelayed")
                 .scope("scope1")
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build());
         AssertExtensions.assertThrows("Should throw Exception", createStreamStatus,
-                throwable -> throwable instanceof StatusRuntimeException);
+                throwable -> ExceptionHelpers.getRealException(throwable.getCause()) instanceof StatusRuntimeException);
 
         // Verify that the same RPC with permissible keepalive time succeeds.
         int serverPort2 = TestUtils.getAvailableListenPort();
@@ -597,15 +618,55 @@ public class ControllerImplTest {
                 .permitKeepAliveTime(5, TimeUnit.SECONDS)
                 .build()
                 .start();
-        controller = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort2)
-                .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true));
-        createStreamStatus = controller.createStream(StreamConfiguration.builder()
+        @Cleanup
+        final ControllerImpl controller1 = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort2)
+                .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true),
+                ControllerImplConfig.builder().retryAttempts(1).build(), this.executor);
+        createStreamStatus = controller1.createStream(StreamConfiguration.builder()
                 .streamName("streamdelayed")
                 .scope("scope1")
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build());
         assertTrue(createStreamStatus.get());
         testServer.shutdownNow();
+    }
+
+    @Test
+    public void testRetries() throws IOException, ExecutionException, InterruptedException {
+
+        // Verify retries exhausted error after multiple attempts.
+        @Cleanup
+        final ControllerImpl controller1 = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
+                ControllerImplConfig.builder().retryAttempts(3).build(), this.executor);
+        CompletableFuture<Boolean> createStreamStatus = controller1.createStream(StreamConfiguration.builder()
+                .streamName("streamretryfailure")
+                .scope("scope1")
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build());
+        AssertExtensions.assertThrows("Should throw RetriesExhaustedException", createStreamStatus,
+                throwable -> throwable instanceof RetriesExhaustedException);
+
+        // The following call with retries should fail since number of retries is not sufficient.
+        this.retryAttempts.set(0);
+        createStreamStatus = controller1.createStream(StreamConfiguration.builder()
+                .streamName("streamretrysuccess")
+                .scope("scope1")
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build());
+        AssertExtensions.assertThrows("Should throw RetriesExhaustedException", createStreamStatus,
+                throwable -> throwable instanceof RetriesExhaustedException);
+
+        // The RPC should succeed when internal retry attempts is > 3 which is the hardcoded test value for success.
+        this.retryAttempts.set(0);
+        @Cleanup
+        final ControllerImpl controller2 = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
+                ControllerImplConfig.builder().retryAttempts(4).build(), this.executor);
+        createStreamStatus = controller2.createStream(StreamConfiguration.builder()
+                .streamName("streamretrysuccess")
+                .scope("scope1")
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build());
+        assertTrue(createStreamStatus.get());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -430,5 +430,9 @@ public class MockController implements Controller {
         return CompletableFuture.completedFuture(true);
     }
 
+    @Override
+    public void close() {
+        // Nothing to close.
+    }
 }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -332,4 +332,8 @@ public class LocalController implements Controller {
         return controller.isSegmentValid(segment.getScope(), segment.getStreamName(), segment.getSegmentNumber());
     }
 
+    @Override
+    public void close() {
+        // Nothing to close.
+    }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.controller.server.rest.generated.api.JacksonJsonProvider;
 import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
@@ -35,6 +36,7 @@ import io.pravega.controller.server.rest.generated.model.StreamState;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
 import io.pravega.test.integration.utils.SetupUtils;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.RandomStringUtils;
 import org.glassfish.jersey.client.ClientConfig;
@@ -254,7 +256,9 @@ public class ControllerRestApiTest {
         final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
         final String reader1 = RandomStringUtils.randomAlphanumeric(10);
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
-        Controller controller = new ControllerImpl(controllerUri);
+        @Cleanup
+        final Controller controller = new ControllerImpl(controllerUri,
+                ControllerImplConfig.builder().retryAttempts(1).build());
         try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -14,6 +14,7 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.test.system.framework.services.PravegaControllerService;
 import io.pravega.test.system.framework.services.Service;
@@ -35,9 +36,11 @@ abstract class AbstractScaleTests {
     @Getter(lazy = true)
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
     @Getter(lazy = true)
-    private final ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI()));
+    private final ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI(),
+            ControllerImplConfig.builder().retryAttempts(1).build()));
     @Getter(lazy = true)
-    private final ControllerImpl controller = new ControllerImpl(getControllerURI());
+    private final ControllerImpl controller = new ControllerImpl(getControllerURI(),
+            ControllerImplConfig.builder().retryAttempts(1).build());
 
     private URI createControllerURI() {
         Service conService = new PravegaControllerService("controller", null);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -137,23 +137,23 @@ public class ControllerFailoverTest {
         // Connect with first controller instance.
         URI controllerUri = getTestControllerServiceURI();
         @Cleanup
-        final Controller controller = new ControllerImpl(controllerUri,
+        final Controller controller1 = new ControllerImpl(controllerUri,
                 ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Create scope, stream, and a transaction with high timeout value.
-        controller.createScope(scope).join();
+        controller1.createScope(scope).join();
         log.info("Scope {} created successfully", scope);
 
-        createStream(controller, scope, stream, ScalingPolicy.fixed(initialSegments));
+        createStream(controller1, scope, stream, ScalingPolicy.fixed(initialSegments));
         log.info("Stream {}/{} created successfully", scope, stream);
 
         long txnCreationTimestamp = System.nanoTime();
-        TxnSegments txnSegments = controller.createTransaction(
+        TxnSegments txnSegments = controller1.createTransaction(
                 new StreamImpl(scope, stream), lease, maxExecutionTime, scaleGracePeriod).join();
         log.info("Transaction {} created successfully, beginTime={}", txnSegments.getTxnId(), txnCreationTimestamp);
 
         // Initiate scale operation. It will block until ongoing transaction is complete.
-        CompletableFuture<Boolean> scaleFuture = controller.scaleStream(
+        CompletableFuture<Boolean> scaleFuture = controller1.scaleStream(
                 new StreamImpl(scope, stream), segmentsToSeal, newRangesToCreate, EXECUTOR_SERVICE).getFuture();
 
         // Ensure that scale is not yet done.
@@ -167,13 +167,13 @@ public class ControllerFailoverTest {
         // Connect to another controller instance.
         controllerUri = getControllerURI();
         @Cleanup
-        final Controller controller1 = new ControllerImpl(controllerUri,
+        final Controller controller2 = new ControllerImpl(controllerUri,
                 ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Fetch status of transaction.
         log.info("Fetching status of transaction {}, time elapsed since its creation={}",
                 txnSegments.getTxnId(), System.nanoTime() - txnCreationTimestamp);
-        Transaction.Status status = controller1.checkTransactionStatus(new StreamImpl(scope, stream),
+        Transaction.Status status = controller2.checkTransactionStatus(new StreamImpl(scope, stream),
                 txnSegments.getTxnId()).join();
         log.info("Transaction {} status={}", txnSegments.getTxnId(), status);
 
@@ -181,7 +181,7 @@ public class ControllerFailoverTest {
             // Abort the ongoing transaction.
             log.info("Trying to abort transaction {}, by sending request to controller at {}", txnSegments.getTxnId(),
                     controllerUri);
-            controller1.abortTransaction(new StreamImpl(scope, stream), txnSegments.getTxnId()).join();
+            controller2.abortTransaction(new StreamImpl(scope, stream), txnSegments.getTxnId()).join();
         }
 
         // Scale operation should now complete on the second controller instance.
@@ -190,7 +190,7 @@ public class ControllerFailoverTest {
 
         // Ensure that the stream has 3 segments now.
         log.info("Checking whether scale operation succeeded by fetching current segments");
-        StreamSegments streamSegments = controller1.getCurrentSegments(scope, stream).join();
+        StreamSegments streamSegments = controller2.getCurrentSegments(scope, stream).join();
         log.info("Current segment count=", streamSegments.getSegments().size());
         Assert.assertEquals(initialSegments - segmentsToSeal.size() + newRangesToCreate.size(),
                 streamSegments.getSegments().size());

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -20,6 +20,7 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.controller.server.rest.generated.api.JacksonJsonProvider;
 import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
@@ -41,6 +42,7 @@ import io.pravega.test.system.framework.services.PravegaControllerService;
 import io.pravega.test.system.framework.services.PravegaSegmentStoreService;
 import io.pravega.test.system.framework.services.Service;
 import io.pravega.test.system.framework.services.ZookeeperService;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.apache.commons.lang.RandomStringUtils;
@@ -296,7 +298,9 @@ public class ControllerRestApiTest {
         final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
         final String reader1 = RandomStringUtils.randomAlphanumeric(10);
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
-        Controller controller = new ControllerImpl(controllerUri);
+        @Cleanup
+        final Controller controller = new ControllerImpl(controllerUri,
+                ControllerImplConfig.builder().retryAttempts(1).build());
         try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -11,6 +11,7 @@ package io.pravega.test.system;
 
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
+import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.common.util.Retry;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.system.framework.Environment;
@@ -166,11 +167,14 @@ public class MultiControllerTest {
         // All APIs should throw exception and fail.
         controllerServiceInstance3.stop();
         log.info("Test tcp:// with no controller instances running");
-        AssertExtensions.assertThrows(ExecutionException.class,
-                () -> createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect).get());
+        AssertExtensions.assertThrows("Should throw RetriesExhaustedException",
+                createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect),
+                throwable -> throwable instanceof RetriesExhaustedException);
+
         log.info("Test pravega:// with no controller instances running");
-        AssertExtensions.assertThrows(ExecutionException.class,
-                () -> createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover).get());
+        AssertExtensions.assertThrows("Should throw RetriesExhaustedException",
+                createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover),
+                throwable -> throwable instanceof RetriesExhaustedException);
 
         log.info("multiControllerTest execution completed");
     }

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -10,6 +10,7 @@
 package io.pravega.test.system;
 
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.util.Retry;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.system.framework.Environment;
@@ -25,6 +26,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
+
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -181,7 +184,9 @@ public class MultiControllerTest {
     }
 
     private CompletableFuture<Boolean> createScope(String scopeName, URI controllerURI) {
-        final ControllerImpl controllerClient = new ControllerImpl(controllerURI);
+        @Cleanup
+        final ControllerImpl controllerClient = new ControllerImpl(controllerURI,
+                ControllerImplConfig.builder().retryAttempts(1).build());
         return controllerClient.createScope(scopeName);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -24,6 +24,7 @@ import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
@@ -174,7 +175,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         //read and write count variables
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);
@@ -186,6 +187,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
 
     @After
     public void tearDown() {
+        controller.close();
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
         executorService.shutdownNow();

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
@@ -183,7 +184,9 @@ public class MultiReaderWriterWithFailOverTest {
         URI controllerUri = controllerURIDirect;
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
-        Controller controller = new ControllerImpl(controllerUri);
+        @Cleanup
+        Controller controller = new ControllerImpl(controllerUri,
+                ControllerImplConfig.builder().retryAttempts(1).build(), connectionFactory.getInternalExecutor());
 
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -22,6 +22,7 @@ import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
@@ -128,7 +129,9 @@ public class PravegaTest {
         log.info("Invoking create stream with Controller URI: {}", controllerUri);
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
-        ControllerImpl controller = new ControllerImpl(controllerUri);
+        @Cleanup
+        ControllerImpl controller = new ControllerImpl(controllerUri,
+                ControllerImplConfig.builder().retryAttempts(1).build(), connectionFactory.getInternalExecutor());
 
         assertTrue(controller.createScope(STREAM_SCOPE).get());
         assertTrue(controller.createStream(config).get());

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -93,7 +93,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().build());
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         testState = new TestState();
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -15,6 +15,7 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.StreamSegments;
 import io.pravega.common.Exceptions;
 import io.pravega.test.system.framework.Environment;
@@ -92,12 +93,13 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().build());
         testState = new TestState();
     }
 
     @After
     public void tearDown() {
+        controller.close();
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
         executorService.shutdownNow();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -15,6 +15,7 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
@@ -93,12 +94,13 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         testState = new TestState();
     }
 
     @After
     public void tearDown() {
+        controller.close();
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
         executorService.shutdownNow();


### PR DESCRIPTION
**Change log description**
* Added a retry wrapper over all controller client gRPC calls. The gRPC calls will be replayed on any exceptions from the transport layer or from controller server.
* Used the same default backoff retry values as the pravega client.
* Currently controller client cleanup using close() is not consistent across the code, this will be addressed as a separate issue #1688, since this requires a little more refactoring which could make this PR cumbersome to review.

**Purpose of the change**
Fixes #674 

**What the code does**
Resends the client RPC calls on any gRPC or controller server exceptions.

**How to verify it**
Included unit test to verify retries