### PR TITLE
Issue 1819: Change timeout values when creating a ZK client in controller tests

### DIFF
--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
@@ -38,7 +38,7 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
     public void setupCheckpointStore() throws Exception {
         zkServer = new TestingServerStarter().start();
         zkServer.start();
-        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 10, 10, new RetryOneTime(10));
+        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 10000, 10000, new RetryOneTime(10000));
         cli.start();
         checkpointStore = CheckpointStoreFactory.createZKStore(cli);
     }


### PR DESCRIPTION
**Change log description**
* Multiply current timeout values by 1000 when creating the zk client in `ZKCheckpointStoreTests`.

**Purpose of the change**
Fixes #1819 

**What the code does**
Changes time out values when creating a zk client in controller tests.

**How to verify it**
Run unit tests.