### PR TITLE
Issue 1706: Sporadic build failure: NPE during EventProcessor Cell shutdown causes test failure. 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -127,11 +127,15 @@ class EventProcessorCell<T extends ControllerEvent> {
 
                 // First close the reader, which implicitly notifies reader position to the reader group
                 log.info("Closing reader for {}", objectId);
-                reader.close();
+                if (reader != null) {
+                    reader.close();
+                } 
 
                 // Next, clean up the reader and its position from checkpoint store
                 log.info("Cleaning up checkpoint store for {}", objectId);
-                checkpointStore.removeReader(process, readerGroupName, readerId);
+                if (checkpointStore != null) {
+                    checkpointStore.removeReader(process, readerGroupName, readerId);
+                }
             }
         }
 


### PR DESCRIPTION
**Change log description**
NPE during EventProcessorCell shutdown as reader is null. 
This causes unit test to fail sporadically. 
**Purpose of the change**
Fixes issue 1706

**What the code does**
Checks if reader is not null before calling close on it. 
**How to verify it**
Unit test should pass consistently. 