### PR TITLE
Unit tests for `LocalPravegaEmulator`

### DIFF
--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -12,11 +12,13 @@ package io.pravega.local;
 
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LocalPravegaEmulator implements AutoCloseable {
 
+    @Getter
     private final InProcPravegaCluster inProcPravegaCluster;
 
     @Builder
@@ -92,8 +94,9 @@ public class LocalPravegaEmulator implements AutoCloseable {
 
     /**
      * Start controller and host.
+     * @throws Exception passes on the exception thrown by `inProcPravegaCluster`
      */
-    private void start() throws Exception {
+    public void start() throws Exception {
         inProcPravegaCluster.start();
     }
 

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -96,7 +96,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
      * Start controller and host.
      * @throws Exception passes on the exception thrown by `inProcPravegaCluster`
      */
-    public void start() throws Exception {
+    void start() throws Exception {
         inProcPravegaCluster.start();
     }
 

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.local;
+
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import java.net.URI;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for standalone
+ */
+@Slf4j
+public class InProcPravegaClusterTest {
+    LocalPravegaEmulator localPravega;
+
+    @Before
+    public void setUp() throws Exception {
+        ServiceBuilderConfig config = ServiceBuilderConfig
+                .builder()
+                .include(System.getProperties())
+                .build();
+        SingleNodeConfig conf = config.getConfig(SingleNodeConfig::builder);
+
+        localPravega = LocalPravegaEmulator.builder()
+                                           .controllerPort(TestUtils.getAvailableListenPort())
+                                           .segmentStorePort(TestUtils.getAvailableListenPort())
+                                           .zkPort(TestUtils.getAvailableListenPort())
+                                           .restServerPort(TestUtils.getAvailableListenPort())
+                                           .build();
+        localPravega.start();
+    }
+
+    /**
+     * Create the test stream.
+     *
+     * @throws Exception on any errors.
+     */
+    @Test
+    public void createTestStream()
+            throws Exception {
+
+        String scope = "Scope";
+        String streamName = "Stream";
+        int numSegments = 10;
+
+        @Cleanup
+        StreamManager streamManager = StreamManager.create(URI.create(
+                localPravega.getInProcPravegaCluster().getControllerURI()
+        ));
+
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName,
+                StreamConfiguration.builder()
+                                   .scope(scope)
+                                   .streamName(streamName)
+                                   .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                   .build());
+        log.info("Created stream: " + streamName);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        localPravega.close();
+    }
+}

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -13,11 +13,13 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
 import java.net.URI;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +28,7 @@ import org.junit.Test;
  */
 @Slf4j
 public class InProcPravegaClusterTest {
-    LocalPravegaEmulator localPravega;
+    private LocalPravegaEmulator localPravega;
 
     @Before
     public void setUp() throws Exception {
@@ -53,7 +55,7 @@ public class InProcPravegaClusterTest {
     @Test
     public void createTestStream()
             throws Exception {
-
+        Assert.assertNotNull("Pravega not initialized", localPravega);
         String scope = "Scope";
         String streamName = "Stream";
         int numSegments = 10;
@@ -64,17 +66,20 @@ public class InProcPravegaClusterTest {
         ));
 
         streamManager.createScope(scope);
-        streamManager.createStream(scope, streamName,
-                StreamConfiguration.builder()
+        Assert.assertTrue("Stream creation is not successful ",
+                streamManager.createStream(scope, streamName, StreamConfiguration.builder()
                                    .scope(scope)
                                    .streamName(streamName)
                                    .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                                   .build());
+                                   .build()) == true);
+
         log.info("Created stream: " + streamName);
     }
 
     @After
     public void tearDown() throws Exception {
-        localPravega.close();
+        if (localPravega != null) {
+            localPravega.close();
+        }
     }
 }

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -13,7 +13,6 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
-import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
 import java.net.URI;
 import lombok.Cleanup;
@@ -71,7 +70,7 @@ public class InProcPravegaClusterTest {
                                    .scope(scope)
                                    .streamName(streamName)
                                    .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                                   .build()) == true);
+                                   .build()));
 
         log.info("Created stream: " + streamName);
     }


### PR DESCRIPTION
**Change log description**
Creates a `LocalPravegaEmulator` deployment 
Creates a sample scope and stream

**Purpose of the change**
To test Pravega standalone deployment. This fixes #1881 

**What the code does**
Adds unit test for LocalPravegaEmulator.

**How to verify it**
The unit tests pass.