### PR TITLE
Issue 1800: Loop predicate for pinging in MultiReaderTxnWriterWithFailoverTest 

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -403,7 +403,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
 
                     // Sets a recurrent delayed task to ping the txn. It exits when the
                     // txn completes and no longer needs pinging
-                    FutureHelpers.loop(txnIsDone::get, () -> {
+                    FutureHelpers.loop(() -> !txnIsDone.get(), () -> {
                         return FutureHelpers.delayedTask(() -> {
                             if (transaction.checkStatus() == Transaction.Status.OPEN) {
                                 FutureHelpers.runOrFail(() -> {


### PR DESCRIPTION
**Change log description**
* Fixes the asynchronous loop predicate to ping an ongoing txn, which is currently incorrect. The value is initialized to false and the loop is supposed to leave when it changes to true, so the logic needs to be the opposite of what we currently have.

**Purpose of the change**
Fixes #1800 

**What the code does**
Fixes the predicate for an asynchronous loop in a system test case.

**How to verify it**
Run system tests.