### PR TITLE
Issue 1854: Change Pravega version to 0.2.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ typesafeConfigVersion=1.3.0
 apacheCommonsCsvVersion=1.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.1.0-SNAPSHOT
+pravegaVersion=0.2.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**
* Changes pravegaVersion in gradle.properties to 0.2.0-SNAPSHOT

**Purpose of the change**
Fixes #1854 

**What the code does**
No code changes, only configuration.

**How to verify it**
Visual inspection.