### PR TITLE
Issue 1803: AutoScaleProcessor expired entries are put back into the cache after posting an event for them

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -173,10 +173,10 @@ public class AutoScaleProcessor {
                         segment.getSegmentNumber(), AutoScaleEvent.DOWN, timestamp, 0, silent);
                 writeRequest(event).thenAccept(x -> {
                     if (!silent) {
+                        // mute only scale downs
                         cache.put(streamSegmentName, new ImmutablePair<>(0L, timestamp));
                     }
                 });
-                // mute only scale downs
             }
         }
     }
@@ -241,5 +241,9 @@ public class AutoScaleProcessor {
         cache.put(streamSegmentName, lrImmutablePair);
     }
 
+    @VisibleForTesting
+    Pair<Long, Long> get(String streamSegmentName) {
+        return cache.getIfPresent(streamSegmentName);
+    }
 }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -171,8 +171,11 @@ public class AutoScaleProcessor {
                 Segment segment = Segment.fromScopedName(streamSegmentName);
                 AutoScaleEvent event = new AutoScaleEvent(segment.getScope(), segment.getStreamName(),
                         segment.getSegmentNumber(), AutoScaleEvent.DOWN, timestamp, 0, silent);
-                writeRequest(event).thenAccept(x -> cache.put(streamSegmentName,
-                        new ImmutablePair<>(0L, timestamp)));
+                writeRequest(event).thenAccept(x -> {
+                    if (!silent) {
+                        cache.put(streamSegmentName, new ImmutablePair<>(0L, timestamp));
+                    }
+                });
                 // mute only scale downs
             }
         }


### PR DESCRIPTION
**Change log description**
A segment, for which traffic has not been seen for a while is expired from the cache in autoscale processor.
This results in a scale down request being sent for it. We use the same triggerScaleDown method for this purpose. This method, after posting the scale down request for a segment, updates the last posted timestamp for the segment in the cache.
This results in expired entry being added to the cache, when ideally it should have been expired to free up the cache.

Also, this causes unnecessary noise in the requeststream if the expired segment cannot be scaled at that point.

**Purpose of the change**
Fixes #1803

**What the code does**
If the scale down is sent because of cache expiry, then the segment is not added back into the cache

**How to verify it**
Unit test added