### PR TITLE
Issue 589: Do not turn off logging during HDFSStorageTest

### DIFF
--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorageTest.java
@@ -9,12 +9,15 @@
  */
 package io.pravega.segmentstore.storage.impl.hdfs;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
 import io.pravega.common.io.FileHelpers;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageTestBase;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.concurrent.Executor;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.hadoop.conf.Configuration;
@@ -31,13 +34,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Collections;
-import java.util.concurrent.Executor;
 
 /**
  * Unit tests for HDFSStorage.
@@ -51,9 +47,6 @@ public class HDFSStorageTest extends StorageTestBase {
 
     @Before
     public void setUp() throws Exception {
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        context.getLoggerList().get(0).setLevel(Level.OFF);
-
         this.baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
         this.hdfsCluster = HDFSClusterHelpers.createMiniDFSCluster(this.baseDir.getAbsolutePath());
         this.adapterConfig = HDFSStorageConfig


### PR DESCRIPTION
**Change log description**
Removed unnecessary calls that turn off logging while running `HDFSStorageTest` - they were ineffective

**Purpose of the change**
Fixes #589.

**What the code does**
Removes calls to turning off logging.

**How to verify it**
