### PR TITLE
Issue 1363: Allow period and hyphen in stream names

### DIFF
--- a/shared/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/src/main/java/io/pravega/shared/NameUtils.java
@@ -54,7 +54,7 @@ public class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
-        Preconditions.checkArgument(name.matches("[a-zA-Z0-9]+"), "Name must be [a-zA-Z0-9]+");
+        Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
 
@@ -68,7 +68,7 @@ public class NameUtils {
         Preconditions.checkNotNull(name);
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
-        final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[a-zA-Z0-9]+";
+        final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }

--- a/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -43,6 +43,18 @@ public class NameUtilsTest {
         } catch (NullPointerException e) {
             // expected
         }
+        
+        try {
+            NameUtils.validateUserStreamName("a-b-c");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        
+        try {
+            NameUtils.validateUserStreamName("1.2.3");
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 
     @Test
@@ -78,6 +90,19 @@ public class NameUtilsTest {
             Assert.fail();
         } catch (NullPointerException e) {
             // expected
+        }
+        
+        
+        try {
+            NameUtils.validateUserStreamName("a-b-c");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        
+        try {
+            NameUtils.validateUserStreamName("1.2.3");
+        } catch (Exception e) {
+            Assert.fail();
         }
     }
 

--- a/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -92,7 +92,6 @@ public class NameUtilsTest {
             // expected
         }
         
-        
         try {
             NameUtils.validateUserStreamName("a-b-c");
         } catch (Exception e) {


### PR DESCRIPTION
**Change log description**
Allows periods and hyphens in stream names.

**Purpose of the change**
Fixes #1363 

**What the code does**
Adds these two characters to the supported regex.

**How to verify it**
All tests should pass. Code was also searched to make sure there weren't any other places duplicating the verification.