### PR TITLE
Issue 1733: Metrics fixes

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
@@ -14,7 +14,7 @@ package io.pravega.shared.metrics;
  * functions on a Long. Metrics like the number of topics, persist queue size
  * etc. should use this.
  */
-public interface Counter {
+public interface Counter extends AutoCloseable {
     /**
      * Clear this stat.
      */
@@ -46,4 +46,7 @@ public interface Counter {
      * Gets name.
      */
     String getName();
+
+    @Override
+    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
@@ -14,7 +14,7 @@ package io.pravega.shared.metrics;
  * functions on a Long. Metrics like the number of topics, persist queue size
  * etc. should use this.
  */
-public interface Counter extends AutoCloseable {
+public interface Counter extends Metric {
     /**
      * Clear this stat.
      */
@@ -41,12 +41,4 @@ public interface Counter extends AutoCloseable {
      * Get the value associated with this stat.
      */
     long get();
-
-    /**
-     * Gets name.
-     */
-    String getName();
-
-    @Override
-    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
@@ -13,8 +13,8 @@ import java.util.function.Consumer;
 
 class CounterProxy extends MetricProxy<Counter> implements Counter {
 
-    CounterProxy(Counter counter, Consumer<String> closeCallback) {
-        super(counter, closeCallback);
+    CounterProxy(Counter counter, String proxyName, Consumer<String> closeCallback) {
+        super(counter, proxyName, closeCallback);
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
@@ -9,54 +9,36 @@
  */
 package io.pravega.shared.metrics;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
-public class CounterProxy implements Counter {
-    private final AtomicReference<Counter> instance = new AtomicReference<>();
+class CounterProxy extends MetricProxy<Counter> implements Counter {
 
-    CounterProxy(Counter counter) {
-        instance.set(counter);
-    }
-
-    void setCounter(Counter counter) {
-        instance.set(counter);
+    CounterProxy(Counter counter, Consumer<String> closeCallback) {
+        super(counter, closeCallback);
     }
 
     @Override
     public void clear() {
-        instance.get().clear();
+        getInstance().clear();
     }
 
     @Override
     public void inc() {
-        instance.get().inc();
+        getInstance().inc();
     }
 
     @Override
     public void dec() {
-        instance.get().dec();
+        getInstance().dec();
     }
 
     @Override
     public void add(long delta) {
-        instance.get().add(delta);
+        getInstance().add(delta);
     }
 
     @Override
     public long get() {
-        return instance.get().get();
-    }
-
-    @Override
-    public String getName() {
-        return instance.get().getName();
-    }
-
-    @Override
-    public void close() {
-        Counter c = instance.get();
-        if (c != null) {
-            c.close();
-        }
+        return getInstance().get();
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
@@ -51,4 +51,12 @@ public class CounterProxy implements Counter {
     public String getName() {
         return instance.get().getName();
     }
+
+    @Override
+    public void close() {
+        Counter c = instance.get();
+        if (c != null) {
+            c.close();
+        }
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
@@ -12,11 +12,14 @@ package io.pravega.shared.metrics;
 /**
  * Defines a Gauge, which will wrap a gauge instance and its name.
  */
-public interface Gauge {
+public interface Gauge extends AutoCloseable {
     /**
      * Gets name.
      *
      * @return the name of Gauge
      */
     String getName();
+
+    @Override
+    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -18,8 +18,8 @@ class GaugeProxy extends MetricProxy<Gauge> implements Gauge {
     @Getter
     private final Supplier<? extends Number> valueSupplier;
 
-    GaugeProxy(Gauge gauge, Supplier<? extends Number> valueSupplier, Consumer<String> closeCallback) {
-        super(gauge, closeCallback);
+    GaugeProxy(Gauge gauge, String proxyName, Supplier<? extends Number> valueSupplier, Consumer<String> closeCallback) {
+        super(gauge, proxyName, closeCallback);
         this.valueSupplier = Preconditions.checkNotNull(valueSupplier, "valueSupplier");
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -26,4 +26,12 @@ public class GaugeProxy implements Gauge {
     public String getName() {
         return instance.get().getName();
     }
+
+    @Override
+    public void close() {
+        Gauge g = instance.get();
+        if (g != null) {
+            g.close();
+        }
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -9,29 +9,17 @@
  */
 package io.pravega.shared.metrics;
 
-import java.util.concurrent.atomic.AtomicReference;
+import com.google.common.base.Preconditions;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import lombok.Getter;
 
-public class GaugeProxy implements Gauge {
-    private final AtomicReference<Gauge> instance = new AtomicReference<>();
+class GaugeProxy extends MetricProxy<Gauge> implements Gauge {
+    @Getter
+    private final Supplier<? extends Number> valueSupplier;
 
-    GaugeProxy(Gauge gauge) {
-        instance.set(gauge);
-    }
-
-    void setGauge(Gauge gauge) {
-        instance.set(gauge);
-    }
-
-    @Override
-    public String getName() {
-        return instance.get().getName();
-    }
-
-    @Override
-    public void close() {
-        Gauge g = instance.get();
-        if (g != null) {
-            g.close();
-        }
+    GaugeProxy(Gauge gauge, Supplier<? extends Number> valueSupplier, Consumer<String> closeCallback) {
+        super(gauge, closeCallback);
+        this.valueSupplier = Preconditions.checkNotNull(valueSupplier, "valueSupplier");
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
@@ -12,7 +12,7 @@ package io.pravega.shared.metrics;
 /**
  * A meter metric which measures mean throughput and exponentially-weighted moving average throughput.
  */
-public interface Meter {
+public interface Meter extends AutoCloseable {
     /**
      * Record the occurrence of an event in Meter.
      */
@@ -38,4 +38,7 @@ public interface Meter {
      * @return the name of Gauge
      */
     String getName();
+
+    @Override
+    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
@@ -12,7 +12,7 @@ package io.pravega.shared.metrics;
 /**
  * A meter metric which measures mean throughput and exponentially-weighted moving average throughput.
  */
-public interface Meter extends AutoCloseable {
+public interface Meter extends Metric {
     /**
      * Record the occurrence of an event in Meter.
      */
@@ -31,14 +31,4 @@ public interface Meter extends AutoCloseable {
      * @return the count
      */
     long getCount();
-
-    /**
-     * Gets name.
-     *
-     * @return the name of Gauge
-     */
-    String getName();
-
-    @Override
-    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
@@ -9,44 +9,25 @@
  */
 package io.pravega.shared.metrics;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
-public class MeterProxy implements Meter {
-    private final AtomicReference<Meter> instance = new AtomicReference<>();
-
-    MeterProxy(Meter meter) {
-        instance.set(meter);
-    }
-
-    void setMeter(Meter meter) {
-        instance.set(meter);
+public class MeterProxy extends MetricProxy<Meter> implements Meter {
+    MeterProxy(Meter meter, Consumer<String> closeCallback) {
+        super(meter, closeCallback);
     }
 
     @Override
     public void recordEvent() {
-        instance.get().recordEvent();
+        getInstance().recordEvent();
     }
 
     @Override
     public void recordEvents(long n) {
-        instance.get().recordEvents(n);
+        getInstance().recordEvents(n);
     }
 
     @Override
     public long getCount() {
-        return instance.get().getCount();
-    }
-
-    @Override
-    public String getName() {
-        return instance.get().getName();
-    }
-
-    @Override
-    public void close() {
-        Meter m = instance.get();
-        if (m != null) {
-            m.close();
-        }
+        return getInstance().getCount();
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
@@ -12,8 +12,8 @@ package io.pravega.shared.metrics;
 import java.util.function.Consumer;
 
 public class MeterProxy extends MetricProxy<Meter> implements Meter {
-    MeterProxy(Meter meter, Consumer<String> closeCallback) {
-        super(meter, closeCallback);
+    MeterProxy(Meter meter, String proxyName, Consumer<String> closeCallback) {
+        super(meter, proxyName, closeCallback);
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
@@ -41,4 +41,12 @@ public class MeterProxy implements Meter {
     public String getName() {
         return instance.get().getName();
     }
+
+    @Override
+    public void close() {
+        Meter m = instance.get();
+        if (m != null) {
+            m.close();
+        }
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Metric.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Metric.java
@@ -7,10 +7,20 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
+
 package io.pravega.shared.metrics;
 
 /**
- * Defines a Gauge, which will wrap a gauge instance and its name.
+ * Defines common methods for a Metric.
  */
-public interface Gauge extends Metric {
+interface Metric extends AutoCloseable {
+    /**
+     * Gets name.
+     *
+     * @return the name.
+     */
+    String getName();
+
+    @Override
+    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
@@ -11,8 +11,10 @@
 package io.pravega.shared.metrics;
 
 import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import lombok.Getter;
 
 /**
  * Base class for a Metric Proxy.
@@ -21,16 +23,20 @@ import java.util.function.Consumer;
  */
 abstract class MetricProxy<T extends Metric> implements AutoCloseable {
     private final AtomicReference<T> instance = new AtomicReference<>();
+    @Getter
+    private final String proxyName;
     private final Consumer<String> closeCallback;
 
     /**
      * Creates a new instance of the MetricProxy class.
      *
      * @param instance      The initial Metric Instance.
+     * @param proxyName          The name of the MetricProxy. This may be different from the name of the Metric's instance.
      * @param closeCallback A Consumer that will be invoked when this Proxy is closed.
      */
-    MetricProxy(T instance, Consumer<String> closeCallback) {
+    MetricProxy(T instance, String proxyName, Consumer<String> closeCallback) {
         this.closeCallback = Preconditions.checkNotNull(closeCallback, "closeCallback");
+        this.proxyName = Exceptions.checkNotNullOrEmpty(proxyName, "name");
         updateInstance(instance);
     }
 
@@ -39,17 +45,27 @@ abstract class MetricProxy<T extends Metric> implements AutoCloseable {
         T i = getInstance();
         if (i != null) {
             i.close();
-            this.closeCallback.accept(i.getName());
+            this.closeCallback.accept(this.proxyName);
         }
     }
 
+    /**
+     * Gets the name of the underlying metric.
+     *
+     * @return The name.
+     */
     public String getName() {
         return getInstance().getName();
     }
 
+    /**
+     * Updates the underlying Metric instance with the given one, and closes out the previous one.
+     *
+     * @param instance The instance to update to.
+     */
     void updateInstance(T instance) {
         T oldInstance = this.instance.getAndSet(Preconditions.checkNotNull(instance, "instance"));
-        if (oldInstance != null) {
+        if (oldInstance != null && oldInstance != instance) {
             oldInstance.close();
         }
     }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.shared.metrics;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Base class for a Metric Proxy.
+ *
+ * @param <T> Type of Metric.
+ */
+abstract class MetricProxy<T extends Metric> implements AutoCloseable {
+    private final AtomicReference<T> instance = new AtomicReference<>();
+    private final Consumer<String> closeCallback;
+
+    /**
+     * Creates a new instance of the MetricProxy class.
+     *
+     * @param instance      The initial Metric Instance.
+     * @param closeCallback A Consumer that will be invoked when this Proxy is closed.
+     */
+    MetricProxy(T instance, Consumer<String> closeCallback) {
+        this.closeCallback = Preconditions.checkNotNull(closeCallback, "closeCallback");
+        updateInstance(instance);
+    }
+
+    @Override
+    public void close() {
+        T i = getInstance();
+        if (i != null) {
+            i.close();
+            this.closeCallback.accept(i.getName());
+        }
+    }
+
+    public String getName() {
+        return getInstance().getName();
+    }
+
+    void updateInstance(T instance) {
+        T oldInstance = this.instance.getAndSet(Preconditions.checkNotNull(instance, "instance"));
+        if (oldInstance != null) {
+            oldInstance.close();
+        }
+    }
+
+    protected T getInstance() {
+        return this.instance.get();
+    }
+}

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
@@ -1,13 +1,12 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.pravega.shared.metrics;
 
 import com.google.common.base.Preconditions;
@@ -31,7 +30,7 @@ abstract class MetricProxy<T extends Metric> implements AutoCloseable {
      * Creates a new instance of the MetricProxy class.
      *
      * @param instance      The initial Metric Instance.
-     * @param proxyName          The name of the MetricProxy. This may be different from the name of the Metric's instance.
+     * @param proxyName     The name of the MetricProxy. This may be different from the name of the Metric's instance.
      * @param closeCallback A Consumer that will be invoked when this Proxy is closed.
      */
     MetricProxy(T instance, String proxyName, Consumer<String> closeCallback) {

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
@@ -37,6 +37,11 @@ public class NullStatsLogger implements StatsLogger {
         public String getName() {
             return NULLNAME;
         }
+
+        @Override
+        public void close() {
+            // nop
+        }
     }
 
     @Override
@@ -86,6 +91,11 @@ public class NullStatsLogger implements StatsLogger {
         public void clear() {
             // nop
         }
+
+        @Override
+        public void close() {
+            // nop
+        }
     }
 
     private static class NullCounter implements Counter {
@@ -118,6 +128,11 @@ public class NullStatsLogger implements StatsLogger {
         public String getName() {
             return NULLNAME;
         }
+
+        @Override
+        public void close() {
+            // nop
+        }
     }
 
     private static class NullMeter implements Meter {
@@ -139,6 +154,11 @@ public class NullStatsLogger implements StatsLogger {
         @Override
         public String getName() {
             return NULLNAME;
+        }
+
+        @Override
+        public void close() {
+            // nop(DONE)
         }
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
@@ -93,6 +93,11 @@ public class NullStatsLogger implements StatsLogger {
         }
 
         @Override
+        public String getName() {
+            return NULLNAME;
+        }
+
+        @Override
         public void close() {
             // nop
         }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 /**
  * This interface handles logging of statistics related to each operation (Write, Read etc.).
  */
-public interface OpStatsLogger extends AutoCloseable {
+public interface OpStatsLogger extends Metric {
 
     /**
      * Increment the succeeded op counter with the given eventLatency in NanoSeconds.
@@ -55,7 +55,4 @@ public interface OpStatsLogger extends AutoCloseable {
      * Clear stats for this operation.
      */
     void clear();
-
-    @Override
-    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 /**
  * This interface handles logging of statistics related to each operation (Write, Read etc.).
  */
-public interface OpStatsLogger {
+public interface OpStatsLogger extends AutoCloseable {
 
     /**
      * Increment the succeeded op counter with the given eventLatency in NanoSeconds.
@@ -55,4 +55,7 @@ public interface OpStatsLogger {
      * Clear stats for this operation.
      */
     void clear();
+
+    @Override
+    void close();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -60,6 +60,11 @@ class OpStatsLoggerImpl implements OpStatsLogger {
     //region OpStatsLogger Implementation
 
     @Override
+    public String getName() {
+        return this.successName;
+    }
+
+    @Override
     public void reportFailEvent(Duration duration) {
         fail.update(duration.toMillis(), TimeUnit.MILLISECONDS);
     }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -51,7 +51,7 @@ class OpStatsLoggerImpl implements OpStatsLogger {
     }
 
     @Override
-    public void finalize() {
+    protected void finalize() {
         close();
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -9,26 +9,56 @@
  */
 package io.pravega.shared.metrics;
 
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
-
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.concurrent.TimeUnit;
 
-class OpStatsLoggerImpl implements OpStatsLogger {
-    private final Timer success;
-    private final Timer fail;
+import static com.codahale.metrics.MetricRegistry.name;
 
-    OpStatsLoggerImpl(Timer success, Timer fail) {
-        Preconditions.checkNotNull(success, "success");
-        Preconditions.checkNotNull(fail, "fail");
-        this.success = success;
-        this.fail = fail;
+class OpStatsLoggerImpl implements OpStatsLogger {
+    //region Members
+
+    private final Timer success;
+    private final String successName;
+    private final Timer fail;
+    private final String failName;
+    private final MetricRegistry metricRegistry;
+
+    //endregion
+
+    //region Constructor
+
+    OpStatsLoggerImpl(MetricRegistry metricRegistry, String basename, String statName) {
+        this.metricRegistry = Preconditions.checkNotNull(metricRegistry, "metrics");
+        this.successName = name(basename, statName);
+        this.failName = name(basename, statName + "-fail");
+        this.success = this.metricRegistry.timer(this.successName);
+        this.fail = this.metricRegistry.timer(this.failName);
     }
 
-    // OpStatsLogger functions
+    //endregion
+
+    //region AutoCloseable and Finalizer Implementation
+
+    @Override
+    public void close() {
+        this.metricRegistry.remove(this.successName);
+        this.metricRegistry.remove(this.failName);
+    }
+
+    @Override
+    public void finalize() {
+        close();
+    }
+
+    //endregion
+
+    //region OpStatsLogger Implementation
+
     @Override
     public void reportFailEvent(Duration duration) {
         fail.update(duration.toMillis(), TimeUnit.MILLISECONDS);
@@ -70,4 +100,6 @@ class OpStatsLoggerImpl implements OpStatsLogger {
         }
         return new OpStatsData(numSuccess, numFailed, avgLatencyMillis, percentileLongMap);
     }
+
+    //endregion
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
@@ -52,4 +52,12 @@ public class OpStatsLoggerProxy implements OpStatsLogger {
     public void clear() {
         instance.get().clear();
     }
+
+    @Override
+    public void close() {
+        OpStatsLogger o = instance.get();
+        if (o != null) {
+            o.close();
+        }
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
@@ -14,8 +14,8 @@ import java.util.function.Consumer;
 
 public class OpStatsLoggerProxy extends MetricProxy<OpStatsLogger> implements OpStatsLogger {
 
-    OpStatsLoggerProxy(OpStatsLogger logger, Consumer<String> closeCallback) {
-        super(logger, closeCallback);
+    OpStatsLoggerProxy(OpStatsLogger logger, String proxyName, Consumer<String> closeCallback) {
+        super(logger, proxyName, closeCallback);
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
@@ -10,54 +10,41 @@
 package io.pravega.shared.metrics;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
-public class OpStatsLoggerProxy implements OpStatsLogger {
-    private final AtomicReference<OpStatsLogger> instance = new AtomicReference<>();
+public class OpStatsLoggerProxy extends MetricProxy<OpStatsLogger> implements OpStatsLogger {
 
-    OpStatsLoggerProxy(OpStatsLogger logger) {
-        instance.set(logger);
-    }
-
-    void setLogger(OpStatsLogger logger) {
-        instance.set(logger);
+    OpStatsLoggerProxy(OpStatsLogger logger, Consumer<String> closeCallback) {
+        super(logger, closeCallback);
     }
 
     @Override
     public void reportSuccessEvent(Duration duration) {
-        instance.get().reportSuccessEvent(duration);
+        getInstance().reportSuccessEvent(duration);
     }
 
     @Override
     public void reportFailEvent(Duration duration) {
-        instance.get().reportFailEvent(duration);
+        getInstance().reportFailEvent(duration);
     }
 
     @Override
     public void reportSuccessValue(long value) {
-        instance.get().reportSuccessValue(value);
+        getInstance().reportSuccessValue(value);
     }
 
     @Override
     public void reportFailValue(long value) {
-        instance.get().reportFailValue(value);
+        getInstance().reportFailValue(value);
     }
 
     @Override
     public OpStatsData toOpStatsData() {
-        return instance.get().toOpStatsData();
+        return getInstance().toOpStatsData();
     }
 
     @Override
     public void clear() {
-        instance.get().clear();
-    }
-
-    @Override
-    public void close() {
-        OpStatsLogger o = instance.get();
-        if (o != null) {
-            o.close();
-        }
+        getInstance().clear();
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -10,9 +10,9 @@
 package io.pravega.shared.metrics;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import java.util.function.Supplier;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -23,54 +23,40 @@ import static io.pravega.shared.metrics.NullStatsLogger.NULLOPSTATSLOGGER;
 
 @Slf4j
 public class StatsLoggerImpl implements StatsLogger {
-    protected final String basename;
+    private final String basename;
     private final MetricRegistry metrics;
 
     StatsLoggerImpl(MetricRegistry metrics, String basename) {
-        Preconditions.checkNotNull(metrics, "metrics");
-        this.metrics = metrics;
+        this.metrics = Preconditions.checkNotNull(metrics, "metrics");
         this.basename = basename;
     }
 
     @Override
     public OpStatsLogger createStats(String statName) {
         try {
-            Timer success = metrics.timer(name(basename, statName));
-            Timer failure = metrics.timer(name(basename, statName + "-fail"));
-            return new OpStatsLoggerImpl(success, failure);
+            return new OpStatsLoggerImpl(metrics, basename, statName);
         } catch (Exception e) {
-            log.warn("createStats failure: {}", e);
+            log.warn("createStats failure: {}", statName, e);
             return NULLOPSTATSLOGGER;
-
         }
     }
 
     @Override
     public Counter createCounter(String statName) {
         try {
-            final com.codahale.metrics.Counter c = metrics.counter(name(basename, statName));
-            return new CounterImpl(c, name(basename, statName));
+            return new CounterImpl(statName);
         } catch (Exception e) {
-            log.warn("createCounter failure: {}", e);
+            log.warn("createCounter failure: {}", statName, e);
             return NULLCOUNTER;
         }
     }
 
     @Override
-    public <T extends Number> Gauge registerGauge(final String statName, Supplier<T> value) {
+    public <T extends Number> Gauge registerGauge(final String statName, Supplier<T> valueSupplier) {
         try {
-            String metricName = name(basename, statName);
-            com.codahale.metrics.Gauge<T> gauge = new com.codahale.metrics.Gauge<T>() {
-                @Override
-                public T getValue() {
-                    return value.get();
-                }
-            };
-            metrics.remove(metricName);
-            metrics.register(metricName, gauge);
-            return new GaugeImpl<>(gauge, metricName);
+            return new GaugeImpl<>(statName, valueSupplier);
         } catch (Exception e) {
-            log.warn("registerGauge failure: {}", e);
+            log.warn("registerGauge failure: {}", statName, e);
             return NULLGAUGE;
         }
     }
@@ -78,10 +64,9 @@ public class StatsLoggerImpl implements StatsLogger {
     @Override
     public Meter createMeter(String statName) {
         try {
-            final com.codahale.metrics.Meter meter = metrics.meter(name(basename, statName));
-            return new MeterImpl(meter, name(basename, statName));
+            return new MeterImpl(statName);
         } catch (Exception e) {
-            log.warn("createMeter failure: {}", e);
+            log.warn("createMeter failure: {}", statName, e);
             return NULLMETER;
         }
     }
@@ -97,13 +82,24 @@ public class StatsLoggerImpl implements StatsLogger {
         return new StatsLoggerImpl(metrics, scopeName);
     }
 
-    private static class CounterImpl implements Counter {
+    private class CounterImpl implements Counter {
         private final com.codahale.metrics.Counter counter;
+        @Getter
         private final String name;
 
-        CounterImpl(com.codahale.metrics.Counter c, String name) {
-            counter = c;
-            this.name = name;
+        CounterImpl(String statName) {
+            this.name = name(basename, statName);
+            this.counter = metrics.counter(name);
+        }
+
+        @Override
+        public void close() {
+            metrics.remove(this.name);
+        }
+
+        @Override
+        public void finalize() {
+            close();
         }
 
         @Override
@@ -131,35 +127,49 @@ public class StatsLoggerImpl implements StatsLogger {
         public void add(long delta) {
             counter.inc(delta);
         }
-
-        @Override
-        public String getName() {
-            return name;
-        }
     }
 
-    private static class GaugeImpl<T> implements Gauge {
+    private class GaugeImpl<T> implements Gauge {
         private final com.codahale.metrics.Gauge<T> gauge;
+        @Getter
         private final String name;
 
-        GaugeImpl(com.codahale.metrics.Gauge<T> gauge, String name) {
-            this.gauge = gauge;
-            this.name = name;
+        GaugeImpl(String statName, Supplier<T> value) {
+            this.name = name(basename, statName);
+            this.gauge = value::get;
+            metrics.remove(name);
+            metrics.register(name, gauge);
         }
 
         @Override
-        public String getName() {
-            return name;
+        public void close() {
+            metrics.remove(this.name);
+        }
+
+        @Override
+        public void finalize() {
+            close();
         }
     }
 
-    private static class MeterImpl implements Meter {
+    private class MeterImpl implements Meter {
         private final com.codahale.metrics.Meter meter;
+        @Getter
         private final String name;
 
-        MeterImpl(com.codahale.metrics.Meter meter, String name) {
-            this.meter = meter;
-            this.name = name;
+        MeterImpl(String statName) {
+            this.name = name(basename, statName);
+            this.meter = metrics.meter(this.name);
+        }
+
+        @Override
+        public void close() {
+            metrics.remove(this.name);
+        }
+
+        @Override
+        public void finalize() {
+            close();
         }
 
         @Override
@@ -175,11 +185,6 @@ public class StatsLoggerImpl implements StatsLogger {
         @Override
         public long getCount() {
             return meter.getCount();
-        }
-
-        @Override
-        public String getName() {
-            return name;
         }
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -98,7 +98,7 @@ public class StatsLoggerImpl implements StatsLogger {
         }
 
         @Override
-        public void finalize() {
+        protected void finalize() {
             close();
         }
 
@@ -147,7 +147,7 @@ public class StatsLoggerImpl implements StatsLogger {
         }
 
         @Override
-        public void finalize() {
+        protected void finalize() {
             close();
         }
     }
@@ -168,7 +168,7 @@ public class StatsLoggerImpl implements StatsLogger {
         }
 
         @Override
-        public void finalize() {
+        protected void finalize() {
             close();
         }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
@@ -11,6 +11,8 @@ package io.pravega.shared.metrics;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,34 +30,32 @@ public class StatsLoggerProxy implements StatsLogger {
 
     void setLogger(StatsLogger logger) {
         this.statsLoggerRef.set(logger);
-        this.opStatsLoggers.values().forEach(v -> v.updateInstance(createStats(v.getName())));
-        this.counters.values().forEach(v -> v.updateInstance(createCounter(v.getName())));
-        this.meters.values().forEach(v -> v.updateInstance(createMeter(v.getName())));
-        this.gauges.values().forEach(v -> v.updateInstance(registerGauge(v.getName(), v.getValueSupplier())));
+        this.opStatsLoggers.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createStats(v.getProxyName())));
+        this.counters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createCounter(v.getProxyName())));
+        this.meters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createMeter(v.getProxyName())));
+        this.gauges.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().registerGauge(v.getProxyName(), v.getValueSupplier())));
     }
 
     @Override
     public OpStatsLogger createStats(String name) {
-        return getOrSet(this.opStatsLoggers,
-                () -> new OpStatsLoggerProxy(this.statsLoggerRef.get().createStats(name), this.opStatsLoggers::remove));
+        return getOrSet(this.opStatsLoggers, name, this.statsLoggerRef.get()::createStats, OpStatsLoggerProxy::new);
     }
 
     @Override
     public Counter createCounter(String name) {
-        return getOrSet(this.counters,
-                () -> new CounterProxy(this.statsLoggerRef.get().createCounter(name), this.counters::remove));
+        return getOrSet(this.counters, name, this.statsLoggerRef.get()::createCounter, CounterProxy::new);
     }
 
     @Override
     public Meter createMeter(String name) {
-        return getOrSet(this.meters,
-                () -> new MeterProxy(this.statsLoggerRef.get().createMeter(name), this.meters::remove));
+        return getOrSet(this.meters, name, this.statsLoggerRef.get()::createMeter, MeterProxy::new);
     }
 
     @Override
     public <T extends Number> Gauge registerGauge(String name, Supplier<T> value) {
-        return getOrSet(this.gauges,
-                () -> new GaugeProxy(this.statsLoggerRef.get().registerGauge(name, value), value, this.gauges::remove));
+        return getOrSet(this.gauges, name,
+                metricName -> this.statsLoggerRef.get().registerGauge(metricName, value),
+                (metric, proxyName, c) -> new GaugeProxy(metric, proxyName, value, c));
     }
 
     @Override
@@ -68,25 +68,35 @@ public class StatsLoggerProxy implements StatsLogger {
     /**
      * Atomically gets an existing MetricProxy from the given cache or creates a new one and adds it.
      *
-     * @param cache         The Cache to get or insert into.
-     * @param proxySupplier A Supplier that creates a new MetricProxy.
-     * @param <T>           Type of Metric.
-     * @param <V>           Type of MetricProxy.
+     * @param cache        The Cache to get or insert into.
+     * @param name         Metric/Proxy name.
+     * @param createMetric A Function that creates a new Metric given its name.
+     * @param createProxy  A Function that creates a MetricProxy given its input.
+     * @param <T>          Type of Metric.
+     * @param <V>          Type of MetricProxy.
      * @return Either the existing MetricProxy (if it is already registered) or the newly created one.
      */
-    private <T extends Metric, V extends MetricProxy<T>> V getOrSet(ConcurrentHashMap<String, V> cache, Supplier<V> proxySupplier) {
+    private <T extends Metric, V extends MetricProxy<T>> V getOrSet(ConcurrentHashMap<String, V> cache, String name,
+                                                                    Function<String, T> createMetric,
+                                                                    ProxyCreator<T, V> createProxy) {
         // We could simply use Map.computeIfAbsent to do everything atomically, however in ConcurrentHashMap, the function
         // is evaluated while holding the lock. As per the method's guidelines, the computation should be quick and not
         // do any IO or acquire other locks, however we have no control over new Metric creation. As such, we use optimistic
         // concurrency, where we assume that the MetricProxy does not exist, create it, and then if it does exist, close
         // the newly created one.
-        V newObject = proxySupplier.get();
-        V existingObject = cache.putIfAbsent(newObject.getName(), newObject);
-        if (existingObject != null) {
-            newObject.close();
-            return existingObject;
+        T newMetric = createMetric.apply(name);
+        V newProxy = createProxy.apply(newMetric, name, cache::remove);
+        V existingProxy = cache.putIfAbsent(newProxy.getProxyName(), newProxy);
+        if (existingProxy != null) {
+            newProxy.close();
+            newMetric.close();
+            return existingProxy;
         } else {
-            return newObject;
+            return newProxy;
         }
+    }
+
+    private interface ProxyCreator<T1, R> {
+        R apply(T1 metricInstance, String proxyName, Consumer<String> closeCallback);
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -141,12 +141,21 @@ public class MetricsProviderTest {
     @Test
     public void testContinuity() {
         statsLogger.createCounter("continuity-counter");
-        MetricsConfig config = MetricsConfig.builder()
+        Assert.assertNotNull("Not registered before disabling.",
+                MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.testStatsLogger.continuity-counter"));
+
+        MetricsConfig disableConfig = MetricsConfig.builder()
                                             .with(MetricsConfig.ENABLE_STATISTICS, false)
                                             .build();
-        MetricsProvider.initialize(config);
+        MetricsProvider.initialize(disableConfig);
+        Assert.assertNull("Still registered after disabling.",
+                MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.testStatsLogger.continuity-counter"));
 
-        Assert.assertNotNull(null,
+        MetricsConfig enableConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
+                .build();
+        MetricsProvider.initialize(enableConfig);
+        Assert.assertNotNull("Not registered after re-enabling.",
                 MetricsProvider.METRIC_REGISTRY.getCounters().get("pravega.testStatsLogger.continuity-counter"));
     }
 

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.shared.metrics;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the StatsLoggerProxy class.
+ */
+public class StatsLoggerProxyTest {
+    private static final int METRIC_COUNT = 4;
+
+    /**
+     * Verifies the behavior of setLogger with respect to registering/unregistering metrics.
+     */
+    @Test
+    public void testSetLogger() {
+        val metrics1 = new ArrayList<TestMetric>();
+        val l1 = new TestLogger(metrics1::add);
+        val proxy = new StatsLoggerProxy(l1);
+        createMetrics(proxy, "");
+        Assert.assertEquals("Unexpected number of metrics registered with first logger.", METRIC_COUNT, metrics1.size());
+        Assert.assertFalse("Metrics were not supposed to be closed yet.", metrics1.stream().anyMatch(TestMetric::isClosed));
+
+        // Update the logger and verify old instances are closed.
+        val metrics2 = new ArrayList<TestMetric>();
+        val l2 = new TestLogger(metrics2::add);
+        proxy.setLogger(l2);
+        Assert.assertFalse("Metrics were not supposed to be closed yet.", metrics2.stream().anyMatch(TestMetric::isClosed));
+        Assert.assertEquals("Unexpected number of metrics registered with second logger.", metrics1.size(), metrics2.size());
+        Assert.assertTrue("Old metrics were not closed when logger changed.", metrics1.stream().allMatch(TestMetric::isClosed));
+    }
+
+    /**
+     * Tests the ability to re-use metrics if they're already cached.
+     */
+    @Test
+    public void testGetOrCreate() {
+        val metrics = new ArrayList<TestMetric>();
+        val logger = new TestLogger(metrics::add);
+        val proxy = new StatsLoggerProxy(logger);
+        createMetrics(proxy, "");
+        Assert.assertEquals("Unexpected number of metrics registered initially.", METRIC_COUNT, metrics.size());
+
+        // Re-create/request the same metrics. Verify the original ones have not been touched, but we did create (and close)
+        // a new set.
+        createMetrics(proxy, "");
+        Assert.assertEquals("Unexpected number of metrics registered after re-registering same names.", 2 * METRIC_COUNT, metrics.size());
+        Assert.assertFalse("Original metrics were not supposed to be closed.", metrics.subList(0, METRIC_COUNT).stream().anyMatch(TestMetric::isClosed));
+        Assert.assertTrue("Attempted-added metrics were supposed to be closed.",
+                metrics.stream().skip(METRIC_COUNT).allMatch(TestMetric::isClosed));
+
+        // Create a new set of metrics and verify the original ones were not touched.
+        createMetrics(proxy, "foo");
+        Assert.assertEquals("Unexpected number of metrics registered after adding new ones.", 3 * METRIC_COUNT, metrics.size());
+        Assert.assertFalse("Original metrics were not supposed to be closed.", metrics.subList(0, METRIC_COUNT).stream().anyMatch(TestMetric::isClosed));
+        Assert.assertFalse("Newly-added metrics were not supposed to be closed.",
+                metrics.stream().skip(2 * METRIC_COUNT).anyMatch(TestMetric::isClosed));
+
+    }
+
+    @Test
+    public void testCloseCreate() {
+        // Verify counter is being closed and then re-created when requested.
+        val metrics = new ArrayList<TestMetric>();
+        val logger = new TestLogger(metrics::add);
+        val proxy = new StatsLoggerProxy(logger);
+        val proxies = createMetrics(proxy, "");
+        proxies.forEach(Metric::close);
+        Assert.assertTrue("Expected all metrics to be closed.", metrics.stream().allMatch(TestMetric::isClosed));
+
+        // Re-create them and verify new metric instances are created.
+        createMetrics(proxy, "");
+        Assert.assertEquals("Unexpected number of metrics registered after adding new ones.", 2 * METRIC_COUNT, metrics.size());
+        Assert.assertFalse("Newly-added metrics were not supposed to be closed.",
+                metrics.stream().skip(METRIC_COUNT).anyMatch(TestMetric::isClosed));
+    }
+
+    private Collection<Metric> createMetrics(StatsLoggerProxy proxy, String suffix) {
+        return Arrays.asList(
+                proxy.createStats("stats" + suffix),
+                proxy.createCounter("counter" + suffix),
+                proxy.createMeter("meter" + suffix),
+                proxy.registerGauge("gauge+suffix", () -> 1));
+    }
+
+    private static class TestLogger implements StatsLogger {
+        private final Consumer<TestMetric> onCreate;
+
+        TestLogger(Consumer<TestMetric> onCreate) {
+            this.onCreate = onCreate;
+        }
+
+        @Override
+        public OpStatsLogger createStats(String name) {
+            return create(name);
+        }
+
+        @Override
+        public Counter createCounter(String name) {
+            return create(name);
+        }
+
+        @Override
+        public Meter createMeter(String name) {
+            return create(name);
+        }
+
+        @Override
+        public <T extends Number> Gauge registerGauge(String name, Supplier<T> value) {
+            return create(name);
+        }
+
+        @Override
+        public StatsLogger createScopeLogger(String scope) {
+            return this;
+        }
+
+        private TestMetric create(String name) {
+            val r = new TestMetric(name);
+            this.onCreate.accept(r);
+            return r;
+        }
+    }
+
+    private static class TestMetric implements OpStatsLogger, Counter, Meter, Gauge {
+        @Getter
+        private final String name;
+        @Getter
+        private boolean closed;
+
+        TestMetric(String name) {
+            this.name = "prefix-" + name;
+        }
+
+        @Override
+        public void close() {
+            this.closed = true;
+        }
+
+        //region Not Implemented
+
+        @Override
+        public void inc() {
+
+        }
+
+        @Override
+        public void dec() {
+
+        }
+
+        @Override
+        public void add(long delta) {
+
+        }
+
+        @Override
+        public long get() {
+            return 0;
+        }
+
+        @Override
+        public void recordEvent() {
+
+        }
+
+        @Override
+        public void recordEvents(long n) {
+
+        }
+
+        @Override
+        public long getCount() {
+            return 0;
+        }
+
+        @Override
+        public void reportSuccessEvent(Duration duration) {
+
+        }
+
+        @Override
+        public void reportFailEvent(Duration duration) {
+
+        }
+
+        @Override
+        public void reportSuccessValue(long value) {
+
+        }
+
+        @Override
+        public void reportFailValue(long value) {
+
+        }
+
+        @Override
+        public OpStatsData toOpStatsData() {
+            return null;
+        }
+
+        @Override
+        public void clear() {
+
+        }
+
+        //endregion
+    }
+}


### PR DESCRIPTION
**Change log description**
Made Metrics objects (Counters, Meters, OpStatsLoggers, Gauges) and their proxies implement `AutoCloseable` so that they may be unregistered when no longer needed.

Fixed a number of bugs in `StatsLoggerProxy`:
- Every time `setLogger` was invoked, all (four) meter lists would double in size.
- Every time `setLogger` was invoked, the existing elements in the meter list (proxies) would point to other proxies that were just created, while the newly created proxies would (correctly) point to Meter instances
- The correct behavior for this class would be: `setLogger` does not affect the size of the collections and each `MeterProxy` wraps around a `Meter` instance (not another `MeterProxy`)

**Purpose of the change**
Fixes #1733. Required for #1734 .

**What the code does**
Better metrics.

**How to verify it**
The existing Metrics unit tests must pass, as well as the newly added ones.
Metrics must still be published (correctly) when running Pravega.