### PR TITLE
Issue 1740 : No need to sleep if we are on the last attempt of the retry.

### DIFF
--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -202,11 +202,14 @@ public final class Retry {
                     }
                 }
 
-                final long sleepFor = delay;
-                Exceptions.handleInterrupted(() -> Thread.sleep(sleepFor));
+                if (attemptNumber < params.attempts) {
+                    // no need to sleep if it is the last attempt
+                    final long sleepFor = delay;
+                    Exceptions.handleInterrupted(() -> Thread.sleep(sleepFor));
 
-                delay = Math.min(params.maxDelay, params.multiplier * delay);
-                log.debug("Retrying command. Retry #{}, timestamp={}", attemptNumber, Instant.now());
+                    delay = Math.min(params.maxDelay, params.multiplier * delay);
+                    log.debug("Retrying command. Retry #{}, timestamp={}", attemptNumber, Instant.now());
+                }
             }
             throw new RetriesExhaustedException(last);
         }


### PR DESCRIPTION
**Change log description**
Ensure we do not sleep after the last retry.

**Purpose of the change**
Fixes #1740 

**How to verify it**
Test should pass.