### PR TITLE
Allow metrics configuration through `InProcPravegaCluster` API.

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -34,6 +34,7 @@ import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.ZooKeeperServiceRunner;
+import io.pravega.shared.metrics.MetricsConfig;
 import lombok.Builder;
 import lombok.Cleanup;
 import lombok.Synchronized;
@@ -58,6 +59,7 @@ public class InProcPravegaCluster implements AutoCloseable {
 
     /* Cluster name */
     private final String clusterName = "singlenode-" + UUID.randomUUID();
+    private boolean enableMetrics = false;
 
     /*Controller related variables*/
     private boolean isInProcController;
@@ -102,7 +104,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                                 boolean isInProcHDFS,
                                 boolean isInProcController, int controllerCount, String controllerURI,
                                 boolean isInProcSegmentStore, int segmentStoreCount, int containerCount,
-                                boolean startRestServer, int restServerPort) {
+                                boolean startRestServer, int restServerPort, boolean enableMetrics) {
 
         //Check for valid combinations of flags
         //For ZK
@@ -134,6 +136,7 @@ public class InProcPravegaCluster implements AutoCloseable {
         this.containerCount = containerCount;
         this.startRestServer = startRestServer;
         this.restServerPort = restServerPort;
+        this.enableMetrics = enableMetrics;
     }
 
     @Synchronized
@@ -251,7 +254,9 @@ public class InProcPravegaCluster implements AutoCloseable {
                                           .with(ReadIndexConfig.CACHE_POLICY_MAX_TIME, 60 * 1000)
                                           .with(ReadIndexConfig.CACHE_POLICY_MAX_SIZE, 128 * 1024 * 1024L))
                     .include(AutoScalerConfig.builder()
-                                             .with(AutoScalerConfig.CONTROLLER_URI, "tcp://localhost:" + controllerPorts[0]));
+                                             .with(AutoScalerConfig.CONTROLLER_URI, "tcp://localhost:" + controllerPorts[0]))
+                    .include(MetricsConfig.builder()
+                                            .with(MetricsConfig.ENABLE_STATISTICS, enableMetrics));
 
             ServiceStarter.Options.OptionsBuilder optBuilder = ServiceStarter.Options.builder().rocksDb(true)
                     .zkSegmentManager(true);

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -34,6 +34,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
                 .containerCount(4)
                 .startRestServer(true)
                 .restServerPort(restServerPort)
+                .enableMetrics(false)
                 .build();
         inProcPravegaCluster.setControllerPorts(new int[] {controllerPort});
         inProcPravegaCluster.setSegmentStorePorts(new int[] {segmentStorePort});


### PR DESCRIPTION
**Change log description**
Allows access to `metrics.enableStatistics` through `InProcPravegaCluster` API.
**Purpose of the change**
Enable/disable metrics collection for `InProcPravegaCluster` through `InProcPravegaCluster` builder interface.
**What the code does**
Enable/disable metrics collection for `InProcPravegaCluster` through `InProcPravegaCluster` builder interface.
**How to verify it**
Metrics are not collected when the setting is disabled.