### PR TITLE
Issue 1865: (BugFix) BookKeeperLog can stop processing writes if an unhandled exception occurs

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -116,8 +116,8 @@ class BookKeeperLog implements DurableDataLog {
         this.logNodePath = HierarchyUtils.getPath(logId, this.config.getZkHierarchyDepth());
         this.traceObjectId = String.format("Log[%d]", logId);
         this.writes = new WriteQueue(this.config.getMaxConcurrentWrites());
-        this.writeProcessor = new SequentialAsyncProcessor(this::processWritesSync, this.executorService);
-        this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, this.executorService);
+        this.writeProcessor = new SequentialAsyncProcessor(this::processWritesSync, this::handleWriteProcessorFailures, this.executorService);
+        this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, this::handleRolloverFailure, this.executorService);
     }
 
     //endregion
@@ -273,6 +273,24 @@ class BookKeeperLog implements DurableDataLog {
         } else if (!processPendingWrites() && !this.closed.get()) {
             // We were not able to complete execution of all writes. Try again.
             this.writeProcessor.runAsync();
+        }
+    }
+
+    /**
+     * Handles a failure from the WriteProcessor.
+     *
+     * @param exception    The causing exception.
+     * @param failureCount The number of consecutive failures.
+     * @return True if the WriteProcessor should be reinvoked, false otherwise.
+     */
+    private boolean handleWriteProcessorFailures(Throwable exception, int failureCount) {
+        log.error("{}: processWritesSync (attempt {}/{}) failed.", this.traceObjectId, failureCount, this.config.getMaxWriteAttempts(), exception);
+        if (failureCount >= this.config.getMaxWriteAttempts()) {
+            log.warn("{}: Too many write processor failures; closing.", this.traceObjectId);
+            close();
+            return false;
+        } else {
+            return true;
         }
     }
 
@@ -671,8 +689,9 @@ class BookKeeperLog implements DurableDataLog {
      *
      * NOTE: this method is not thread safe and is not meant to be executed concurrently. It should only be invoked as
      * part of the Rollover Processor.
+     * @throws DurableDataLogException If an Exception happened during rollover.
      */
-    private void rollover() {
+    private void rollover() throws DurableDataLogException {
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "rollover");
         val l = getWriteLedger().ledger;
         if (!l.isClosed() && l.getLength() < this.config.getBkLedgerMaxSize()) {
@@ -709,16 +728,30 @@ class BookKeeperLog implements DurableDataLog {
             Ledgers.close(oldLedger);
             log.debug("{}: Rollover: swapped ledger and metadata pointers (Old = {}, New = {}) and closed old ledger.",
                     this.traceObjectId, oldLedger.getId(), newLedger.getId());
-        } catch (Throwable ex) {
-            if (!ExceptionHelpers.mustRethrow(ex)) {
-                log.error("{}: Rollover failure; log may be unusable.", ex);
-            }
+        } finally {
+            // It's possible that we have writes in the queue that didn't get picked up because they exceeded the predicted
+            // ledger length. Invoke the Write Processor to execute them.
+            this.writeProcessor.runAsync();
+            LoggerHelpers.traceLeave(log, this.traceObjectId, "rollover", traceId, true);
         }
+    }
 
-        // It's possible that we have writes in the queue that didn't get picked up because they exceeded the predicted
-        // ledger length. Invoke the Write Processor to execute them.
-        this.writeProcessor.runAsync();
-        LoggerHelpers.traceLeave(log, this.traceObjectId, "rollover", traceId, true);
+    /**
+     * Handles a failure from the Rollover Processor.
+     *
+     * @param exception    The causing exception.
+     * @param failureCount The number of consecutive failures.
+     * @return True if the RolloverProcessor should be reinvoked, false otherwise.
+     */
+    private boolean handleRolloverFailure(Throwable exception, int failureCount) {
+        log.error("{}: Rollover failure (attempt {}/{}); log may be unusable.", this.traceObjectId, failureCount, this.config.getMaxWriteAttempts(), exception);
+        if (failureCount >= this.config.getMaxWriteAttempts()) {
+            log.warn("{}: Too many rollover failures; closing.", this.traceObjectId);
+            close();
+            return false;
+        } else {
+            return true;
+        }
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -9,7 +9,9 @@
  */
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,18 +33,24 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
     public static final String PROPERTY_ZK_PORT = "zkPort";
     private static final InetAddress LOOPBACK_ADDRESS = InetAddress.getLoopbackAddress();
     private final AtomicReference<ZooKeeperServer> server = new AtomicReference<>();
+    private final AtomicReference<NIOServerCnxnFactory> serverFactory = new AtomicReference<>();
     private final int zkPort;
-    private File tmpDir;
+    private final AtomicReference<File> tmpDir = new AtomicReference<>();
 
     @Override
     public void close() throws Exception {
-        if (this.server.get() != null) {
-            this.server.get().shutdown();
-        }
+        stop();
 
-        if (this.tmpDir != null) {
-            log.info("Cleaning up " + this.tmpDir);
-            FileUtils.deleteDirectory(this.tmpDir);
+        File t = this.tmpDir.getAndSet(null);
+        if (t != null) {
+            log.info("Cleaning up " + t);
+            FileUtils.deleteDirectory(t);
+        }
+    }
+
+    public void initialize() throws IOException {
+        if (this.tmpDir.compareAndSet(null, IOUtils.createTempDir("zookeeper", "inproc"))) {
+            this.tmpDir.get().deleteOnExit();
         }
     }
 
@@ -52,20 +60,34 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
      * @throws Exception If an exception occurred.
      */
     public void start() throws Exception {
-        this.tmpDir = IOUtils.createTempDir("zookeeper", "inproc");
-        this.tmpDir.deleteOnExit();
+        Preconditions.checkState(this.tmpDir.get() != null, "Not Initialized.");
+        val s = new ZooKeeperServer(this.tmpDir.get(), this.tmpDir.get(), ZooKeeperServer.DEFAULT_TICK_TIME);
+        if (!this.server.compareAndSet(null, s)) {
+            s.shutdown();
+            throw new IllegalStateException("Already started.");
+        }
 
-        val s = new ZooKeeperServer(this.tmpDir, this.tmpDir, ZooKeeperServer.DEFAULT_TICK_TIME);
-        this.server.set(s);
-        val serverFactory = new NIOServerCnxnFactory();
-
+        this.serverFactory.set(new NIOServerCnxnFactory());
         val address = LOOPBACK_ADDRESS.getHostAddress() + ":" + this.zkPort;
         log.info("Starting Zookeeper server at " + address + " ...");
-        serverFactory.configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000);
-        serverFactory.startup(s);
+        this.serverFactory.get().configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000);
+        this.serverFactory.get().startup(s);
 
         boolean b = waitForServerUp(this.zkPort);
         log.info("ZooKeeper server {}.", b ? "up" : "not up");
+    }
+
+    public void stop() {
+        ZooKeeperServer zs = this.server.getAndSet(null);
+        if (zs != null) {
+            zs.shutdown();
+        }
+
+        NIOServerCnxnFactory sf = this.serverFactory.getAndSet(null);
+        if (sf != null) {
+            sf.closeAll();
+            sf.shutdown();
+        }
     }
 
     /**

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
+import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.curator.framework.CuratorFramework;
@@ -170,12 +171,12 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
     }
 
     /**
-     * Tests the ability to auto-close upon a permanent write failure.
+     * Tests the ability to auto-close upon a permanent write failure caused by BookKeeper.
      *
      * @throws Exception If one got thrown.
      */
     @Test
-    public void testAutoCloseOnFailure() throws Exception {
+    public void testAutoCloseOnBookieFailure() throws Exception {
         try (DurableDataLog log = createDurableDataLog()) {
             log.initialize(TIMEOUT);
 
@@ -206,10 +207,50 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
     }
 
     /**
+     * Tests the ability to auto-close upon a permanent write failure caused by ZooKeeper
+     *
+     * @throws Exception If one got thrown.
+     */
+    @Test
+    public void testAutoCloseOnZooKeeperFailure() throws Exception {
+        int writeCount = getWriteCount();
+        try (DurableDataLog log = createDurableDataLog()) {
+            log.initialize(TIMEOUT);
+
+            try {
+                // Suspend a bookie (this will trigger write errors).
+                suspendZooKeeper();
+
+                // It may be a while until the BK client realizes that ZK is closed. So we send out a number of appends
+                // and wait for one of them to fail.
+                val appends = new ArrayList<CompletableFuture<LogAddress>>();
+                for (int i = 0; i < writeCount; i++) {
+                    appends.add(log.append(new ByteArraySegment(getWriteData()), TIMEOUT));
+                }
+
+                AssertExtensions.assertThrows(
+                        "First write did not fail with the appropriate exception.",
+                        () -> FutureHelpers.allOf(appends),
+                        ex -> ex instanceof CancellationException);
+
+                // Subsequent writes should be rejected since the BookKeeperLog is now closed.
+                AssertExtensions.assertThrows(
+                        "Second write did not fail with the appropriate exception.",
+                        () -> log.append(new ByteArraySegment(getWriteData()), TIMEOUT),
+                        ex -> ex instanceof ObjectClosedException
+                                || ex instanceof CancellationException);
+            } finally {
+                // Don't forget to cleanup after the test.
+                resumeZooKeeper();
+            }
+        }
+    }
+
+    /**
      * Tests the ability to retry writes when Bookies fail.
      */
     @Test
-    public void testAppendTransientFailure() throws Exception {
+    public void testAppendTransientBookieFailure() throws Exception {
         TreeMap<LogAddress, byte[]> writeData = new TreeMap<>(Comparator.comparingLong(LogAddress::getSequence));
         try (DurableDataLog log = createDurableDataLog()) {
             log.initialize(TIMEOUT);
@@ -236,7 +277,56 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
                 resumeFirstBookie();
             }
 
-            // Wait for all writes to complete, then reassemble the data in the order ste by LogAddress.
+            // Wait for all writes to complete, then reassemble the data in the order set by LogAddress.
+            val addresses = FutureHelpers.allOfWithResults(futures).join();
+            for (int i = 0; i < dataList.size(); i++) {
+                writeData.put(addresses.get(i), dataList.get(i));
+            }
+        }
+
+        // Verify data.
+        try (DurableDataLog log = createDurableDataLog()) {
+            log.initialize(TIMEOUT);
+            verifyReads(log, writeData);
+        }
+    }
+
+    /**
+     * Tests the ability to retry writes when ZooKeeper fails.
+     */
+    @Test
+    public void testAppendTransientZooKeeperFailure() throws Exception {
+        TreeMap<LogAddress, byte[]> writeData = new TreeMap<>(Comparator.comparingLong(LogAddress::getSequence));
+        int writeCount = getWriteCount();
+        int failEvery = writeCount / 5;
+        try (DurableDataLog log = createDurableDataLog()) {
+            log.initialize(TIMEOUT);
+
+            val dataList = new ArrayList<byte[]>();
+            val futures = new ArrayList<CompletableFuture<LogAddress>>();
+
+            try {
+                // Issue appends in parallel.
+                for (int i = 0; i < writeCount; i++) {
+                    byte[] data = getWriteData();
+                    futures.add(log.append(new ByteArraySegment(data), TIMEOUT));
+                    dataList.add(data);
+                    if (i % failEvery == 0) {
+                        FutureHelpers.allOf(futures).join();
+                        suspendZooKeeper();
+                        resumeZooKeeper();
+                    }
+                }
+            } finally {
+                // Don't forget to cleanup after the test.
+                try {
+                    resumeZooKeeper();
+                } catch (IllegalStateException ex) {
+                    // Ignore.
+                }
+            }
+
+            // Wait for all writes to complete, then reassemble the data in the order set by LogAddress.
             val addresses = FutureHelpers.allOfWithResults(futures).join();
             for (int i = 0; i < dataList.size(); i++) {
                 writeData.put(addresses.get(i), dataList.get(i));
@@ -303,6 +393,15 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
 
     private static void resumeFirstBookie() {
         BK_SERVICE.get().resumeBookie(0);
+    }
+
+    private static void suspendZooKeeper() {
+        BK_SERVICE.get().suspendZooKeeper();
+    }
+
+    @SneakyThrows
+    private static void resumeZooKeeper() {
+        BK_SERVICE.get().resumeZooKeeper();
     }
 
     private static boolean isLedgerClosedException(Throwable ex) {


### PR DESCRIPTION
**Change log description**
Fixed a bug in `BookKeeperLog` that could cause it to stall the Write Processor if an unhandled exception bubbled up to the main method.
- Both the `WriteProcessor` and `RolloverProcessor` use the `SequentialAsyncProcessor` to control their behavior. If either of their main methods would let an exception bubble out of them, it would be possible for them not to be reinvoked again, even if there was work left to do.
- `SequentialAsyncProcessor` has been fixed to catch all exceptions, run them through an exception handler and re-run the task if the handler indicates so.
- `BookKeeperLog` will auto-close if either the `WriteProcessor` or `RolloverProcessor` fail to execute more than a number of times in a row (based on an existing config value).

**Purpose of the change**
Fixes #1865.

**What the code does**
See **Change Log Description**.

**How to verify it**
A unit test has been added for `SequentialAsyncProcessor`. Some unit tests were added for `BookKeeperLog` to verify behavior for ZK failures. Unfortunately it is nearly impossible to create a unit test that reproduces the problem described in issue #1865, since both BK and ZK need to fail in the correct order and (possibly) resume functioning at the right time(s) in order for that behavior to be triggered.