### PR TITLE
Issue 1871: Scale conflict exception should not be retried with backoffs but failed immediately

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -430,7 +430,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
         } else {
             log.debug("scale conflict for stream {}/{} with segments to seal {}", scope, name, sealedSegments);
 
-            return FutureHelpers.failedFuture(new ScaleOperationExceptions.ScaleStartException());
+            return FutureHelpers.failedFuture(new ScaleOperationExceptions.ScaleConflictException());
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ScaleOperationExceptions.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ScaleOperationExceptions.java
@@ -28,6 +28,9 @@ public class ScaleOperationExceptions {
     public static class ScaleStartException extends ScaleOperationException implements RetryableException {
     }
 
+    public static class ScaleConflictException extends ScaleOperationException {
+    }
+
     public static class ScalePostException extends ScaleOperationException implements RetryableException {
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -397,11 +397,11 @@ public abstract class StreamMetadataStoreTest {
         final int scale2ActiveEpoch = response.getActiveEpoch();
         store.setState(scope, stream, State.SCALING, null, executor).get();
 
-        // rerun of scale 1 -- should fail with precondition failure
+        // rerun of scale 1 -- should fail with conflict exception
         AssertExtensions.assertThrows("", () ->
                 store.startScale(scope, stream, scale1SealedSegments,
                         Arrays.asList(segment1, segment2), scaleTs, false, null, executor).join(),
-                e -> ExceptionHelpers.getRealException(e) instanceof ScaleOperationExceptions.ScaleStartException);
+                e -> ExceptionHelpers.getRealException(e) instanceof ScaleOperationExceptions.ScaleConflictException);
 
         // rerun of scale 1's new segments created method
         AssertExtensions.assertThrows("", () ->


### PR DESCRIPTION
**Change log description**
In concurrent event processor, we can resume processing post a failover from an older checkpoint. Which means we can get already processed events for reprocessing. 

Since we have moved all scale processing for a stream to be serialized, we could have failed over while performing a scale and resumed with trying to run scale against some older events. Processing these older events will get Scale Start Exception. This is a retryable exception and thrown back to event processor. The generic logic in event processor is to retry any retryableException several times before putting the event back in the stream. This introduces artificial delays in reaching and completing any partial processing that we had left.

Scale conflict is no longer a retryable exception because two different scale operations on a stream cannot be attempted concurrently because of serialized request handler. Consequently, if a scale is in progress and we pick an event for processing which has a different input, it implies its an older event, and we dont need to process it. We throw a non-retryable exception and move on.

**Purpose of the change**
Fixes issue #1871

**What the code does**
Throws non-retryable exception for scale conflict scenarios.

**How to verify it**
Unit test added. 