### PR TITLE
Issue 1826: Fix the error handling logic in CommitEventProcessor.writeEvent

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessor.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.eventProcessor.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.controller.store.checkpoint.CheckpointStoreException;
 import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.client.stream.Position;
@@ -72,7 +73,8 @@ public abstract class EventProcessor<T extends ControllerEvent> {
      * Returns a stream writer that can be used to write events to the underlying event stream.
      * @return a stream writer that can be used to write events to the underlying event stream.
      */
-    protected Writer<T> getSelfWriter() {
+    @VisibleForTesting
+    public Writer<T> getSelfWriter() {
         return selfWriter;
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/CommitEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/CommitEventProcessor.java
@@ -136,12 +136,13 @@ public class CommitEventProcessor extends EventProcessor<CommitEvent> {
         UUID txnId = event.getTxid();
         log.debug("Transaction {}, pushing back CommitEvent to commitStream", txnId);
         return this.getSelfWriter().write(event).handleAsync((v, e) -> {
-            if (e != null) {
+            if (e == null) {
                 log.debug("Transaction {}, sent request to commitStream", txnId);
                 return null;
             } else {
                 Throwable realException = ExceptionHelpers.getRealException(e);
-                log.warn("Transaction {}, failed sending event to commitStream. Retrying...", txnId);
+                log.warn("Transaction {}, failed sending event to commitStream. Exception: {} Retrying...", txnId,
+                        realException.getClass().getSimpleName());
                 throw new WriteFailedException(realException);
             }
         }, executor);


### PR DESCRIPTION
**Change log description**
-  Fix the error handling logic in CommitEventProcessor.writeEvent

**Purpose of the change**
Fixes #1826 

**What the code does**
- Ensure WriteFailedException is thrown if there is an exception while writing CommitEvent.

**How to verify it**
Tests should pass.