### PR TITLE
Issue 522: Add error handling JVM options

### DIFF
--- a/deployment/aws/installer/entry_point_template.yml
+++ b/deployment/aws/installer/entry_point_template.yml
@@ -6,7 +6,7 @@
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 
-- hosts: all 
+- hosts: all
   roles:
     - { role: install-prereqs }
   remote_user: root
@@ -22,7 +22,7 @@
   environment:
     LD_LIBRARY_PATH: /opt/bk_all/lib
     JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  roles: 
+  roles:
     - { role: install-bk }
   remote_user: root
 
@@ -32,7 +32,13 @@
     REST_SERVER_PORT: 10080
     CONTROLLER_SERVER_PORT: 9090
     ZK_URL: ZKNODE:2181
-    JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+    JAVA_OPTS: |
+      -Dconfig.controller.metricenableCSVReporter=false
+      -Xmx512m
+      -XX:OnError="kill -9 p%"
+      -XX:+ExitOnOutOfMemoryError
+      -XX:+CrashOnOutOfMemoryError
+      -XX:+HeapDumpOnOutOfMemoryError
   roles:
     - { role: install-controller }
   remote_user: root
@@ -44,7 +50,14 @@
     HDFS_URL: NAMENODE:8020
     ZK_URL: ZKNODE:2181
     CONTROLLER_URL: tcp://CONTROLLERNODE:9090
-    JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dbookkeeper.zkAddress=ZKNODE:2181 -Xmx900m
+    JAVA_OPTS: |
+      -Dmetrics.enableCSVReporter=false
+      -Dbookkeeper.zkAddress=ZKNODE:2181
+      -Xmx900m
+      -XX:OnError="kill -9 p%"
+      -XX:+ExitOnOutOfMemoryError
+      -XX:+CrashOnOutOfMemoryError
+      -XX:+HeapDumpOnOutOfMemoryError
     HADOOP_USER_NAME: hdfs
   roles:
     - { role: install-hosts }

--- a/docker/compose/docker-compose-extendeds3.yml
+++ b/docker/compose/docker-compose-extendeds3.yml
@@ -55,7 +55,13 @@ services:
       REST_SERVER_PORT: 10080
       CONTROLLER_SERVER_PORT: 9090
       ZK_URL: zookeeper:2181
-      JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+      JAVA_OPTS: |
+        -Dconfig.controller.metricenableCSVReporter=false
+        -Xmx512m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
     links:
       - zookeeper
@@ -75,7 +81,14 @@ services:
       EXTENDEDS3_URI: ${EXTENDEDS3_URI}
       ZK_URL: zookeeper:2181
       CONTROLLER_URL: tcp://${HOST_IP}:9091
-      JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress=${HOST_IP} -Xmx900m
+      JAVA_OPTS: |
+        -Dmetrics.enableCSVReporter=false
+        -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Xmx900m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
     links:
       - zookeeper
       - bookie1

--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -55,7 +55,13 @@ services:
       REST_SERVER_PORT: 10080
       CONTROLLER_SERVER_PORT: 9090
       ZK_URL: zookeeper:2181
-      JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+      JAVA_OPTS: |
+        -Dconfig.controller.metricenableCSVReporter=false
+        -Xmx512m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
     links:
       - zookeeper
@@ -76,7 +82,14 @@ services:
       HDFS_URL: ${HOST_IP}:8020
       ZK_URL: zookeeper:2181
       CONTROLLER_URL: tcp://${HOST_IP}:9090
-      JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress=${HOST_IP} -Xmx900m
+      JAVA_OPTS: |
+        -Dmetrics.enableCSVReporter=false
+        -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Xmx900m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
     links:
       - zookeeper
       - bookie1

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -62,7 +62,13 @@ services:
       REST_SERVER_PORT: 10080
       CONTROLLER_SERVER_PORT: 9090
       ZK_URL: zookeeper:2181
-      JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+      JAVA_OPTS: |
+        -Dconfig.controller.metricenableCSVReporter=false
+        -Xmx512m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
     links:
       - zookeeper
@@ -82,7 +88,14 @@ services:
       HDFS_URL: ${HOST_IP}:8020
       ZK_URL: zookeeper:2181
       CONTROLLER_URL: tcp://${HOST_IP}:9090
-      JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress=${HOST_IP} -Xmx900m
+      JAVA_OPTS: |
+        -Dmetrics.enableCSVReporter=false
+        -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Xmx900m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
     links:
       - zookeeper
       - bookie1

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -69,7 +69,13 @@ services:
       REST_SERVER_PORT: 10080
       CONTROLLER_SERVER_PORT: 9090
       ZK_URL: zookeeper:2181
-      JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+      JAVA_OPTS: |
+        -Dconfig.controller.metricenableCSVReporter=false
+        -Xmx512m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
     links:
       - zookeeper
@@ -85,7 +91,14 @@ services:
       HDFS_URL: ${HOST_IP}:8020
       ZK_URL: zookeeper:2181
       CONTROLLER_URL: tcp://${HOST_IP}:9090
-      JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress=${HOST_IP} -Xmx900m
+      JAVA_OPTS: |
+        -Dmetrics.enableCSVReporter=false
+        -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Xmx900m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
     links:
       - zookeeper
       - hdfs

--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -25,7 +25,13 @@ services:
     environment:
       WAIT_FOR: ${ZK_URL:-zookeeper:2181}
       ZK_URL: ${ZK_URL:-zookeeper:2181}
-      JAVA_OPTS: -Dconfig.controller.metricenableCSVReporter=false -Xmx512m
+      JAVA_OPTS: |
+        -Dconfig.controller.metricenableCSVReporter=false
+        -Xmx512m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
 
   segmentstore:
     image: pravega/pravega
@@ -37,4 +43,12 @@ services:
       HDFS_URL: hdfs://${HDFS_URL:-hdfs:8020}
       ZK_URL: ${ZK_URL:-zookeeper:2181}
       CONTROLLER_URL: tcp://controller:9090
-      JAVA_OPTS: -Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress=${PUBLISHED_ADDRESS} -Dpravegaservice.listeningIPAddress=${LISTENING_ADDRESS} -Xmx900m
+      JAVA_OPTS: |
+        -Dmetrics.enableCSVReporter=false
+        -Dpravegaservice.publishedIPAddress=${PUBLISHED_ADDRESS}
+        -Dpravegaservice.listeningIPAddress=${LISTENING_ADDRESS}
+        -Xmx900m
+        -XX:OnError="kill -9 p%"
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+CrashOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -61,7 +61,7 @@ for instance in to_create:
           -e HDFS_URL={hdfs_url} \
           -e ZK_URL={zk_url} \
           -e CONTROLLER_URL=tcp://controller:9090 \
-          -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Xmx900m' \
+          -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \
           pravega/pravega segmentstore"""
 
     cmd = template.format(


### PR DESCRIPTION
This PR is my first stab at this project. I’ve simply verified launching with `docker compose`. Assuming the proposed changes make sense, I’d like to know what should be done to test it more throughly.

HTH

**Change log description**
Add the following JVM flags
 - `-XX:OnError="kill -9 p%"`
 - `-XX:+HeapDumpOnOutOfMemoryError`
 - `-XX:+ExitOnOutOfMemoryError`
 - `-XX:+CrashOnOutOfMemoryError`

and reformat to avoid long lines.

_The last two options were added with JDK 8u92_

**Purpose of the change**
Address  #522 

**What the code does**
Kills the JVM process on unrecoverable errors.

**How to verify it**
TBD