### PR TITLE
Issue 1725: Delete old epoch during Txn completion step iff new epoch has been created during the scale operation.

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -443,7 +443,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
                 .thenCompose(historyTable -> {
                     CompletableFuture<Boolean> result = new CompletableFuture<>();
 
-                    if (TableHelper.isPartialHistoryRecord(historyTable.getData())) {
+                    if (TableHelper.isNewEpochCreated(historyTable.getData())) {
                         deleteEpochNode(epoch)
                                 .whenComplete((r, e) -> {
                                     if (e != null) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -440,13 +440,10 @@ public abstract class PersistentStreamBase<T> implements Stream {
     @Override
     public CompletableFuture<Boolean> scaleTryDeleteEpoch(final int epoch) {
         return getHistoryTableFromStore()
-                .thenCompose(historyTable -> getSegmentTableFromStore().thenApply(segmentTable -> new ImmutablePair<>(historyTable, segmentTable)))
-                .thenCompose(pair -> {
-                    Data<T> segmentTable = pair.getRight();
-                    Data<T> historyTable = pair.getLeft();
+                .thenCompose(historyTable -> {
                     CompletableFuture<Boolean> result = new CompletableFuture<>();
 
-                    if (TableHelper.isScaleOngoing(historyTable.getData(), segmentTable.getData())) {
+                    if (TableHelper.isPartialHistoryRecord(historyTable.getData())) {
                         deleteEpochNode(epoch)
                                 .whenComplete((r, e) -> {
                                     if (e != null) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/tables/TableHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/tables/TableHelper.java
@@ -431,6 +431,16 @@ public class TableHelper {
     }
 
     /**
+     * Method to check if a scale operation is currently ongoing and has created a new epoch (presence of partial record).
+     * @param historyTable history table
+     * @return true if a scale operation is ongoing, false otherwise
+     */
+    public static boolean isPartialHistoryRecord(final byte[] historyTable) {
+        HistoryRecord latestHistoryRecord = HistoryRecord.readLatestRecord(historyTable, false).get();
+        return latestHistoryRecord.isPartial();
+    }
+
+    /**
      * Method to check if no scale operation is currently ongoing and scale operation can be performed with given input.
      * @param segmentsToSeal segments to seal
      * @param historyTable history table

--- a/controller/src/main/java/io/pravega/controller/store/stream/tables/TableHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/tables/TableHelper.java
@@ -435,7 +435,7 @@ public class TableHelper {
      * @param historyTable history table
      * @return true if a scale operation is ongoing, false otherwise
      */
-    public static boolean isPartialHistoryRecord(final byte[] historyTable) {
+    public static boolean isNewEpochCreated(final byte[] historyTable) {
         HistoryRecord latestHistoryRecord = HistoryRecord.readLatestRecord(historyTable, false).get();
         return latestHistoryRecord.isPartial();
     }

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -476,20 +476,21 @@ public abstract class StreamMetadataStoreTest {
         store.setState(scope, stream, State.ACTIVE, null, executor).get();
 
         long scaleTs = System.currentTimeMillis();
-        SimpleEntry<Double, Double> segment1 = new SimpleEntry<>(0.5, 0.75);
-        SimpleEntry<Double, Double> segment2 = new SimpleEntry<>(0.75, 1.0);
+        SimpleEntry<Double, Double> segment2 = new SimpleEntry<>(0.5, 0.75);
+        SimpleEntry<Double, Double> segment3 = new SimpleEntry<>(0.75, 1.0);
         List<Integer> scale1SealedSegments = Collections.singletonList(1);
 
+        // region Txn created before scale and during scale
         // scale with transaction test
         VersionedTransactionData tx1 = store.createTransaction(scope, stream, UUID.randomUUID(),
                 100, 100, 100, null, executor).get();
         assertEquals(0, tx1.getEpoch());
         StartScaleResponse response = store.startScale(scope, stream, scale1SealedSegments,
-                Arrays.asList(segment1, segment2), scaleTs, false, null, executor).join();
+                Arrays.asList(segment2, segment3), scaleTs, false, null, executor).join();
         final List<Segment> scale1SegmentsCreated = response.getSegmentsCreated();
         final int epoch = response.getActiveEpoch();
         assertEquals(0, epoch);
-        assertNotNull(scale1SealedSegments);
+        assertNotNull(scale1SegmentsCreated);
 
         // assert that txn is created on old epoch
         VersionedTransactionData tx2 = store.createTransaction(scope, stream, UUID.randomUUID(),
@@ -526,6 +527,46 @@ public abstract class StreamMetadataStoreTest {
 
         deleteResponse = store.tryDeleteEpochIfScaling(scope, stream, 1, null, executor).get(); // should not delete epoch
         assertEquals(false, deleteResponse.isDeleted());
+        // endregion
+
+        // region Txn created and deleted after scale starts
+        List<Integer> scale2SealedSegments = Collections.singletonList(0);
+        long scaleTs2 = System.currentTimeMillis();
+        SimpleEntry<Double, Double> segment4 = new SimpleEntry<>(0.0, 0.25);
+        SimpleEntry<Double, Double> segment5 = new SimpleEntry<>(0.25, 0.5);
+
+        StartScaleResponse response2 = store.startScale(scope, stream, scale2SealedSegments,
+                Arrays.asList(segment4, segment5), scaleTs2, false, null, executor).join();
+        final List<Segment> scale2SegmentsCreated = response2.getSegmentsCreated();
+        final int epoch2 = response2.getActiveEpoch();
+        assertEquals(1, epoch2);
+        assertNotNull(scale2SegmentsCreated);
+
+        VersionedTransactionData txn = store.createTransaction(scope, stream, UUID.randomUUID(),
+                100, 100, 100, null, executor).get();
+        assertEquals(1, txn.getEpoch());
+
+        store.sealTransaction(scope, stream, txn.getId(), true, Optional.of(txn.getVersion()), null, executor).get();
+        store.commitTransaction(scope, stream, txn.getEpoch(), txn.getId(), null, executor).get(); // should not happen
+        deleteResponse = store.tryDeleteEpochIfScaling(scope, stream, 1, null, executor).get(); // should not delete epoch
+        // verify that epoch is not deleted as new epoch is not yet created
+        assertEquals(false, deleteResponse.isDeleted());
+
+        // verify that new txns can be created and are created on old epoch
+        VersionedTransactionData txn2 = store.createTransaction(scope, stream, UUID.randomUUID(),
+                100, 100, 100, null, executor).get();
+        assertEquals(1, txn2.getEpoch());
+
+        store.setState(scope, stream, State.SCALING, null, executor).get();
+
+        store.scaleNewSegmentsCreated(scope, stream, scale2SealedSegments, scale2SegmentsCreated,
+                response2.getActiveEpoch(), scaleTs2, null, executor).join();
+
+        store.sealTransaction(scope, stream, txn2.getId(), true, Optional.of(txn2.getVersion()), null, executor).get();
+        store.commitTransaction(scope, stream, txn2.getEpoch(), txn2.getId(), null, executor).get(); // should not happen
+        deleteResponse = store.tryDeleteEpochIfScaling(scope, stream, 1, null, executor).get(); // should not delete epoch
+        // now that new segments are created, we should be able to delete old epoch.
+        assertEquals(true, deleteResponse.isDeleted());
     }
 }
 


### PR DESCRIPTION
**Change log description**
While completing a txn, we delete the old epoch if scale has been started and no other txns exist on the epoch. 
However, this check does not wait to ensure that old epoch is deleted only if new epoch is created. 
It can result in old epoch being deleted even before new segments are created..
which means txn creation will fail for a bit until scale creates new epoch (as attempts to create txns against old epoch will keep throwing DataNotFoundException upon which txn creation will retry for a while before failing).


**Purpose of the change**
Fixes issue #1725
**What the code does**

Txn completion should delete old epoch and proceed to complete scale only after it is guaranteed that new segments are created successfully in SSS.
This can be determined by looking for new epoch in history table.
The code looks for the latest entry in history table to determine if scale is ongoing or not rather than using the isScaleOngoing method which also looks at segment table and declares scale is on going if new segments are created in segment table alone. 

**How to verify it**
Added new test. All existing tests should also pass.