### PR TITLE
Issue 1879: Zookeeper service not initialized in standalone Pravega

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -121,6 +121,7 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         }
 
         ZooKeeperServiceRunner runner = new ZooKeeperServiceRunner(zkPort);
+        runner.initialize();
         runner.start();
         Thread.sleep(Long.MAX_VALUE);
     }

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -184,6 +184,7 @@ public class InProcPravegaCluster implements AutoCloseable {
 
     private void startLocalZK() throws Exception {
         zkService = new ZooKeeperServiceRunner(zkPort);
+        zkService.initialize();
         zkService.start();
     }
 


### PR DESCRIPTION
**Change log description**
* Initializes zkService before starting it in InProcPravegaCluster, otherwise the start call fails on the 
temporary directory precondition.

* Adds initialization to the main method in ZooKeeperServiceRunner.

**Purpose of the change**
Fixes #1879 

**What the code does**
Adds initialization to `zkService` for standalone. 

**How to verify it**
Run standalone Pravega.