### PR TITLE
Issue 1858: DataAppended should have an event range for client validation

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -230,6 +230,12 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
         }
 
+        private Long getInFlightBelow(long ackLevel) {
+            synchronized (lock) {
+                return inflight.floorKey(ackLevel);
+            }
+        }
+
         private void releaseIfEmptyInflight() {
             synchronized (lock) {
                 if (inflight.isEmpty()) {
@@ -321,6 +327,12 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         public void dataAppended(DataAppended dataAppended) {
             log.trace("Received ack: {}", dataAppended);
             long ackLevel = dataAppended.getEventNumber();
+            long previousAckLevel = dataAppended.getPreviousEventNumber();
+            try {
+                checkAckLevels(ackLevel, previousAckLevel);
+            } catch (Exception e) {
+                failConnection(e);
+            }
             ackUpTo(ackLevel);
         }
         
@@ -365,7 +377,21 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
             state.releaseIfEmptyInflight();
         }
-        
+
+        private void checkAckLevels(long ackLevel, long previousAckLevel) {
+            if (previousAckLevel > ackLevel) {
+                throw new IllegalStateException("Bad ack from server - previousAckLevel = " +
+                                                previousAckLevel + ", ackLevel = " + ackLevel);
+            } else {
+                Long inFlightBelowPreviousAckLevel = state.getInFlightBelow(previousAckLevel);
+                if (inFlightBelowPreviousAckLevel != null) {
+                    throw new IllegalStateException("Missed ack from server - previousAckLevel = " +
+                                                    previousAckLevel + ", ackLevel = " + ackLevel + ", " +
+                                                    "inFlightLevel = " + inFlightBelowPreviousAckLevel);
+                }
+            }
+        }
+
         private void conditionalFail(long eventNumber) {
             PendingEvent toAck = state.removeSingleInflight(eventNumber);
             if (toAck != null) {

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -327,11 +327,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         public void dataAppended(DataAppended dataAppended) {
             log.trace("Received ack: {}", dataAppended);
             long ackLevel = dataAppended.getEventNumber();
-            Long previousAckLevel = dataAppended.getPreviousEventNumber();
+            long previousAckLevel = dataAppended.getPreviousEventNumber();
             try {
-                if (previousAckLevel != null) {
-                    checkAckLevels(ackLevel, previousAckLevel);
-                }
+                checkAckLevels(ackLevel, previousAckLevel);
                 ackUpTo(ackLevel);
             } catch (Exception e) {
                 failConnection(e);

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -265,7 +265,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked));
         verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked.isDone());
-        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
+        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked.isCompletedExceptionally());
         assertEquals(true, acked.isDone());
         verify(connection, Mockito.atMost(1)).send(new WireCommands.KeepAlive());
@@ -295,7 +295,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -304,7 +304,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 1L)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 1)));
         assertEquals(false, acked2.isCompletedExceptionally());
         assertEquals(true, acked2.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -333,7 +333,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -373,7 +373,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -384,7 +384,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 3L));
+        cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 3));
 
         // check that client reconnected
         verify(cf, times(2)).establishConnection(any(), any());
@@ -493,7 +493,7 @@ public class SegmentOutputStreamTest {
             output.close();
         }, () -> {            
             cf.getProcessor(uri).appendSetup(new AppendSetup(2, SEGMENT, cid, 0));
-            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L));
+            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0));
         });
         inOrder.verify(connection).send(new WireCommands.KeepAlive());
         inOrder.verify(connection).send(new SetupAppend(2, cid, SEGMENT));

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -265,7 +265,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked));
         verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked.isDone());
-        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
         assertEquals(false, acked.isCompletedExceptionally());
         assertEquals(true, acked.isDone());
         verify(connection, Mockito.atMost(1)).send(new WireCommands.KeepAlive());
@@ -295,7 +295,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -304,7 +304,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 1)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 1L)));
         assertEquals(false, acked2.isCompletedExceptionally());
         assertEquals(true, acked2.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -333,7 +333,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -344,9 +344,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 3, 2)));
-        assertEquals(false, acked2.isCompletedExceptionally());
-        assertEquals(true, acked2.isDone());
+        cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 3, 2L));
 
         // check that client reconnected
         verify(cf, times(2)).establishConnection(any(), any());
@@ -375,7 +373,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -386,9 +384,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 3)));
-        assertEquals(false, acked2.isCompletedExceptionally());
-        assertEquals(true, acked2.isDone());
+        cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 3L));
 
         // check that client reconnected
         verify(cf, times(2)).establishConnection(any(), any());
@@ -497,7 +493,7 @@ public class SegmentOutputStreamTest {
             output.close();
         }, () -> {            
             cf.getProcessor(uri).appendSetup(new AppendSetup(2, SEGMENT, cid, 0));
-            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0));
+            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0L));
         });
         inOrder.verify(connection).send(new WireCommands.KeepAlive());
         inOrder.verify(connection).send(new SetupAppend(2, cid, SEGMENT));

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.times;
 
 
 public class SegmentOutputStreamTest {
@@ -308,6 +309,90 @@ public class SegmentOutputStreamTest {
         assertEquals(true, acked2.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
         order.verifyNoMoreInteractions();
+    }
+
+    @Test(timeout = 10000)
+    public void testReconnectOnMissedAcks() throws ConnectionFailedException, SegmentSealedException {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+        MockConnectionFactoryImpl cf = Mockito.spy(new MockConnectionFactoryImpl());
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        InOrder order = Mockito.inOrder(connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE);
+        output.reconnect();
+        order.verify(connection).send(new SetupAppend(1, cid, SEGMENT));
+        cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
+        ByteBuffer data = getBuffer("test");
+
+        CompletableFuture<Boolean> acked1 = new CompletableFuture<>();
+        output.write(new PendingEvent(null, data, acked1));
+        order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
+        assertEquals(false, acked1.isDone());
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        assertEquals(false, acked1.isCompletedExceptionally());
+        assertEquals(true, acked1.isDone());
+        order.verify(connection).send(new WireCommands.KeepAlive());
+
+        //simulate missed ack
+
+        CompletableFuture<Boolean> acked2 = new CompletableFuture<>();
+        output.write(new PendingEvent(null, data, acked2));
+        order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
+        assertEquals(false, acked2.isDone());
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 3, 2)));
+        assertEquals(false, acked2.isCompletedExceptionally());
+        assertEquals(true, acked2.isDone());
+
+        // check that client reconnected
+        verify(cf, times(2)).establishConnection(any(), any());
+
+    }
+
+    @Test(timeout = 10000)
+    public void testReconnectOnBadAcks() throws ConnectionFailedException, SegmentSealedException {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+        MockConnectionFactoryImpl cf = Mockito.spy(new MockConnectionFactoryImpl());
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        InOrder order = Mockito.inOrder(connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE);
+        output.reconnect();
+        order.verify(connection).send(new SetupAppend(1, cid, SEGMENT));
+        cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
+        ByteBuffer data = getBuffer("test");
+
+        CompletableFuture<Boolean> acked1 = new CompletableFuture<>();
+        output.write(new PendingEvent(null, data, acked1));
+        order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
+        assertEquals(false, acked1.isDone());
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
+        assertEquals(false, acked1.isCompletedExceptionally());
+        assertEquals(true, acked1.isDone());
+        order.verify(connection).send(new WireCommands.KeepAlive());
+
+        //simulate bad ack
+
+        CompletableFuture<Boolean> acked2 = new CompletableFuture<>();
+        output.write(new PendingEvent(null, data, acked2));
+        order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
+        assertEquals(false, acked2.isDone());
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 3)));
+        assertEquals(false, acked2.isCompletedExceptionally());
+        assertEquals(true, acked2.isDone());
+
+        // check that client reconnected
+        verify(cf, times(2)).establishConnection(any(), any());
+
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -264,7 +264,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked));
         verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked.isDone());
-        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1)));
+        Async.testBlocking(() -> output.close(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked.isCompletedExceptionally());
         assertEquals(true, acked.isDone());
         verify(connection, Mockito.atMost(1)).send(new WireCommands.KeepAlive());
@@ -294,7 +294,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked1));
         order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked1.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0)));
         assertEquals(false, acked1.isCompletedExceptionally());
         assertEquals(true, acked1.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -303,7 +303,7 @@ public class SegmentOutputStreamTest {
         output.write(new PendingEvent(null, data, acked2));
         order.verify(connection).send(new Append(SEGMENT, cid, 2, Unpooled.wrappedBuffer(data), null));
         assertEquals(false, acked2.isDone());
-        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2)));
+        Async.testBlocking(() -> output.flush(), () -> cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 2, 1)));
         assertEquals(false, acked2.isCompletedExceptionally());
         assertEquals(true, acked2.isDone());
         order.verify(connection).send(new WireCommands.KeepAlive());
@@ -412,7 +412,7 @@ public class SegmentOutputStreamTest {
             output.close();
         }, () -> {            
             cf.getProcessor(uri).appendSetup(new AppendSetup(2, SEGMENT, cid, 0));
-            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1));
+            cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(cid, 1, 0));
         });
         inOrder.verify(connection).send(new WireCommands.KeepAlive());
         inOrder.verify(connection).send(new SetupAppend(2, cid, SEGMENT));

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -219,7 +219,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private void handleAppendResult(final Append append, Throwable exception) {
         try {
             boolean conditionalFailed = exception != null && (ExceptionHelpers.getRealException(exception) instanceof BadOffsetException);
-            Long previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
+            long previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
             synchronized (lock) {
                 if (outstandingAppend != append) {
                     throw new IllegalStateException(

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -219,6 +219,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private void handleAppendResult(final Append append, Throwable exception) {
         try {
             boolean conditionalFailed = exception != null && (ExceptionHelpers.getRealException(exception) instanceof BadOffsetException);
+            Long previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
             synchronized (lock) {
                 if (outstandingAppend != append) {
                     throw new IllegalStateException(
@@ -246,7 +247,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 if (statsRecorder != null) {
                     statsRecorder.record(append.getSegment(), append.getDataLength(), append.getEventCount());
                 }
-                connection.send(new DataAppended(append.getWriterId(), append.getEventNumber()));
+                connection.send(new DataAppended(append.getWriterId(), append.getEventNumber(), previousEventNumber));
                 DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
                 DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
             }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -148,8 +148,8 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1, 0L));
-        verify(connection).send(new DataAppended(clientId, 2, 1L));
+        verify(connection).send(new DataAppended(clientId, 1, 0));
+        verify(connection).send(new DataAppended(clientId, 2, 1));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }
@@ -180,7 +180,7 @@ public class AppendProcessorTest {
         verify(store).append(streamSegmentName, 0L, data, updateEventNumber(clientId, 2, 1, 1), AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1, 0L));
+        verify(connection).send(new DataAppended(clientId, 1, 0));
         verify(connection).send(new ConditionalCheckFailed(clientId, 2));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
@@ -266,9 +266,9 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection, atLeast(0)).resumeReading();
         verify(connection).send(new AppendSetup(1, segment1, clientId1, 0));
-        verify(connection).send(new DataAppended(clientId1, data.length, 0L));
+        verify(connection).send(new DataAppended(clientId1, data.length, 0));
         verify(connection).send(new AppendSetup(2, segment2, clientId2, 0));
-        verify(connection).send(new DataAppended(clientId2, data.length, 0L));
+        verify(connection).send(new DataAppended(clientId2, data.length, 0));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -76,7 +76,7 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, data.length));
+        verify(connection).send(new DataAppended(clientId, data.length, 0));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }
@@ -148,8 +148,8 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1));
-        verify(connection).send(new DataAppended(clientId, 2));
+        verify(connection).send(new DataAppended(clientId, 1, 0));
+        verify(connection).send(new DataAppended(clientId, 2, 1));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }
@@ -180,7 +180,7 @@ public class AppendProcessorTest {
         verify(store).append(streamSegmentName, 0L, data, updateEventNumber(clientId, 2, 1, 1), AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1));
+        verify(connection).send(new DataAppended(clientId, 1, 0));
         verify(connection).send(new ConditionalCheckFailed(clientId, 2));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
@@ -266,9 +266,9 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection, atLeast(0)).resumeReading();
         verify(connection).send(new AppendSetup(1, segment1, clientId1, 0));
-        verify(connection).send(new DataAppended(clientId1, data.length));
+        verify(connection).send(new DataAppended(clientId1, data.length, 0));
         verify(connection).send(new AppendSetup(2, segment2, clientId2, 0));
-        verify(connection).send(new DataAppended(clientId2, data.length));
+        verify(connection).send(new DataAppended(clientId2, data.length, 0));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -76,7 +76,7 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, data.length, 0));
+        verify(connection).send(new DataAppended(clientId, data.length, 0L));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }
@@ -148,8 +148,8 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1, 0));
-        verify(connection).send(new DataAppended(clientId, 2, 1));
+        verify(connection).send(new DataAppended(clientId, 1, 0L));
+        verify(connection).send(new DataAppended(clientId, 2, 1L));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }
@@ -180,7 +180,7 @@ public class AppendProcessorTest {
         verify(store).append(streamSegmentName, 0L, data, updateEventNumber(clientId, 2, 1, 1), AppendProcessor.TIMEOUT);
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
         verify(connection, atLeast(0)).resumeReading();
-        verify(connection).send(new DataAppended(clientId, 1, 0));
+        verify(connection).send(new DataAppended(clientId, 1, 0L));
         verify(connection).send(new ConditionalCheckFailed(clientId, 2));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
@@ -266,9 +266,9 @@ public class AppendProcessorTest {
                              AppendProcessor.TIMEOUT);
         verify(connection, atLeast(0)).resumeReading();
         verify(connection).send(new AppendSetup(1, segment1, clientId1, 0));
-        verify(connection).send(new DataAppended(clientId1, data.length, 0));
+        verify(connection).send(new DataAppended(clientId1, data.length, 0L));
         verify(connection).send(new AppendSetup(2, segment2, clientId2, 0));
-        verify(connection).send(new DataAppended(clientId2, data.length, 0));
+        verify(connection).send(new DataAppended(clientId2, data.length, 0L));
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -510,7 +510,8 @@ public final class WireCommands {
         final WireCommandType type = WireCommandType.DATA_APPENDED;
         final UUID writerId;
         final long eventNumber;
-        final long previousEventNumber;
+        // using Long instead of long to allow null checking as the field may be missing from server
+        final Long previousEventNumber;
 
         @Override
         public void process(ReplyProcessor cp) {
@@ -528,7 +529,10 @@ public final class WireCommands {
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
             long offset = in.readLong();
-            long previousEventNumber = in.readLong();
+            Long previousEventNumber = null;
+            if (length == 32) {
+                previousEventNumber = in.readLong();
+            }
             return new DataAppended(writerId, offset, previousEventNumber);
         }
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -510,8 +510,7 @@ public final class WireCommands {
         final WireCommandType type = WireCommandType.DATA_APPENDED;
         final UUID writerId;
         final long eventNumber;
-        // using Long instead of long to allow null checking as the field may be missing from server
-        final Long previousEventNumber;
+        final long previousEventNumber;
 
         @Override
         public void process(ReplyProcessor cp) {
@@ -529,10 +528,7 @@ public final class WireCommands {
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
             long offset = in.readLong();
-            Long previousEventNumber = null;
-            if (length == 32) {
-                previousEventNumber = in.readLong();
-            }
+            long previousEventNumber = in.readLong();
             return new DataAppended(writerId, offset, previousEventNumber);
         }
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -510,6 +510,7 @@ public final class WireCommands {
         final WireCommandType type = WireCommandType.DATA_APPENDED;
         final UUID writerId;
         final long eventNumber;
+        final long previousEventNumber;
 
         @Override
         public void process(ReplyProcessor cp) {
@@ -521,12 +522,14 @@ public final class WireCommands {
             out.writeLong(writerId.getMostSignificantBits());
             out.writeLong(writerId.getLeastSignificantBits());
             out.writeLong(eventNumber);
+            out.writeLong(previousEventNumber);
         }
 
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
             long offset = in.readLong();
-            return new DataAppended(writerId, offset);
+            long previousEventNumber = in.readLong();
+            return new DataAppended(writerId, offset, previousEventNumber);
         }
     }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -70,7 +70,7 @@ public class WireCommandsTest {
 
     @Test
     public void testDataAppended() throws IOException {
-        testCommand(new WireCommands.DataAppended(uuid, l));
+        testCommand(new WireCommands.DataAppended(uuid, l, Long.MIN_VALUE));
     }
 
     @Test

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -128,7 +128,7 @@ public class AppendTest {
                                                       new Append(segment, uuid, data.readableBytes(), data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(data.readableBytes(), ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, (long) ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
     }
 
     @Test(timeout = 10000)
@@ -153,13 +153,13 @@ public class AppendTest {
                 new Append(segment, uuid, 1, data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(1, ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, (long) ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
 
         DataAppended ack2 = (DataAppended) sendRequest(channel,
                 new Append(segment, uuid, 2, data, null));
         assertEquals(uuid, ack2.getWriterId());
         assertEquals(2, ack2.getEventNumber());
-        assertEquals(1, (long) ack2.getPreviousEventNumber());
+        assertEquals(1, ack2.getPreviousEventNumber());
     }
 
 

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -131,8 +131,8 @@ public class AppendTest {
         assertEquals(Long.MIN_VALUE, (long) ack.getPreviousEventNumber());
     }
 
-    @Test
-    public void multipleAppends() throws Exception {
+    @Test(timeout = 10000)
+    public void testMultipleAppends() throws Exception {
         String segment = "123";
         ByteBuf data = Unpooled.wrappedBuffer("Hello world\n".getBytes());
         StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -128,7 +128,7 @@ public class AppendTest {
                                                       new Append(segment, uuid, data.readableBytes(), data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(data.readableBytes(), ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, (long)ack.getPreviousEventNumber());
     }
 
     @Test
@@ -153,13 +153,13 @@ public class AppendTest {
                 new Append(segment, uuid, 1, data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(1, ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, (long)ack.getPreviousEventNumber());
 
         DataAppended ack2 = (DataAppended) sendRequest(channel,
                 new Append(segment, uuid, 2, data, null));
         assertEquals(uuid, ack2.getWriterId());
         assertEquals(2, ack2.getEventNumber());
-        assertEquals(1, ack2.getPreviousEventNumber());
+        assertEquals(1, (long)ack2.getPreviousEventNumber());
     }
 
 

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -128,7 +128,40 @@ public class AppendTest {
                                                       new Append(segment, uuid, data.readableBytes(), data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(data.readableBytes(), ack.getEventNumber());
+        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
     }
+
+    @Test
+    public void multipleAppends() throws Exception {
+        String segment = "123";
+        ByteBuf data = Unpooled.wrappedBuffer("Hello world\n".getBytes());
+        StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();
+
+        EmbeddedChannel channel = createChannel(store);
+
+        SegmentCreated created = (SegmentCreated) sendRequest(channel, new CreateSegment(1, segment, CreateSegment.NO_SCALE, 0));
+        assertEquals(segment, created.getSegment());
+
+        UUID uuid = UUID.randomUUID();
+        AppendSetup setup = (AppendSetup) sendRequest(channel, new SetupAppend(2, uuid, segment));
+
+        assertEquals(segment, setup.getSegment());
+        assertEquals(uuid, setup.getWriterId());
+
+        data.retain();
+        DataAppended ack = (DataAppended) sendRequest(channel,
+                new Append(segment, uuid, 1, data, null));
+        assertEquals(uuid, ack.getWriterId());
+        assertEquals(1, ack.getEventNumber());
+        assertEquals(Long.MIN_VALUE, ack.getPreviousEventNumber());
+
+        DataAppended ack2 = (DataAppended) sendRequest(channel,
+                new Append(segment, uuid, 2, data, null));
+        assertEquals(uuid, ack2.getWriterId());
+        assertEquals(2, ack2.getEventNumber());
+        assertEquals(1, ack2.getPreviousEventNumber());
+    }
+
 
     static Reply sendRequest(EmbeddedChannel channel, Request request) throws Exception {
         channel.writeInbound(request);

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -128,7 +128,7 @@ public class AppendTest {
                                                       new Append(segment, uuid, data.readableBytes(), data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(data.readableBytes(), ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, (long)ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, (long) ack.getPreviousEventNumber());
     }
 
     @Test
@@ -153,13 +153,13 @@ public class AppendTest {
                 new Append(segment, uuid, 1, data, null));
         assertEquals(uuid, ack.getWriterId());
         assertEquals(1, ack.getEventNumber());
-        assertEquals(Long.MIN_VALUE, (long)ack.getPreviousEventNumber());
+        assertEquals(Long.MIN_VALUE, (long) ack.getPreviousEventNumber());
 
         DataAppended ack2 = (DataAppended) sendRequest(channel,
                 new Append(segment, uuid, 2, data, null));
         assertEquals(uuid, ack2.getWriterId());
         assertEquals(2, ack2.getEventNumber());
-        assertEquals(1, (long)ack2.getPreviousEventNumber());
+        assertEquals(1, (long) ack2.getPreviousEventNumber());
     }
 
 


### PR DESCRIPTION
**Change log description**
This adds a new field `previousEventNumber` in the server response command DataAppended. The field represents the previously acknowledged event number. This is used on the client to verify that no acknowledgements have been missed. If a gap is detected, the connection is re-established.

**Purpose of the change**
Fixes #1858 
**What the code does**
Fixes #1858 

**How to verify it**
Unit and integration tests have been added.
