### PR TITLE
Issue 1816: Fix the wrong backoffsecs in segmentstore deployment with system test framework

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -37,7 +37,6 @@ import static io.pravega.test.system.framework.TestFrameworkException.Type.Inter
 public class PravegaSegmentStoreService extends MarathonBasedService {
 
     private static final int SEGMENTSTORE_PORT = 12345;
-    private static final int BACK_OFF_SECS = 7200;
     private final URI zkUri;
     private int instances = 1;
     private double cpu = 0.1;
@@ -95,7 +94,6 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
     private App createPravegaSegmentStoreApp() {
         App app = new App();
         app.setId(this.id);
-        app.setBackoffSeconds(BACK_OFF_SECS);
         app.setCpus(cpu);
         app.setMem(mem);
         app.setInstances(instances);


### PR DESCRIPTION
**Change log description**
*Correct the wrong value of backoffsecs used in segmentstore deployment.

**Purpose of the change**
Fixes #1816 

**What the code does**
Backoffsecs used for pravega segmentstore deployment is incorrect.

**How to verify it**
Run system tests