### PR TITLE
Issue 1829: (SegmentStore) Ability to recover incomplete Segment Creations.

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
@@ -84,10 +84,10 @@ public final class FutureHelpers {
      *                       of the Future from futureSupplier.
      * @param <T>            Return type of Future.
      */
-    public static <T> void completeAfter(Supplier<CompletableFuture<T>> futureSupplier, CompletableFuture<T> toComplete) {
+    public static <T> void completeAfter(Supplier<CompletableFuture<? extends T>> futureSupplier, CompletableFuture<T> toComplete) {
         Preconditions.checkArgument(!toComplete.isDone(), "toComplete is already completed.");
         try {
-            CompletableFuture<T> f = futureSupplier.get();
+            CompletableFuture<? extends T> f = futureSupplier.get();
 
             // Async termination.
             f.thenAccept(toComplete::complete);
@@ -260,6 +260,33 @@ public final class FutureHelpers {
                 CallbackHelpers.invokeSafely(exceptionListener, (E) ex, null);
             }
         });
+    }
+
+    /**
+     * Same as CompletableFuture.exceptionally(), except that it allows returning a CompletableFuture instead of a single value.
+     *
+     * @param future  The original CompletableFuture to attach an Exception Listener.
+     * @param handler A Function that consumes a Throwable and returns a CompletableFuture of the same type as the original one.
+     *                This Function will be invoked if the original Future completed exceptionally.
+     * @param <T>     Type of the value of the original Future.
+     * @return A new CompletableFuture that will be completed either with the result of future (if it completed normally),
+     * or with the result of handler when applied to the exception of future, should future complete exceptionally.
+     */
+    public static <T> CompletableFuture<T> exceptionallyCompose(CompletableFuture<T> future, Function<Throwable, CompletableFuture<? extends T>> handler) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        future.thenAccept(result::complete);
+        future.exceptionally(ex -> {
+            try {
+                FutureHelpers.completeAfter(() -> handler.apply(ex), result);
+            } catch (Throwable ex2) {
+                if (ex2 != ex) {
+                    ex2.addSuppressed(ex);
+                }
+                result.completeExceptionally(ex2);
+            }
+            return null;
+        });
+        return result;
     }
 
     /**

--- a/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/FutureHelpers.java
@@ -278,11 +278,11 @@ public final class FutureHelpers {
         future.exceptionally(ex -> {
             try {
                 FutureHelpers.completeAfter(() -> handler.apply(ex), result);
-            } catch (Throwable ex2) {
-                if (ex2 != ex) {
-                    ex2.addSuppressed(ex);
+            } catch (Throwable innerException) {
+                if (innerException != ex) {
+                    innerException.addSuppressed(ex);
                 }
-                result.completeExceptionally(ex2);
+                result.completeExceptionally(innerException);
             }
             return null;
         });

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
@@ -208,12 +208,12 @@ public class StreamSegmentMapper {
                 .exceptionallyCompose(
                         this.storage.create(segmentName, timer.getRemaining()),
                         ex -> handleStorageCreateException(segmentName, ExceptionHelpers.getRealException(ex), timer))
-                .thenComposeAsync(si ->
+                .thenComposeAsync(segmentProps ->
                                 // Need to create the state file before we throw any further exceptions in order to recover from
                                 // previous partial executions (where we created a segment but no or empty state file).
-                                this.stateStore.put(segmentName, getState(si, attributes), timer.getRemaining())
+                                this.stateStore.put(segmentName, getState(segmentProps, attributes), timer.getRemaining())
                                                .thenRun(() -> {
-                                                   if (si.getLength() > 0) {
+                                                   if (segmentProps.getLength() > 0) {
                                                        throw new CompletionException(new StreamSegmentExistsException(segmentName));
                                                    }
                                                }),

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/InMemoryStateStore.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/InMemoryStateStore.java
@@ -42,7 +42,7 @@ public class InMemoryStateStore implements AsyncMap<String, SegmentState> {
     }
 
     @Override
-    @SneakyThrows(IOException.class)
+    @SneakyThrows
     public CompletableFuture<SegmentState> get(String segmentName, Duration timeout) {
         ByteArraySegment s = this.map.getOrDefault(segmentName, null);
         if (s == null) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateStoreTests.java
@@ -10,13 +10,29 @@
 package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.util.AsyncMap;
+import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
+import io.pravega.shared.segment.StreamSegmentNameUtils;
+import io.pravega.test.common.AssertExtensions;
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.TimeUnit;
 import lombok.val;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Unit tests for the SegmentStateStore class.
  */
 public class SegmentStateStoreTests extends StateStoreTests {
+    private InMemoryStorage storage;
+
+    @Before
+    public void setUp() {
+        this.storage = new InMemoryStorage(executorService());
+        this.storage.initialize(1);
+    }
+
     @Override
     public int getThreadPoolSize() {
         return 5;
@@ -24,8 +40,39 @@ public class SegmentStateStoreTests extends StateStoreTests {
 
     @Override
     protected AsyncMap<String, SegmentState> createStateStore() {
-        val storage = new InMemoryStorage(executorService());
-        storage.initialize(1);
-        return new SegmentStateStore(storage, executorService());
+        return new SegmentStateStore(this.storage, executorService());
+    }
+
+    /**
+     * Tests the get() method when there exists a state in Storage, however it is an empty file.
+     */
+    @Test
+    public void testGetEmptyState() throws Exception {
+        final String segmentName = "foo";
+        final String stateSegment = StreamSegmentNameUtils.getStateSegmentName(segmentName);
+        val store = createStateStore();
+        this.storage.create(stateSegment, TIMEOUT).join();
+        val state = store.get(segmentName, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        Assert.assertNull("Not expecting any state for a segment with no state.", state);
+    }
+
+    /**
+     * Tests the get() method when there exists a state in Storage, however it is a corrupted file.
+     */
+    @Test
+    public void testGetCorruptedState() throws Exception {
+        final String segmentName = "foo";
+        final String stateSegment = StreamSegmentNameUtils.getStateSegmentName(segmentName);
+        val store = createStateStore();
+
+        // Write some dummy contents in the file which is not how a SegmentState would be serialized.
+        this.storage.create(stateSegment, TIMEOUT)
+                    .thenCompose(si -> this.storage.openWrite(stateSegment))
+                    .thenCompose(handle -> this.storage.write(handle, 0, new ByteArrayInputStream(new byte[1]), 1, TIMEOUT))
+                    .join();
+        AssertExtensions.assertThrows(
+                "Unexpected behavior when attempting to read a corrupted state file.",
+                () -> store.get(segmentName, TIMEOUT),
+                ex -> ex instanceof DataCorruptionException);
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
  * Defines tests for a generic State Store (AsyncMap(String, SegmentState))
  */
 public abstract class StateStoreTests extends ThreadPooledTestSuite {
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    protected static final Duration TIMEOUT = Duration.ofSeconds(10);
     private static final int ATTRIBUTE_COUNT = 10;
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());


### PR DESCRIPTION
**Change log description**
Added the ability to recover from an incomplete call to CreateSegment/CreateTransaction. Since a Segment is created using 3 calls to Storage (Create Segment, Create State File, Write State File), it is possible that a previous call executed the first 1 or 2 of these steps but not the rest, which means that the Segment might not be usable. A subsequent call to createSegment/createTransaction may be able to recover this in certain conditions.
- If the Segment exists, but the State File does not exist or is corrupted, a subsequent call to CreateSegment/CreateTransaction will attempt to rebuild the State File (and return success).
- If the Segment exists and has a non-zero length, and the State File does not exist or is corrupted, a subsequent call to CreateSegment/CreateTransaction will rebuild the State File (and return `StreamSegmentExistsException`)
- If both the Segment and its associated State File exist (and the State File is valid), then `StreamSegmentExistsException` is returned.

Component changes:
- `StreamSegmentMapper`: added ability to recover from an incomplete Segment/Transaction creation that was previously run (see description above)
- `SegmentStateStore`: 
    - Treating empty State files the same as non-existing State files
    - Throwing `DataCorruptionException` if a State File is invalid (non-zero length, but can't be parsed).
- `FutureHelpers`: added exceptionallyCompose which helps return CompletableFutures instead of direct values.

**Purpose of the change**
Fixes #1829.

**What the code does**
See **Change Description** above.

**How to verify it**
New unit tests added; some existing unit tests were updated.
