### PR TITLE
Update controller URI according to the scheme.

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -270,7 +270,10 @@ public class InProcPravegaCluster implements AutoCloseable {
         for (int i = 0; i < this.controllerCount; i++) {
             controllerServers[i] = startLocalController(i);
         }
-        controllerURI = "localhost:" + controllerPorts[0];
+        controllerURI = "tcp://localhost:" + controllerPorts[0];
+        for (int i = 0; i < this.controllerCount; i++) {
+            controllerURI += ",localhost:" + controllerPorts[i];
+        }
 
     }
 


### PR DESCRIPTION
**Change log description**
Update the controller URI generated for `InProcPravegaCluster` to match the expected scheme.

**Purpose of the change**
Fixes #1862 

The controller URI generated for standalone Pravega deployment right now does not have any scheme. The scheme should match the one defined in ControllerResolverFactory.

**What the code does**
Update controller URI according to the scheme.

**How to verify it**
Check the controller URI during run of standalone.