### PR TITLE
Issue 1720: (SegmentStore) BugFix for CacheManager when Read Indices are empty

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheManager.java
@@ -209,10 +209,6 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         int maxGeneration = 0;
         long totalSize = 0;
         Collection<Client> clients = getCurrentClients();
-        if (clients.size() == 0) {
-            return null;
-        }
-
         for (Client c : clients) {
             CacheStatus clientStatus;
             try {
@@ -236,6 +232,11 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
 
             minGeneration = Math.min(minGeneration, clientStatus.oldestGeneration);
             maxGeneration = Math.max(maxGeneration, clientStatus.newestGeneration);
+        }
+
+        if (minGeneration > maxGeneration) {
+            // Either no clients or clients are empty.
+            return null;
         }
 
         return new CacheStatus(totalSize, minGeneration, maxGeneration);


### PR DESCRIPTION
**Change log description**
Fixed a bug where the CacheManager would throw errors (harmless) if it has registered clients that have no data in them.

**Purpose of the change**
Fixes #1720.

**What the code does**
CacheManager takes no action if either:
1. There are no registered clients (read indices) - this is pre-existing.
2. There are clients, but they have no data.

**How to verify it**
Added new unit test to verify scenario.