### PR TITLE
Issue 1753: (SegmentStore) BugFix for Orphan Transaction Metadata

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -335,7 +335,7 @@ public class DurableLog extends AbstractService implements OperationLog {
             }
         } catch (Exception ex) {
             // Both the inner try and finally blocks above can throw, so we need to catch both of those cases here.
-            log.error("{} Recovery FAILED. {}", this.traceObjectId, ex);
+            log.error("{} Recovery FAILED.", this.traceObjectId, ex);
             throw new CompletionException(ex);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeTransactionOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeTransactionOperation.java
@@ -133,7 +133,7 @@ public class MergeTransactionOperation extends StorageOperation {
     @Override
     public String toString() {
         return String.format(
-                "%s, StreamSegmentId = %d, Length = %s, ParentOffset = %s",
+                "%s, TransactionSegmentId = %d, Length = %s, ParentOffset = %s",
                 super.toString(),
                 getTransactionSegmentId(),
                 toString(getLength(), -1),

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
@@ -27,7 +27,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for StreamSegmentContainerMetadata class.
@@ -37,8 +39,8 @@ public class StreamSegmentContainerMetadataTests {
     private static final int SEGMENT_COUNT = 100;
     private static final int TRANSACTIONS_PER_SEGMENT_COUNT = 2;
 
-    //    @Rule
-    //    public Timeout globalTimeout = Timeout.seconds(10);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
      * Tests SequenceNumber-related operations.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -1409,7 +1409,7 @@ public class DurableLogTests extends OperationLogTestBase {
 
     //endregion
 
-    // CorruptedDurableLog
+    //region CorruptedDurableLog
 
     private static class CorruptedDurableLog extends DurableLog {
         private static final AtomicInteger FAIL_AT_INDEX = new AtomicInteger();


### PR DESCRIPTION
**Change log description**
Fixed a bug in StreamSegmentContainerMetadata where it would be possible to evict a Parent SegmentMetadata while at least one of its Transaction Metadatas was still active.
- This is possible if the `getEvictionCandidates` needs to trim off the result due to a max cap restriction (we are instructed to only clean up so many items at once)
- Repro case:
    - We have Segment A with N transactions (A1->AN) 
    - We have an eviction cap of M <= N
    - A and A1..AN are all eligible for eviction, and A is not the Most Recently Used 
    - Since we can only evict M (M <= N) and have N+1 segments eligible, we will only evict the least recently used M. In this case, this includes segment A and N-1 of its transactions, leaving one transaction orphaned in the metadata.
- This would not cause any issues until that transaction would have to be merged or a recovery happens (during which we try to access its parent).

**Purpose of the change**
Fixes #1753.

**What the code does**
- I determined it would be too difficult to handle this in `getEvictionCandidates` and decided to tackle it in `cleanup` (which is the better place anyway, since a number of changes could have been made to the Metadata between the calls which narrowed down the eviction scope).
- `cleanup` now counts the exact number of active transactions per Segment, by subtracting those that will be removed from the total count (which is computed on the fly).

**How to verify it**
All pre-existing unit tests must pass. New unit test added to test this exact scenario.