### PR TITLE
Issue 1692: Sporadic No Value Present error for getSuccessors call

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -383,7 +383,11 @@ public abstract class PersistentStreamBase<T> implements Stream {
                         // fresh run
                         // Ensure that segment.creation time is monotonically increasing after each new scale
                         long lastScaleTime = HistoryRecord.readLatestRecord(historyTable.getData(), true).map(HistoryRecord::getScaleTime).orElse(0L);
-                        long segmentCreationTimestamp = Math.max(scaleTimestamp, lastScaleTime + 1);
+
+                        long scaleEventTime = Math.max(System.currentTimeMillis(), scaleTimestamp);
+
+                        long segmentCreationTimestamp = Math.max(scaleEventTime, lastScaleTime + 1);
+
                         return scaleCreateNewSegments(newRanges, segmentCreationTimestamp, segmentTable, activeEpoch);
                     }
                 })

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -241,8 +241,8 @@ public abstract class PersistentStreamBase<T> implements Stream {
     private CompletableFuture<List<Segment>> getSuccessorsForSegment(final int number) {
         return getHistoryTable()
                 .thenApply(historyTable -> {
-                    val segmentFuture = getSegment(number);
-                    val indexTableFuture = getIndexTable();
+                    CompletableFuture<Segment> segmentFuture = getSegment(number);
+                    CompletableFuture<Data<T>> indexTableFuture = getIndexTable();
                     return new ImmutableTriple<>(historyTable, segmentFuture, indexTableFuture);
                 })
                 .thenCompose(triple -> CompletableFuture.allOf(triple.getMiddle(), triple.getRight())

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -381,7 +381,9 @@ public abstract class PersistentStreamBase<T> implements Stream {
 
                         log.info("Scale {}/{} for segments started. Creating new segments. SegmentsToSeal {}", scope, name, sealedSegments);
                         // fresh run
-                        // Ensure that segment.creation time is monotonically increasing after each new scale
+                        // Ensure that segment.creation time is monotonically increasing after each new scale.
+                        // because scale time could be supplied by a controller with a skewed clock, we should:
+                        // take max(scaleTime, lastScaleTime + 1, System.currentTimeMillis)
                         long lastScaleTime = HistoryRecord.readLatestRecord(historyTable.getData(), true).map(HistoryRecord::getScaleTime).orElse(0L);
 
                         long scaleEventTime = Math.max(System.currentTimeMillis(), scaleTimestamp);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
@@ -141,7 +141,7 @@ public class StreamTest {
     }
 
     @Test
-    public void testNoValuePresent()  throws Exception {
+    public void testNoValuePresent() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(1);
 
         final StreamMetadataStore store = new ZKStreamMetadataStore(cli, executor);
@@ -186,7 +186,7 @@ public class StreamTest {
         AtomicBoolean segmentCalled = new AtomicBoolean(false);
         // mock.. If segment table is fetched before history table, throw runtime exception so that the test fails
         doAnswer((Answer<CompletableFuture<Data<Integer>>>) invocation -> {
-            if (segmentCalled.get()) {
+            if (!historyCalled.get() && segmentCalled.get()) {
                 throw new RuntimeException();
             }
             historyCalled.set(true);
@@ -217,7 +217,7 @@ public class StreamTest {
         segmentCalled.set(false);
         historyCalled.set(false);
         doAnswer((Answer<CompletableFuture<Data<Integer>>>) invocation -> {
-            if (segmentCalled.get()) {
+            if (!historyCalled.get() && segmentCalled.get()) {
                 throw new RuntimeException();
             }
             historyCalled.set(true);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
@@ -193,7 +193,7 @@ public class StreamTest {
             return historyTable;
         }).when(zkStream).getHistoryTable();
         doAnswer((Answer<CompletableFuture<Data<Integer>>>) invocation -> {
-            if (!historyCalled.get()){
+            if (!historyCalled.get()) {
                 throw new RuntimeException();
             }
             segmentCalled.set(true);
@@ -224,7 +224,7 @@ public class StreamTest {
             return historyTable;
         }).when(zkStream).getHistoryTable();
         doAnswer((Answer<CompletableFuture<Data<Integer>>>) invocation -> {
-            if (!historyCalled.get()){
+            if (!historyCalled.get()) {
                 throw new RuntimeException();
             }
             segmentCalled.set(true);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
@@ -140,8 +140,8 @@ public class StreamTest {
         assertEquals(CreateStreamResponse.CreateStatus.EXISTS_ACTIVE, response.getStatus());
     }
 
-    @Test
-    public void testNoValuePresent() throws Exception {
+    @Test(timeout = 10000)
+    public void testConcurrentGetSuccessorScale() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(1);
 
         final StreamMetadataStore store = new ZKStreamMetadataStore(cli, executor);
@@ -221,14 +221,14 @@ public class StreamTest {
                 throw new RuntimeException();
             }
             historyCalled.set(true);
-            return historyTable;
+            return historyTable2;
         }).when(zkStream).getHistoryTable();
         doAnswer((Answer<CompletableFuture<Data<Integer>>>) invocation -> {
             if (!historyCalled.get()) {
                 throw new RuntimeException();
             }
             segmentCalled.set(true);
-            return segmentTable;
+            return segmentTable2;
         }).when(zkStream).getSegmentTable();
 
         successors = zkStream.getSuccessorsWithPredecessors(0).get();

--- a/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
@@ -172,7 +172,7 @@ public class TableHelperTest {
         assertEquals(successors, Lists.newArrayList(6));
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testSegmentCreationBeforePreviousScale() throws ParseException {
         // no value present error comes because:
         // - Index is not yet updated.


### PR DESCRIPTION
**Change log description**
The issue was that while creating segments in segment table, we can supply an old timestamp (time when scale request was generated). This timestamp can be older than the previous scale operation's timestamp in the history table. 
This caused our search logic in history table to look include records which were older than segment creation record which broke the search logic. 

So as a fix, we have done two things here -> 
1. ensure that segment creation time is strictly greater than timestamp on previous scale record in history table. 
2. Ensure that even if segment start time is less than previous scale record in history table, our computation is able to handle it. 

Another low probability chance when we may find record in history table but not in segment table:

While doing get Successor, we should first fetch history table followed by segment table. 
This is because while performing scale we first write to segment table and then to history table. 

Currently code concurrently fetches history and segment tables. 
The problem that can happen now is if there is a race with scale, then getHistoryTable may get the updated table while getSegmentTable may retrieve older value. This will cause getSuccessors to throw `No value present` when it tries to retrieve new segment from the segmentTable.

This is very low probability because after we create segments in segment table, we contact SSS to create segments in segment store. only after that do we create partial record in history table.
for a get successor to come and get updated history table but stale segment table while trying to fetch them both concurrently is less likely though theoretically possible.
 
**Purpose of the change**
Fixes #1692

**What the code does**
Three things:
1. Ensure segment creation times in segment table is always monotonically increasing and greater than previous scale's time. 
2. Ensure that even if segment creationTime is less than previous scale time, the core logic in table helper is able to compute and find successors correctly. 
3. Ensures that in getSuccessors computation on controller's stream store, we first fetch history table, followed by segment table in thenCompose of getHistoryTable's future. 

**How to verify it**
Two new unit test added.