### PR TITLE
Issue 1829: Corrupt statefile keeps the segment in permanent error state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ project('segmentstore:server') {
         compile project(':segmentstore:contracts')
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
+        compile group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3ControllerContractVersion
         testCompile project(':test:testcommon')
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
@@ -120,20 +120,19 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .exceptionally(this::handleSegmentNotExistsException);
 
         return CompletableFuture.allOf(retVal1, retVal2).thenApplyAsync((v) -> {
-            SegmentState s1 = states[0].join();
-            SegmentState s2 = states[1].join();
+            SegmentState s1 = states[0] == null ? null : states[0].join();
+            SegmentState s2 = states[1] == null ? null : states[1].join();
 
-            assert s1 != null || s2 != null : "No valid segmentstate exists";
             if (s1 == null) {
                 return s2;
             }
             if (s2 == null) {
                 return s1;
             }
-            if (props[0].getLastModified().asDate().compareTo(props[1].getLastModified().asDate()) < 0) {
-                return s2;
-            } else {
+            if (props[0].getLastModified().asDate().compareTo(props[1].getLastModified().asDate()) > 0) {
                 return s1;
+            } else {
+                return s2;
             }
         }, this.executor);
     }
@@ -166,10 +165,9 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .exceptionally(this::handleSegmentNotExistsException);
 
         return CompletableFuture.allOf(retVal1, retVal2).thenApplyAsync((v) -> {
-            SegmentState s1 = states[0].join();
-            SegmentState s2 = states[1].join();
+            SegmentState s1 = states[0] == null ? null : states[0].join();
+            SegmentState s2 = states[1] == null ? null : states[1].join();
 
-            assert s1 != null || s2 != null : "No valid segmentstate exists";
             if (s1 == null) {
                 return stateSegment1;
             }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
@@ -105,7 +105,8 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .getStreamSegmentInfo(stateSegment1, timer.getRemaining())
                 .thenComposeAsync(sp -> {
                     props[0] = sp;
-                    states[0] = readSegmentState(sp, timer.getRemaining());
+                    states[0] = readSegmentState(sp, timer.getRemaining())
+                            .exceptionally(this::handleSegmentNotExistsException);
                     return states[0];
                 }, this.executor)
                 .exceptionally(this::handleSegmentNotExistsException);
@@ -114,7 +115,8 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .getStreamSegmentInfo(stateSegment2, timer.getRemaining())
                 .thenComposeAsync(sp -> {
                     props[1] = sp;
-                    states[1] = readSegmentState(sp, timer.getRemaining());
+                    states[1] = readSegmentState(sp, timer.getRemaining())
+                            .exceptionally(this::handleSegmentNotExistsException);
                     return states[1];
                 }, this.executor)
                 .exceptionally(this::handleSegmentNotExistsException);
@@ -150,7 +152,8 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .getStreamSegmentInfo(stateSegment1, timer.getRemaining())
                 .thenComposeAsync(sp -> {
                     props[0] = sp;
-                    states[0] = readSegmentState(sp, timer.getRemaining());
+                    states[0] = readSegmentState(sp, timer.getRemaining())
+                            .exceptionally(this::handleSegmentNotExistsException);
                     return states[0];
                 }, this.executor)
                 .exceptionally(this::handleSegmentNotExistsException);
@@ -159,7 +162,8 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
                 .getStreamSegmentInfo(stateSegment2, timer.getRemaining())
                 .thenComposeAsync(sp -> {
                     props[1] = sp;
-                    states[1] = readSegmentState(sp, timer.getRemaining());
+                    states[1] = readSegmentState(sp, timer.getRemaining())
+                            .exceptionally(this::handleSegmentNotExistsException);
                     return states[1];
                 }, this.executor)
                 .exceptionally(this::handleSegmentNotExistsException);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentStateStore.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -143,7 +144,7 @@ class SegmentStateStore implements AsyncMap<String, SegmentState> {
     @SneakyThrows(Throwable.class)
     private <T> T handleSegmentNotExistsException(Throwable ex) {
         ex = ExceptionHelpers.getRealException(ex);
-        if (ex instanceof StreamSegmentNotExistsException) {
+        if (ex instanceof StreamSegmentNotExistsException || ex instanceof EOFException) {
             // It's ok if the state segment does not exist.
             return null;
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
@@ -11,7 +11,6 @@ package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.util.AsyncMap;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
-import lombok.val;
 
 /**
  * Unit tests for the SegmentStateStore class.
@@ -35,7 +34,7 @@ public class SegmentStateStoreTests extends StateStoreTests {
     public void emptySegment(String segmentName) {
         String firstStateSegment = segmentName + "$state1";
         storage.openWrite(firstStateSegment)
-               .thenApply(handle -> storage.delete(handle,null))
+               .thenApply(handle -> storage.delete(handle, null))
                 .thenApply(v -> storage.create(firstStateSegment, null)).join();
 
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
@@ -17,6 +17,8 @@ import lombok.val;
  * Unit tests for the SegmentStateStore class.
  */
 public class SegmentStateStoreTests extends StateStoreTests {
+    private InMemoryStorage storage;
+
     @Override
     public int getThreadPoolSize() {
         return 5;
@@ -24,8 +26,17 @@ public class SegmentStateStoreTests extends StateStoreTests {
 
     @Override
     protected AsyncMap<String, SegmentState> createStateStore() {
-        val storage = new InMemoryStorage(executorService());
+        storage = new InMemoryStorage(executorService());
         storage.initialize(1);
         return new SegmentStateStore(storage, executorService());
+    }
+
+    @Override
+    public void emptySegment(String segmentName) {
+        String firstStateSegment = segmentName + "$state1";
+        storage.openWrite(firstStateSegment)
+               .thenApply(handle -> storage.delete(handle,null))
+                .thenApply(v -> storage.create(firstStateSegment, null)).join();
+
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -137,14 +137,17 @@ public abstract class StateStoreTests extends ThreadPooledTestSuite {
      * Unit tests for the InMemoryStateStore class.
      */
     public static class InMemoryStateStoreTests extends StateStoreTests {
+        private InMemoryStateStore stateStore = null;
+
         @Override
         protected AsyncMap<String, SegmentState> createStateStore() {
-            return new InMemoryStateStore();
+            stateStore = new InMemoryStateStore();
+            return stateStore;
         }
 
         @Override
         public void emptySegment(String segmentName) {
-           //TODO: implement this.
+            stateStore.remove(segmentName, null);
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
  * Defines tests for a generic State Store (AsyncMap(String, SegmentState))
  */
 public abstract class StateStoreTests extends ThreadPooledTestSuite {
-    private static final Duration TIMEOUT = Duration.ofSeconds(10000);
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
     private static final int ATTRIBUTE_COUNT = 10;
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
  * Defines tests for a generic State Store (AsyncMap(String, SegmentState))
  */
 public abstract class StateStoreTests extends ThreadPooledTestSuite {
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TIMEOUT = Duration.ofSeconds(10000);
     private static final int ATTRIBUTE_COUNT = 10;
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
  * Defines tests for a generic State Store (AsyncMap(String, SegmentState))
  */
 public abstract class StateStoreTests extends ThreadPooledTestSuite {
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TIMEOUT = Duration.ofSeconds(10000);
     private static final int ATTRIBUTE_COUNT = 10;
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
@@ -99,6 +99,22 @@ public abstract class StateStoreTests extends ThreadPooledTestSuite {
         }
     }
 
+    /**
+     * Tests the get() after a corrupt put().
+     */
+    @Test
+    public void testGetAfterCorruptPut() throws Exception {
+        final String segmentName = "foo";
+        final SegmentState state1 = createState(segmentName);
+        val ss = createStateStore();
+
+        ss.put(segmentName, state1, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        this.emptySegment(segmentName);
+
+        val deserialized = ss.get(segmentName, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        Assert.assertNull("Corrupt state should be discarded", deserialized);
+    }
     //endregion
 
     protected abstract AsyncMap<String, SegmentState> createStateStore();
@@ -113,6 +129,8 @@ public abstract class StateStoreTests extends ThreadPooledTestSuite {
                 new StreamSegmentInformation(segmentName, 0, false, false, attributes, new ImmutableDate()));
     }
 
+    public abstract void emptySegment(String segmentName);
+
     //region InMemoryStateStoreTests
 
     /**
@@ -122,6 +140,11 @@ public abstract class StateStoreTests extends ThreadPooledTestSuite {
         @Override
         protected AsyncMap<String, SegmentState> createStateStore() {
             return new InMemoryStateStore();
+        }
+
+        @Override
+        public void emptySegment(String segmentName) {
+           //TODO: implement this.
         }
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperation.java
@@ -62,7 +62,8 @@ class GetInfoOperation extends FileSystemOperation<String> implements Callable<S
                 throw fnf;
             }
 
-            result = new StreamSegmentInformation(segmentName, length, isSealed, false, new ImmutableDate());
+            result = new StreamSegmentInformation(segmentName, length, isSealed, false,
+                    new ImmutableDate(findAllRaw(segmentName)[0].getModificationTime()));
         } while (result == null);
         LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, segmentName, result);
         return result;

--- a/shared/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
+++ b/shared/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
@@ -21,7 +21,12 @@ public final class StreamSegmentNameUtils {
     /**
      * This is appended to the end of the Segment/Transaction name to indicate it stores its custom attributes.
      */
-    private static final String STATE_SUFFIX = "$state";
+    private static final String STATE_SUFFIX_FIRST = "$state1";
+
+    /**
+     * This is appended to the end of the Segment/Transaction name to indicate it stores its custom attributes.
+     */
+    private static final String STATE_SUFFIX_SECOND = "$state2";
 
     /**
      * This is appended to the end of the Parent Segment Name, then we append a unique identifier.
@@ -84,8 +89,19 @@ public final class StreamSegmentNameUtils {
      * @param segmentName The name of the Segment to get the State segment name for.
      * @return The result.
      */
-    public static String getStateSegmentName(String segmentName) {
-        Preconditions.checkArgument(!segmentName.contains(STATE_SUFFIX), "segmentName is already a state segment name");
-        return segmentName + STATE_SUFFIX;
+    public static String getFirstStateSegmentName(String segmentName) {
+        Preconditions.checkArgument(!segmentName.contains(STATE_SUFFIX_FIRST), "segmentName is already a state segment name");
+        return segmentName + STATE_SUFFIX_FIRST;
+    }
+
+    /**
+     * Gets the name of the meta-Segment mapped to the given Segment Name that is responsible with storing Segment State.
+     *
+     * @param segmentName The name of the Segment to get the State segment name for.
+     * @return The result.
+     */
+    public static String getSecondStateSegmentName(String segmentName) {
+        Preconditions.checkArgument(!segmentName.contains(STATE_SUFFIX_SECOND), "segmentName is already a state segment name");
+        return segmentName + STATE_SUFFIX_SECOND;
     }
 }


### PR DESCRIPTION
**Change log description**
- Treating a corrupt statefile as non-existent statefile.

**Purpose of the change**


**What the code does**
The state of each segment is stored in Tier-2 in a statefile. The current state is periodically flushed to the statefile. When a segmentstore accesses a segment for the first time, this state is loaded from the statefile. In case of non-existent statefile, a default state is returned which is then converted to specific state. The code does not take care of the case where the statefile is corrupt. Segmentstore tries to load the statefile before any operation on the segment. In case of corruption of statefile, no operation will proceed.
The pull request changes the behavior such that  corrupt statefile is treated as the same case where statefile does not exist at all. In this case a new statefile will be created.

**How to verify it**
TBD: Add unit tests.
Run system tests and verify that the error does not exist.