### PR TITLE
Issue 1782: Ensure we close connectionFactory during the tear down of AbstractFailoverTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -90,7 +90,6 @@ abstract class AbstractFailoverTests {
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
-
     }
 
     void performFailoverTest() {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 
+import static java.util.Collections.synchronizedList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -81,10 +82,15 @@ abstract class AbstractFailoverTests {
         final AtomicReference<Throwable> getWriteException = new AtomicReference<>();
         final AtomicReference<Throwable> getReadException =  new AtomicReference<>();
         final AtomicInteger currentNumOfSegments = new AtomicInteger(0);
+        //list of all writer's futures
+        final List<CompletableFuture<Void>> writers = synchronizedList(new ArrayList<CompletableFuture<Void>>());
+        //list of all reader's futures
+        final List<CompletableFuture<Void>> readers = synchronizedList(new ArrayList<CompletableFuture<Void>>());
         final List<CompletableFuture<Void>> writersListComplete = new ArrayList<>();
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
+
     }
 
     void performFailoverTest() {
@@ -256,6 +262,7 @@ abstract class AbstractFailoverTests {
                 writerFutureList.add(writerFuture);
             }
         }).thenRun(() -> {
+            testState.writers.addAll(writerFutureList);
             FutureHelpers.completeAfter(() -> FutureHelpers.allOf(writerFutureList),
                     testState.writersListComplete.get(0));
             FutureHelpers.exceptionListener(testState.writersListComplete.get(0),
@@ -290,6 +297,7 @@ abstract class AbstractFailoverTests {
                 readerFutureList.add(readerFuture);
             }
         }).thenRun(() -> {
+            testState.readers.addAll(readerFutureList);
             FutureHelpers.completeAfter(() -> FutureHelpers.allOf(readerFutureList), testState.readersComplete);
             FutureHelpers.exceptionListener(testState.readersComplete,
                     t -> log.error("Exception while waiting for all readers to complete", t));
@@ -316,6 +324,7 @@ abstract class AbstractFailoverTests {
                 newWritersFutureList.add(writerFuture);
             }
         }).thenRun(() -> {
+            testState.writers.addAll(newWritersFutureList);
             FutureHelpers.completeAfter(() -> FutureHelpers.allOf(newWritersFutureList), testState.writersListComplete.get(1));
             FutureHelpers.exceptionListener(testState.writersListComplete.get(1),
                     t -> log.error("Exception while waiting for writers to complete", t));

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -29,7 +29,9 @@ import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,12 +49,18 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     private static final int INIT_NUM_WRITERS = 2;
     private static final int NUM_READERS = 2;
     private static final int TOTAL_NUM_WRITERS = 8;
+
+    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(15 * 60);
+
     private final String scope = "testReadWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
             .streamName(AUTO_SCALE_STREAM).scalingPolicy(scalingPolicy).build();
-
+    private ClientFactory clientFactory;
+    private ReaderGroupManager readerGroupManager;
 
     @Environment
     public static void initialize() throws MarathonException, URISyntaxException {
@@ -61,7 +69,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         URI controllerUri = startPravegaControllerInstances(zkUri);
         startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
-
 
     @Before
     public void setup() {
@@ -97,14 +104,23 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
         testState.writersListComplete.add(1, testState.newWritersComplete);
+
+        createScopeAndStream(scope, AUTO_SCALE_STREAM, config, controllerURIDirect);
+        log.info("Scope passed to client factory {}", scope);
+
+        clientFactory = new ClientFactoryImpl(scope, controller);
+        readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
     }
 
     @After
     public void tearDown() {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
+        //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
+        clientFactory.close();
+        readerGroupManager.close();
         executorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
     }
@@ -112,43 +128,38 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @Test(timeout = 12 * 60 * 1000)
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
-        createScopeAndStream(scope, AUTO_SCALE_STREAM, config, controllerURIDirect);
-        log.info("Scope passed to client factory {}", scope);
-        try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller);
-             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect)) {
 
-            createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
+        createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
 
-            //run the failover test before scaling
-            performFailoverTest();
+        //run the failover test before scaling
+        performFailoverTest();
 
-            //bring the instances back to 3 before performing failover during scaling
-            controllerInstance.scaleService(3, true);
-            segmentStoreInstance.scaleService(3, true);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover during scaling
+        controllerInstance.scaleService(3, true);
+        segmentStoreInstance.scaleService(3, true);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+        addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
 
-            //run the failover test while scaling
-            performFailoverTest();
+        //run the failover test while scaling
+        performFailoverTest();
 
-            waitForScaling();
+        waitForScaling();
 
-            //bring the instances back to 3 before performing failover
-            controllerInstance.scaleService(3, true);
-            segmentStoreInstance.scaleService(3, true);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover
+        controllerInstance.scaleService(3, true);
+        segmentStoreInstance.scaleService(3, true);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            //run the failover test after scaling
-            performFailoverTest();
+        //run the failover test after scaling
+        performFailoverTest();
 
-            stopWriters();
-            stopReaders();
-            validateResults(readerGroupManager, readerGroupName);
+        stopWriters();
+        stopReaders();
+        validateResults(readerGroupManager, readerGroupName);
 
-        }
-        cleanUp(scope, AUTO_SCALE_STREAM);
+        cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
     }
 
     private void waitForScaling() throws InterruptedException, ExecutionException {

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -116,12 +116,12 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     public void tearDown() {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        //scale the controller and segmentStore back to 1 instance.
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
         //interrupt writers and readers threads if they are still running.
         testState.writers.forEach(future -> future.cancel(true));
         testState.readers.forEach(future -> future.cancel(true));
+        //scale the controller and segmentStore back to 1 instance.
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
         clientFactory.close();
         readerGroupManager.close();
         executorService.shutdownNow();
@@ -129,7 +129,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     }
 
 
-    @Test(timeout = 12 * 60 * 1000)
+    @Test
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
 
         createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -119,6 +119,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
+        //interrupt writers and readers threads if they are still running.
+        testState.writers.forEach(future -> future.cancel(true));
+        testState.readers.forEach(future -> future.cancel(true));
         clientFactory.close();
         readerGroupManager.close();
         executorService.shutdownNow();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -119,13 +119,13 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //interrupt writers and readers threads if they are still running.
         testState.writers.forEach(future -> future.cancel(true));
         testState.readers.forEach(future -> future.cancel(true));
-        //scale the controller and segmentStore back to 1 instance.
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
         clientFactory.close();
         readerGroupManager.close();
         executorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
+        //scale the controller and segmentStore back to 1 instance.
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
     }
 
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -30,7 +30,9 @@ import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -50,11 +52,18 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
+
+    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(15 * 60);
+
     private final String scope = "testReadWriteAndScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1); // auto scaling is not enabled.
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
             .streamName(SCALE_STREAM).scalingPolicy(scalingPolicy).build();
+    private ClientFactory clientFactory;
+    private ReaderGroupManager readerGroupManager;
 
     @Environment
     public static void initialize() throws InterruptedException, MarathonException, URISyntaxException {
@@ -97,81 +106,84 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
+
+        createScopeAndStream(scope, SCALE_STREAM, config, controllerURIDirect);
+        log.info("Scope passed to client factory {}", scope);
+        clientFactory = new ClientFactoryImpl(scope, controller);
+        readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
     }
 
     @After
     public void tearDown() {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
+        //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
+        clientFactory.close(); //close the clientFactory/connectionFactory.
+        readerGroupManager.close();
         executorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
     }
 
     @Test(timeout = 12 * 60 * 1000)
     public void readWriteAndScaleWithFailoverTest() throws Exception {
-        createScopeAndStream(scope, SCALE_STREAM, config, controllerURIDirect);
 
-        log.info("Scope passed to client factory {}", scope);
-        try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller);
-             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect)) {
+        createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
 
-            createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
+        //run the failover test before scaling
+        performFailoverTest();
 
-            //run the failover test before scaling
-            performFailoverTest();
+        //bring the instances back to 3 before performing failover during scaling
+        controllerInstance.scaleService(3, true);
+        segmentStoreInstance.scaleService(3, true);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            //bring the instances back to 3 before performing failover during scaling
-            controllerInstance.scaleService(3, true);
-            segmentStoreInstance.scaleService(3, true);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //scale manually
+        log.debug("Number of Segments before manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
+                .get().getSegments().size());
 
-            //scale manually
-            log.debug("Number of Segments before manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
-                    .get().getSegments().size());
+        Map<Double, Double> keyRanges = new HashMap<>();
+        keyRanges.put(0.0, 0.5);
+        keyRanges.put(0.5, 1.0);
 
-            Map<Double, Double> keyRanges = new HashMap<>();
-            keyRanges.put(0.0, 0.5);
-            keyRanges.put(0.5, 1.0);
+        CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
+                Collections.singletonList(0),
+                keyRanges,
+                executorService).getFuture();
+        FutureHelpers.exceptionListener(scaleStatus, t -> log.error("Scale Operation completed with an error", t));
 
-            CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
-                    Collections.singletonList(0),
-                    keyRanges,
-                    executorService).getFuture();
-            FutureHelpers.exceptionListener(scaleStatus, t -> log.error("Scale Operation completed with an error", t));
+        //run the failover test while scaling
+        performFailoverTest();
 
-            //run the failover test while scaling
-            performFailoverTest();
-
-            //do a get on scaleStatus
-            if (FutureHelpers.await(scaleStatus)) {
-                log.info("Scale operation has completed: {}", scaleStatus.get());
-                if (!scaleStatus.get()) {
-                    log.error("Scale operation did not complete", scaleStatus.get());
-                    Assert.fail("Scale operation did not complete successfully");
-                }
-            } else {
-                Assert.fail("Scale operation threw an exception");
+        //do a get on scaleStatus
+        if (FutureHelpers.await(scaleStatus)) {
+            log.info("Scale operation has completed: {}", scaleStatus.get());
+            if (!scaleStatus.get()) {
+                log.error("Scale operation did not complete", scaleStatus.get());
+                Assert.fail("Scale operation did not complete successfully");
             }
-
-            log.debug("Number of Segments post manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
-                    .get().getSegments().size());
-
-            //bring the instances back to 3 before performing failover after scaling
-            controllerInstance.scaleService(3, true);
-            segmentStoreInstance.scaleService(3, true);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
-
-            //run the failover test after scaling
-            performFailoverTest();
-
-            stopWriters();
-            stopReaders();
-            validateResults(readerGroupManager, readerGroupName);
+        } else {
+            Assert.fail("Scale operation threw an exception");
         }
-        cleanUp(scope, SCALE_STREAM);
+
+        log.debug("Number of Segments post manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
+                .get().getSegments().size());
+
+        //bring the instances back to 3 before performing failover after scaling
+        controllerInstance.scaleService(3, true);
+        segmentStoreInstance.scaleService(3, true);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+
+        //run the failover test after scaling
+        performFailoverTest();
+
+        stopWriters();
+        stopReaders();
+        validateResults(readerGroupManager, readerGroupName);
+
+        cleanUp(scope, SCALE_STREAM); //cleanup if validation is successful.
         log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -120,6 +120,9 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
+        //interrupt writers and readers threads if they are still running.
+        testState.writers.forEach(future -> future.cancel(true));
+        testState.readers.forEach(future -> future.cancel(true));
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();
         executorService.shutdownNow();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -117,19 +117,19 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     public void tearDown() {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        //scale the controller and segmentStore back to 1 instance.
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
         //interrupt writers and readers threads if they are still running.
         testState.writers.forEach(future -> future.cancel(true));
         testState.readers.forEach(future -> future.cancel(true));
+        //scale the controller and segmentStore back to 1 instance.
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();
         executorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
     }
 
-    @Test(timeout = 12 * 60 * 1000)
+    @Test
     public void readWriteAndScaleWithFailoverTest() throws Exception {
 
         createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
@@ -144,7 +144,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
         //scale manually
-        log.debug("Number of Segments before manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
+        log.debug("Number of Segments before manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
                 .get().getSegments().size());
 
         Map<Double, Double> keyRanges = new HashMap<>();
@@ -171,7 +171,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
             Assert.fail("Scale operation threw an exception");
         }
 
-        log.debug("Number of Segments post manual scale:" + controller.getCurrentSegments(scope, SCALE_STREAM)
+        log.debug("Number of Segments post manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
                 .get().getSegments().size());
 
         //bring the instances back to 3 before performing failover after scaling

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -120,13 +120,13 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //interrupt writers and readers threads if they are still running.
         testState.writers.forEach(future -> future.cancel(true));
         testState.readers.forEach(future -> future.cancel(true));
-        //scale the controller and segmentStore back to 1 instance.
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();
         executorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
+        //scale the controller and segmentStore back to 1 instance.
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
     }
 
     @Test


### PR DESCRIPTION
**Change log description**
* AbstractFailoverTests(`ReadWriteAndAutoScaleWithFailoverTest `and `ReadWriteAndScaleWithFailoverTest`) close ClientFactory( internally ConnectionFactory) in case of an exception before stopping the reader and writer threads. This causes some log noise. The change intends to reduce this noise.

**Purpose of the change**
Fixes #1782

**What the code does**
- Stop readers and writers before closing connectionFactory
- Ensure over all execution of the the test and its setup methods are time limited to 15 mins.

**How to verify it**
- reduced log noise after test execution.