### PR TITLE
Issue 1704: Controller can recreate segment with identical range for scale up if traffic is less than double of target rate for over 10 minutes

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/AutoScaleRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/AutoScaleRequestHandler.java
@@ -92,7 +92,7 @@ public class AutoScaleRequestHandler implements RequestHandler<AutoScaleEvent> {
         return streamMetadataStore.getSegment(request.getScope(), request.getStream(), request.getSegmentNumber(), context, executor)
                 .thenComposeAsync(segment -> {
                     // do not go above scale factor. Minimum scale factor is 2 though.
-                    int numOfSplits = Math.min(request.getNumOfSplits(), Math.max(2, policy.getScaleFactor()));
+                    int numOfSplits = Math.min(Math.max(2, request.getNumOfSplits()), Math.max(2, policy.getScaleFactor()));
                     double delta = (segment.getKeyEnd() - segment.getKeyStart()) / numOfSplits;
 
                     final ArrayList<AbstractMap.SimpleEntry<Double, Double>> simpleEntries = new ArrayList<>();

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -141,7 +141,8 @@ public class ScaleRequestHandlerTest {
         AutoScaleRequestHandler requestHandler = new AutoScaleRequestHandler(streamMetadataTasks, streamStore, executor);
         ScaleOperationRequestHandler scaleRequestHandler = new ScaleOperationRequestHandler(streamMetadataTasks, streamStore, executor);
         RequestHandlerMultiplexer multiplexer = new RequestHandlerMultiplexer(requestHandler, scaleRequestHandler);
-        AutoScaleEvent request = new AutoScaleEvent(scope, stream, 2, AutoScaleEvent.UP, System.currentTimeMillis(), 2, false);
+        // Send number of splits = 1
+        AutoScaleEvent request = new AutoScaleEvent(scope, stream, 2, AutoScaleEvent.UP, System.currentTimeMillis(), 1, false);
         CompletableFuture<ScaleOpEvent> request1 = new CompletableFuture<>();
         CompletableFuture<ScaleOpEvent> request2 = new CompletableFuture<>();
         EventStreamWriter<ControllerEvent> writer = createWriter(x -> {
@@ -172,6 +173,7 @@ public class ScaleRequestHandlerTest {
         List<Segment> activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
 
         assertTrue(activeSegments.stream().noneMatch(z -> z.getNumber() == 2));
+        // verify that two splits are created even when we sent 1 as numOfSplits in AutoScaleEvent.
         assertTrue(activeSegments.stream().anyMatch(z -> z.getNumber() == 3));
         assertTrue(activeSegments.stream().anyMatch(z -> z.getNumber() == 4));
         assertTrue(activeSegments.size() == 4);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -203,8 +203,8 @@ public class AutoScaleProcessor {
                     if ((twoMinuteRate > 5.0 * targetRate && currentTime - startTime > TWO_MINUTES) ||
                             (fiveMinuteRate > 2.0 * targetRate && currentTime - startTime > FIVE_MINUTES) ||
                             (tenMinuteRate > targetRate && currentTime - startTime > TEN_MINUTES)) {
-                        int numOfSplits = (int) (Double.max(Double.max(twoMinuteRate, fiveMinuteRate), tenMinuteRate) / targetRate);
-                        log.debug("triggering scale up for {}", streamSegmentName);
+                        int numOfSplits = Math.max(2, (int) (Double.max(Double.max(twoMinuteRate, fiveMinuteRate), tenMinuteRate) / targetRate));
+                        log.debug("triggering scale up for {} with number of splits {}", streamSegmentName, numOfSplits);
 
                         triggerScaleUp(streamSegmentName, numOfSplits);
                     }


### PR DESCRIPTION
**Change log description**
The auto scale processor can request for number of splits as 1 if traffic/target Rate is between 1 and 2. 

**Purpose of the change**
Fixes issue 1704
**What the code does**
added additional check on controller and segment store to use numOfSplits as minimum 2
**How to verify it**
unit tests added/updated. 
