### PR TITLE
Issue 1726: System test and sporadic build failure with timeouts:  Manual scale is stuck and never completes. 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -346,7 +346,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
                                                             final List<AbstractMap.SimpleEntry<Double, Double>> newRanges,
                                                             final long scaleTimestamp,
                                                             boolean runOnlyIfStarted) {
-        return verifyState(() -> getHistoryTable()
+        return getHistoryTable()
                 .thenCompose(historyTable -> getSegmentTable().thenApply(segmentTable -> new ImmutablePair<>(historyTable, segmentTable)))
                 .thenCompose(pair -> {
                     final Data<T> segmentTable = pair.getRight();
@@ -380,9 +380,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
                         epochStartSegmentpair.getRight() + newRanges.size())
                         .boxed()
                         .collect(Collectors.toList()))
-                        .thenApply(newSegments -> new StartScaleResponse(epochStartSegmentpair.getLeft(), newSegments))),
-                Lists.newArrayList(State.ACTIVE, State.SCALING)
-        );
+                        .thenApply(newSegments -> new StartScaleResponse(epochStartSegmentpair.getLeft(), newSegments)));
     }
 
     private CompletableFuture<ImmutablePair<Integer, Integer>> scaleCreateNewSegments(final List<SimpleEntry<Double, Double>> newRanges,
@@ -395,8 +393,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
         final Data<T> updatedData = new Data<>(updated, segmentTable.getVersion());
 
         return setSegmentTable(updatedData)
-                .thenApply(z -> new ImmutablePair<>(activeEpoch, nextSegmentNumber))
-                .thenCompose(response -> updateState(State.SCALING).thenApply(x -> response));
+                .thenApply(z -> new ImmutablePair<>(activeEpoch, nextSegmentNumber));
     }
 
     private CompletableFuture<ImmutablePair<Integer, Integer>> isScaleRerun(final List<Integer> sealedSegments,

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -396,10 +396,10 @@ public abstract class PersistentStreamBase<T> implements Stream {
 
         return setSegmentTable(updatedData)
                 .thenApply(z -> new ImmutablePair<>(activeEpoch, nextSegmentNumber))
-                .thenCompose(response -> updateState(State.SCALING).thenApply(x -> {
+                .thenApply(response -> {
                     log.debug("scale {}/{} new segments created successfully", scope, name);
                     return response;
-                }));
+                });
     }
 
     private CompletableFuture<ImmutablePair<Integer, Integer>> isScaleRerun(final List<Integer> sealedSegments,

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -326,18 +326,19 @@ public class StreamMetadataTasks extends TaskBase {
                 context,
                 executor), executor)
                 .thenCompose(response -> streamMetadataStore.setState(scaleInput.getScope(), scaleInput.getStream(), State.SCALING, context, executor)
-                        .thenCompose(updated -> notifyNewSegments(scaleInput.getScope(), scaleInput.getStream(), response.getSegmentsCreated(), context)
-                                .thenCompose(x -> {
-                                    assert !response.getSegmentsCreated().isEmpty();
+                        .thenApply(updated -> response))
+                .thenCompose(response -> notifyNewSegments(scaleInput.getScope(), scaleInput.getStream(), response.getSegmentsCreated(), context)
+                        .thenCompose(x -> {
+                            assert !response.getSegmentsCreated().isEmpty();
 
-                                    long scaleTs = response.getSegmentsCreated().get(0).getStart();
+                            long scaleTs = response.getSegmentsCreated().get(0).getStart();
 
-                                    return withRetries(() -> streamMetadataStore.scaleNewSegmentsCreated(scaleInput.getScope(), scaleInput.getStream(),
-                                            scaleInput.getSegmentsToSeal(), response.getSegmentsCreated(), response.getActiveEpoch(),
-                                            scaleTs, context, executor), executor);
-                                })
-                                .thenCompose(x -> tryCompleteScale(scaleInput.getScope(), scaleInput.getStream(), response.getActiveEpoch(), context))
-                                .thenApply(y -> response.getSegmentsCreated())));
+                            return withRetries(() -> streamMetadataStore.scaleNewSegmentsCreated(scaleInput.getScope(), scaleInput.getStream(),
+                                    scaleInput.getSegmentsToSeal(), response.getSegmentsCreated(), response.getActiveEpoch(),
+                                    scaleTs, context, executor), executor);
+                        })
+                        .thenCompose(x -> tryCompleteScale(scaleInput.getScope(), scaleInput.getStream(), response.getActiveEpoch(), context))
+                        .thenApply(y -> response.getSegmentsCreated()));
     }
 
     /**

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -125,6 +125,7 @@ public class ControllerServiceTest {
         scaleTs = System.currentTimeMillis();
         StartScaleResponse startScaleResponse = streamStore.startScale(SCOPE, stream1, sealedSegments, Arrays.asList(segment1, segment2), startTs + 20, false, null, executor).get();
         List<Segment> segmentCreated = startScaleResponse.getSegmentsCreated();
+        streamStore.setState(SCOPE, stream1, State.SCALING, null, executor).get();
         streamStore.scaleNewSegmentsCreated(SCOPE, stream1, sealedSegments, segmentCreated, startScaleResponse.getActiveEpoch(), scaleTs, null, executor).get();
         streamStore.scaleSegmentsSealed(SCOPE, stream1, sealedSegments, segmentCreated, startScaleResponse.getActiveEpoch(), scaleTs, null, executor).get();
 
@@ -134,6 +135,7 @@ public class ControllerServiceTest {
         sealedSegments = Arrays.asList(0, 1, 2);
         startScaleResponse = streamStore.startScale(SCOPE, stream2, sealedSegments, Arrays.asList(segment3, segment4, segment5), startTs + 20, false, null, executor).get();
         segmentCreated = startScaleResponse.getSegmentsCreated();
+        streamStore.setState(SCOPE, stream2, State.SCALING, null, executor).get();
         streamStore.scaleNewSegmentsCreated(SCOPE, stream2, sealedSegments, segmentCreated, startScaleResponse.getActiveEpoch(), scaleTs, null, executor).get();
         streamStore.scaleSegmentsSealed(SCOPE, stream2, sealedSegments, segmentCreated, startScaleResponse.getActiveEpoch(), scaleTs, null, executor).get();
         // endregion

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -223,6 +223,7 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
         StartScaleResponse response = store.startScale(scope, stream, existingSegments, newRanges,
                 scaleTimestamp, false, null, executor).join();
         List<Segment> segmentsCreated = response.getSegmentsCreated();
+        store.setState(scope, stream, State.SCALING, null, executor).join();
         store.scaleNewSegmentsCreated(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(),
                 scaleTimestamp, null, executor).join();
         store.scaleSegmentsSealed(scope, stream, existingSegments, segmentsCreated, response.getActiveEpoch(),

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -253,6 +253,7 @@ public class ZkStreamTest {
         ArrayList<Integer> sealedSegments = Lists.newArrayList(3, 4);
         StartScaleResponse response = store.startScale(SCOPE, streamName, sealedSegments, newRanges, scale1, false, context, executor).get();
         List<Segment> newSegments = response.getSegmentsCreated();
+        store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
         store.scaleNewSegmentsCreated(SCOPE, streamName, sealedSegments, newSegments, response.getActiveEpoch(), scale1, context, executor).get();
         store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments, newSegments, response.getActiveEpoch(), scale1, context, executor).get();
 
@@ -271,6 +272,7 @@ public class ZkStreamTest {
         ArrayList<Integer> sealedSegments1 = Lists.newArrayList(1, 2, 5);
         response = store.startScale(SCOPE, streamName, sealedSegments1, newRanges, scale2, false, context, executor).get();
         List<Segment> segmentsCreated = response.getSegmentsCreated();
+        store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
         store.scaleNewSegmentsCreated(SCOPE, streamName, sealedSegments1, segmentsCreated, response.getActiveEpoch(), scale2, context, executor).get();
         store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments1, segmentsCreated, response.getActiveEpoch(), scale2, context, executor).get();
 
@@ -289,6 +291,7 @@ public class ZkStreamTest {
         ArrayList<Integer> sealedSegments2 = Lists.newArrayList(7, 8);
         response = store.startScale(SCOPE, streamName, sealedSegments2, newRanges, scale3, false, context, executor).get();
         segmentsCreated = response.getSegmentsCreated();
+        store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
         store.scaleNewSegmentsCreated(SCOPE, streamName, sealedSegments2, segmentsCreated, response.getActiveEpoch(), scale3, context, executor).get();
         store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments2, segmentsCreated, response.getActiveEpoch(), scale3, context, executor).get();
 

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -9,12 +9,20 @@
  */
 package io.pravega.controller.task.Stream;
 
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.Transaction;
+import io.pravega.common.ExceptionHelpers;
 import io.pravega.controller.mocks.EventStreamWriterMock;
 import io.pravega.controller.mocks.ScaleEventStreamWriterMock;
+import io.pravega.controller.server.eventProcessor.ScaleOpEvent;
+import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.ScaleOperationExceptions;
 import io.pravega.controller.store.stream.StartScaleResponse;
+import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.tables.State;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
+import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.controller.server.ControllerService;
@@ -34,6 +42,8 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import lombok.Data;
+import lombok.Getter;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -47,6 +57,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -116,6 +127,7 @@ public class StreamMetadataTasksTest {
         List<Integer> sealedSegments = Collections.singletonList(1);
         StartScaleResponse response = streamStorePartialMock.startScale(SCOPE, stream1, sealedSegments, Arrays.asList(segment1, segment2), start + 20, false, null, executor).get();
         List<Segment> segmentsCreated = response.getSegmentsCreated();
+        streamStorePartialMock.setState(SCOPE, stream1, State.SCALING, null, executor).get();
         streamStorePartialMock.scaleNewSegmentsCreated(SCOPE, stream1, sealedSegments, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
         streamStorePartialMock.scaleSegmentsSealed(SCOPE, stream1, sealedSegments, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
     }
@@ -187,5 +199,90 @@ public class StreamMetadataTasksTest {
 
         scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 5, null).get();
         assertEquals(Controller.ScaleStatusResponse.ScaleStatus.INVALID_INPUT, scaleStatusResult.getStatus());
+    }
+
+    @Test
+    public void manualScaleTest() throws Exception {
+        final ScalingPolicy policy = ScalingPolicy.fixed(1);
+
+        final StreamConfiguration configuration = StreamConfiguration.builder().scope(SCOPE).streamName("test").scalingPolicy(policy).build();
+
+        streamStorePartialMock.createStream(SCOPE, "test", configuration, System.currentTimeMillis(), null, executor).get();
+        streamStorePartialMock.setState(SCOPE, "test", State.ACTIVE, null, executor).get();
+
+        WriterMock requestEventWriter = new WriterMock(streamMetadataTasks, executor);
+        streamMetadataTasks.setRequestEventWriter(requestEventWriter);
+        List<AbstractMap.SimpleEntry<Double, Double>> newRanges = new ArrayList<>();
+        newRanges.add(new AbstractMap.SimpleEntry<>(0.0, 0.5));
+        newRanges.add(new AbstractMap.SimpleEntry<>(0.5, 1.0));
+        ScaleResponse scaleOpResult = streamMetadataTasks.manualScale(SCOPE, "test", Collections.singletonList(0),
+                newRanges, 30, null).get();
+
+        assertEquals(ScaleStreamStatus.STARTED, scaleOpResult.getStatus());
+        // explicitly set the state to active.
+        OperationContext context = streamStorePartialMock.createContext(SCOPE, "test");
+        assertEquals(streamStorePartialMock.getState(SCOPE, "test", context, executor).get(), State.ACTIVE);
+
+        // Now when startScale runs even after that we should get the state as active.
+        StartScaleResponse response = streamStorePartialMock.startScale(SCOPE, "test", Collections.singletonList(0), newRanges, 30, true, null, executor).get();
+        assertEquals(response.getActiveEpoch(), 0);
+        assertEquals(streamStorePartialMock.getState(SCOPE, "test", context, executor).get(), State.ACTIVE);
+
+        AssertExtensions.assertThrows("", () -> streamStorePartialMock.scaleNewSegmentsCreated(SCOPE, "test",
+                Collections.singletonList(0), response.getSegmentsCreated(),
+                response.getActiveEpoch(), 30, context, executor).get(),
+                ex -> ExceptionHelpers.getRealException(ex) instanceof StoreException.IllegalStateException);
+
+        List<Segment> segments = streamMetadataTasks.startScale(requestEventWriter.getScaleOp(), true, context).get();
+
+        assertTrue(segments.stream().anyMatch(x -> x.getNumber() == 1 && x.getKeyStart() == 0.0 && x.getKeyEnd() == 0.5));
+        assertTrue(segments.stream().anyMatch(x -> x.getNumber() == 2 && x.getKeyStart() == 0.5 && x.getKeyEnd() == 1.0));
+    }
+
+    @Data
+    public class WriterMock implements EventStreamWriter<ControllerEvent> {
+        private final StreamMetadataTasks streamMetadataTasks;
+        private final ScheduledExecutorService executor;
+        @Getter
+        private ScaleOpEvent scaleOp;
+
+        @Override
+        public CompletableFuture<Void> writeEvent(ControllerEvent event) {
+            if (event instanceof ScaleOpEvent) {
+                scaleOp = (ScaleOpEvent) event;
+            }
+
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeEvent(String routingKey, ControllerEvent event) {
+            return writeEvent(event);
+        }
+
+        @Override
+        public Transaction<ControllerEvent> beginTxn(long transactionTimeout, long maxExecutionTime, long scaleGracePeriod) {
+            return null;
+        }
+
+        @Override
+        public Transaction<ControllerEvent> getTxn(UUID transactionId) {
+            return null;
+        }
+
+        @Override
+        public EventWriterConfig getConfig() {
+            return null;
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() {
+
+        }
     }
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -219,7 +219,6 @@ public class StreamMetadataTasksTest {
                 newRanges, 30, null).get();
 
         assertEquals(ScaleStreamStatus.STARTED, scaleOpResult.getStatus());
-        // explicitly set the state to active.
         OperationContext context = streamStorePartialMock.createContext(SCOPE, "test");
         assertEquals(streamStorePartialMock.getState(SCOPE, "test", context, executor).get(), State.ACTIVE);
 

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -127,6 +127,7 @@ public class TaskTest {
         List<Integer> sealedSegments = Collections.singletonList(1);
         StartScaleResponse response = streamStore.startScale(SCOPE, stream1, sealedSegments, Arrays.asList(segment1, segment2), start + 20, false, null, executor).get();
         List<Segment> segmentsCreated = response.getSegmentsCreated();
+        streamStore.setState(SCOPE, stream1, State.SCALING, null, executor).get();
         streamStore.scaleNewSegmentsCreated(SCOPE, stream1, sealedSegments, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
         streamStore.scaleSegmentsSealed(SCOPE, stream1, sealedSegments, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
 
@@ -135,8 +136,8 @@ public class TaskTest {
         AbstractMap.SimpleEntry<Double, Double> segment5 = new AbstractMap.SimpleEntry<>(0.75, 1.0);
         List<Integer> sealedSegments1 = Arrays.asList(0, 1, 2);
         response = streamStore.startScale(SCOPE, stream2, sealedSegments1, Arrays.asList(segment3, segment4, segment5), start + 20, false, null, executor).get();
-
         segmentsCreated = response .getSegmentsCreated();
+        streamStore.setState(SCOPE, stream2, State.SCALING, null, executor).get();
         streamStore.scaleNewSegmentsCreated(SCOPE, stream2, sealedSegments1, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
         streamStore.scaleSegmentsSealed(SCOPE, stream2, sealedSegments1, segmentsCreated, response.getActiveEpoch(), start + 20, null, executor).get();
         // endregion


### PR DESCRIPTION
**Change log description**
In manual scale we did two steps before returning to the caller -->
1. create new segments in metadata store
2. set stream state to scaling

The scale operation is picked and run concurrently with manual scale which checks if scale has been started (runonlyifstarted) and if so, it moved to subsequent steps like creating segments in SSS and adding partial record to history table. 

Since both these could happen concurrently, there was a race between setting state to SCALING and updating history table with partial record which expects state to be SCALING.

Hence we sporadically got Illegal State exception thrown by addPartialRecordToHistoryTable. 

This had few other problems: If controller instance handling manual scale crashed after creating the segments but before setting state to scaling, no subsequent scale operation can be executed on the stream and the stream state would never move to SCALING either. 
 Also, if another state change request like say sealing or update configuration ran concurrently with scale and succeeded in updating the state first, then scale would not retry but fail with illegalstateexception.
with current change, if scale is unable to update the state after having updated the segment table, it can keep retrying until scale succeeds eventually. 
**Purpose of the change**
Fixes issue 1726

**What the code does**

We fix the issue by moving state set to SCALING out of store.startScale method and making it part of streamMetadataTask to explicitly set the state to scaling once store.startScale returns. 

This will ensure that a scale operation once started, will always complete and we will never break because of illegal state exception. 
Also, updated existing unit tests which use store.startScale to also explicitly setState to scaling. 

**How to verify it**
New unit test added. 
All unit tests should pass. 