### PR TITLE
Issue 1828 : Sending too many metric updates on sealed segments

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -154,6 +154,10 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
         return withCompletion(getStream(scope, name, context).delete(), executor)
                 .thenApply(result -> {
                     DELETE_STREAM.reportSuccessValue(1);
+                    DYNAMIC_LOGGER.freezeCounter(nameFromStream(COMMIT_TRANSACTION, scope, name));
+                    DYNAMIC_LOGGER.freezeGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name));
+                    DYNAMIC_LOGGER.freezeCounter(nameFromStream(SEGMENTS_SPLITS, scope, name));
+                    DYNAMIC_LOGGER.freezeCounter(nameFromStream(SEGMENTS_MERGES, scope, name));
                     return result;
                 });
     }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -92,6 +92,8 @@ import static io.pravega.segmentstore.contracts.ReadResultEntryType.Future;
 import static io.pravega.shared.MetricsNames.SEGMENT_CREATE_LATENCY;
 import static io.pravega.shared.MetricsNames.SEGMENT_READ_BYTES;
 import static io.pravega.shared.MetricsNames.SEGMENT_READ_LATENCY;
+import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_BYTES;
+import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_EVENTS;
 import static io.pravega.shared.MetricsNames.nameFromSegment;
 import static io.pravega.shared.protocol.netty.WireCommands.TYPE_PLUS_LENGTH_SIZE;
 import static java.lang.Math.max;
@@ -450,6 +452,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         CompletableFuture<Long> future = segmentStore.sealStreamSegment(segment, TIMEOUT);
         future.thenAccept(size -> {
             connection.send(new SegmentSealed(sealSegment.getRequestId(), segment));
+            DYNAMIC_LOGGER.freezeCounter(nameFromSegment(SEGMENT_WRITE_BYTES, segment));
+            DYNAMIC_LOGGER.freezeCounter(nameFromSegment(SEGMENT_WRITE_EVENTS, segment));
         }).whenComplete((r, e) -> {
             if (e != null) {
                 handleException(sealSegment.getRequestId(), segment, "Seal segment", e);
@@ -468,6 +472,9 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         CompletableFuture<Void> future = segmentStore.deleteStreamSegment(segment, TIMEOUT);
         future.thenRun(() -> {
             connection.send(new SegmentDeleted(deleteSegment.getRequestId(), segment));
+            DYNAMIC_LOGGER.freezeCounter(nameFromSegment(SEGMENT_WRITE_BYTES, segment));
+            DYNAMIC_LOGGER.freezeCounter(nameFromSegment(SEGMENT_WRITE_EVENTS, segment));
+            DYNAMIC_LOGGER.freezeCounter(nameFromSegment(SEGMENT_READ_BYTES, segment));
         }).exceptionally(e -> {
             handleException(deleteSegment.getRequestId(), segment, "Delete segment", e);
             return null;

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
@@ -31,6 +31,13 @@ public interface DynamicLogger {
     void updateCounterValue(String name, long value);
 
     /**
+     * Notifies that the counter will not be updated.
+     *
+     * @param name              the name of counter
+     */
+    void freezeCounter(String name);
+
+    /**
      * Report gauge value.
      *
      * @param <T>   the type of value
@@ -38,6 +45,13 @@ public interface DynamicLogger {
      * @param value the value to be reported
      */
     <T extends Number> void reportGaugeValue(String name, T value);
+
+    /**
+     * Notifies that the gauge value will not be updated.
+     *
+     * @param name  the name of gauge
+     */
+    void freezeGaugeValue(String name);
 
     /**
      * Record the occurrence of a given number of events in Meter.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -119,6 +119,13 @@ public class DynamicLoggerImpl implements DynamicLogger {
     }
 
     @Override
+    public void freezeCounter(String name) {
+        String counterName = name + ".Counter";
+        countersCache.invalidate(counterName);
+        metrics.remove(counterName);
+    }
+
+    @Override
     public <T extends Number> void reportGaugeValue(String name, T value) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(value);
@@ -144,6 +151,13 @@ public class DynamicLoggerImpl implements DynamicLogger {
         } else {
             gaugesCache.put(gaugeName, newGauge);
         }
+    }
+
+    @Override
+    public void freezeGaugeValue(String name) {
+        String gaugeName = name + ".Gauge";
+        gaugesCache.invalidate(gaugeName);
+        metrics.remove(gaugeName);
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerProxy.java
@@ -33,8 +33,18 @@ public class DynamicLoggerProxy implements DynamicLogger {
     }
 
     @Override
+    public void freezeCounter(String name) {
+        this.instance.get().freezeCounter(name);
+    }
+
+    @Override
     public <T extends Number> void reportGaugeValue(String name, T value) {
         this.instance.get().reportGaugeValue(name, value);
+    }
+
+    @Override
+    public void freezeGaugeValue(String name) {
+        this.instance.get().freezeGaugeValue(name);
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullDynamicLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullDynamicLogger.java
@@ -23,7 +23,17 @@ public class NullDynamicLogger implements DynamicLogger {
     }
 
     @Override
+    public void freezeCounter(String name) {
+        // nop
+    }
+
+    @Override
     public <T extends Number> void reportGaugeValue(String name, T value) {
+        // nop
+    }
+
+    @Override
+    public void freezeGaugeValue(String name) {
         // nop
     }
 

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -73,6 +73,8 @@ public class MetricsProviderTest {
             dynamicLogger.incCounterValue("dynamicCounter", i);
             assertEquals(sum, MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.dynamicCounter.Counter").getCount());
         }
+        dynamicLogger.freezeCounter("dynamicCounter");
+        assertEquals(null, MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.dynamicCounter.Counter"));
     }
 
     /**
@@ -110,6 +112,8 @@ public class MetricsProviderTest {
             assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("pravega.testStatsLogger.testGauge").getValue());
             assertEquals(i, MetricsProvider.METRIC_REGISTRY.getGauges().get("pravega.dynamicGauge.Gauge").getValue());
         }
+        dynamicLogger.freezeGaugeValue("dynamicGauge");
+        assertEquals(null, MetricsProvider.METRIC_REGISTRY.getGauges().get("pravega.dynamicGauge.Gauge"));
     }
 
     /**


### PR DESCRIPTION

**Change log description**
* Update metrics code to ensure that selected counters and gauges can be removed from reporting.
* Use the added features to ensure that dynamic counters and gauges are frozen as segments and streams are sealed/deleted

**Purpose of the change**
This fixes #1828.

**What the code does**
Disables gauges/counters from syncing which will not change any further. 

**How to verify it**
Unit tests.
Verify the traffic in platform deployments.