### PR TITLE
Issue 1802: CreateTransaction does not handle segmentAlreadyExists response

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -221,6 +221,11 @@ public class SegmentHelper {
             }
 
             @Override
+            public void segmentAlreadyExists(WireCommands.SegmentAlreadyExists segmentAlreadyExists) {
+                result.complete(txId);
+            }
+
+            @Override
             public void processingFailure(Exception error) {
                 result.completeExceptionally(error);
             }


### PR DESCRIPTION
**Change log description**
Create transaction is not idempotent wrt segmentAlreadyExists response. 

**Purpose of the change**
Fixes issue 1802

**What the code does**
Treats segmentAlreadyExists as a successful response. 
**How to verify it**
All existing tests should pass, system tests should not observe this issue. 