### PR TITLE
Issue 1856: Remove rc0 from pravegaVersion property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ typesafeConfigVersion=1.3.0
 apacheCommonsCsvVersion=1.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.1.0-rc0
+pravegaVersion=0.1.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**
* Remove rc0 suffix from `pravegaVersion`.

**Purpose of the change**
Fixes #1856 . Remove unnecessary suffix.

**What the code does**
There are no code changes.

**How to verify it**
Visual inspection.