### PR TITLE
Issue 1499: Ping txn can be received on different controller instances whereby abort can be performed by some controller with a stale ping. 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -403,15 +403,8 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
             return CompletableFuture.completedFuture(createStatus(Status.DISCONNECTED));
         }
 
-        if (timeoutService.containsTxn(scope, stream, txnId)) {
-            // If timeout service knows about this transaction, attempt to increase its lease.
-            log.debug("Txn={}, extending lease in timeout service", txnId);
-            return CompletableFuture.completedFuture(timeoutService.pingTxn(scope, stream, txnId, lease));
-        } else {
-            // Otherwise, fence other potential processes managing timeout for this txn, and update its lease.
-            log.debug("Txn={}, updating txn node in store and extending lease", txnId);
-            return fenceTxnUpdateLease(scope, stream, txnId, lease, ctx);
-        }
+        log.debug("Txn={}, updating txn node in store and extending lease", txnId);
+        return fenceTxnUpdateLease(scope, stream, txnId, lease, ctx);
     }
 
     private PingTxnStatus createStatus(Status status) {
@@ -466,8 +459,13 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
                         // Even if timeout service has an active/executing timeout task for this txn, it is bound
                         // to fail, since version of txn node has changed because of the above store.pingTxn call.
                         // Hence explicitly add a new timeout task.
-                        log.debug("Txn={}, adding txn to host-txn index", txnId);
-                        timeoutService.addTxn(scope, stream, txnId, version, lease, expiryTime, scaleGracePeriod);
+                        if (timeoutService.containsTxn(scope, stream, txnId)) {
+                            // If timeout service knows about this transaction, attempt to increase its lease.
+                            log.debug("Txn={}, extending lease in timeout service", txnId);
+                            timeoutService.pingTxn(scope, stream, txnId, lease);
+                        } else {
+                            timeoutService.addTxn(scope, stream, txnId, version, lease, expiryTime, scaleGracePeriod);
+                        }
                         return createStatus(Status.OK);
                     }, executor);
                 }, executor);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -462,7 +462,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
                         if (timeoutService.containsTxn(scope, stream, txnId)) {
                             // If timeout service knows about this transaction, attempt to increase its lease.
                             log.debug("Txn={}, extending lease in timeout service", txnId);
-                            timeoutService.pingTxn(scope, stream, txnId, lease);
+                            timeoutService.pingTxn(scope, stream, txnId, version, lease);
                         } else {
                             timeoutService.addTxn(scope, stream, txnId, version, lease, expiryTime, scaleGracePeriod);
                         }

--- a/controller/src/main/java/io/pravega/controller/timeout/TimeoutService.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimeoutService.java
@@ -87,10 +87,10 @@ public interface TimeoutService extends Service {
      * @param scope  Scope name.
      * @param stream Stream name.
      * @param txnId  Transaction id.
-     * @param lease  Additional amount of time for the transaction to be in open state.
-     * @return Ping status
+     * @param version Transaction version.
+     *@param lease  Additional amount of time for the transaction to be in open state.  @return Ping status
      */
-    PingTxnStatus pingTxn(final String scope, final String stream, final UUID txnId, long lease);
+    PingTxnStatus pingTxn(final String scope, final String stream, final UUID txnId, int version, long lease);
 
     /**
      * This method returns a boolean indicating whether it manages timeout for the specified transaction.

--- a/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
@@ -141,9 +141,8 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
             this.timeout = hashedWheelTimer.newTimeout(task, lease, TimeUnit.MILLISECONDS);
         }
 
-        public TxnData updateLease(final String scope, final String stream, final UUID txnId, final long lease) {
-            return new TxnData(scope, stream, txnId, this.version, lease,
-                    this.maxExecutionTimeExpiry, this.scaleGracePeriod);
+        public TxnData updateLease(final String scope, final String stream, final UUID txnId, int version, final long lease) {
+            return new TxnData(scope, stream, txnId, version, lease, this.maxExecutionTimeExpiry, this.scaleGracePeriod);
         }
     }
 
@@ -209,7 +208,7 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
     }
 
     @Override
-    public PingTxnStatus pingTxn(final String scope, final String stream, final UUID txnId, long lease) {
+    public PingTxnStatus pingTxn(final String scope, final String stream, final UUID txnId, int version, long lease) {
 
         if (!this.isRunning()) {
             return PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.DISCONNECTED).build();
@@ -219,6 +218,10 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
         Preconditions.checkState(map.containsKey(key), "Stream not found in the map");
 
         final TxnData txnData = map.get(key);
+
+        if (txnData == null) {
+            return PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.UNRECOGNIZED).build();
+        }
 
         if (lease > maxLeaseValue || lease > txnData.getScaleGracePeriod()) {
             return PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.LEASE_TOO_LARGE).build();
@@ -230,7 +233,7 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
             Timeout timeout = txnData.getTimeout();
             boolean cancelSucceeded = timeout.cancel();
             if (cancelSucceeded) {
-                TxnData newTxnData = txnData.updateLease(scope, stream, txnId, lease);
+                TxnData newTxnData = txnData.updateLease(scope, stream, txnId, version, lease);
                 map.replace(key, txnData, newTxnData);
                 return PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build();
             } else {

--- a/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
@@ -220,7 +220,7 @@ public class TimerWheelTimeoutService extends AbstractService implements Timeout
         final TxnData txnData = map.get(key);
 
         if (txnData == null) {
-            return PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.UNRECOGNIZED).build();
+            throw new IllegalStateException(String.format("Transaction %s not added to timerWheelTimeoutService", txnId));
         }
 
         if (lease > maxLeaseValue || lease > txnData.getScaleGracePeriod()) {


### PR DESCRIPTION
**Change log description**
The issue was that client can send pings to different controllers. 
A controller, upon receiving the ping, creates a fence using zk node to claim ownership for txn's timeout management. 
However, if client sends ping to Controller-1 followed by controller-2 and then back to controller-1, then controller-1 doesnt try to reacquire lease on the txn, falsely assuming it continues to own the lease even though the ownership had passed to controller-2. 
Controller-2, upon its timeout will attempt to abort the txn and will be able to successfully do so because it has the lease. This is incorrect because the clients intent was to renew the lease and it achieved this by pinging more times which landed on controller-1.

To fix this, we are now making all pings resulting in lease transfer to controller receiving the ping. 

**Purpose of the change**
Fixes #1499

**What the code does**
Always fences txn by updating the corresponding znode. 

**How to verify it**
System test should not observe this scenario. 