### PR TITLE
Issue 1747: Move retransmission on segment sealed to a background threadpool

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -383,11 +383,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                                            event.getExpectedOffset()));
             } catch (ConnectionFailedException e) {
                 log.warn("Connection " + writerId + " failed due to: ", e);
-                try {
-                    getConnection(); // As the messages is inflight, this will perform the retransmition.
-                } catch (SegmentSealedException e2) {
-                    return;
-                }
+                reconnect(); // As the messages is inflight, this will perform the retransmition.
             }
         }
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -383,7 +383,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                                            event.getExpectedOffset()));
             } catch (ConnectionFailedException e) {
                 log.warn("Connection " + writerId + " failed due to: ", e);
-                reconnect(); // As the messages is inflight, this will perform the retransmition.
+                reconnect(); // As the message is inflight, this will perform the retransmission.
             }
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -40,10 +40,11 @@ import io.pravega.client.stream.InvalidStreamException;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.shared.NameUtils;
 import lombok.val;
-
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -106,7 +107,8 @@ public class ClientFactoryImpl implements ClientFactory {
     @Override
     public <T> EventStreamWriter<T> createEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {
         Stream stream = new StreamImpl(scope, streamName);
-        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config);
+        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"+stream.getScopedName());
+        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, executor);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -107,7 +107,8 @@ public class ClientFactoryImpl implements ClientFactory {
     @Override
     public <T> EventStreamWriter<T> createEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {
         Stream stream = new StreamImpl(scope, streamName);
-        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"+stream.getScopedName());
+        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"
+                + stream.getScopedName());
         return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, executor);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -22,6 +22,7 @@ import io.pravega.client.stream.mock.MockSegmentIoStreams;
 import io.pravega.common.Exceptions;
 import io.pravega.common.util.ReusableLatch;
 import io.pravega.test.common.Async;
+import io.pravega.test.common.InlineExecutor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,11 +60,8 @@ public class EventStreamWriterTest {
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
         MockSegmentIoStreams outputStream = new MockSegmentIoStreams(segment);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any())).thenReturn(outputStream);
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       new JavaSerializer<>(),
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
+                new JavaSerializer<>(), config, new InlineExecutor());
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
         writer.close();
@@ -103,11 +101,8 @@ public class EventStreamWriterTest {
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
         SegmentOutputStream outputStream = Mockito.mock(SegmentOutputStream.class);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any())).thenReturn(outputStream);
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       new JavaSerializer<>(),
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
+                new JavaSerializer<>(), config, new InlineExecutor());
         Mockito.doThrow(new RuntimeException("Intentional exception")).when(outputStream).close();
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
@@ -239,11 +234,8 @@ public class EventStreamWriterTest {
                .thenReturn(getSegmentsFuture(segment1))
                .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -292,11 +284,8 @@ public class EventStreamWriterTest {
                 .thenReturn(getSegmentsFuture(segment1))
                 .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
-        EventStreamWriterImpl<String> writer = Mockito.spy(new EventStreamWriterImpl<>(stream,
-                controller,
-                streamFactory,
-                serializer,
-                config));
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -347,11 +336,8 @@ public class EventStreamWriterTest {
 
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         Transaction<String> txn = writer.beginTxn(0, 0, 0);
         txn.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
@@ -383,11 +369,8 @@ public class EventStreamWriterTest {
 
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         Transaction<String> txn = writer.beginTxn(0, 0, 0);
         outputStream.invokeSealedCallBack();
         try {
@@ -415,11 +398,8 @@ public class EventStreamWriterTest {
 
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -449,11 +429,8 @@ public class EventStreamWriterTest {
                 });
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -491,11 +468,8 @@ public class EventStreamWriterTest {
                 });
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                controller,
-                streamFactory,
-                serializer,
-                config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -537,11 +511,8 @@ public class EventStreamWriterTest {
                 });
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                controller,
-                streamFactory,
-                serializer,
-                config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -585,11 +556,8 @@ public class EventStreamWriterTest {
                 });
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                controller,
-                streamFactory,
-                serializer,
-                config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream1.getUnackedEventsOnSeal().size() > 0);
@@ -643,11 +611,8 @@ public class EventStreamWriterTest {
                 });
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
-        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream,
-                                                                       controller,
-                                                                       streamFactory,
-                                                                       serializer,
-                                                                       config);
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, new InlineExecutor());
         writer.writeEvent(routingKey, "Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertEquals(1, outputStream1.getUnackedEventsOnSeal().size());

--- a/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
@@ -15,7 +15,10 @@ import io.pravega.common.function.RunnableWithException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -43,6 +46,16 @@ public final class ExecutorServiceHelpers {
         } else {
             return null;
         }
+    }
+    
+    public static ThreadPoolExecutor getShrinkingExecutor(int maxThreads, int threadTimeout, String poolName) {
+        return new ThreadPoolExecutor(0, maxThreads, threadTimeout, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), new ThreadFactory() {
+            private final ThreadGroup group = new ThreadGroup(poolName);
+            @Override
+            public Thread newThread(Runnable r) {
+                return new Thread(group, r);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
**Change log description**
Moves the retransmission of inflight events from being performed on the connection threadpool to a dedicated on to avoid tying up the main pool.

**Purpose of the change**
Fixes #1747

**What the code does**
Creates a new threadpool in the client that by default has 0 threads and can, on demand have up to one per stream.

**How to verify it**
System tests should not longer lock up with a constant write count.