### PR TITLE
Issue 1792: Deadlock on application supplied executor thread in controller client

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ClientFactory.java
@@ -62,8 +62,7 @@ public interface ClientFactory extends AutoCloseable {
      */
     static ClientFactory withScope(String scope, URI controllerUri) {
         val connectionFactory = new ConnectionFactoryImpl(false);
-        return new ClientFactoryImpl(scope, new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
-                connectionFactory.getInternalExecutor()), connectionFactory);
+        return new ClientFactoryImpl(scope, new ControllerImpl(controllerUri, ControllerImplConfig.builder().build()), connectionFactory);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -48,8 +48,7 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     public ReaderGroupManagerImpl(String scope, URI controllerUri, ConnectionFactory connectionFactory) {
         this.scope = scope;
-        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
-                connectionFactory.getInternalExecutor());
+        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build());
         this.connectionFactory = connectionFactory;
         this.clientFactory = new ClientFactoryImpl(scope, this.controller, connectionFactory);
     }

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -32,7 +32,7 @@ public class StreamManagerImpl implements StreamManager {
     
     public StreamManagerImpl(URI controllerUri) {
         this.executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "StreamManager-Controller");
-        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(), executor);
+        this.controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build());
     }
 
     @VisibleForTesting

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -808,7 +808,7 @@ public class ControllerImpl implements Controller, AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         executor.shutdown();
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -71,7 +71,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
@@ -22,11 +22,13 @@ public class ControllerImplConfig implements Serializable {
     private final int maxBackoffMillis;
     private final int retryAttempts;
     private final int backoffMultiple;
+    private final int threadpoolSize;
 
     public static final class ControllerImplConfigBuilder {
         private int initialBackoffMillis = 1;
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
+        private int threadpoolSize = 2;
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
@@ -123,7 +123,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(
                 URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
 
         // Verify we could reach all 3 controllers.
@@ -141,7 +141,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(
                 URI.create("pravega://" + localIP + ":" + serverPort1 + "," + localIP + ":" + serverPort2),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
 
         // Verify we could reach all 3 controllers.
@@ -161,7 +161,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(
                 URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Verify that we can read from the 2 live servers.
         Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 2);
@@ -188,7 +188,7 @@ public class ControllerImplLBTest {
         Assert.assertTrue(testRPCServer3.isTerminated());
         final ControllerImpl client = new ControllerImpl(
                 URI.create("pravega://localhost:" + serverPort1 + ",localhost:" + serverPort2),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         AssertExtensions.assertThrows(ExecutionException.class, () -> client.getEndpointForSegment("a/b/0").get());
     }
 
@@ -203,7 +203,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1
                 + ",localhost:" + serverPort2 + ",localhost:" + serverPort3),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
         Assert.assertEquals(3, uris.size());
     }
@@ -220,7 +220,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://" + localIP + ":" + serverPort1
                 + "," + localIP + ":" + serverPort2 + "," + localIP + ":" + serverPort3),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         final Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 3);
         Assert.assertEquals(3, uris.size());
     }
@@ -240,7 +240,7 @@ public class ControllerImplLBTest {
         InlineExecutor executor = new InlineExecutor();
         final ControllerImpl controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort1
                 + ",localhost:" + serverPort2 + ",localhost:" + serverPort3),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         Set<PravegaNodeUri> uris = fetchFromServers(controllerClient, 2);
         Assert.assertEquals(2, uris.size());
         Assert.assertFalse(uris.contains(new PravegaNodeUri("localhost1", 1)));

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -583,7 +583,7 @@ public class ControllerImplTest {
                 .start();
         executor = Executors.newSingleThreadScheduledExecutor();
         controllerClient = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
-                ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
     }
 
     @After
@@ -598,7 +598,7 @@ public class ControllerImplTest {
         // Verify that keep-alive timeout less than permissible by the server results in a failure.
         final ControllerImpl controller = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort)
                 .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true),
-                ControllerImplConfig.builder().retryAttempts(1).build(), this.executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         CompletableFuture<Boolean> createStreamStatus = controller.createStream(StreamConfiguration.builder()
                 .streamName("streamdelayed")
                 .scope("scope1")
@@ -616,7 +616,7 @@ public class ControllerImplTest {
                 .start();
         final ControllerImpl controller1 = new ControllerImpl(NettyChannelBuilder.forAddress("localhost", serverPort2)
                 .keepAliveTime(10, TimeUnit.SECONDS).usePlaintext(true),
-                ControllerImplConfig.builder().retryAttempts(1).build(), this.executor);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         createStreamStatus = controller1.createStream(StreamConfiguration.builder()
                 .streamName("streamdelayed")
                 .scope("scope1")
@@ -631,7 +631,7 @@ public class ControllerImplTest {
 
         // Verify retries exhausted error after multiple attempts.
         final ControllerImpl controller1 = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
-                ControllerImplConfig.builder().retryAttempts(3).build(), this.executor);
+                ControllerImplConfig.builder().retryAttempts(3).build());
         CompletableFuture<Boolean> createStreamStatus = controller1.createStream(StreamConfiguration.builder()
                 .streamName("streamretryfailure")
                 .scope("scope1")
@@ -653,7 +653,7 @@ public class ControllerImplTest {
         // The RPC should succeed when internal retry attempts is > 3 which is the hardcoded test value for success.
         this.retryAttempts.set(0);
         final ControllerImpl controller2 = new ControllerImpl(URI.create("tcp://localhost:" + serverPort),
-                ControllerImplConfig.builder().retryAttempts(4).build(), this.executor);
+                ControllerImplConfig.builder().retryAttempts(4).build());
         createStreamStatus = controller2.createStream(StreamConfiguration.builder()
                 .streamName("streamretrysuccess")
                 .scope("scope1")

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -239,7 +239,7 @@ public class ControllerRestApiTest {
         @Cleanup("shutdown")
         InlineExecutor executor = new InlineExecutor();
         final Controller controller = new ControllerImpl(controllerUri,
-                                                         ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+                                                         ControllerImplConfig.builder().retryAttempts(1).build());
         try (StreamManager streamManager = new StreamManagerImpl(controller)) {
             log.info("Creating scope: {}", testScope);
             streamManager.createScope(testScope);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,10 +37,10 @@ abstract class AbstractScaleTests {
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
     @Getter(lazy = true)
     private final ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(1).build(), getConnectionFactory().getInternalExecutor()));
+            ControllerImplConfig.builder().retryAttempts(1).build()));
     @Getter(lazy = true)
     private final ControllerImpl controller = new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(1).build(), getConnectionFactory().getInternalExecutor());
+            ControllerImplConfig.builder().retryAttempts(1).build());
 
     private URI createControllerURI() {
         Service conService = new PravegaControllerService("controller", null);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -135,7 +135,7 @@ public class ControllerFailoverTest {
         // Connect with first controller instance.
         URI controllerUri = getTestControllerServiceURI();
         final Controller controller1 = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Create scope, stream, and a transaction with high timeout value.
         controller1.createScope(scope).join();
@@ -164,7 +164,7 @@ public class ControllerFailoverTest {
         // Connect to another controller instance.
         controllerUri = getControllerURI();
         final Controller controller2 = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().retryAttempts(1).build());
 
         // Fetch status of transaction.
         log.info("Fetching status of transaction {}, time elapsed since its creation={}",

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -301,7 +301,7 @@ public class ControllerRestApiTest {
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
         @Cleanup("shutdown")
         InlineExecutor executor = new InlineExecutor();
-        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1).build());
         try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -187,7 +187,7 @@ public class MultiControllerTest {
 
     private CompletableFuture<Boolean> createScope(String scopeName, URI controllerURI) {
         final ControllerImpl controllerClient = new ControllerImpl(controllerURI,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().retryAttempts(1).build());
         return controllerClient.createScope(scopeName);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -178,7 +178,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 2,
                                                                         "MultiReaderTxnWriterWithFailoverTest");
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         //read and write count variables
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -184,7 +184,7 @@ public class MultiReaderWriterWithFailOverTest {
         URI controllerUri = controllerURIDirect;
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
         Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1)
-                .build(), executorService);
+                .build());
 
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -130,7 +130,7 @@ public class PravegaTest {
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
         ControllerImpl controller = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), connectionFactory.getInternalExecutor());
+                ControllerImplConfig.builder().retryAttempts(1).build());
 
         assertTrue(controller.createScope(STREAM_SCOPE).get());
         assertTrue(controller.createStream(config).get());

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -93,7 +93,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
         testState.writersListComplete.add(1, testState.newWritersComplete);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -94,7 +94,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         //num. of readers + num. of writers + 1 to run checkScale operation
         executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1);
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build());
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
     }


### PR DESCRIPTION
**Change log description**
Controller client (controllerImpl.java) uses an executor for to make rpc calls asynchronously.
This executor is supplied by the client application.
The problem is that EventStreamWriterImpl calls into controllerImpl.rpc calls and blocks on them.
So if the client application has used the same executor to pass to controllerImpl and run their writer or reader clients on the same executor then we could run out of all threads in the executor with all of them blocked on response to rpc call. And rpc call cannot be made because there is no free thread in the executor to run it.

e.g. Lets say our executor has one thread.
executor = Executors.singleThreadScheduledExecutor()
controller = new ControllerImpl(uri, executor)
writer = clientFactory.createEventWriter()
CompletableFuture.runAsync(x -> writer.beginTxn(), executor);

EventStreamWriterImpl.java
```
  public Transaction<Type> beginTxn(long timeout, long maxExecutionTime, long scaleGracePeriod) {
       TxnSegments txnSegments = getAndHandleExceptions(
               controller.createTransaction(stream, timeout, maxExecutionTime, scaleGracePeriod),
               RuntimeException::new);
```
ControllerImpl.java
```
    public CompletableFuture<TxnSegments> createTransaction(final Stream stream, final long lease, final long maxExecutionTime, final long scaleGracePeriod) {
        final CompletableFuture<CreateTxnResponse> result = this.retryConfig.runAsync(() -> {
            RPCAsyncCallback<CreateTxnResponse> callback = new RPCAsyncCallback<>();
            client.createTransaction(
                    CreateTxnRequest.newBuilder().build(),
                    callback, executor);
```
This will block the lone thread in the executor and controller client will not have a thread to make the rpc call.
**Purpose of the change**
Fixes issue 1792

**What the code does**
Makes controller client create its own executor for making rpc calls asynchronously. 

**How to verify it**
All existing tests should pass. System tests should not encounter the deadlock. 