### PR TITLE
Issue 1716: (SegmentStore) Reuse physical buffers when creating new DataFrames

### DIFF
--- a/common/src/main/java/io/pravega/common/SimpleMovingAverage.java
+++ b/common/src/main/java/io/pravega/common/SimpleMovingAverage.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common;
+
+import com.google.common.base.Preconditions;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Helps calculate simple moving averages for a number of values. Only the last values added to the series will be included
+ * in the calculation.
+ */
+@NotThreadSafe
+public class SimpleMovingAverage {
+    private final int[] samples;
+    private long sum;
+    private int count;
+    private int lastIndex;
+
+    /**
+     * Creates a new instance of the SimpleMovingAverage class.
+     *
+     * @param count The maximum number of elements to keep track of.
+     */
+    public SimpleMovingAverage(int count) {
+        Preconditions.checkArgument(count > 0, "count must be a positive integer.");
+        this.samples = new int[count];
+        reset();
+    }
+
+    /**
+     * Adds the given value to the moving average. If the moving average is already at capacity, this will overwrite
+     * the oldest value in the series.
+     *
+     * @param value The value to add.
+     */
+    public void add(int value) {
+        int newIndex = (this.lastIndex + 1) % this.samples.length;
+        if (this.count >= this.samples.length) {
+            // We are going to overwrite a value, so subtract it from the grand sum.
+            this.sum -= this.samples[newIndex];
+        } else {
+            this.count++;
+        }
+
+        // Record the new value and update stats.
+        this.samples[newIndex] = value;
+        this.sum += value;
+        this.lastIndex = newIndex;
+    }
+
+    /**
+     * Clears the SimpleMovingAverage of any data.
+     */
+    public void reset() {
+        // No need to clear the array; we will be overwriting it when we repopulate it anyway.
+        this.sum = 0;
+        this.count = 0;
+        this.lastIndex = -1;
+    }
+
+    /**
+     * Gets a value indicating the current moving average.
+     *
+     * @param defaultValue The default value to use.
+     * @return The average, or defaultValue if there are no values recorded.
+     */
+    public double getAverage(double defaultValue) {
+        return this.count == 0 ? defaultValue : (double) this.sum / this.count;
+    }
+}

--- a/common/src/test/java/io/pravega/common/SimpleMovingAverageTests.java
+++ b/common/src/test/java/io/pravega/common/SimpleMovingAverageTests.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common;
+
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the SimpleMovingAve
+ */
+public class SimpleMovingAverageTests {
+    private static final double PRECISION = 0.01;
+    private static final int ADD_COUNT = 1000;
+    private static final int MOVING_COUNT = 10;
+
+    /**
+     * Tests the add() and getAverage() methods.
+     */
+    @Test
+    public void testAdd() {
+        val sma1 = new SimpleMovingAverage(1);
+        val sma10 = new SimpleMovingAverage(MOVING_COUNT);
+        Assert.assertEquals("Unexpected SMA(1) when empty.", -1, sma1.getAverage(-1), PRECISION);
+        Assert.assertEquals("Unexpected SMA(10) when empty.", -1, sma10.getAverage(-1), PRECISION);
+        for (int i = 0; i < ADD_COUNT; i++) {
+            sma1.add(i);
+            sma10.add(i);
+            Assert.assertEquals("Unexpected SMA(1) when adding " + i, i, sma1.getAverage(-1), PRECISION);
+            double expectedResult = getExpected(i);
+            Assert.assertEquals("Unexpected SMA(10) when adding " + i, expectedResult, sma10.getAverage(-1), PRECISION);
+        }
+    }
+
+    /**
+     * Tests the reset() method.
+     */
+    @Test
+    public void testReset() {
+        val sma10 = new SimpleMovingAverage(MOVING_COUNT);
+        for (int i = 0; i < MOVING_COUNT; i++) {
+            sma10.add(i);
+        }
+        sma10.reset();
+        for (int i = 0; i < MOVING_COUNT; i++) {
+            sma10.add(i);
+            double expectedResult = getExpected(i);
+            Assert.assertEquals("Unexpected SMA(10) when adding " + i, expectedResult, sma10.getAverage(-1), PRECISION);
+        }
+    }
+
+    private double getExpected(int i) {
+        // Expected = Sum(1..i) - Sum(1..i-MOVING_COUNT+1)
+        int min = Math.max(0, i - MOVING_COUNT + 1);
+        return (i * (i + 1) - min * (min - 1)) / 2.0 / (i - min + 1);
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -95,6 +95,7 @@ class DataFrameBuilder<T extends LogItem> implements AutoCloseable {
     void flush() {
         Exceptions.checkNotClosed(this.closed.get(), this);
         this.outputStream.flush();
+        this.outputStream.releaseBuffers();
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -95,7 +95,7 @@ class DataFrameBuilder<T extends LogItem> implements AutoCloseable {
     void flush() {
         Exceptions.checkNotClosed(this.closed.get(), this);
         this.outputStream.flush();
-        this.outputStream.releaseBuffers();
+        this.outputStream.releaseBuffer();
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
@@ -235,7 +235,7 @@ class DataFrameOutputStream extends OutputStream {
     @RequiredArgsConstructor
     @NotThreadSafe
     private static class BufferFactory {
-        private static final int DEFAULT_MIN_LENGTH = 8 * 1024;
+        private static final int MIN_LENGTH = 1024; // Min amount of space remaining in the buffer when trying to reuse it.
         private final SimpleMovingAverage lastBuffers = new SimpleMovingAverage(10);
         private final int maxLength;
         private byte[] current;
@@ -265,7 +265,7 @@ class DataFrameOutputStream extends OutputStream {
         void markUsed(int length) {
             this.currentUsed += length;
             this.lastBuffers.add(length);
-            int minLength = (int) this.lastBuffers.getAverage(DEFAULT_MIN_LENGTH);
+            int minLength = (int) Math.max(MIN_LENGTH, this.lastBuffers.getAverage(0));
 
             if (this.current != null && (this.current.length - this.currentUsed < minLength)) {
                 this.current = null;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
@@ -207,9 +207,9 @@ class DataFrameOutputStream extends OutputStream {
     /**
      * Releases any buffers that may be lingering around and are no longer needed.
      */
-    void releaseBuffers() {
+    void releaseBuffer() {
         Exceptions.checkNotClosed(this.closed, this);
-        this.bufferFactory.releaseBuffers();
+        this.bufferFactory.reset();
     }
 
     private void createNewFrame() {
@@ -268,16 +268,17 @@ class DataFrameOutputStream extends OutputStream {
             int minLength = (int) this.lastBuffers.getAverage(DEFAULT_MIN_LENGTH);
 
             if (this.current != null && (this.current.length - this.currentUsed < minLength)) {
-                releaseBuffers();
+                this.current = null;
             }
         }
 
         /**
-         * Releases the current buffer (if any). After this method is called, the first call to next() will allocate a new
-         * buffer.
+         * Releases the current buffer (if any) and resets the stats. After this method is called, the first call to next()
+         * will allocate a new buffer.
          */
-        void releaseBuffers() {
+        void reset() {
             this.current = null;
+            this.lastBuffers.reset();
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
@@ -11,12 +11,14 @@ package io.pravega.segmentstore.server.logs;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
+import io.pravega.common.SimpleMovingAverage;
 import io.pravega.common.util.ByteArraySegment;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * An OutputStream that abstracts writing to Data Frames. Allows writing arbitrary bytes, and seamlessly transitions
@@ -26,12 +28,12 @@ import lombok.Getter;
 class DataFrameOutputStream extends OutputStream {
     //region Members
 
-    private final int maxDataFrameSize;
     private final Consumer<DataFrame> dataFrameCompleteCallback;
     private DataFrame currentFrame;
     private boolean hasDataInCurrentFrame;
     @Getter
     private boolean closed;
+    private final BufferFactory bufferFactory;
 
     //endregion
 
@@ -46,9 +48,10 @@ class DataFrameOutputStream extends OutputStream {
      * @throws NullPointerException     If any of the arguments are null.
      */
     DataFrameOutputStream(int maxDataFrameSize, Consumer<DataFrame> dataFrameCompleteCallback) {
-        Exceptions.checkArgument(maxDataFrameSize > 0, "maxDataFrameSize", "Must be a positive integer.");
+        Exceptions.checkArgument(maxDataFrameSize > DataFrame.MIN_ENTRY_LENGTH_NEEDED, "maxDataFrameSize",
+                "Must be a at least %s.", DataFrame.MIN_ENTRY_LENGTH_NEEDED);
 
-        this.maxDataFrameSize = maxDataFrameSize;
+        this.bufferFactory = new BufferFactory(maxDataFrameSize);
         this.dataFrameCompleteCallback = Preconditions.checkNotNull(dataFrameCompleteCallback, "dataFrameCompleteCallback");
     }
 
@@ -127,6 +130,7 @@ class DataFrameOutputStream extends OutputStream {
         // Invoke the callback. At the end of this, the frame is committed so we can get rid of it.
         if (!this.currentFrame.isEmpty()) {
             // Only flush something if it's not empty.
+            this.bufferFactory.markUsed(this.currentFrame.getLength());
             this.dataFrameCompleteCallback.accept(this.currentFrame);
         }
 
@@ -200,10 +204,18 @@ class DataFrameOutputStream extends OutputStream {
         this.hasDataInCurrentFrame = false;
     }
 
+    /**
+     * Releases any buffers that may be lingering around and are no longer needed.
+     */
+    void releaseBuffers() {
+        Exceptions.checkNotClosed(this.closed, this);
+        this.bufferFactory.releaseBuffers();
+    }
+
     private void createNewFrame() {
         Preconditions.checkState(this.currentFrame == null || this.currentFrame.isSealed(), "Cannot create a new frame if we currently have a non-sealed frame.");
 
-        this.currentFrame = new DataFrame(this.maxDataFrameSize);
+        this.currentFrame = DataFrame.wrap(this.bufferFactory.next());
         this.hasDataInCurrentFrame = false;
     }
 
@@ -216,5 +228,59 @@ class DataFrameOutputStream extends OutputStream {
     }
 
     //endregion
+
+    /**
+     * Buffer Factory for use with DataFrames.
+     */
+    @RequiredArgsConstructor
+    @NotThreadSafe
+    private static class BufferFactory {
+        private static final int DEFAULT_MIN_LENGTH = 8 * 1024;
+        private final SimpleMovingAverage lastBuffers = new SimpleMovingAverage(10);
+        private final int maxLength;
+        private byte[] current;
+        private int currentUsed;
+
+        /**
+         * Gets a ByteArraySegment that can be used as a DataFrame buffer, which wraps a physical buffer (byte array).
+         * Tries to reuse the last used physical buffer as much as possible if space allows, otherwise a new byte array
+         * will be allocated.
+         *
+         * @return The ByteArraySegment to use.
+         */
+        ByteArraySegment next() {
+            if (this.current == null) {
+                this.current = new byte[this.maxLength];
+                this.currentUsed = 0;
+            }
+
+            return new ByteArraySegment(this.current, this.currentUsed, this.current.length - this.currentUsed);
+        }
+
+        /**
+         * Indicates that the given number of bytes have been used in the given buffer.
+         *
+         * @param length The number of bytes used.
+         */
+        void markUsed(int length) {
+            this.currentUsed += length;
+            this.lastBuffers.add(length);
+            int minLength = (int) this.lastBuffers.getAverage(DEFAULT_MIN_LENGTH);
+
+            if (this.current != null && (this.current.length - this.currentUsed < minLength)) {
+                releaseBuffers();
+            }
+        }
+
+        /**
+         * Releases the current buffer (if any). After this method is called, the first call to next() will allocate a new
+         * buffer.
+         */
+        void releaseBuffers() {
+            this.current = null;
+        }
+    }
+
+
 }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
@@ -496,7 +496,7 @@ class DataFrameReader<T extends LogItem> implements CloseableIterator<DataFrameR
 
             DataFrame frame;
             try {
-                frame = new DataFrame(nextItem.getPayload(), nextItem.getLength());
+                frame = DataFrame.from(nextItem.getPayload(), nextItem.getLength());
                 frame.setAddress(nextItem.getAddress());
             } catch (SerializationException ex) {
                 throw new DataCorruptionException(String.format("Unable to deserialize DataFrame. LastReadFrameSequence =  %d.",

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
@@ -120,7 +120,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
             // Read all entries in the Log and interpret them as DataFrames, then verify the records can be reconstructed.
             await(() -> commitFrames.size() >= order.size(), 20);
 
-            List<DataFrame> frames = dataLog.getAllEntries(readItem -> new DataFrame(readItem.getPayload(), readItem.getLength()));
+            List<DataFrame> frames = dataLog.getAllEntries(readItem -> DataFrame.from(readItem.getPayload(), readItem.getLength()));
             Assert.assertEquals("Unexpected number of frames generated.", commitFrames.size(), frames.size());
 
             // Check the correctness of the commit callback.
@@ -209,7 +209,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
         AssertExtensions.assertListEquals("Items read back do not match expected values.", expectedItems, readItems, TestLogItem::equals);
 
         // Read all entries in the Log and interpret them as DataFrames, then verify the records can be reconstructed.
-        List<DataFrame> frames = dataLog.getAllEntries(ri -> new DataFrame(ri.getPayload(), ri.getLength()));
+        List<DataFrame> frames = dataLog.getAllEntries(ri -> DataFrame.from(ri.getPayload(), ri.getLength()));
 
         // Check the correctness of the commit callback.
         AssertExtensions.assertGreaterThan("Not enough Data Frames were generated.", 1, frames.size());
@@ -256,7 +256,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
             Assert.assertEquals("Exactly one Data Frame was expected so far.", 1, commitFrames.size());
 
             //Read all entries in the Log and interpret them as DataFrames, then verify the records can be reconstructed.
-            List<DataFrame> frames = dataLog.getAllEntries(readItem -> new DataFrame(readItem.getPayload(), readItem.getLength()));
+            List<DataFrame> frames = dataLog.getAllEntries(readItem -> DataFrame.from(readItem.getPayload(), readItem.getLength()));
             Assert.assertEquals("Unexpected number of frames generated.", commitFrames.size(), frames.size());
             DataFrameTestHelpers.checkReadRecords(frames, records, r -> new ByteArraySegment(r.getFullSerialization()));
         }
@@ -310,7 +310,7 @@ public class DataFrameBuilderTests extends ThreadPooledTestSuite {
             }
 
             //Read all entries in the Log and interpret them as DataFrames, then verify the records can be reconstructed.
-            List<DataFrame> frames = dataLog.getAllEntries(readItem -> new DataFrame(readItem.getPayload(), readItem.getLength()));
+            List<DataFrame> frames = dataLog.getAllEntries(readItem -> DataFrame.from(readItem.getPayload(), readItem.getLength()));
             DataFrameTestHelpers.checkReadRecords(frames, records, r -> new ByteArraySegment(r.getFullSerialization()));
         }
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.logs;
 
+import io.pravega.common.util.ArrayView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
@@ -18,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import lombok.Cleanup;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -79,6 +81,46 @@ public class DataFrameOutputStreamTests {
         Assert.assertNotNull("No frame has been created when flush() was called.", writtenFrame);
         Assert.assertTrue("Created frame is not sealed.", writtenFrame.get().isSealed());
         DataFrameTestHelpers.checkReadRecords(writtenFrame.get(), records, ByteArraySegment::new);
+    }
+
+    /**
+     * Tests the ability to reuse existing physical buffers, and discard them if needed.
+     */
+    @Test
+    public void testBufferReuse() throws Exception {
+        final int count = 500;
+        final int resetEvery = 50;
+        final byte[] writeData = new byte[1000];
+        final int maxFrameSize = 10 * 1024;
+
+        // Callback for when a frame is written.
+        AtomicReference<DataFrame> writtenFrame = new AtomicReference<>();
+
+        int expectedStartIndex = 0;
+        @Cleanup
+        DataFrameOutputStream s = new DataFrameOutputStream(maxFrameSize, writtenFrame::set);
+        for (int i = 0; i < count; i++) {
+            if (i % resetEvery == 0) {
+                s.releaseBuffers();
+                expectedStartIndex = 0;
+            }
+
+            // We generate some frame of fixed size.
+            s.startNewRecord();
+            s.write(writeData);
+            s.endRecord();
+            s.flush();
+
+            // Then we inspect it's ArrayView's buffer characteristics, especially the array offset. If it increases as
+            // expect it to (and then resets when it exceeds a certain size), then we know the same physical buffer is
+            // reused.
+            ArrayView av = writtenFrame.getAndSet(null).getData();
+            Assert.assertEquals("Unexpected buffer index after flush #" + (i + 1), expectedStartIndex, av.arrayOffset());
+            expectedStartIndex += av.getLength();
+            if (maxFrameSize - expectedStartIndex < av.getLength()) {
+                expectedStartIndex = 0;
+            }
+        }
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
@@ -101,7 +101,7 @@ public class DataFrameOutputStreamTests {
         DataFrameOutputStream s = new DataFrameOutputStream(maxFrameSize, writtenFrame::set);
         for (int i = 0; i < count; i++) {
             if (i % resetEvery == 0) {
-                s.releaseBuffers();
+                s.releaseBuffer();
                 expectedStartIndex = 0;
             }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.server.logs;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.test.common.AssertExtensions;
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import lombok.val;
 import org.junit.Assert;
@@ -39,7 +40,7 @@ public class DataFrameTests {
         List<ByteArraySegment> allRecords = DataFrameTestHelpers.generateRecords(maxRecordCount, minRecordSize, maxRecordSize, ByteArraySegment::new);
 
         // Append some records.
-        DataFrame df = new DataFrame(maxFrameSize);
+        DataFrame df = DataFrame.ofSize(maxFrameSize);
         int recordsAppended = appendRecords(allRecords, df);
         AssertExtensions.assertGreaterThan("Did not append enough records. Test may not be valid.", allRecords.size() / 2, recordsAppended);
         df.seal();
@@ -61,7 +62,7 @@ public class DataFrameTests {
         List<ByteArraySegment> allRecords = DataFrameTestHelpers.generateRecords(maxRecordCount, minRecordSize, maxRecordSize, ByteArraySegment::new);
 
         // Append some records.
-        DataFrame writeFrame = new DataFrame(maxFrameSize);
+        DataFrame writeFrame = DataFrame.ofSize(maxFrameSize);
         int recordsAppended = appendRecords(allRecords, writeFrame);
         AssertExtensions.assertGreaterThan("Did not append enough records. Test may not be valid.", allRecords.size() / 2, recordsAppended);
         writeFrame.seal();
@@ -70,7 +71,7 @@ public class DataFrameTests {
         Assert.assertEquals("Unexpected length from getData().", writeFrame.getLength(), frameData.getLength());
 
         // Read them back, by deserializing the frame.
-        DataFrame readFrame = new DataFrame(new ByteArraySegment(frameData.array(), frameData.arrayOffset(), frameData.getLength()));
+        DataFrame readFrame = DataFrame.from(new ByteArrayInputStream(frameData.array(), frameData.arrayOffset(), frameData.getLength()), frameData.getLength());
         DataFrameTestHelpers.checkReadRecords(readFrame, allRecords, b -> b);
     }
 
@@ -80,7 +81,7 @@ public class DataFrameTests {
     @Test
     public void testStartEndDiscardEntry() {
         int dataFrameSize = 1000;
-        DataFrame df = new DataFrame(dataFrameSize);
+        DataFrame df = DataFrame.ofSize(dataFrameSize);
         AssertExtensions.assertThrows(
                 "append(byte) worked even though no entry started.",
                 () -> df.append((byte) 1),
@@ -159,7 +160,7 @@ public class DataFrameTests {
     public void testFrameSequence() {
         long newSequence = 67890;
         int dataFrameSize = 1000;
-        DataFrame df = new DataFrame(dataFrameSize);
+        DataFrame df = DataFrame.ofSize(dataFrameSize);
 
         LogAddress a = new LogAddress(newSequence) {
         };

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -840,7 +840,7 @@ public class DurableLogTests extends OperationLogTestBase {
                         if (readCounter.incrementAndGet() > failReadAfter && readItem.getLength() > DataFrame.MIN_ENTRY_LENGTH_NEEDED) {
                             // Mangle with the payload and overwrite its contents with a DataFrame having a bogus
                             // previous sequence number.
-                            DataFrame df = new DataFrame(readItem.getLength());
+                            DataFrame df = DataFrame.ofSize(readItem.getLength());
                             df.seal();
                             ArrayView serialization = df.getData();
                             return new InjectedReadItem(serialization.getReader(), serialization.getLength(), readItem.getAddress());


### PR DESCRIPTION
**Change log description**
Previously, every time we create a `DataFrame` a new 1MB buffer is allocated, regardless of how big the frame ends up being (whether 1KB or 1MB). This 1MB buffer is pointed to as long as the `DataFrame` exists, which is only "released" after it is written to BookKeeper. In case BookKeeper is backed up, a lot of these frames can exist at any given times, hence a lot of 1MB buffers.

In this change, we attempt to improve the situation by reusing the previously used buffer, if it still has capacity. Main points:
- We keep track of the length of the last 10 built `DataFrames`.
- DataFrames already take a `ByteArraySegment` as input. The `DataFrameOutputStream` has been changed to return a sub-segment of a physical byte array vs a `ByteArraySegment` that wraps a new byte array.
- We also keep track of the last used offset inside this physical array. When asked to allocate a new `DataFrame` it tries to use the same buffer, but from the last used offset (until its end).
- This buffer is also released when: 
    - Not enough space is available (based on the average of the last 10 `DataFrame` lengths).
    - We have no more data to write (no more operations, thus not a high chance of requiring a `DataFrame` soon), thus releasing the 1MB buffer.
    - Since the buffer is used by consecutive `DataFrame`s, it will be released to the GC rather quickly, as soon as the last `DataFrame` that uses it is written to BK.
- With this change, we only use as much memory as we actually need, with very little waste (much less than before).

**Purpose of the change**
Fixes #1716.

**What the code does**
Attempts to reuse the previously used buffer, if possible.

**How to verify it**
All unit tests must pass. New unit tests added to verify buffer reuse and release.
SelfTester can be used to stress-test the SegmentStore and verify memory usage.