### PR TITLE
Issue 1813: Ensure staging is complete before returning status of pravega services

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -72,7 +72,7 @@ public abstract class MarathonBasedService implements Service {
             GetAppResponse app = marathonClient.getApp(this.id);
             log.debug("App Details: {}", app);
             //app is not running until the desired instance count is equal to the number of task/docker containers
-            if (app.getApp().getTasksRunning() == app.getApp().getInstances()) {
+            if (app.getApp().getTasksRunning().intValue() == app.getApp().getInstances().intValue()) {
                 log.info("App {} is running", this.id);
                 return true;
             } else {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -214,7 +214,7 @@ public abstract class MarathonBasedService implements Service {
         }
     }
 
-    private void waitUntilStagingComplete() throws MarathonException {
+    private void waitUntilStagingComplete() {
         final CompletableFuture<Void> status = FutureHelpers.loop(() -> isAppBeingStaged(this.id), //condition
                 () -> FutureHelpers.delayedFuture(Duration.ofSeconds(5), executorService),
                 executorService);


### PR DESCRIPTION
**Change log description**
* Ensure the framework waits until tasks staging is complete and the tasks are running.

**Purpose of the change**
Fixes #1813

**What the code does**
When tasks are being staged, `io.pravega.test.system.framework.services.MarathonBasedService#isRunning` should wait until all the tasks are staged before returning a value. (staging is a transient state and it should not decide the outcome of isRunning method.)

Update: ensuring the task running count is equal to desired instance count is a better way to fix this issue. 

**How to verify it**
System tests should pass.