### PR TITLE
Issue 1794: Update controller client retry configuration for failover tests.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -55,7 +55,7 @@ abstract class AbstractFailoverTests {
 
     static final String AUTO_SCALE_STREAM = "testReadWriteAndAutoScaleStream";
     static final String SCALE_STREAM = "testReadWriteAndScaleStream";
-    static final int ADD_NUM_WRITERS = 6;
+    static final int ADD_NUM_WRITERS = 2;
     //Duration for which the system test waits for writes/reads to happen post failover.
     //10s (SessionTimeout) + 10s (RebalanceContainers) + 20s (For Container recovery + start) + NetworkDelays
     static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -55,7 +55,6 @@ abstract class AbstractFailoverTests {
 
     static final String AUTO_SCALE_STREAM = "testReadWriteAndAutoScaleStream";
     static final String SCALE_STREAM = "testReadWriteAndScaleStream";
-    static final int ADD_NUM_WRITERS = 2;
     //Duration for which the system test waits for writes/reads to happen post failover.
     //10s (SessionTimeout) + 10s (RebalanceContainers) + 20s (For Container recovery + start) + NetworkDelays
     static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,10 +37,12 @@ abstract class AbstractScaleTests {
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
     @Getter(lazy = true)
     private final ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(1).build(), getConnectionFactory().getInternalExecutor()));
+            ControllerImplConfig.builder().retryAttempts(12).maxBackoffMillis(5000).build(), getConnectionFactory()
+            .getInternalExecutor()));
     @Getter(lazy = true)
     private final ControllerImpl controller = new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(1).build(), getConnectionFactory().getInternalExecutor());
+            ControllerImplConfig.builder().retryAttempts(12).maxBackoffMillis(5000).build(), getConnectionFactory()
+            .getInternalExecutor());
 
     private URI createControllerURI() {
         Service conService = new PravegaControllerService("controller", null);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,12 +37,10 @@ abstract class AbstractScaleTests {
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
     @Getter(lazy = true)
     private final ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(12).maxBackoffMillis(5000).build(), getConnectionFactory()
-            .getInternalExecutor()));
+            ControllerImplConfig.builder().build(), getConnectionFactory().getInternalExecutor()));
     @Getter(lazy = true)
     private final ControllerImpl controller = new ControllerImpl(getControllerURI(),
-            ControllerImplConfig.builder().retryAttempts(12).maxBackoffMillis(5000).build(), getConnectionFactory()
-            .getInternalExecutor());
+            ControllerImplConfig.builder().build(), getConnectionFactory().getInternalExecutor());
 
     private URI createControllerURI() {
         Service conService = new PravegaControllerService("controller", null);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -135,7 +135,7 @@ public class ControllerFailoverTest {
         // Connect with first controller instance.
         URI controllerUri = getTestControllerServiceURI();
         final Controller controller1 = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().build(), EXECUTOR_SERVICE);
 
         // Create scope, stream, and a transaction with high timeout value.
         controller1.createScope(scope).join();
@@ -164,7 +164,7 @@ public class ControllerFailoverTest {
         // Connect to another controller instance.
         controllerUri = getControllerURI();
         final Controller controller2 = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().build(), EXECUTOR_SERVICE);
 
         // Fetch status of transaction.
         log.info("Fetching status of transaction {}, time elapsed since its creation={}",

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -301,7 +301,7 @@ public class ControllerRestApiTest {
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
         @Cleanup("shutdown")
         InlineExecutor executor = new InlineExecutor();
-        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1).build(), executor);
+        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(), executor);
         try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, controller);
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -187,7 +187,7 @@ public class MultiControllerTest {
 
     private CompletableFuture<Boolean> createScope(String scopeName, URI controllerURI) {
         final ControllerImpl controllerClient = new ControllerImpl(controllerURI,
-                ControllerImplConfig.builder().retryAttempts(1).build(), EXECUTOR_SERVICE);
+                ControllerImplConfig.builder().build(), EXECUTOR_SERVICE);
         return controllerClient.createScope(scopeName);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -178,7 +178,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 2,
                                                                         "MultiReaderTxnWriterWithFailoverTest");
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().build(), executorService);
         //read and write count variables
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -183,8 +183,8 @@ public class MultiReaderWriterWithFailOverTest {
         //get Controller Uri
         URI controllerUri = controllerURIDirect;
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
-        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1)
-                .build(), executorService);
+        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
+                executorService);
 
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -130,7 +130,7 @@ public class PravegaTest {
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
         ControllerImpl controller = new ControllerImpl(controllerUri,
-                ControllerImplConfig.builder().retryAttempts(1).build(), connectionFactory.getInternalExecutor());
+                ControllerImplConfig.builder().build(), connectionFactory.getInternalExecutor());
 
         assertTrue(controller.createScope(STREAM_SCOPE).get());
         assertTrue(controller.createStream(config).get());

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -46,7 +46,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     private static final int INIT_NUM_WRITERS = 2;
     private static final int NUM_READERS = 2;
-    private static final int TOTAL_NUM_WRITERS = 8;
+    private static final int TOTAL_NUM_WRITERS = 4;
     private final String scope = "testReadWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);
@@ -92,8 +92,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS);
-        //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        // total retry duration is around 32+ seconds.
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(12)
+                .maxBackoffMillis(5000).build(), executorService);
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
         testState.writersListComplete.add(1, testState.newWritersComplete);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -45,8 +45,9 @@ import static org.junit.Assert.assertTrue;
 public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests {
 
     private static final int INIT_NUM_WRITERS = 2;
+    private static final int ADD_NUM_WRITERS = 2;
     private static final int NUM_READERS = 2;
-    private static final int TOTAL_NUM_WRITERS = 4;
+    private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
     private final String scope = "testReadWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -100,8 +100,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
         //executor service
         executorService = Executors.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS);
-        //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        // total retry duration is around 32+ seconds.
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(12)
+                .maxBackoffMillis(5000).build(), executorService);
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
         testState.writersListComplete.add(1, testState.newWritersComplete);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -93,8 +93,9 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
         //num. of readers + num. of writers + 1 to run checkScale operation
         executorService = Executors.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1);
-        //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(1).build(), executorService);
+        // total retry duration is around 32+ seconds.
+        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().retryAttempts(12)
+                .maxBackoffMillis(5000).build(), executorService);
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
     }


### PR DESCRIPTION
**Change log description**
- The retry count for controller client is 1 . It needs to be increased since with the current configuration retry happens within 1 ms.
- Reduces the number of Additional writers created for ReadWriteAndAutoScaleWithFailoverTest. There is no need to have a total of 8 writers to trigger autoscale. 

**Purpose of the change**
Fixes #1794 

**What the code does**
Fixes #1794 and reduces the number of additional writers to trigger autoscale.

**How to verify it**
Verified that system tests pass.