### PR TITLE
Issue 1769: Abort transaction is not idempotent if segment is already deleted on the segment store

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -316,6 +316,11 @@ public class SegmentHelper {
             }
 
             @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                result.complete(TxnStatus.newBuilder().setStatus(TxnStatus.Status.SUCCESS).build());
+            }
+
+            @Override
             public void processingFailure(Exception error) {
                 result.completeExceptionally(error);
             }


### PR DESCRIPTION
**Change log description**
* Handles `noSuchSegment` response from the segment store for aborts

**Purpose of the change**
Fixes issue 1769

**What the code does**
We fixed a similar issue in commitTransaction but missed fixing this for abort transaction. 
If abortTransaction returns noSuchSegment, controller should be idempotent to it. 

**How to verify it**
All existing tests should pass