### PR TITLE
Issue 1706: Sporadic build failure: Test passes null readers to eventprocessor whereby causing NPE during shutdown

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -9,6 +9,8 @@
  */
 package io.pravega.controller.eventProcessor.impl;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.controller.eventProcessor.CheckpointConfig;
 import io.pravega.controller.store.checkpoint.CheckpointStore;
@@ -234,6 +236,12 @@ class EventProcessorCell<T extends ControllerEvent> {
                        final String readerId,
                        final int index,
                        final CheckpointStore checkpointStore) {
+        Preconditions.checkNotNull(eventProcessorConfig);
+        Preconditions.checkNotNull(reader);
+        Preconditions.checkNotNull(selfWriter);
+        Preconditions.checkNotNull(checkpointStore);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(process));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(readerId));
         this.reader = reader;
         this.selfWriter = selfWriter;
         this.checkpointStore = checkpointStore;

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -127,11 +127,15 @@ class EventProcessorCell<T extends ControllerEvent> {
 
                 // First close the reader, which implicitly notifies reader position to the reader group
                 log.info("Closing reader for {}", objectId);
-                reader.close();
+                if (reader != null) {
+                    reader.close();
+                } 
 
                 // Next, clean up the reader and its position from checkpoint store
                 log.info("Cleaning up checkpoint store for {}", objectId);
-                checkpointStore.removeReader(process, readerGroupName, readerId);
+                if (checkpointStore != null) {
+                    checkpointStore.removeReader(process, readerGroupName, readerId);
+                }
             }
         }
 

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -129,15 +129,11 @@ class EventProcessorCell<T extends ControllerEvent> {
 
                 // First close the reader, which implicitly notifies reader position to the reader group
                 log.info("Closing reader for {}", objectId);
-                if (reader != null) {
-                    reader.close();
-                } 
+                reader.close();
 
                 // Next, clean up the reader and its position from checkpoint store
                 log.info("Cleaning up checkpoint store for {}", objectId);
-                if (checkpointStore != null) {
-                    checkpointStore.removeReader(process, readerGroupName, readerId);
-                }
+                checkpointStore.removeReader(process, readerGroupName, readerId);
             }
         }
 

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -233,14 +233,11 @@ class EventProcessorCell<T extends ControllerEvent> {
                        final int index,
                        final CheckpointStore checkpointStore) {
         Preconditions.checkNotNull(eventProcessorConfig);
-        Preconditions.checkNotNull(reader);
-        Preconditions.checkNotNull(selfWriter);
-        Preconditions.checkNotNull(checkpointStore);
         Preconditions.checkArgument(!Strings.isNullOrEmpty(process));
         Preconditions.checkArgument(!Strings.isNullOrEmpty(readerId));
-        this.reader = reader;
-        this.selfWriter = selfWriter;
-        this.checkpointStore = checkpointStore;
+        this.reader = Preconditions.checkNotNull(reader);
+        this.selfWriter = Preconditions.checkNotNull(selfWriter);
+        this.checkpointStore = Preconditions.checkNotNull(checkpointStore);
         this.process = process;
         this.readerGroupName = eventProcessorConfig.getConfig().getReaderGroupName();
         this.readerId = readerId;

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -369,7 +369,7 @@ public class EventProcessorTest {
 
         createEventProcessorGroupConfig(3);
 
-        EventProcessorSystemImpl system = createMockSystem(systemName, PROCESS, SCOPE, createEventReaders(1, input),
+        EventProcessorSystemImpl system = createMockSystem(systemName, PROCESS, SCOPE, createEventReaders(3, input),
                 writer, readerGroupName);
 
         EventProcessorConfig<TestEvent> eventProcessorConfig = EventProcessorConfig.<TestEvent>builder()


### PR DESCRIPTION
**Change log description**
In the test we mock clientFactory for creating readers. 
We create 3 event processors but only 1 reader. 
ClientFactory mock returns a sequenceAnswer which only has one reader. This means two event processors are created with null reader. hence NPE during shutdown.  

**Purpose of the change**
Fixes issue 1706
**What the code does**
We fix the test to create 3 readers. 
Also added precondition checks in eventprocessorCell contructor to check for null references. 

**How to verify it**
Unit test should pass consistently 