### PR TITLE
Issue 1775: Ensure that thread pool is available for controller operations in multireaderwriterwithfailovertest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
@@ -205,8 +204,7 @@ public class MultiReaderWriterWithFailOverTest {
         //get ClientFactory instance
         log.info("Scope passed to client factory {}", scope);
         try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
-                     ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerUri)) {
-
+             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerUri)) {
 
             log.info("Client factory details {}", clientFactory.toString());
             //create writers
@@ -256,8 +254,7 @@ public class MultiReaderWriterWithFailOverTest {
             //start reading asynchronously
             List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
             readerList.forEach(reader -> {
-                CompletableFuture<Void> readerFuture = startReading(eventsReadFromPravega, eventData, eventReadCount,
-                        stopReadFlag, reader);
+                CompletableFuture<Void> readerFuture = startReading(eventsReadFromPravega, eventData, eventReadCount, stopReadFlag, reader);
                 readerFutureList.add(readerFuture);
             });
 
@@ -303,8 +300,8 @@ public class MultiReaderWriterWithFailOverTest {
             CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
             log.info("Deleting scope {}", scope);
             assertTrue(deleteScopeStatus.get());
+            log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
         }
-        log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
     }
 
     private void cleanUp() {

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -161,7 +161,7 @@ public class MultiReaderWriterWithFailOverTest {
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
 
-        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS, "MultiReaderWriterWithFailOverTest");
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1, "MultiReaderWriterWithFailOverTest");
 
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -288,21 +288,21 @@ public class MultiReaderWriterWithFailOverTest {
             //delete readergroup
             log.info("Deleting readergroup {}", readerGroupName);
             readerGroupManager.deleteReaderGroup(readerGroupName);
-            //seal the stream
-            CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
-            log.info("Sealing stream {}", STREAM_NAME);
-            assertTrue(sealStreamStatus.get());
-            //delete the stream
-            CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
-            log.info("Deleting stream {}", STREAM_NAME);
-            assertTrue(deleteStreamStatus.get());
-
-            //delete the scope
-            CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
-            log.info("Deleting scope {}", scope);
-            assertTrue(deleteScopeStatus.get());
-            log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
         }
+        //seal the stream
+        CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
+        log.info("Sealing stream {}", STREAM_NAME);
+        assertTrue(sealStreamStatus.get());
+        //delete the stream
+        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
+        log.info("Deleting stream {}", STREAM_NAME);
+        assertTrue(deleteStreamStatus.get());
+
+        //delete the scope
+        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
+        log.info("Deleting scope {}", scope);
+        assertTrue(deleteScopeStatus.get());
+        log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
     }
 
     private void cleanUp() {

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -204,106 +204,106 @@ public class MultiReaderWriterWithFailOverTest {
 
         //get ClientFactory instance
         log.info("Scope passed to client factory {}", scope);
-        @Cleanup //connectionFactory is closed by clientFactory.close()
-        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
-        @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerUri);
+        try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
+                     ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerUri)) {
 
-        log.info("Client factory details {}", clientFactory.toString());
-        //create writers
-        log.info("Creating {} writers", NUM_WRITERS);
-        log.info("Writers writing in the scope {}", scope);
-        for (int i = 0; i < NUM_WRITERS; i++) {
-            log.info("Starting writer{}", i);
-            final EventStreamWriter<Long> writer = clientFactory.createEventWriter(STREAM_NAME,
-                    new JavaSerializer<Long>(),
-                    EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                            .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
-            writerList.add(writer);
+
+            log.info("Client factory details {}", clientFactory.toString());
+            //create writers
+            log.info("Creating {} writers", NUM_WRITERS);
+            log.info("Writers writing in the scope {}", scope);
+            for (int i = 0; i < NUM_WRITERS; i++) {
+                log.info("Starting writer{}", i);
+                final EventStreamWriter<Long> writer = clientFactory.createEventWriter(STREAM_NAME,
+                        new JavaSerializer<Long>(),
+                        EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
+                                .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
+                writerList.add(writer);
+            }
+
+            //create a reader group
+            log.info("Creating Reader group : {}", readerGroupName);
+            log.info("Scope passed to readergroup manager {}", scope);
+
+            readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().startingTime(0).build(),
+                    Collections.singleton(STREAM_NAME));
+            log.info("Reader group name {} ", readerGroupManager.getReaderGroup(readerGroupName).getGroupName());
+            log.info("Reader group scope {}", readerGroupManager.getReaderGroup(readerGroupName).getScope());
+            log.info("Online readers {}", readerGroupManager.getReaderGroup(readerGroupName).getOnlineReaders());
+
+            //create readers
+            log.info("Creating {} readers", NUM_READERS);
+            String readerName = "reader" + new Random().nextInt(Integer.MAX_VALUE);
+            log.info("Scope that is seen by readers {}", scope);
+            //start reading events
+            for (int i = 0; i < NUM_READERS; i++) {
+                log.info("Starting reader{}", i);
+                log.info("Creating reader with id {}", readerName + i);
+                final EventStreamReader<Long> reader = clientFactory.createReader(readerName + i,
+                        readerGroupName,
+                        new JavaSerializer<Long>(),
+                        ReaderConfig.builder().build());
+                readerList.add(reader);
+            }
+
+            // start writing asynchronously
+            List<CompletableFuture<Void>> writerFutureList = new ArrayList<>();
+            writerList.forEach(writer -> {
+                CompletableFuture<Void> writerFuture = startWriting(eventData, writer, stopWriteFlag);
+                writerFutureList.add(writerFuture);
+            });
+
+            //start reading asynchronously
+            List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
+            readerList.forEach(reader -> {
+                CompletableFuture<Void> readerFuture = startReading(eventsReadFromPravega, eventData, eventReadCount,
+                        stopReadFlag, reader);
+                readerFutureList.add(readerFuture);
+            });
+
+            //perform the scaling operations
+            performFailoverTest();
+
+            //set the stop write flag to true
+            log.info("Stop write flag status {}", stopWriteFlag);
+            stopWriteFlag.set(true);
+
+            //wait for writers completion
+            log.info("Wait for writers execution to complete");
+            FutureHelpers.allOf(writerFutureList).get();
+
+            //set the stop read flag to true
+            log.info("Stop read flag status {}", stopReadFlag);
+            stopReadFlag.set(true);
+
+            //wait for readers completion
+            log.info("Wait for readers execution to complete");
+            FutureHelpers.allOf(readerFutureList).get();
+
+            log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +
+                    "Count: {}", eventData.get(), eventsReadFromPravega.size());
+            assertEquals(eventData.get(), eventsReadFromPravega.size());
+            assertEquals(eventData.get(), new TreeSet<>(eventsReadFromPravega).size()); //check unique events.
+
+            cleanUp();
+
+            //delete readergroup
+            log.info("Deleting readergroup {}", readerGroupName);
+            readerGroupManager.deleteReaderGroup(readerGroupName);
+            //seal the stream
+            CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
+            log.info("Sealing stream {}", STREAM_NAME);
+            assertTrue(sealStreamStatus.get());
+            //delete the stream
+            CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
+            log.info("Deleting stream {}", STREAM_NAME);
+            assertTrue(deleteStreamStatus.get());
+
+            //delete the scope
+            CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
+            log.info("Deleting scope {}", scope);
+            assertTrue(deleteScopeStatus.get());
         }
-
-        //create a reader group
-        log.info("Creating Reader group : {}", readerGroupName);
-        log.info("Scope passed to readergroup manager {}", scope);
-
-        readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().startingTime(0).build(),
-                Collections.singleton(STREAM_NAME));
-        log.info("Reader group name {} ", readerGroupManager.getReaderGroup(readerGroupName).getGroupName());
-        log.info("Reader group scope {}", readerGroupManager.getReaderGroup(readerGroupName).getScope());
-        log.info("Online readers {}", readerGroupManager.getReaderGroup(readerGroupName).getOnlineReaders());
-
-        //create readers
-        log.info("Creating {} readers", NUM_READERS);
-        String readerName = "reader" + new Random().nextInt(Integer.MAX_VALUE);
-        log.info("Scope that is seen by readers {}", scope);
-        //start reading events
-        for (int i = 0; i < NUM_READERS; i++) {
-            log.info("Starting reader{}", i);
-            log.info("Creating reader with id {}", readerName + i);
-            final EventStreamReader<Long> reader = clientFactory.createReader(readerName + i,
-                    readerGroupName,
-                    new JavaSerializer<Long>(),
-                    ReaderConfig.builder().build());
-            readerList.add(reader);
-        }
-
-        // start writing asynchronously
-        List<CompletableFuture<Void>> writerFutureList = new ArrayList<>();
-        writerList.forEach(writer -> {
-            CompletableFuture<Void> writerFuture = startWriting(eventData, writer, stopWriteFlag);
-            writerFutureList.add(writerFuture);
-        });
-
-        //start reading asynchronously
-        List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
-        readerList.forEach(reader -> {
-            CompletableFuture<Void> readerFuture = startReading(eventsReadFromPravega, eventData, eventReadCount,
-                    stopReadFlag, reader);
-            readerFutureList.add(readerFuture);
-        });
-
-        //perform the scaling operations
-        performFailoverTest();
-
-        //set the stop write flag to true
-        log.info("Stop write flag status {}", stopWriteFlag);
-        stopWriteFlag.set(true);
-
-        //wait for writers completion
-        log.info("Wait for writers execution to complete");
-        FutureHelpers.allOf(writerFutureList).get();
-
-        //set the stop read flag to true
-        log.info("Stop read flag status {}", stopReadFlag);
-        stopReadFlag.set(true);
-
-        //wait for readers completion
-        log.info("Wait for readers execution to complete");
-        FutureHelpers.allOf(readerFutureList).get();
-
-        log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +
-                "Count: {}", eventData.get(), eventsReadFromPravega.size());
-        assertEquals(eventData.get(), eventsReadFromPravega.size());
-        assertEquals(eventData.get(), new TreeSet<>(eventsReadFromPravega).size()); //check unique events.
-
-        cleanUp();
-
-        //delete readergroup
-        log.info("Deleting readergroup {}", readerGroupName);
-        readerGroupManager.deleteReaderGroup(readerGroupName);
-        //seal the stream
-        CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
-        log.info("Sealing stream {}", STREAM_NAME);
-        assertTrue(sealStreamStatus.get());
-        //delete the stream
-        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
-        log.info("Deleting stream {}", STREAM_NAME);
-        assertTrue(deleteStreamStatus.get());
-
-        //delete the scope
-        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
-        log.info("Deleting scope {}", scope);
-        assertTrue(deleteScopeStatus.get());
         log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
     }
 


### PR DESCRIPTION
**Change log description**
- Changes executor used by controller client

- Adds a thread to the pool to handle controller-related retries

**Purpose of the change**
Fixes #1775

**What the code does**
@ Cleanup annotation is used close the clientFactory which ensures ConnectionFactory.close() is invoked after all the operations within the test. Removed the try with resources statement.

**How to verify it**
Verified it by running system tests.