### PR TITLE
Issue 1792: Add executor service for controllerImpl in system tests.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -67,6 +67,7 @@ abstract class AbstractFailoverTests {
     Service segmentStoreInstance;
     URI controllerURIDirect = null;
     ScheduledExecutorService executorService;
+    ScheduledExecutorService controllerExecutorService;
     Controller controller;
     TestState testState;
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -83,6 +83,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
     private final List<EventStreamWriter<Long>> writerList = synchronizedList(new ArrayList<>());
     private final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
     private ScheduledExecutorService executorService;
+    private ScheduledExecutorService controllerExecutorService;
     private AtomicBoolean stopReadFlag;
     private AtomicBoolean stopWriteFlag;
     private AtomicLong eventData;
@@ -182,9 +183,13 @@ public class MultiReaderTxnWriterWithFailoverTest {
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
         //executor service
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 2,
-                                                                        "MultiReaderTxnWriterWithFailoverTest");
+                                                                        "MultiReaderTxnWriterWithFailoverTest-main");
+        controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
+                                                                                  "MultiReaderTxnWriterWithFailoverTest-controller");
         //get Controller Uri
-        controller = new ControllerImpl(controllerURIDirect, ControllerImplConfig.builder().build(), executorService);
+        controller = new ControllerImpl(controllerURIDirect,
+                                        ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
+                                        controllerExecutorService);
         //read and write count variables
         eventsReadFromPravega = new ConcurrentLinkedQueue<>();
         stopReadFlag = new AtomicBoolean(false);
@@ -199,6 +204,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
         executorService.shutdownNow();
+        controllerExecutorService.shutdownNow();
         eventsReadFromPravega.clear();
     }
 


### PR DESCRIPTION
**Change log description**
* Adds an executor service that is exclusive to the controller implementation on the client.
* The thread pool needs one thread for the RPC, which is invoked asynchronously. We add
one more to enable some parallelism.

**Purpose of the change**
Fixes #1792 

**What the code does**
Adds an executor service to some system tests that is used exclusively by `ControllerImpl`.

**How to verify it**
Run system tests.