### PR TITLE
Issue 1699: Segmentstore publishedIPAddress is set to CONTROLLERNODE on AWS

### DIFF
--- a/deployment/aws/installer/entry_point_template.yml
+++ b/deployment/aws/installer/entry_point_template.yml
@@ -44,7 +44,7 @@
     HDFS_URL: NAMENODE:8020
     ZK_URL: ZKNODE:2181
     CONTROLLER_URL: tcp://CONTROLLERNODE:9090
-    JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dbookkeeper.zkAddress=ZKNODE:2181 -Dpravegaservice.publishedIPAddress=CONTROLLERNODE -Xmx900m
+    JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dbookkeeper.zkAddress=ZKNODE:2181 -Xmx900m
     HADOOP_USER_NAME: hdfs
   roles:
     - { role: install-hosts }

--- a/deployment/aws/installer/roles/install-hosts/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-hosts/tasks/main.yml
@@ -11,6 +11,10 @@
       src: data/config.properties
       dest: /opt/pravega/conf/config.properties
 
+- name: Set publish IP address
+  shell: echo pravegaservice.publishedIPAddress=$(ifconfig | awk '/inet addr/{print substr($2,6)}' | sed -n 1p) >> /opt/pravega/conf/config.properties
+  sudo: yes
+
 - name: Run hosts
   shell: nohup /opt/pravega/bin/pravega-segmentstore 2>&1 &> /tmp/host.log &
   sudo: yes


### PR DESCRIPTION
**Change log description**
* Changes of the register IP address of controller for AWS deployment.

**Purpose of the change**
To assign only one ip address to the controller

**What the code does**
Fixes #1699 

**How to verify it**
Deploying on aws cluster