### PR TITLE
Issue 1697: Change client background reconnect logic to be asynchronous 

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -398,8 +398,11 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         if (state.isAlreadySealed()) {
             throw new SegmentSealedException(this.segmentName);
         }
+        if (state.getConnection() == null) {
+            reconnect();
+        }
         CompletableFuture<ClientConnection> future =  new CompletableFuture<>();
-        state.setupConnection.runReleaserAndAwait(this::reconnect, future);
+        state.setupConnection.await(future);
         return future;
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -278,10 +278,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 Retry.indefinitelyWithExpBackoff(retrySchedule.getInitialMillis(), retrySchedule.getMultiplier(),
                                                  retrySchedule.getMaxDelay(),
                                                  t -> log.error(writerId + " to invoke sealed callback: ", t))
-                     .runAsync(() -> {
+                     .runInExecutor(() -> {
                          log.debug("Invoking SealedSegment call back for {}", segmentIsSealed);
                          callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));
-                         return null;
                      }, connectionFactory.getInternalExecutor());
             }
         }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -411,7 +411,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                     try {
                         connection.send(cmd);
                     } catch (Exception e) {
-                        failConnection(e);
+                        state.failConnection(e);
                         throw e;
                     }
                 }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -129,8 +129,10 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             synchronized (lock) {
                 toComplete = connectionSetupCompleted;
             }
-            toComplete.complete(null);
-            setupConnection.release(connection);
+            if (toComplete != null) {
+                toComplete.complete(null);
+                setupConnection.release(connection);
+            }
         }
 
         /**

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -140,6 +140,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             synchronized (lock) {
                 connectionSetup.reset();
                 exception = null;
+                reconnecting.set(false);
                 connection = newConnection;
             }
         }
@@ -322,7 +323,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                     if (e == null) {
                         state.connectionSetupComplete();
                     } else {
-                        state.failConnection(e);
+                        failConnection(e);
                     }
                 });
             }
@@ -410,7 +411,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                     try {
                         connection.send(cmd);
                     } catch (Exception e) {
-                        state.failConnection(e);
+                        failConnection(e);
                         throw e;
                     }
                 }
@@ -468,7 +469,6 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          } catch (ConnectionFailedException exception) {
                              throw Lombok.sneakyThrow(exception);
                          }
-                         state.reconnecting.set(false);
                      }
                  }, connectionFactory.getInternalExecutor());
         }

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -271,6 +271,9 @@ public class SegmentOutputStreamTest {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
@@ -505,9 +508,9 @@ public class SegmentOutputStreamTest {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
-        @Cleanup("shutdown")
-        InlineExecutor inlineExecutor = new InlineExecutor();
-        cf.setExecutor(inlineExecutor);
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -549,9 +549,9 @@ public class SegmentOutputStreamTest {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
-        @Cleanup("shutdown")
-        InlineExecutor inlineExecutor = new InlineExecutor();
-        cf.setExecutor(inlineExecutor);
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
         ClientConnection connection = mock(ClientConnection.class);
         InOrder inOrder = inOrder(connection);
@@ -617,9 +617,9 @@ public class SegmentOutputStreamTest {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
-        @Cleanup("shutdown")
-        InlineExecutor inlineExecutor = new InlineExecutor();
-        cf.setExecutor(inlineExecutor);
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);

--- a/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * This class is similar to {@link ReusableLatch} but that works with {@link CompletableFuture} so
+ * that blocking can be async and exceptions and results can be passed.
+ * @param <T> The type of the futures that this class works with.
+ */
+public class ReusableFutureLatch<T> {
+    private final Object lock = new Object();
+    @GuardedBy("lock")
+    private final ArrayList<CompletableFuture<T>> waitingFutures = new ArrayList<>();
+    @GuardedBy("lock")
+    private T result;
+    @GuardedBy("lock")
+    private Exception e;
+    @GuardedBy("lock")
+    private boolean released;
+
+    public ReusableFutureLatch() {
+        released = false;
+    }
+
+    /**
+     * Supply a future to be notified when {@link #release(Object)} is called. If release has already been
+     * called, it will be compltedImmediatly.
+     * 
+     * @param toNotify The future that should be completed.
+     */
+    public void await(CompletableFuture<T> toNotify) {
+        T result;
+        Exception e;
+        synchronized (lock) {
+            if (released) {
+                result = this.result;
+                e = this.e;
+            } else {
+                waitingFutures.add(toNotify);
+                return;
+            }
+        }
+        if (e == null) {
+            toNotify.complete(result);
+        } else {
+            toNotify.completeExceptionally(e);
+        }
+    }
+
+    /**
+     * Complete all waiting futures, and all future calls to await to run immediately. If release is
+     * called twice consecutively the second value will be the one passed to future callers of
+     * {@link #await(CompletableFuture)}
+     * 
+     * @param result The result to pass to waiting futures.
+     */
+    public void release(T result) {
+        ArrayList<CompletableFuture<T>> toComplete = null;
+        synchronized (lock) {
+            if (!waitingFutures.isEmpty()) {
+                toComplete = new ArrayList<>(toComplete);
+                toComplete.clear();
+            }
+            e = null;
+            this.result = result;
+            released = true;
+        }
+        if (toComplete != null) {
+            for (CompletableFuture<T> f : toComplete) {
+                f.complete(result);
+            }
+        }
+    }
+    
+    /**
+     * Complete all waiting futures, and all future calls to await to run immediately. If release is
+     * called twice consecutively the second value will be the one passed to future callers of
+     * {@link #await(CompletableFuture)}
+     * 
+     * @param e The exception to pass to waiting futures.
+     */
+    public void releaseExceptionally(Exception e) {
+        ArrayList<CompletableFuture<T>> toComplete = null;
+        synchronized (lock) {
+            if (!waitingFutures.isEmpty()) {
+                toComplete = new ArrayList<>(toComplete);
+                toComplete.clear();
+            }
+            this.e = e;
+            this.result = null;
+            released = true;
+        }
+        if (toComplete != null) {
+            for (CompletableFuture<T> f : toComplete) {
+                f.completeExceptionally(e);
+            }
+        }
+    }
+
+    /**
+     * If {@link #release(Object)} or {@link #releaseExceptionally(Exception)} has been called it
+     * resets the object into the unreleased state. If release has not been called this will have no effect.
+     */
+    public void reset() {
+        synchronized (lock) {
+            released = false;
+            e = null;
+            result = null;
+        }
+    }
+}

--- a/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
@@ -37,11 +37,11 @@ public class ReusableFutureLatch<T> {
 
     /**
      * Supply a future to be notified when {@link #release(Object)} is called. If release has already been
-     * called, it will be compltedImmediatly.
+     * called, it will be completed immediately.
      * 
      * @param toNotify The future that should be completed.
      */
-    public void await(CompletableFuture<T> toNotify) {
+    public void register(CompletableFuture<T> toNotify) {
         T result;
         Throwable e;
         synchronized (lock) {
@@ -72,7 +72,7 @@ public class ReusableFutureLatch<T> {
      * @param willCallRelease A runnable that should result in {@link #release(Object)} being called.
      * @param toNotify The future to notify once release is called.
      */
-    public void runReleaserAndAwait(Runnable willCallRelease, CompletableFuture<T> toNotify) {
+    public void registerAndRunReleaser(Runnable willCallRelease, CompletableFuture<T> toNotify) {
         boolean run = false;
         boolean complete = false;
         T result = null;
@@ -115,9 +115,9 @@ public class ReusableFutureLatch<T> {
     }
 
     /**
-     * Complete all waiting futures, and all future calls to await to run immediately. If release is
+     * Complete all waiting futures, and all future calls to register be notified immediately. If release is
      * called twice consecutively the second value will be the one passed to future callers of
-     * {@link #await(CompletableFuture)}
+     * {@link #register(CompletableFuture)}
      * 
      * @param result The result to pass to waiting futures.
      */
@@ -140,9 +140,9 @@ public class ReusableFutureLatch<T> {
     }
     
     /**
-     * Complete all waiting futures, and all future calls to await to run immediately. If release is
+     * Complete all waiting futures, and all future calls to register be notified immediately. If release is
      * called twice consecutively the second value will be the one passed to future callers of
-     * {@link #await(CompletableFuture)}
+     * {@link #register(CompletableFuture)}
      * 
      * @param e The exception to pass to waiting futures.
      */

--- a/common/src/main/java/io/pravega/common/util/ReusableLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableLatch.java
@@ -111,4 +111,9 @@ public class ReusableLatch {
             }
         }
     }
+    
+    @Override
+    public String toString() {
+        return "LatchReleased: " + released.get();
+    }
 }

--- a/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ReusableFutureLatchTests {
+
+    @Test(timeout = 5000)
+    public void testRelease() throws InterruptedException, ExecutionException {
+        ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
+        CompletableFuture<String> str1 = new CompletableFuture<>();
+        CompletableFuture<String> str2 = new CompletableFuture<>();
+        latch.await(str1);
+        latch.await(str2);
+        assertFalse(str1.isDone());
+        assertFalse(str2.isDone());
+        latch.release("Done");
+        assertTrue(str1.isDone());
+        assertTrue(str2.isDone());
+        assertEquals("Done", str1.get());
+        assertEquals("Done", str2.get());
+    }
+    
+    @Test(timeout = 5000)
+    public void testReleaseExceptionally() {
+        ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
+        CompletableFuture<String> str1 = new CompletableFuture<>();
+        CompletableFuture<String> str2 = new CompletableFuture<>();
+        latch.await(str1);
+        latch.await(str2);
+        assertFalse(str1.isDone());
+        assertFalse(str2.isDone());
+        latch.releaseExceptionally(new RuntimeException("Foo"));
+        assertTrue(str1.isCompletedExceptionally());
+        assertTrue(str2.isCompletedExceptionally());
+        assertThrows("Wrong exception", () -> str1.get(),
+                     e -> e instanceof RuntimeException && e.getMessage().equals("Foo"));
+        assertThrows("Wrong exception", () -> str2.get(),
+                     e -> e instanceof RuntimeException && e.getMessage().equals("Foo"));
+    }
+    
+    @Test(timeout = 5000)
+    public void testAlreadyRelease() throws InterruptedException, ExecutionException {
+        ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
+        CompletableFuture<String> str1 = new CompletableFuture<>();
+        CompletableFuture<String> str2 = new CompletableFuture<>();
+        latch.release("Done");
+        latch.await(str1);
+        latch.await(str2);
+        assertTrue(str1.isDone());
+        assertTrue(str2.isDone());
+        assertEquals("Done", str1.get());
+        assertEquals("Done", str2.get());
+    }
+    
+    @Test(timeout = 5000)
+    public void testReset() throws InterruptedException, ExecutionException {
+        ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
+        CompletableFuture<String> str1 = new CompletableFuture<>();
+        CompletableFuture<String> str2 = new CompletableFuture<>();
+        latch.await(str1);
+        latch.release("1");
+        latch.reset();
+        latch.await(str2);
+        assertTrue(str1.isDone());
+        assertEquals("1", str1.get());
+        assertFalse(str2.isDone());
+        latch.release("Done");
+        assertTrue(str2.isDone());
+        assertEquals("Done", str2.get());
+    }
+    
+    @Test(timeout = 5000)
+    public void testReleaseExceptionallyAndReset() {
+        ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
+        CompletableFuture<String> str1 = new CompletableFuture<>();
+        CompletableFuture<String> str2 = new CompletableFuture<>();
+        latch.await(str1);
+        assertFalse(str1.isDone());
+        latch.releaseExceptionallyAndReset(new RuntimeException("Foo"));
+        assertTrue(str1.isCompletedExceptionally());        
+        assertThrows("Wrong exception", () -> str1.get(),
+                     e -> e instanceof RuntimeException && e.getMessage().equals("Foo"));    
+        latch.await(str2);
+        assertFalse(str2.isDone());
+        latch.releaseExceptionallyAndReset(new RuntimeException("Bar"));
+        assertTrue(str2.isCompletedExceptionally());
+        assertThrows("Wrong exception", () -> str2.get(),
+                     e -> e instanceof RuntimeException && e.getMessage().equals("Bar"));
+    }
+    
+}

--- a/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
@@ -26,8 +26,8 @@ public class ReusableFutureLatchTests {
         ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
-        latch.await(str1);
-        latch.await(str2);
+        latch.register(str1);
+        latch.register(str2);
         assertFalse(str1.isDone());
         assertFalse(str2.isDone());
         latch.release("Done");
@@ -44,10 +44,10 @@ public class ReusableFutureLatchTests {
         ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
-        latch.runReleaserAndAwait(() -> {
+        latch.registerAndRunReleaser(() -> {
             ran1.set(true);
         }, str1);
-        latch.runReleaserAndAwait(() -> {
+        latch.registerAndRunReleaser(() -> {
             ran2.set(true);
         }, str2);
         assertFalse(str1.isDone());
@@ -67,8 +67,8 @@ public class ReusableFutureLatchTests {
         ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
-        latch.await(str1);
-        latch.await(str2);
+        latch.register(str1);
+        latch.register(str2);
         assertFalse(str1.isDone());
         assertFalse(str2.isDone());
         latch.releaseExceptionally(new RuntimeException("Foo"));
@@ -86,8 +86,8 @@ public class ReusableFutureLatchTests {
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
         latch.release("Done");
-        latch.await(str1);
-        latch.await(str2);
+        latch.register(str1);
+        latch.register(str2);
         assertTrue(str1.isDone());
         assertTrue(str2.isDone());
         assertEquals("Done", str1.get());
@@ -99,10 +99,10 @@ public class ReusableFutureLatchTests {
         ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
-        latch.await(str1);
+        latch.register(str1);
         latch.release("1");
         latch.reset();
-        latch.await(str2);
+        latch.register(str2);
         assertTrue(str1.isDone());
         assertEquals("1", str1.get());
         assertFalse(str2.isDone());
@@ -116,13 +116,13 @@ public class ReusableFutureLatchTests {
         ReusableFutureLatch<String> latch = new ReusableFutureLatch<>();
         CompletableFuture<String> str1 = new CompletableFuture<>();
         CompletableFuture<String> str2 = new CompletableFuture<>();
-        latch.await(str1);
+        latch.register(str1);
         assertFalse(str1.isDone());
         latch.releaseExceptionallyAndReset(new RuntimeException("Foo"));
         assertTrue(str1.isCompletedExceptionally());        
         assertThrows("Wrong exception", () -> str1.get(),
                      e -> e instanceof RuntimeException && e.getMessage().equals("Foo"));    
-        latch.await(str2);
+        latch.register(str2);
         assertFalse(str2.isDone());
         latch.releaseExceptionallyAndReset(new RuntimeException("Bar"));
         assertTrue(str2.isCompletedExceptionally());

--- a/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import io.pravega.test.common.Async;
+import org.junit.Test;
+
+public class ReusableLatchTests {
+
+    @Test(timeout = 5000)
+    public void testRelease() {
+        ReusableLatch latch = new ReusableLatch(false);
+        Async.testBlocking(() -> latch.awaitUninterruptibly(), () -> latch.release());
+    }
+    
+    @Test(timeout = 5000)
+    public void testAlreadyRelease() throws InterruptedException {
+        ReusableLatch latch = new ReusableLatch(false);
+        latch.release();
+        latch.await();
+
+        latch = new ReusableLatch(true);
+        latch.await(); 
+    }
+    
+}


### PR DESCRIPTION
**Change log description**
* Fixes a race condition described in #1697. 
* Changes the reconnect logic to be asynchronous to avoid tying up a thread and allow it to maintain exponential backoff even with after connection re-establishment.

**Purpose of the change**
Fixes #1697 

**What the code does**
Creates a new class ReusableAsyncLatch which abstracts out the concept of having multiple futures waiting on a single state transition, and ensuring that one of them triggers the process that will result in the transition.

**How to verify it**
New tests are added to cover the new class and to reproduce the race condition. The later of which fails against master and is passing here.