### PR TITLE
Issue 1695: Fail the test if any error while closing the writer/reader in failover system tests

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -179,6 +179,7 @@ abstract class AbstractFailoverTests {
             writer.close();
         } catch (Throwable e) {
             log.error("Error while closing writer", e);
+            Assert.fail("Error while closing writer. Test failure");
         }
     }
 
@@ -216,6 +217,7 @@ abstract class AbstractFailoverTests {
             reader.close();
         } catch (Throwable e) {
             log.error("Error while closing reader", e);
+            Assert.fail("Error while closing reader. Test failure");
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -179,7 +179,7 @@ abstract class AbstractFailoverTests {
             writer.close();
         } catch (Throwable e) {
             log.error("Error while closing writer", e);
-            testState.getWriteException.set(e);
+            testState.getWriteException.compareAndSet(null, e);
         }
     }
 
@@ -217,7 +217,7 @@ abstract class AbstractFailoverTests {
             reader.close();
         } catch (Throwable e) {
             log.error("Error while closing reader", e);
-            testState.getReadException.set(e);
+            testState.getReadException.compareAndSet(null, e);
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -179,7 +179,7 @@ abstract class AbstractFailoverTests {
             writer.close();
         } catch (Throwable e) {
             log.error("Error while closing writer", e);
-            Assert.fail("Error while closing writer. Test failure");
+            testState.getWriteException.set(e);
         }
     }
 
@@ -217,7 +217,7 @@ abstract class AbstractFailoverTests {
             reader.close();
         } catch (Throwable e) {
             log.error("Error while closing reader", e);
-            Assert.fail("Error while closing reader. Test failure");
+            testState.getReadException.set(e);
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -325,23 +324,9 @@ public class MultiReaderTxnWriterWithFailoverTest {
 
     private void closeReadersAndWriters() {
         log.info("Closing writers");
-        writerList.forEach(writer -> {
-            try {
-                writer.close();
-            } catch (Throwable e) {
-                log.error("Error closing writer", e);
-                Assert.fail("Error while closing writer. Test failure");
-            }
-        });
+        writerList.forEach(writer -> writer.close());
         log.info("Closing readers");
-        readerList.forEach(reader -> {
-            try {
-                reader.close();
-            } catch (Throwable e) {
-                log.error("Error closing reader", e);
-                Assert.fail("Error while closing reader. Test failure");
-            }
-        });
+        readerList.forEach(reader -> reader.close());
     }
 
     private void performFailoverTest() {

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -329,6 +330,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
                 writer.close();
             } catch (Throwable e) {
                 log.error("Error closing writer", e);
+                Assert.fail("Error while closing writer. Test failure");
             }
         });
         log.info("Closing readers");
@@ -337,6 +339,7 @@ public class MultiReaderTxnWriterWithFailoverTest {
                 reader.close();
             } catch (Throwable e) {
                 log.error("Error closing reader", e);
+                Assert.fail("Error while closing reader. Test failure");
             }
         });
     }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -312,6 +313,7 @@ public class MultiReaderWriterWithFailOverTest {
                 writer.close();
             } catch (Throwable e) {
                 log.error("Error closing reader", e);
+                Assert.fail("Error while closing writer. Test failure");
             }
         });
         log.info("Closing readers");
@@ -320,6 +322,7 @@ public class MultiReaderWriterWithFailOverTest {
                 reader.close();
             } catch (Throwable e) {
                 log.error("Error closing reader", e);
+                Assert.fail("Error while closing reader. Test failure");
             }
         });
     }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -312,7 +312,7 @@ public class MultiReaderWriterWithFailOverTest {
             try {
                 writer.close();
             } catch (Throwable e) {
-                log.error("Error closing reader", e);
+                log.error("Error closing writer", e);
                 Assert.fail("Error while closing writer. Test failure");
             }
         });

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -308,23 +307,9 @@ public class MultiReaderWriterWithFailOverTest {
 
     private void cleanUp() {
         log.info("Closing writers");
-        writerList.forEach(writer -> {
-            try {
-                writer.close();
-            } catch (Throwable e) {
-                log.error("Error closing writer", e);
-                Assert.fail("Error while closing writer. Test failure");
-            }
-        });
+        writerList.forEach(writer -> writer.close());
         log.info("Closing readers");
-        readerList.forEach(reader -> {
-            try {
-                reader.close();
-            } catch (Throwable e) {
-                log.error("Error closing reader", e);
-                Assert.fail("Error while closing reader. Test failure");
-            }
-        });
+        readerList.forEach(reader -> reader.close());
     }
 
     private void performFailoverTest() {


### PR DESCRIPTION
**Change log description**
`Assert.fail(" ")`  if any error in `writer.close()` or `reader.close()`
**Purpose of the change**
We are just logging the error when we confront an error while closing readers/writers.
**What the code does**
Fixes #1695 
**How to verify it**
Run system tests