### PR TITLE
Issue 1760: Fixing HDFSStorage for small clusters

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -13,9 +13,9 @@ import io.pravega.common.Exceptions;
 import io.pravega.common.cluster.Host;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
 import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsFactory;
+import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
@@ -225,6 +225,10 @@ public final class ServiceStarter {
                     .include(System.getProperty(ServiceBuilderConfig.CONFIG_FILE_PROPERTY_NAME, "config.properties"))
                     .include(System.getProperties())
                     .build();
+
+            // For debugging purposes, it may be useful to know the non-default values for configurations being used.
+            // This will unfortunately include all System Properties as well, but knowing those can be useful too sometimes.
+            config.forEach((key, value) -> log.debug("Config:{}={}.", key, value));
             serviceStarter.set(new ServiceStarter(config, Options.builder()
                     .bookKeeper(true).rocksDb(true).zkSegmentManager(true).build()));
         } catch (Throwable e) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -130,6 +130,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
             this.writer.close();
             this.durableLog.close();
             this.readIndex.close();
+            this.storage.close();
             log.info("{}: Closed.", this.traceObjectId);
         }
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
@@ -16,6 +16,7 @@ import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -77,6 +78,15 @@ public class ServiceBuilderConfig {
         try (val s = new FileOutputStream(file, false)) {
             this.properties.store(s, "");
         }
+    }
+
+    /**
+     * Executes the given BiConsumer on all non-default properties in this configuration.
+     *
+     * @param consumer The BiConsumer to execute.
+     */
+    public void forEach(BiConsumer<? super Object, ? super Object> consumer) {
+        this.properties.forEach(consumer);
     }
 
     //region Default Configuration

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperation.java
@@ -51,7 +51,7 @@ class CreateOperation extends FileSystemOperation<String> implements Callable<Se
         // Create the first file in the segment.
         Path fullPath = getFilePath(segmentName, 0, this.context.epoch);
         long traceId = LoggerHelpers.traceEnter(log, "create", segmentName, fullPath);
-        createEmptyFile(fullPath);
+        atomicCreate(fullPath);
 
         // Determine if someone also created it at the same time, but with a different epoch.
         List<FileDescriptor> allFiles;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -82,7 +81,6 @@ class HDFSStorage implements Storage {
     private final Executor executor;
     private final HDFSStorageConfig config;
     private final AtomicBoolean closed;
-    @Getter
     private FileSystemOperation.OperationContext context;
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -9,12 +9,12 @@
  */
 package io.pravega.segmentstore.storage.impl.hdfs;
 
+import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.function.RunnableWithException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
-import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.SegmentHandle;
-import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.Storage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -22,7 +22,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -134,6 +133,11 @@ class HDFSStorage implements Storage {
         conf.set("fs.default.name", this.config.getHdfsHostURL());
         conf.set("fs.default.fs", this.config.getHdfsHostURL());
         conf.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
+        if (!this.config.isReplaceDataNodesOnFailure()) {
+            // Default is DEFAULT, so we only set this if we want it disabled.
+            conf.set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER");
+        }
+
         this.context = new FileSystemOperation.OperationContext(epoch, openFileSystem(conf), this.config);
         log.info("Initialized (HDFSHost = '{}', Epoch = {}).", this.config.getHdfsHostURL(), epoch);
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -81,6 +82,7 @@ class HDFSStorage implements Storage {
     private final Executor executor;
     private final HDFSStorageConfig config;
     private final AtomicBoolean closed;
+    @Getter
     private FileSystemOperation.OperationContext context;
 
     //endregion
@@ -133,6 +135,10 @@ class HDFSStorage implements Storage {
         conf.set("fs.default.name", this.config.getHdfsHostURL());
         conf.set("fs.default.fs", this.config.getHdfsHostURL());
         conf.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
+
+        // FileSystem has a bad habit of caching Clients/Instances based on target URI. We do not like this, since we
+        // want to own our implementation so that when we close it, we don't interfere with others.
+        conf.set("fs.hdfs.impl.disable.cache", "true");
         if (!this.config.isReplaceDataNodesOnFailure()) {
             // Default is DEFAULT, so we only set this if we want it disabled.
             conf.set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER");

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageConfig.java
@@ -27,6 +27,7 @@ public class HDFSStorageConfig {
     public static final Property<String> ROOT = Property.named("hdfsRoot", "");
     public static final Property<Integer> REPLICATION = Property.named("replication", 3);
     public static final Property<Integer> BLOCK_SIZE = Property.named("blockSize", 1024 * 1024);
+    public static final Property<Boolean> REPLACE_DATANODES_ON_FAILURE = Property.named("replaceDataNodesOnFailure", true);
     private static final String COMPONENT_CODE = "hdfs";
 
     //endregion
@@ -59,6 +60,13 @@ public class HDFSStorageConfig {
     @Getter
     private final long blockSize;
 
+    /**
+     * Whether to replace DataNodes on failure or not. This should be set to TRUE for deployments where sufficient data
+     * nodes are available(More than Max(3, replication)), otherwise set to FALSE.
+     */
+    @Getter
+    private final boolean replaceDataNodesOnFailure;
+
     //endregion
 
     //region Constructor
@@ -73,6 +81,7 @@ public class HDFSStorageConfig {
         this.hdfsRoot = properties.get(ROOT);
         this.replication = (short) properties.getInt(REPLICATION);
         this.blockSize = properties.getInt(BLOCK_SIZE);
+        this.replaceDataNodesOnFailure = properties.getBoolean(REPLACE_DATANODES_ON_FAILURE);
     }
 
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/OpenWriteOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/OpenWriteOperation.java
@@ -97,7 +97,7 @@ class OpenWriteOperation extends FileSystemOperation<String> implements Callable
     private HDFSSegmentHandle fenceOut(String segmentName, long offset) throws IOException, StorageNotPrimaryException {
         // Create a new, empty file, and verify nobody else beat us to it.
         val newFile = new FileDescriptor(getFilePath(segmentName, offset, this.context.epoch), offset, 0, this.context.epoch, false);
-        createEmptyFile(newFile.getPath());
+        atomicCreate(newFile.getPath());
         List<FileDescriptor> allFiles;
         try {
             allFiles = checkForFenceOut(segmentName, -1, newFile);

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperationTests.java
@@ -9,8 +9,14 @@
  */
 package io.pravega.segmentstore.storage.impl.hdfs;
 
+import com.google.common.util.concurrent.Runnables;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.function.RunnableWithException;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.test.common.AssertExtensions;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.val;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -107,10 +113,76 @@ public class CreateOperationTests extends FileSystemOperationTestBase {
         Assert.assertFalse("Fenced-out file was not deleted (higher-epoch test).", fs.exists(context1.getFileName(SEGMENT_NAME, 0)));
     }
 
+    /**
+     * Tests CreateOperation for two concurrent Create requests on the same segment. This actually tests atomicCreate()
+     * on FileSystemOperation.
+     */
+    @Test
+    public void testAtomicCreate() throws Exception {
+        @Cleanup
+        val fs = new MockFileSystem();
+        val context = newContext(1, fs);
+        val path = context.getFileName(SEGMENT_NAME, 0);
+
+        val wasInvoked = new AtomicBoolean(); // Verifies we don't invoke FileSystem.create() multiple times.
+        val creationInvoked = new CompletableFuture<Void>(); // Completed when FileSystem.create() is in progress.
+        val creationReleased = new CompletableFuture<Void>(); // Completed when ready to unblock FileSystem.create().
+        val creationCompleted = new CompletableFuture<Void>(); // Completed when FileSystem.create() is done.
+        fs.setOnCreate(p -> {
+            Assert.assertFalse("Multiple invocations to FileSystem.create().", wasInvoked.getAndSet(true));
+            creationInvoked.complete(null);
+            return fs.new WaitAction(path, creationReleased);
+        });
+
+        // Execute the first create and wait for it to have been invoked (which means we should have registered the creation).
+        val op1 = new AtomicCreateOperation(SEGMENT_NAME, context);
+        ExecutorServiceHelpers.execute(
+                () -> {
+                    op1.run();
+                    creationCompleted.complete(null);
+                },
+                ex -> Assert.fail("Unexpected exception on first call. " + ex),
+                Runnables.doNothing(),
+                ForkJoinPool.commonPool());
+        creationInvoked.join();
+
+        // Execute the second operation and verify it fails.
+        val op2 = new AtomicCreateOperation(SEGMENT_NAME, context);
+        AssertExtensions.assertThrows(
+                "Second concurrent call did not fail with appropriate exception.",
+                op2::run,
+                ex -> ex instanceof FileAlreadyExistsException);
+
+        // Complete the first creation, wait for it to actually be done, and verify the file has been created.
+        creationReleased.complete(null);
+        creationCompleted.join();
+        checkFileExists(context);
+
+        AssertExtensions.assertThrows(
+                "Non-concurrent call did not fail with appropriate exception.",
+                op2::run,
+                ex -> ex instanceof FileAlreadyExistsException);
+    }
+
     private void checkFileExists(TestContext context) throws Exception {
         Path expectedFileName = context.getFileName(SEGMENT_NAME, 0);
         val fsStatus = context.fileSystem.getFileStatus(expectedFileName);
         Assert.assertEquals("Created file is not empty.", 0, fsStatus.getLen());
         Assert.assertFalse("Created file is read-only.", context.isReadOnly(fsStatus));
+    }
+
+    /**
+     * CreateOperation does a few checks before actually executing, so it's not very useful in testing atomicCreate().
+     * This class invokes that method directly, which gives us more testing control over it.
+     */
+    private static class AtomicCreateOperation extends FileSystemOperation<String> implements RunnableWithException {
+        AtomicCreateOperation(String target, OperationContext context) {
+            super(target, context);
+        }
+
+        @Override
+        public void run() throws Exception {
+            atomicCreate(getFilePath(getTarget(), 0, this.context.epoch));
+        }
     }
 }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
@@ -15,8 +15,6 @@ import io.pravega.common.io.FileHelpers;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageTestBase;
-import io.pravega.test.common.AssertExtensions;
-import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.hadoop.conf.Configuration;
@@ -76,40 +74,6 @@ public class HDFSStorageTest extends StorageTestBase {
     }
 
     //region Fencing tests
-    @Test
-    public void testMisc() throws Exception {
-        @Cleanup
-        val s1 = new HDFSStorage(this.adapterConfig, this.executorService());
-        s1.initialize(1);
-        val dfs1 = (DistributedFileSystem) s1.getContext().fileSystem;
-
-        val s2 = new HDFSStorage(this.adapterConfig, this.executorService());
-        s2.initialize(1);
-        val dfs2 = (DistributedFileSystem) s2.getContext().fileSystem;
-
-        val p = new Path("/hello/foo");
-        dfs1.create(p).close();
-        val os1 = dfs1.append(p);
-        os1.write("1".getBytes());
-        os1.close();
-        System.out.println(1);
-        dfs1.close();
-
-        for(int i =0;i<100;i++) {
-            try {
-                val os2 = dfs2.append(p); // This should work since we closed the lease
-                System.out.println(2);
-                os2.write("2".getBytes());
-                os2.close();
-            }catch (Exception ex){
-                ex.printStackTrace();
-                Thread.sleep(100);
-                continue;
-            }
-            break;
-        }
-        System.out.println(3);
-    }
 
     /**
      * Tests fencing abilities. We create two different Storage objects with different owner ids.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/MockFileSystem.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/MockFileSystem.java
@@ -17,8 +17,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.RequiredArgsConstructor;
@@ -346,20 +346,17 @@ class MockFileSystem extends FileSystem {
         }
     }
 
-    class FailAction extends CustomAction {
-        private final Supplier<IOException> exceptionSupplier;
+    class WaitAction extends MockFileSystem.CustomAction {
+        private final CompletableFuture<Void> waitOn;
 
-        FailAction(Path target, Supplier<IOException> exceptionSupplier) {
+        WaitAction(Path target, CompletableFuture<Void> waitOn) {
             super(target);
-            this.exceptionSupplier = exceptionSupplier;
+            this.waitOn = waitOn;
         }
 
         @Override
         void execute() throws IOException {
-            IOException ex = this.exceptionSupplier.get();
-            if (ex != null) {
-                throw ex;
-            }
+            this.waitOn.join();
         }
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -141,8 +141,8 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +
                 setSystemProperty("log.level", "DEBUG") +
-                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)+
-                setSystemProperty("hdfs.replaceDataNodesOnFailure", "false"));
+                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)) +
+                setSystemProperty("hdfs.replaceDataNodesOnFailure", "false");
 
         map.put("PRAVEGA_SEGMENTSTORE_OPTS", hostSystemProperties);
         app.setEnv(map);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -141,7 +141,8 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +
                 setSystemProperty("log.level", "DEBUG") +
-                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000));
+                setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)+
+                setSystemProperty("hdfs.replaceDataNodesOnFailure", "false"));
 
         map.put("PRAVEGA_SEGMENTSTORE_OPTS", hostSystemProperties);
         app.setEnv(map);


### PR DESCRIPTION
**Change log description**
- `StreamSegmentContainer`: 
    - Closing `Storage` when closing the `StreamSegmentContainer` object itself. Closing this also closes the `DFSClient` which closes any open streams (if we have any), thus releasing resources.
- `HDFSStorage`: 
    - Disabling FS Cache. Each instance of HDFSStorage has exactly one instance of a `DistributedFileSystem` class (vs using a shared one across the process). This enables us to properly close that instance when the SegmentContainer shuts down, thus releasing resources.
    - Added option to disable data node replacement if needed. According to the [documentation](https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml), this is recommended for very small clusters to prevent the exact issues we seem to be dealing with.
    - FileSystemOperation/createFile: renamed `createEmptyFile` to `atomicCreate` and made it work atomically. HDFS file creation is a multi-step process (which includes creating the file and then closing the returned stream), which can result to weird exceptions when attempting to create the same file concurrently by multiple callers (none of which is `FileAlreadyExistsException`/`StreamSegmentExistsException`). Since a SegmentContainer is the only one creating Segments, and there is only one instance of a particular Container running at any given time, this was _alleviated_ using a simple `pendingFileCreation` set that keeps track of pending create requests.

**Purpose of the change**
Attempting to fix system test failures. 
Fixes #1760.
Fixes #1338.
Fixes #1287.

**What the code does**
See change log description.

**How to verify it**
