### PR TITLE
Issue 1876: Remove overzealous precondition.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
@@ -90,7 +90,6 @@ final class SegmentTransactionImpl<Type> implements SegmentTransaction<Type> {
             synchronized (lock) {
                 removeCompleted();
                 checkFailed();
-                Preconditions.checkState(outstanding.isEmpty());
             }
         } catch (SegmentSealedException e) {
             throw new TxnFailedException(e);

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.client.stream.impl;
 
-import com.google.common.base.Preconditions;
 import io.pravega.client.segment.impl.SegmentOutputStream;
 import io.pravega.client.segment.impl.SegmentSealedException;
 import io.pravega.client.stream.Serializer;


### PR DESCRIPTION
**Change log description**
* Remove a precondition check state that can be false in the event of a race condition.

**Purpose of the change**
Fix #1876

**What the code does**
Removes the pre-condition mentioned in #1876 that can be incorrect in the event of a race.

**How to verify it**
Look at SegmentOutputStreamImp.flush() and ackUpTo() the inflight event can happen to be empty inducing flush to return immediately. This in turn causes the precondition to fail if the callback for the ack has not yet been invoked by ackUpTo().
