### PR TITLE
Issue 1660: Optimize RetryAndThrowBase#runInExecutor

### DIFF
--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -225,7 +225,7 @@ public final class Retry {
                     () -> !isDone.get(),
                     () -> FutureHelpers.delayedFuture(Duration.ofMillis(delay.get()), executorService)
                             .thenRunAsync(task, executorService)
-                            .thenAccept(v -> isDone.set(true)) // We are done.
+                            .thenRun(() -> isDone.set(true)) // We are done.
                             .exceptionally(ex -> {
                                 if (!canRetry(ex)) {
                                     // Cannot retry this exception. Fail now.

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -217,21 +218,22 @@ public final class Retry {
         public CompletableFuture<Void> runInExecutor(final Runnable task,
                                                      final ScheduledExecutorService executorService) {
             Preconditions.checkNotNull(task);
-            CompletableFuture<Void> result = new CompletableFuture<>();
+            AtomicBoolean isDone = new AtomicBoolean();
             AtomicInteger attemptNumber = new AtomicInteger(1);
             AtomicLong delay = new AtomicLong(0);
-            FutureHelpers.loop(
-                    () -> !result.isDone(),
+            return FutureHelpers.loop(
+                    () -> !isDone.get(),
                     () -> FutureHelpers.delayedFuture(Duration.ofMillis(delay.get()), executorService)
                             .thenRunAsync(task, executorService)
-                            .thenAccept(result::complete) // We are done.
+                            .thenAccept(v -> isDone.set(true)) // We are done.
                             .exceptionally(ex -> {
                                 if (!canRetry(ex)) {
                                     // Cannot retry this exception. Fail now.
-                                    result.completeExceptionally(ex);
+                                    isDone.set(true);
                                 } else if (attemptNumber.get() + 1 > params.attempts) {
                                     // We have retried as many times as we were asked, unsuccessfully.
-                                    result.completeExceptionally(new RetriesExhaustedException(ex));
+                                    isDone.set(true);
+                                    throw new RetriesExhaustedException(ex);
                                 } else {
                                     // Try again.
                                     delay.set(attemptNumber.get() == 1 ?
@@ -243,7 +245,6 @@ public final class Retry {
                                 return null;
                             }),
                     executorService);
-            return result;
         }
         
         public <ReturnT> CompletableFuture<ReturnT> runAsync(final Supplier<CompletableFuture<ReturnT>> r,

--- a/common/src/test/java/io/pravega/common/util/RetryTests.java
+++ b/common/src/test/java/io/pravega/common/util/RetryTests.java
@@ -19,9 +19,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.pravega.common.concurrent.FutureHelpers;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/io/pravega/common/util/RetryTests.java
+++ b/common/src/test/java/io/pravega/common/util/RetryTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.common.util;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
@@ -17,11 +18,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import io.pravega.common.concurrent.FutureHelpers;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test methods for Retry utilities
@@ -158,6 +163,73 @@ public class RetryTests {
     }
 
     @Test
+    public void retryFutureInExecutorTests() {
+        ScheduledExecutorService executorService = ExecutorServiceHelpers.newScheduledThreadPool(5, "testpool");
+
+        // 1. series of retryable exceptions followed by a failure
+        begin = Instant.now();
+        final CompletableFuture<Void> result1 = retryFutureInExecutor(uniformDelay, 1, maxLoops, maxDelay, true, executorService);
+        try {
+            Exceptions.handleInterrupted(() -> result1.get());
+        } catch (ExecutionException e) {
+            log.debug("Exception not expected", e);
+            fail("Exception observed in retryInExecutor");
+        }
+        end = Instant.now();
+        duration = end.toEpochMilli() - begin.toEpochMilli();
+        log.debug("Expected duration = {}", expectedDurationUniform);
+        log.debug("Actual duration   = {}", duration);
+        assertTrue(duration >= expectedDurationUniform);
+
+        // 2, series of retryable exceptions followed by a non-retryable failure
+        begin = Instant.now();
+        CompletableFuture<Void> result2 = retryFutureInExecutor(uniformDelay, 1, maxLoops, maxDelay, false, executorService);
+        try {
+            result2.join();
+        } catch (CompletionException ce) {
+            end = Instant.now();
+            duration = end.toEpochMilli() - begin.toEpochMilli();
+            log.debug("Expected duration = {}", expectedDurationUniform);
+            log.debug("Actual duration   = {}", duration);
+            assertTrue(duration >= expectedDurationUniform);
+            assertTrue(ce.getCause() instanceof NonretryableException);
+            assertEquals(accumulator.get(), expectedResult);
+        }
+
+        // 3. exponential backoff
+        begin = Instant.now();
+        final CompletableFuture<Void> result3 = retryFutureInExecutor(exponentialInitialDelay, multiplier, maxLoops, maxDelay, true, executorService);
+        try {
+            Exceptions.handleInterrupted(() -> result3.get());
+        } catch (ExecutionException e) {
+            log.debug("Exception not expected", e);
+            fail("Exception observed in retryInExecutor");
+        }
+        end = Instant.now();
+        duration = end.toEpochMilli() - begin.toEpochMilli();
+        log.debug("Expected duration = {}", expectedDurationExponential);
+        log.debug("Actual duration   = {}", duration);
+        assertTrue(duration >= expectedDurationExponential);
+
+        // 4. Exhaust retries
+        begin = Instant.now();
+        final CompletableFuture<Void> result4 = retryFutureInExecutor(uniformDelay, 1, maxLoops - 1, maxDelay, true, executorService);
+        try {
+            result4.join();
+        } catch (Exception e) {
+            end = Instant.now();
+            duration = end.toEpochMilli() - begin.toEpochMilli();
+            log.debug("Expected duration = {}", expectedDurationUniform - uniformDelay);
+            log.debug("Actual duration   = {}", duration);
+            assertTrue(duration >= expectedDurationUniform - uniformDelay);
+            assertTrue(e instanceof CompletionException);
+            assertTrue(e.getCause() instanceof RetriesExhaustedException);
+            assertTrue(e.getCause().getCause() instanceof CompletionException);
+            assertTrue(e.getCause().getCause().getCause() instanceof RetryableException);
+        }
+    }
+
+    @Test
     public void retryPredicateTest() {
         AtomicInteger i = new AtomicInteger(0);
         try {
@@ -225,6 +297,35 @@ public class RetryTests {
                 .retryingOn(RetryableException.class)
                 .throwingOn(NonretryableException.class)
                 .runAsync(() -> futureComputation(success, executorService), executorService);
+    }
+
+    private CompletableFuture<Void> retryFutureInExecutor(final long delay,
+                                                   final int multiplier,
+                                                   final int attempts,
+                                                   final long maxDelay,
+                                                   final boolean success,
+                                                   final ScheduledExecutorService executorService) {
+
+        loopCounter.set(0);
+        accumulator.set(0);
+        return Retry.withExpBackoff(delay, multiplier, attempts, maxDelay)
+                .retryingOn(RetryableException.class)
+                .throwingOn(NonretryableException.class)
+                .runInExecutor(() -> {
+                    accumulator.getAndAdd(loopCounter.getAndIncrement());
+                    int i = loopCounter.get();
+                    log.debug("Loop counter = " + i);
+                    if (i % 10 == 0) {
+                        if (success) {
+                            log.debug("result = ", accumulator.get());
+                            return;
+                        } else {
+                            throw new NonretryableException();
+                        }
+                    } else {
+                        throw new RetryableException();
+                    }
+                }, executorService);
     }
 
     private CompletableFuture<Integer> futureComputation(boolean success, ScheduledExecutorService executorService) {


### PR DESCRIPTION
**Change log description**
- Reuse `CompletableFuture` returned by `FutureHelpers.loop` in `RetryAndThrowBase#runInExecutor`

**Purpose of the change**
Fixes #1660 

**What the code does**
- Removes the redundant CompletableFuture created in `RetryAndThrowBase#runInExecutor`

**How to verify it**
- Junits should pass.