### PR TITLE
Issue 1799: Swap wait order of txns and writers

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -277,12 +277,13 @@ public class MultiReaderTxnWriterWithFailoverTest {
             log.info("Stop write flag status {}", stopWriteFlag);
             stopWriteFlag.set(true);
 
-            //wait for txns to get committed
-            FutureHelpers.allOf(txnStatusFutureList).get();
-
             //wait for writers completion
             log.info("Wait for writers execution to complete");
             FutureHelpers.allOf(writerFutureList).get();
+
+            //wait for txns to get committed
+            log.info("Wait for txns to complete");
+            FutureHelpers.allOf(txnStatusFutureList).get();
 
             //set the stop read flag to true
             log.info("Stop read flag status {}", stopReadFlag);


### PR DESCRIPTION
**Change log description**
* Swaps the completion check order of txns and writers in `MultiReaderTxnWriterWithFailoverTest`.

**Purpose of the change**
Fixes #1799 

**What the code does**
If we wait for txns to complete before we do it for writers, then we can have a race where new txns are created and not accounted for. The ultimate result is a discrepancy the write/read counts. This code fixes this issue by swapping the wait order of txns and writers.

**How to verify it**
Run system test case.