### PR TITLE
Issue1521 : Create a system property to configure client's internal thread pool size

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -50,12 +50,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ConnectionFactoryImpl implements ConnectionFactory {
 
+    private static final Integer POOL_SIZE = Integer.valueOf(
+            System.getProperty("pravega.client.internal.threadpool.size",
+                    String.valueOf(Runtime.getRuntime().availableProcessors())));
     private final boolean ssl;
     private EventLoopGroup group;
     private boolean nio = false;
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(
-            Runtime.getRuntime().availableProcessors(),
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(POOL_SIZE,
             new ThreadFactoryBuilder().setNameFormat("clientInternal-%d").build());
 
     /**


### PR DESCRIPTION
**Change log description**
System property `pravega.client.internal.threadpool.size` can now be used to configure clients internal thread pool size.  This thread pool is used to handle connection failures / reconnects and handle processing of segment sealed exception.

**Purpose of the change**
Make the client's internal thread pool size configurable.
**What the code does**
Fixes 1521
**How to verify it**
Tests should pass.
