### PR TITLE
Issue 1770: Fixing license header format and javadoc build errors

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupMetrics.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupMetrics.java
@@ -17,6 +17,8 @@ public interface ReaderGroupMetrics {
     /**
      * Returns the number of bytes between the last recorded position of the readers in the
      * ReaderGroup and the end of the stream. Note: This value may be somewhat delayed.
+     *
+     * @return The number of unread bytes.
      */
     long unreadBytes();
     

--- a/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
+++ b/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the “License”);
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.common.lang;
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ExternalAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ExternalAdapter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the “License”);
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration.selftest.adapters;
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessListenerWithRealStoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessListenerWithRealStoreAdapter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the “License”);
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration.selftest.adapters;
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/OutOfProcessAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/OutOfProcessAdapter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the “License”);
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration.selftest.adapters;
 


### PR DESCRIPTION
**Change log description**
The license header format is incorrect in few files Process Starter.java , InProcessListenerWithRealStoreAdapter.java, OutOfProcessAdapter.java and ExternalAdapter.java .
There is no return value for ` long unreadBytes();` in ReaderGroupMetrics.java .
**Purpose of the change**
Resolve some build errors.  
**What the code does**
Fixes #1770 
**How to verify it**
Build should pass.