### PR TITLE
Issue 1911: (SegmentStore) Refactored SegmentProperties

### DIFF
--- a/docs/segment-store-service.md
+++ b/docs/segment-store-service.md
@@ -76,7 +76,7 @@ Each Segment Container needs to keep per-segment metadata, which it uses to keep
 -   **Name** the name of the Segment.
 -   **Id**: Internally assigned unique Segment Id. This is used to refer to Segments, which is preferred to the Name.
 -   **Storage Length**: the highest offset of the data that exists in Tier-2 Storage.
--   **Durable Log Length**: the highest offset of the committed data in Tier-1 Storage.
+-   **Length**: the highest offset of the committed data in Tier-1 Storage.
 -   **Last Modified**: the timestamp of the last processed (and acknowledged) append.
 -   **IsSealed:** whether the Segment is closed for appends (this value may not have been applied to Tier-2 Storage yet).
 -   **IsSealedInStorage**: whether the Segment is closed for appends (and this has been persisted in Tier-2 Storage).

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
@@ -9,10 +9,12 @@
  */
 package io.pravega.segmentstore.contracts;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.util.ImmutableDate;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import lombok.Builder;
 import lombok.Getter;
 
 /**
@@ -39,34 +41,22 @@ public class StreamSegmentInformation implements SegmentProperties {
     //region Constructor
 
     /**
-     * Creates a new instance of the StreamSegmentInformation class with no attributes.
+     * Creates a new instance of the StreamSegmentInformation class.
      *
-     * @param streamSegmentName The name of the StreamSegment.
-     * @param length            The length of the StreamSegment.
-     * @param isSealed          Whether the StreamSegment is sealed (for modifications).
-     * @param isDeleted         Whether the StreamSegment is deleted (does not exist).
-     * @param lastModified      The last time the StreamSegment was modified.
+     * @param name         The name of the StreamSegment.
+     * @param length       The length of the StreamSegment.
+     * @param sealed       Whether the StreamSegment is sealed (for modifications).
+     * @param deleted      Whether the StreamSegment is deleted (does not exist).
+     * @param attributes   The attributes of this StreamSegment.
+     * @param lastModified The last time the StreamSegment was modified.
      */
-    public StreamSegmentInformation(String streamSegmentName, long length, boolean isSealed, boolean isDeleted, ImmutableDate lastModified) {
-        this(streamSegmentName, length, isSealed, isDeleted, null, lastModified);
-    }
-
-    /**
-     * Creates a new instance of the StreamSegmentInformation class with attributes.
-     *
-     * @param streamSegmentName The name of the StreamSegment.
-     * @param length            The length of the StreamSegment.
-     * @param isSealed          Whether the StreamSegment is sealed (for modifications).
-     * @param isDeleted         Whether the StreamSegment is deleted (does not exist).
-     * @param attributes        The attributes of this StreamSegment.
-     * @param lastModified      The last time the StreamSegment was modified.
-     */
-    public StreamSegmentInformation(String streamSegmentName, long length, boolean isSealed, boolean isDeleted, Map<UUID, Long> attributes, ImmutableDate lastModified) {
-        this.name = streamSegmentName;
+    @Builder
+    private StreamSegmentInformation(String name, long length, boolean sealed, boolean deleted, Map<UUID, Long> attributes, ImmutableDate lastModified) {
+        this.name = Exceptions.checkNotNullOrEmpty(name, "name");
         this.length = length;
-        this.sealed = isSealed;
-        this.deleted = isDeleted;
-        this.lastModified = lastModified;
+        this.sealed = sealed;
+        this.deleted = deleted;
+        this.lastModified = lastModified == null ? new ImmutableDate() : lastModified;
         this.attributes = getAttributes(attributes);
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -9,14 +9,8 @@
  */
 package io.pravega.segmentstore.server.host.handler;
 
+import io.netty.buffer.Unpooled;
 import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.shared.protocol.netty.Append;
-import io.pravega.shared.protocol.netty.FailingRequestProcessor;
-import io.pravega.shared.protocol.netty.WireCommands.AppendSetup;
-import io.pravega.shared.protocol.netty.WireCommands.ConditionalCheckFailed;
-import io.pravega.shared.protocol.netty.WireCommands.DataAppended;
-import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.BadOffsetException;
@@ -24,8 +18,12 @@ import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.SegmentMetadata;
-import io.netty.buffer.Unpooled;
-
+import io.pravega.shared.protocol.netty.Append;
+import io.pravega.shared.protocol.netty.FailingRequestProcessor;
+import io.pravega.shared.protocol.netty.WireCommands.AppendSetup;
+import io.pravega.shared.protocol.netty.WireCommands.ConditionalCheckFailed;
+import io.pravega.shared.protocol.netty.WireCommands.DataAppended;
+import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -313,7 +310,7 @@ public class AppendProcessorTest {
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor());
 
         CompletableFuture<SegmentProperties> propsFuture = CompletableFuture.completedFuture(
-                new StreamSegmentInformation(streamSegmentName, 0, false, false, Collections.EMPTY_MAP, new ImmutableDate()));
+                StreamSegmentInformation.builder().name(streamSegmentName).build());
         when(store.getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT)).thenReturn(propsFuture);
         processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName));
         verify(store).getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT);
@@ -331,8 +328,7 @@ public class AppendProcessorTest {
         Map<UUID, Long> map = new HashMap<>();
         map.put(clientId, 100L);
         map.put(EVENT_COUNT, 100L);
-        propsFuture = CompletableFuture.completedFuture(new StreamSegmentInformation(streamSegmentName, 0, false, false,
-                                                                                     map, new ImmutableDate()));
+        propsFuture = CompletableFuture.completedFuture(StreamSegmentInformation.builder().name(streamSegmentName).attributes(map).build());
 
         when(store.append(streamSegmentName, data, updateEventNumber(clientId, 200, 100, eventCount),
                           AppendProcessor.TIMEOUT)).thenReturn(result);
@@ -353,8 +349,10 @@ public class AppendProcessorTest {
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor());
 
         CompletableFuture<SegmentProperties> propsFuture = CompletableFuture.completedFuture(
-                new StreamSegmentInformation(streamSegmentName, 0, false, false,
-                        Collections.singletonMap(clientId, 100L), new ImmutableDate()));
+                StreamSegmentInformation.builder()
+                        .name(streamSegmentName)
+                        .attributes(Collections.singletonMap(clientId, 100L))
+                        .build());
 
         when(store.getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT)).thenReturn(propsFuture);
         processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName));
@@ -398,9 +396,10 @@ public class AppendProcessorTest {
     }
 
     private void setupGetStreamSegmentInfo(String streamSegmentName, UUID clientId, long eventNumber, StreamSegmentStore store) {
-        CompletableFuture<SegmentProperties> propsFuture = CompletableFuture.completedFuture(
-                new StreamSegmentInformation(streamSegmentName, 0, false, false,
-                        Collections.singletonMap(clientId, eventNumber), new ImmutableDate()));
+        CompletableFuture<SegmentProperties> propsFuture = CompletableFuture.completedFuture(StreamSegmentInformation.builder()
+                .name(streamSegmentName)
+                .attributes(Collections.singletonMap(clientId, eventNumber))
+                .build());
 
         when(store.getStreamSegmentInfo(streamSegmentName, true, AppendProcessor.TIMEOUT))
                 .thenReturn(propsFuture);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
@@ -28,7 +28,7 @@ public interface ReadIndex extends AutoCloseable {
      *                        of the StreamSegment as it exists in the ReadIndex.
      * @param data            The data to append.
      * @throws IllegalArgumentException If the offset does not match the expected value (end of StreamSegment in ReadIndex).
-     * @throws IllegalArgumentException If the offset + data.length exceeds the metadata DurableLogLength of the StreamSegment.
+     * @throws IllegalArgumentException If the offset + data.length exceeds the metadata Length of the StreamSegment.
      */
     void append(long streamSegmentId, long offset, byte[] data);
 
@@ -47,7 +47,7 @@ public interface ReadIndex extends AutoCloseable {
      *                              The offset must be at the end of the StreamSegment as it exists in the ReadIndex.
      * @param sourceStreamSegmentId The Id of the StreamSegment to merge.
      * @throws IllegalArgumentException If the offset does not match the expected value (end of StreamSegment in ReadIndex).
-     * @throws IllegalArgumentException If the offset + SourceStreamSegment.length exceeds the metadata DurableLogLength
+     * @throws IllegalArgumentException If the offset + SourceStreamSegment.length exceeds the metadata Length
      *                                  of the target StreamSegment.
      */
     void beginMerge(long targetStreamSegmentId, long offset, long sourceStreamSegmentId);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -54,11 +54,6 @@ public interface SegmentMetadata extends SegmentProperties {
     long getStorageLength();
 
     /**
-     * Gets a value indicating the length of this entire StreamSegment (the part in Storage + the part in DurableLog).
-     */
-    long getDurableLogLength();
-
-    /**
      * Gets a value representing the when the Segment was last used. The meaning of this value is implementation specific,
      * however higher values should indicate it was used more recently.
      */
@@ -90,10 +85,5 @@ public interface SegmentMetadata extends SegmentProperties {
      */
     default boolean isTransaction() {
         return getParentId() != ContainerMetadata.NO_STREAM_SEGMENT_ID;
-    }
-
-    @Override
-    default long getLength() {
-        return getDurableLogLength();
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableSegmentMetadata.java
@@ -27,12 +27,12 @@ public interface UpdateableSegmentMetadata extends SegmentMetadata {
     void setStorageLength(long value);
 
     /**
-     * Sets the current DurableLog Length for this StreamSegment.
+     * Sets the current Length for this StreamSegment.
      *
-     * @param value The new DurableLog length.
+     * @param value The new length.
      * @throws IllegalArgumentException If the value is invalid.
      */
-    void setDurableLogLength(long value);
+    void setLength(long value);
 
     /**
      * Marks this StreamSegment as sealed for modifications.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -41,7 +41,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     @GuardedBy("this")
     private long storageLength;
     @GuardedBy("this")
-    private long durableLogLength;
+    private long length;
     @GuardedBy("this")
     private boolean sealed;
     @GuardedBy("this")
@@ -97,7 +97,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
         this.deleted = false;
         this.merged = false;
         this.storageLength = -1;
-        this.durableLogLength = -1;
+        this.length = -1;
         this.attributes = new HashMap<>();
         this.lastModified = new ImmutableDate();
         this.lastUsed = 0;
@@ -163,8 +163,8 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     }
 
     @Override
-    public synchronized long getDurableLogLength() {
-        return this.durableLogLength;
+    public synchronized long getLength() {
+        return this.length;
     }
 
     @Override
@@ -175,10 +175,10 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     @Override
     public String toString() {
         return String.format(
-                "Id = %d, StorageLength = %d, DLOffset = %d, Sealed(DL/S) = %s/%s, Deleted = %s, Name = %s",
+                "Id = %d, Length = %d, StorageLength = %d, Sealed(M/S) = %s/%s, Deleted = %s, Name = %s",
                 getId(),
+                getLength(),
                 getStorageLength(),
-                getDurableLogLength(),
                 isSealed(),
                 isSealedInStorage(),
                 isDeleted(),
@@ -199,12 +199,12 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     }
 
     @Override
-    public synchronized void setDurableLogLength(long value) {
-        Exceptions.checkArgument(value >= 0, "value", "Durable Log Length must be a non-negative number.");
-        Exceptions.checkArgument(value >= this.durableLogLength, "value", "New Durable Log Length cannot be smaller than the previous one.");
+    public synchronized void setLength(long value) {
+        Exceptions.checkArgument(value >= 0, "value", "Length must be a non-negative number.");
+        Exceptions.checkArgument(value >= this.length, "value", "New Length cannot be smaller than the previous one.");
 
-        log.trace("{}: DurableLogLength changed from {} to {}.", this.traceObjectId, this.durableLogLength, value);
-        this.durableLogLength = value;
+        log.trace("{}: Length changed from {} to {}.", this.traceObjectId, this.length, value);
+        this.length = value;
     }
 
     @Override
@@ -260,7 +260,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
 
         log.debug("{}: copyFrom {}.", this.traceObjectId, base.getClass().getSimpleName());
         setStorageLength(base.getStorageLength());
-        setDurableLogLength(base.getDurableLogLength());
+        setLength(base.getLength());
         setLastModified(base.getLastModified());
         updateAttributes(base.getAttributes());
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -479,8 +479,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
     private void updateMetadata(StreamSegmentMapping mapping, UpdateableSegmentMetadata metadata) {
         metadata.setStorageLength(mapping.getLength());
 
-        // DurableLogLength must be at least StorageLength.
-        metadata.setDurableLogLength(Math.max(mapping.getLength(), metadata.getDurableLogLength()));
+        // Length must be at least StorageLength.
+        metadata.setLength(Math.max(mapping.getLength(), metadata.getLength()));
         if (mapping.isSealed()) {
             // MapOperations represent the state of the Segment in Storage. If it is sealed in storage, both
             // Seal flags need to be set.
@@ -785,8 +785,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         stream.writeLong(sm.getParentId());
         // S3. Name.
         stream.writeUTF(sm.getName());
-        // S4. DurableLogLength.
-        stream.writeLong(sm.getDurableLogLength());
+        // S4. Length.
+        stream.writeLong(sm.getLength());
         // S5. StorageLength.
         stream.writeLong(sm.getStorageLength());
         // S6. Merged.
@@ -813,8 +813,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
 
         UpdateableSegmentMetadata metadata = getOrCreateSegmentUpdateTransaction(name, segmentId, parentId);
 
-        // S4. DurableLogLength.
-        metadata.setDurableLogLength(stream.readLong());
+        // S4. Length.
+        metadata.setLength(stream.readLong());
         // S5. StorageLength.
         metadata.setStorageLength(stream.readLong());
         // S6. Merged.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
@@ -13,7 +13,7 @@ import io.pravega.segmentstore.contracts.ReadResultEntryType;
 
 /**
  * Read Result Entry for data that is not yet available in the StreamSegment (for an offset that is beyond the
- * StreamSegment's DurableLogLength)
+ * StreamSegment's Length)
  */
 class FutureReadResultEntry extends ReadResultEntryBase {
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -718,7 +718,7 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
 
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "mergeWith", transactionMetadata.getId(), transactionMetadata.getName(), transactionMetadata.isSealedInStorage());
         FlushResult result = new FlushResult();
-        if (!transactionMetadata.isSealedInStorage() || transactionMetadata.getDurableLogLength() > transactionMetadata.getStorageLength()) {
+        if (!transactionMetadata.isSealedInStorage() || transactionMetadata.getLength() > transactionMetadata.getStorageLength()) {
             // Nothing to do. Given Transaction is not eligible for merger yet.
             LoggerHelpers.traceLeave(log, this.traceObjectId, "mergeWith", traceId, result);
             return CompletableFuture.completedFuture(result);
@@ -843,11 +843,11 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
         return this.storage
                 .getStreamSegmentInfo(this.metadata.getName(), timer.getRemaining())
                 .thenAccept(sp -> {
-                    if (sp.getLength() > this.metadata.getDurableLogLength()) {
+                    if (sp.getLength() > this.metadata.getLength()) {
                         // The length of the Segment in Storage is beyond what we have in our DurableLog. This is not
                         // possible in a correct scenario and is usually indicative of an internal bug or some other external
                         // actor altering the Segment. We cannot recover automatically from this situation.
-                        throw new CompletionException(new ReconciliationFailureException("Actual Segment length in Storage is larger than the Metadata DurableLogLength.", this.metadata, sp));
+                        throw new CompletionException(new ReconciliationFailureException("Actual Segment length in Storage is larger than the Metadata Length.", this.metadata, sp));
                     } else if (sp.getLength() < this.metadata.getStorageLength()) {
                         // The length of the Segment in Storage is less than what we thought it was. This is not possible
                         // in a correct scenario, and is usually indicative of an internal bug or a real data loss in Storage.
@@ -1108,23 +1108,23 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
             throw new DataCorruptionException(String.format("Wrong offset for Operation '%s'. Expected: %s, actual: %d.", operation, this.lastAddedOffset, offset));
         }
 
-        // Check that the operation does not exceed the DurableLogLength of the StreamSegment.
-        if (offset + length > this.metadata.getDurableLogLength()) {
+        // Check that the operation does not exceed the Length of the StreamSegment.
+        if (offset + length > this.metadata.getLength()) {
             throw new DataCorruptionException(String.format(
-                    "Operation '%s' has at least one byte beyond its DurableLogLength. Offset = %d, Length = %d, DurableLogLength = %d.",
+                    "Operation '%s' has at least one byte beyond its Length. Offset = %d, Length = %d, Length = %d.",
                     operation,
                     offset,
                     length,
-                    this.metadata.getDurableLogLength()));
+                    this.metadata.getLength()));
         }
 
         if (operation instanceof StreamSegmentSealOperation) {
-            // For StreamSegmentSealOperations, we must ensure the offset of the operation is equal to the DurableLogLength for the segment.
-            if (this.metadata.getDurableLogLength() != offset) {
+            // For StreamSegmentSealOperations, we must ensure the offset of the operation is equal to the Length for the segment.
+            if (this.metadata.getLength() != offset) {
                 throw new DataCorruptionException(String.format(
-                        "Wrong offset for Operation '%s'. Expected: %d (DurableLogLength), actual: %d.",
+                        "Wrong offset for Operation '%s'. Expected: %d (Length), actual: %d.",
                         operation,
-                        this.metadata.getDurableLogLength(),
+                        this.metadata.getLength(),
                         offset));
             }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
@@ -33,7 +33,7 @@ public final class SegmentMetadataComparer {
         Assert.assertEquals(idPrefix + " getParentId() mismatch.", expected.getParentId(), actual.getParentId());
         Assert.assertEquals(idPrefix + " getName() isDeleted.", expected.isDeleted(), actual.isDeleted());
         Assert.assertEquals(idPrefix + " getStorageLength() mismatch.", expected.getStorageLength(), actual.getStorageLength());
-        Assert.assertEquals(idPrefix + " getDurableLogLength() mismatch.", expected.getDurableLogLength(), actual.getDurableLogLength());
+        Assert.assertEquals(idPrefix + " getLength() mismatch.", expected.getLength(), actual.getLength());
         Assert.assertEquals(idPrefix + " getName() mismatch.", expected.getName(), actual.getName());
         Assert.assertEquals(idPrefix + " isSealed() mismatch.", expected.isSealed(), actual.isSealed());
         Assert.assertEquals(idPrefix + " isMerged() mismatch.", expected.isMerged(), actual.isMerged());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentStateTests.java
@@ -11,7 +11,6 @@ package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.io.EnhancedByteArrayOutputStream;
 import io.pravega.common.util.ByteArraySegment;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.test.common.AssertExtensions;
 import java.io.DataInputStream;
@@ -53,6 +52,6 @@ public class SegmentStateTests {
         }
 
         return new SegmentState(attributeCount,
-                new StreamSegmentInformation(Integer.toString(attributeCount), 0, false, false, attributes, new ImmutableDate()));
+                StreamSegmentInformation.builder().name(Integer.toString(attributeCount)).attributes(attributes).build());
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StateStoreTests.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.util.AsyncMap;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -109,8 +108,7 @@ public abstract class StateStoreTests extends ThreadPooledTestSuite {
             attributes.put(UUID.randomUUID(), (long) i);
         }
 
-        return new SegmentState(segmentName.hashCode(),
-                new StreamSegmentInformation(segmentName, 0, false, false, attributes, new ImmutableDate()));
+        return new SegmentState(segmentName.hashCode(), StreamSegmentInformation.builder().name(segmentName).attributes(attributes).build());
     }
 
     //region InMemoryStateStoreTests

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -224,7 +224,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
                 Assert.assertNotNull("No metadata was created for StreamSegment " + name, sm);
                 long expectedLength = getInitialLength.apply(name);
                 boolean expectedSeal = isSealed.test(name);
-                Assert.assertEquals("Metadata does not have the expected length for StreamSegment " + name, expectedLength, sm.getDurableLogLength());
+                Assert.assertEquals("Metadata does not have the expected length for StreamSegment " + name, expectedLength, sm.getLength());
                 Assert.assertEquals("Metadata does not have the expected value for isSealed for StreamSegment " + name, expectedSeal, sm.isSealed());
 
                 val segmentState = context.stateStore.get(name, TIMEOUT).join();
@@ -243,7 +243,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
                 Assert.assertNotNull("No metadata was created for Transaction " + name, sm);
                 long expectedLength = getInitialLength.apply(name);
                 boolean expectedSeal = isSealed.test(name);
-                Assert.assertEquals("Metadata does not have the expected length for Transaction " + name, expectedLength, sm.getDurableLogLength());
+                Assert.assertEquals("Metadata does not have the expected length for Transaction " + name, expectedLength, sm.getLength());
                 Assert.assertEquals("Metadata does not have the expected value for isSealed for Transaction " + name, expectedSeal, sm.isSealed());
 
                 val segmentState = context.stateStore.get(name, TIMEOUT).join();
@@ -458,7 +458,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
             ((StreamSegmentMapOperation) op).setStreamSegmentId(segmentId);
             UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(segmentName, segmentId);
             segmentMetadata.setStorageLength(0);
-            segmentMetadata.setDurableLogLength(0);
+            segmentMetadata.setLength(0);
             addInvoked.complete(null);
             return initialAddFuture;
         };
@@ -631,7 +631,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
 
                 UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(mapOp.getStreamSegmentName(), mapOp.getStreamSegmentId());
                 segmentMetadata.setStorageLength(0);
-                segmentMetadata.setDurableLogLength(mapOp.getLength());
+                segmentMetadata.setLength(mapOp.getLength());
                 if (mapOp.isSealed()) {
                     segmentMetadata.markSealed();
                 }
@@ -645,7 +645,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
 
                 UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(mapOp.getStreamSegmentName(), mapOp.getStreamSegmentId(), mapOp.getParentStreamSegmentId());
                 segmentMetadata.setStorageLength(0);
-                segmentMetadata.setDurableLogLength(mapOp.getLength());
+                segmentMetadata.setLength(mapOp.getLength());
                 if (mapOp.isSealed()) {
                     segmentMetadata.markSealed();
                 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
@@ -85,7 +85,7 @@ public class StreamSegmentMetadataTests {
         StreamSegmentMetadata baseMetadata = new StreamSegmentMetadata(SEGMENT_NAME, SEGMENT_ID, PARENT_SEGMENT_ID, CONTAINER_ID);
         baseMetadata.updateAttributes(generateAttributes(new Random(0)));
         baseMetadata.setStorageLength(1233);
-        baseMetadata.setDurableLogLength(3235342);
+        baseMetadata.setLength(3235342);
         baseMetadata.setLastModified(new ImmutableDate());
         baseMetadata.markDeleted();
         baseMetadata.markSealed();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.segmentstore.server.logs;
 
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
@@ -708,8 +707,12 @@ public class ContainerMetadataUpdateTransactionTests {
 
         // StreamSegmentName already exists and we try to map with the same id. Verify that we are able to update its
         // StorageLength (if different).
-        val updateMap = new StreamSegmentMapOperation(new StreamSegmentInformation(mapOp.getStreamSegmentName(),
-                storageLength, true, false, createAttributes(), new ImmutableDate()));
+        val updateMap = new StreamSegmentMapOperation(StreamSegmentInformation.builder()
+                .name(mapOp.getStreamSegmentName())
+                .length(storageLength)
+                .sealed(true)
+                .attributes(createAttributes())
+                .build());
         updateMap.setStreamSegmentId(mapOp.getStreamSegmentId());
         txn2.preProcessOperation(updateMap);
         txn2.acceptOperation(updateMap);
@@ -790,8 +793,12 @@ public class ContainerMetadataUpdateTransactionTests {
 
         // StreamSegmentName already exists and we try to map with the same id. Verify that we are able to update its
         // StorageLength (if different).
-        val updateMap = new TransactionMapOperation(mapOp.getParentStreamSegmentId(),
-                new StreamSegmentInformation(mapOp.getStreamSegmentName(), mapOp.getLength() + 1, true, false, createAttributes(), new ImmutableDate()));
+        val updateMap = new TransactionMapOperation(mapOp.getParentStreamSegmentId(), StreamSegmentInformation.builder()
+                .name(mapOp.getStreamSegmentName())
+                .length(mapOp.getLength() + 1)
+                .sealed(true)
+                .attributes(createAttributes())
+                .build());
         updateMap.setStreamSegmentId(mapOp.getStreamSegmentId());
         txn3.preProcessOperation(updateMap);
         txn3.acceptOperation(updateMap);
@@ -882,8 +889,10 @@ public class ContainerMetadataUpdateTransactionTests {
         assertMetadataSame("Unexpected metadata before any operation.", metadata, checkpointedMetadata);
 
         // Map another StreamSegment, and add an append
-        StreamSegmentMapOperation mapOp = new StreamSegmentMapOperation(
-                new StreamSegmentInformation(newSegmentName, SEGMENT_LENGTH, false, false, new ImmutableDate()));
+        StreamSegmentMapOperation mapOp = new StreamSegmentMapOperation(StreamSegmentInformation.builder()
+                .name(newSegmentName)
+                .length(SEGMENT_LENGTH)
+                .build());
         processOperation(mapOp, txn, seqNo::incrementAndGet);
         processOperation(new StreamSegmentAppendOperation(mapOp.getStreamSegmentId(), DEFAULT_APPEND_DATA, createAttributeUpdates()), txn, seqNo::incrementAndGet);
         processOperation(checkpoint2, txn, seqNo::incrementAndGet);
@@ -1316,7 +1325,11 @@ public class ContainerMetadataUpdateTransactionTests {
     }
 
     private StreamSegmentMapOperation createMap(String name) {
-        return new StreamSegmentMapOperation(new StreamSegmentInformation(name, SEGMENT_LENGTH, true, false, createAttributes(), new ImmutableDate()));
+        return new StreamSegmentMapOperation(StreamSegmentInformation.builder()
+                .name(name)
+                .length(SEGMENT_LENGTH)
+                .sealed(true)
+                .attributes(createAttributes()).build());
     }
 
     private TransactionMapOperation createTransactionMap(long parentId) {
@@ -1324,7 +1337,12 @@ public class ContainerMetadataUpdateTransactionTests {
     }
 
     private TransactionMapOperation createTransactionMap(long parentId, String name) {
-        return new TransactionMapOperation(parentId, new StreamSegmentInformation(name, SEALED_TRANSACTION_LENGTH, true, false, createAttributes(), new ImmutableDate()));
+        return new TransactionMapOperation(parentId, StreamSegmentInformation.builder()
+                .name(name)
+                .length(SEALED_TRANSACTION_LENGTH)
+                .sealed(true)
+                .attributes(createAttributes())
+                .build());
     }
 
     private MetadataCheckpointOperation createMetadataCheckpoint() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -106,9 +106,9 @@ public class ContainerMetadataUpdateTransactionTests {
                 0, appendOp.getStreamSegmentOffset());
         checkNoSequenceNumberAssigned(appendOp, "call to preProcess in recovery mode");
         Assert.assertEquals("preProcess(Append) seems to have changed the Updater internal state in recovery mode.",
-                SEGMENT_LENGTH, txn1.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, txn1.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("preProcess(Append) seems to have changed the metadata in recovery mode.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
 
         // When everything is OK (no recovery mode).
         metadata.exitRecoveryMode();
@@ -118,9 +118,9 @@ public class ContainerMetadataUpdateTransactionTests {
                 SEGMENT_LENGTH, appendOp.getStreamSegmentOffset());
         checkNoSequenceNumberAssigned(appendOp, "call to preProcess in non-recovery mode");
         Assert.assertEquals("preProcess(Append) seems to have changed the Updater internal state.",
-                SEGMENT_LENGTH, txn2.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, txn2.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("preProcess(Append) seems to have changed the metadata.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
 
         // When StreamSegment is merged (via transaction).
         StreamSegmentAppendOperation transactionAppendOp = new StreamSegmentAppendOperation(SEALED_TRANSACTION_ID, DEFAULT_APPEND_DATA, null);
@@ -176,17 +176,17 @@ public class ContainerMetadataUpdateTransactionTests {
                 ex -> ex instanceof MetadataUpdateException);
 
         Assert.assertEquals("acceptOperation updated the transaction even if it threw an exception.",
-                SEGMENT_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("acceptOperation updated the metadata.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
 
         // When all is good.
         txn.preProcessOperation(appendOp);
         txn.acceptOperation(appendOp);
         Assert.assertEquals("acceptOperation did not update the transaction.",
-                SEGMENT_LENGTH + appendOp.getData().length, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH + appendOp.getData().length, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("acceptOperation updated the metadata.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
     }
 
     /**
@@ -199,16 +199,16 @@ public class ContainerMetadataUpdateTransactionTests {
         val txn = createUpdateTransaction(metadata);
 
         // Append #1 (at offset 0).
-        long offset = metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength();
+        long offset = metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength();
         StreamSegmentAppendOperation appendOp = createAppendWithOffset(offset);
         txn.preProcessOperation(appendOp);
         Assert.assertEquals("Unexpected StreamSegmentOffset after call to preProcess in non-recovery mode.",
                 offset, appendOp.getStreamSegmentOffset());
         checkNoSequenceNumberAssigned(appendOp, "call to preProcess in non-recovery mode");
         Assert.assertEquals("preProcess(Append) seems to have changed the Updater internal state.",
-                offset, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                offset, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("preProcess(Append) seems to have changed the metadata.",
-                offset, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                offset, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         txn.acceptOperation(appendOp);
 
         // Append #2 (after Append #1)
@@ -219,9 +219,9 @@ public class ContainerMetadataUpdateTransactionTests {
                 offset, appendOp.getStreamSegmentOffset());
         checkNoSequenceNumberAssigned(appendOp, "call to preProcess in non-recovery mode");
         Assert.assertEquals("preProcess(Append) seems to have changed the Updater internal state.",
-                offset, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                offset, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("preProcess(Append) seems to have changed the metadata.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         txn.acceptOperation(appendOp);
 
         // Append #3 (wrong offset)
@@ -543,7 +543,7 @@ public class ContainerMetadataUpdateTransactionTests {
                 ex -> ex instanceof MetadataUpdateException);
 
         // In recovery mode, the updater does not set the length; it just validates that it has one.
-        recoveryMergeOp.setLength(metadata.getStreamSegmentMetadata(SEALED_TRANSACTION_ID).getDurableLogLength());
+        recoveryMergeOp.setLength(metadata.getStreamSegmentMetadata(SEALED_TRANSACTION_ID).getLength());
         txn1.preProcessOperation(recoveryMergeOp);
         AssertExtensions.assertLessThan("Unexpected Target StreamSegmentOffset after call to preProcess in recovery mode.",
                 0, recoveryMergeOp.getStreamSegmentOffset());
@@ -624,9 +624,9 @@ public class ContainerMetadataUpdateTransactionTests {
                 ex -> ex instanceof MetadataUpdateException);
 
         Assert.assertEquals("acceptOperation updated the transaction even if it threw an exception (parent segment).",
-                SEGMENT_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("acceptOperation updated the metadata (parent segment).",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         txn.clear(); // This would naturally happen in case of a failure, so we need to simulate this here too.
 
         // When all is good.
@@ -637,9 +637,9 @@ public class ContainerMetadataUpdateTransactionTests {
         Assert.assertFalse("acceptOperation updated the metadata (Transaction).",
                 metadata.getStreamSegmentMetadata(SEALED_TRANSACTION_ID).isMerged());
         Assert.assertEquals("acceptOperation did not update the transaction.",
-                SEGMENT_LENGTH + SEALED_TRANSACTION_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH + SEALED_TRANSACTION_LENGTH, txn.getStreamSegmentMetadata(SEGMENT_ID).getLength());
         Assert.assertEquals("acceptOperation updated the metadata.",
-                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getDurableLogLength());
+                SEGMENT_LENGTH, metadata.getStreamSegmentMetadata(SEGMENT_ID).getLength());
     }
 
     //endregion
@@ -677,8 +677,8 @@ public class ContainerMetadataUpdateTransactionTests {
         val updaterMetadata = txn2.getStreamSegmentMetadata(mapOp.getStreamSegmentId());
         Assert.assertEquals("Unexpected StorageLength after call to acceptOperation (in transaction).",
                 mapOp.getLength(), updaterMetadata.getStorageLength());
-        Assert.assertEquals("Unexpected DurableLogLength after call to acceptOperation (in transaction).",
-                mapOp.getLength(), updaterMetadata.getDurableLogLength());
+        Assert.assertEquals("Unexpected Length after call to acceptOperation (in transaction).",
+                mapOp.getLength(), updaterMetadata.getLength());
         Assert.assertEquals("Unexpected value for isSealed after call to acceptOperation (in transaction).",
                 mapOp.isSealed(), updaterMetadata.isSealed());
         Assert.assertNull("acceptOperation modified the underlying metadata.", metadata.getStreamSegmentMetadata(mapOp.getStreamSegmentId()));
@@ -702,9 +702,9 @@ public class ContainerMetadataUpdateTransactionTests {
                 () -> txn2.preProcessOperation(createMap(mapOp.getStreamSegmentName())),
                 ex -> ex instanceof MetadataUpdateException);
 
-        val durableLogLength = segmentMetadata.getDurableLogLength() + 5;
+        val length = segmentMetadata.getLength() + 5;
         val storageLength = segmentMetadata.getStorageLength() + 1;
-        segmentMetadata.setDurableLogLength(durableLogLength);
+        segmentMetadata.setLength(length);
 
         // StreamSegmentName already exists and we try to map with the same id. Verify that we are able to update its
         // StorageLength (if different).
@@ -718,8 +718,8 @@ public class ContainerMetadataUpdateTransactionTests {
         txn2.commit(metadata);
         Assert.assertEquals("Unexpected StorageLength after call to acceptOperation with remap (post-commit).",
                 storageLength, metadata.getStreamSegmentMetadata(mapOp.getStreamSegmentId()).getStorageLength());
-        Assert.assertEquals("Unexpected DurableLogLength after call to acceptOperation with remap (post-commit).",
-                durableLogLength, metadata.getStreamSegmentMetadata(mapOp.getStreamSegmentId()).getDurableLogLength());
+        Assert.assertEquals("Unexpected Length after call to acceptOperation with remap (post-commit).",
+                length, metadata.getStreamSegmentMetadata(mapOp.getStreamSegmentId()).getLength());
     }
 
     /**
@@ -763,8 +763,8 @@ public class ContainerMetadataUpdateTransactionTests {
         val updaterMetadata = txn3.getStreamSegmentMetadata(mapOp.getStreamSegmentId());
         Assert.assertEquals("Unexpected StorageLength after call to processMetadataOperation (in transaction).",
                 mapOp.getLength(), updaterMetadata.getStorageLength());
-        Assert.assertEquals("Unexpected DurableLogLength after call to processMetadataOperation (in transaction).",
-                mapOp.getLength(), updaterMetadata.getDurableLogLength());
+        Assert.assertEquals("Unexpected Length after call to processMetadataOperation (in transaction).",
+                mapOp.getLength(), updaterMetadata.getLength());
         Assert.assertEquals("Unexpected value for isSealed after call to processMetadataOperation (in transaction).",
                 mapOp.isSealed(), updaterMetadata.isSealed());
         Assert.assertNull("processMetadataOperation modified the underlying metadata.", metadata.getStreamSegmentMetadata(mapOp.getStreamSegmentId()));
@@ -1111,7 +1111,7 @@ public class ContainerMetadataUpdateTransactionTests {
         long expectedLength = SEGMENT_LENGTH + appendCount * DEFAULT_APPEND_DATA.length + SEALED_TRANSACTION_LENGTH;
 
         SegmentMetadata parentMetadata = targetMetadata.getStreamSegmentMetadata(SEGMENT_ID);
-        Assert.assertEquals("Unexpected DurableLogLength in metadata after commit.", expectedLength, parentMetadata.getDurableLogLength());
+        Assert.assertEquals("Unexpected Length in metadata after commit.", expectedLength, parentMetadata.getLength());
         Assert.assertTrue("Unexpected value for isSealed in metadata after commit.", parentMetadata.isSealed());
         checkLastKnownSequenceNumber("Unexpected lastUsed for Parent after commit.", expectedLastUsedParent, parentMetadata);
 
@@ -1182,7 +1182,7 @@ public class ContainerMetadataUpdateTransactionTests {
 
         // Verify metadata is untouched and that the updater has truly rolled back.
         SegmentMetadata parentMetadata = metadata.getStreamSegmentMetadata(SEGMENT_ID);
-        Assert.assertEquals("Unexpected DurableLogLength in metadata after rollback.", expectedLength, parentMetadata.getDurableLogLength());
+        Assert.assertEquals("Unexpected Length in metadata after rollback.", expectedLength, parentMetadata.getLength());
         Assert.assertFalse("Unexpected value for isSealed in metadata after rollback.", parentMetadata.isSealed());
         checkLastKnownSequenceNumber("Unexpected lastUsed for Parent after rollback.", 0, parentMetadata);
 
@@ -1192,7 +1192,7 @@ public class ContainerMetadataUpdateTransactionTests {
 
         // Now the updater
         parentMetadata = txn.getStreamSegmentMetadata(SEGMENT_ID);
-        Assert.assertEquals("Unexpected DurableLogLength in transaction after rollback.", expectedLength, parentMetadata.getDurableLogLength());
+        Assert.assertEquals("Unexpected Length in transaction after rollback.", expectedLength, parentMetadata.getLength());
         Assert.assertFalse("Unexpected value for isSealed in transaction after rollback.", parentMetadata.isSealed());
         checkLastKnownSequenceNumber("Unexpected lastUsed for Parent (txn) after rollback.", 0, parentMetadata);
 
@@ -1265,16 +1265,16 @@ public class ContainerMetadataUpdateTransactionTests {
     private UpdateableContainerMetadata createMetadata() {
         UpdateableContainerMetadata metadata = createBlankMetadata();
         UpdateableSegmentMetadata segmentMetadata = metadata.mapStreamSegmentId(SEGMENT_NAME, SEGMENT_ID);
-        segmentMetadata.setDurableLogLength(SEGMENT_LENGTH);
-        segmentMetadata.setStorageLength(SEGMENT_LENGTH - 1); // Different from DurableLogOffset.
+        segmentMetadata.setLength(SEGMENT_LENGTH);
+        segmentMetadata.setStorageLength(SEGMENT_LENGTH - 1); // Different from Length.
 
         segmentMetadata = metadata.mapStreamSegmentId(SEALED_TRANSACTION_NAME, SEALED_TRANSACTION_ID, SEGMENT_ID);
-        segmentMetadata.setDurableLogLength(SEALED_TRANSACTION_LENGTH);
+        segmentMetadata.setLength(SEALED_TRANSACTION_LENGTH);
         segmentMetadata.setStorageLength(SEALED_TRANSACTION_LENGTH);
         segmentMetadata.markSealed();
 
         segmentMetadata = metadata.mapStreamSegmentId(NOTSEALED_TRANSACTION_NAME, NOTSEALED_TRANSACTION_ID, SEGMENT_ID);
-        segmentMetadata.setDurableLogLength(0);
+        segmentMetadata.setLength(0);
         segmentMetadata.setStorageLength(0);
 
         return metadata;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -12,9 +12,7 @@ package io.pravega.segmentstore.server.logs;
 import com.google.common.util.concurrent.Service;
 import io.pravega.common.ExceptionHelpers;
 import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.common.util.ArrayView;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.common.util.SequencedItemList;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
@@ -26,6 +24,7 @@ import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.segmentstore.server.TestDurableDataLog;
 import io.pravega.segmentstore.server.TestDurableDataLogFactory;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
@@ -1047,8 +1046,7 @@ public class DurableLogTests extends OperationLogTestBase {
 
             // Verify that we can still queue operations to the DurableLog and they can be read.
             // In this case we'll just queue some StreamSegmentMapOperations.
-            StreamSegmentMapOperation newOp = new StreamSegmentMapOperation(
-                    new StreamSegmentInformation("foo", 0, false, false, new ImmutableDate()));
+            StreamSegmentMapOperation newOp = new StreamSegmentMapOperation(StreamSegmentInformation.builder().name("foo").build());
             if (!fullTruncationPossible) {
                 // We were not able to do a full truncation before. Do one now, since we are guaranteed to have a new DataFrame available.
                 MetadataCheckpointOperation lastCheckpoint = new MetadataCheckpointOperation();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -508,7 +508,7 @@ public class DurableLogTests extends OperationLogTestBase {
 
         // Create a segment, which will be used for testing later.
         UpdateableSegmentMetadata segmentMetadata = setup.metadata.mapStreamSegmentId(segmentName, segmentId);
-        segmentMetadata.setDurableLogLength(0);
+        segmentMetadata.setLength(0);
         segmentMetadata.setStorageLength(0);
 
         // Setup a bunch of read operations, and make sure they are blocked (since there is no data).
@@ -587,7 +587,7 @@ public class DurableLogTests extends OperationLogTestBase {
 
         // Create a segment, which will be used for testing later.
         UpdateableSegmentMetadata segmentMetadata = setup.metadata.mapStreamSegmentId(segmentName, segmentId);
-        segmentMetadata.setDurableLogLength(0);
+        segmentMetadata.setLength(0);
 
         Duration shortTimeout = Duration.ofMillis(30);
 
@@ -1199,7 +1199,7 @@ public class DurableLogTests extends OperationLogTestBase {
             long storageOffset = 0;
             for (long segmentId : streamSegmentIds) {
                 val sm = metadata1.getStreamSegmentMetadata(segmentId);
-                sm.setStorageLength(Math.min(storageOffset, sm.getDurableLogLength()));
+                sm.setStorageLength(Math.min(storageOffset, sm.getLength()));
                 storageOffset++;
                 if (sm.isSealed() && storageOffset % 2 == 0) {
                     sm.markSealedInStorage();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.logs;
 
 import io.pravega.common.Exceptions;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.common.util.SequencedItemList;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
@@ -164,8 +163,7 @@ public class MemoryStateUpdaterTests {
         long offset = 0;
         for (int i = 0; i < segmentCount; i++) {
             for (int j = 0; j < operationCountPerType; j++) {
-                StreamSegmentMapOperation mapOp = new StreamSegmentMapOperation(
-                        new StreamSegmentInformation("a", i * j, false, false, new ImmutableDate()));
+                StreamSegmentMapOperation mapOp = new StreamSegmentMapOperation(StreamSegmentInformation.builder().name("a").length(i * j).build());
                 mapOp.setStreamSegmentId(i);
                 operations.add(mapOp);
                 StreamSegmentAppendOperation appendOp = new StreamSegmentAppendOperation(i, Integer.toString(i).getBytes(), null);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -88,7 +88,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
             result.add(streamSegmentId);
             String name = getStreamSegmentName(streamSegmentId);
             UpdateableSegmentMetadata segmentMetadata = containerMetadata.mapStreamSegmentId(name, streamSegmentId);
-            segmentMetadata.setDurableLogLength(0);
+            segmentMetadata.setLength(0);
             segmentMetadata.setStorageLength(0);
         }
 
@@ -130,7 +130,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
                 assert !streamSegmentIds.contains(transactionId) : "duplicate StreamSegmentId (Transaction) generated: " + transactionId;
                 String transactionName = StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, UUID.randomUUID());
                 UpdateableSegmentMetadata transactionMetadata = containerMetadata.mapStreamSegmentId(transactionName, transactionId, streamSegmentId);
-                transactionMetadata.setDurableLogLength(0);
+                transactionMetadata.setLength(0);
                 transactionMetadata.setStorageLength(0);
             }
         }
@@ -258,7 +258,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
             SegmentMetadata transactionMetadata = metadata.getStreamSegmentMetadata(transactionId);
             if (invalidStreamSegmentIds.contains(transactionId)) {
                 Assert.assertTrue("Unexpected data for a Transaction that was invalid.",
-                        transactionMetadata == null || transactionMetadata.getDurableLogLength() == 0);
+                        transactionMetadata == null || transactionMetadata.getLength() == 0);
             } else {
                 Assert.assertEquals("Unexpected Transaction seal state for Transaction " + transactionId,
                         expectTransactionsMerged, transactionMetadata.isSealed());
@@ -273,12 +273,12 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
             SegmentMetadata segmentMetadata = metadata.getStreamSegmentMetadata(streamSegmentId);
             if (invalidStreamSegmentIds.contains(streamSegmentId)) {
                 Assert.assertTrue("Unexpected data for a StreamSegment that was invalid.",
-                        segmentMetadata == null || segmentMetadata.getDurableLogLength() == 0);
+                        segmentMetadata == null || segmentMetadata.getLength() == 0);
             } else {
                 Assert.assertEquals("Unexpected seal state for StreamSegment " + streamSegmentId,
                         expectSegmentsSealed, segmentMetadata.isSealed());
                 Assert.assertEquals("Unexpected length for StreamSegment " + streamSegmentId,
-                        (int) expectedLengths.getOrDefault(streamSegmentId, 0), segmentMetadata.getDurableLogLength());
+                        (int) expectedLengths.getOrDefault(streamSegmentId, 0), segmentMetadata.getLength());
             }
         }
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -306,7 +306,7 @@ public class OperationMetadataUpdaterTests {
         if (referenceMetadata != null) {
             referenceMetadata.getStreamSegmentMetadata(transactionId).markMerged();
             val rsm = referenceMetadata.getStreamSegmentMetadata(parentSegmentId);
-            rsm.setDurableLogLength(rsm.getDurableLogLength() + op.getLength());
+            rsm.setLength(rsm.getLength() + op.getLength());
         }
     }
 
@@ -336,7 +336,7 @@ public class OperationMetadataUpdaterTests {
         process(op, updater);
         if (referenceMetadata != null) {
             val rsm = referenceMetadata.getStreamSegmentMetadata(segmentId);
-            rsm.setDurableLogLength(rsm.getDurableLogLength() + length);
+            rsm.setLength(rsm.getLength() + length);
             val attributes = new HashMap<UUID, Long>();
             op.getAttributeUpdates().forEach(au -> attributes.put(au.getAttributeId(), au.getValue()));
             rsm.updateAttributes(attributes);
@@ -351,7 +351,7 @@ public class OperationMetadataUpdaterTests {
         process(mapOp, updater);
         if (referenceMetadata != null) {
             val rsm = referenceMetadata.mapStreamSegmentId(segmentName, mapOp.getStreamSegmentId());
-            rsm.setDurableLogLength(0);
+            rsm.setLength(0);
             rsm.setStorageLength(0);
         }
 
@@ -366,7 +366,7 @@ public class OperationMetadataUpdaterTests {
         process(mapOp, updater);
         if (referenceMetadata != null) {
             val rsm = referenceMetadata.mapStreamSegmentId(segmentName, mapOp.getStreamSegmentId(), parentSegmentId);
-            rsm.setDurableLogLength(0);
+            rsm.setLength(0);
             rsm.setStorageLength(0);
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.segmentstore.server.logs;
 
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
@@ -346,8 +345,7 @@ public class OperationMetadataUpdaterTests {
     private long mapSegment(OperationMetadataUpdater updater, UpdateableContainerMetadata referenceMetadata) throws Exception {
         String segmentName = "Segment_" + updater.nextOperationSequenceNumber();
 
-        val mapOp = new StreamSegmentMapOperation(
-                new StreamSegmentInformation(segmentName, 0, false, false, null, new ImmutableDate()));
+        val mapOp = new StreamSegmentMapOperation(StreamSegmentInformation.builder().name(segmentName).build());
         process(mapOp, updater);
         if (referenceMetadata != null) {
             val rsm = referenceMetadata.mapStreamSegmentId(segmentName, mapOp.getStreamSegmentId());
@@ -361,8 +359,7 @@ public class OperationMetadataUpdaterTests {
     private long mapTransaction(long parentSegmentId, OperationMetadataUpdater updater, UpdateableContainerMetadata referenceMetadata) throws Exception {
         String segmentName = "Transaction_" + updater.nextOperationSequenceNumber();
 
-        val mapOp = new TransactionMapOperation(parentSegmentId,
-                new StreamSegmentInformation(segmentName, 0, false, false, null, new ImmutableDate()));
+        val mapOp = new TransactionMapOperation(parentSegmentId, StreamSegmentInformation.builder().name(segmentName).build());
         process(mapOp, updater);
         if (referenceMetadata != null) {
             val rsm = referenceMetadata.mapStreamSegmentId(segmentName, mapOp.getStreamSegmentId(), parentSegmentId);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperationTests.java
@@ -9,14 +9,13 @@
  */
 package io.pravega.segmentstore.server.logs.operations;
 
-import io.pravega.common.util.ImmutableDate;
+import io.pravega.common.MathHelpers;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.server.ContainerMetadata;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-
 import lombok.val;
 import org.junit.Assert;
 
@@ -26,13 +25,13 @@ import org.junit.Assert;
 public class StreamSegmentMapOperationTests extends OperationTestsBase<StreamSegmentMapOperation> {
     @Override
     protected StreamSegmentMapOperation createOperation(Random random) {
-        return new StreamSegmentMapOperation(new StreamSegmentInformation(
-                super.getStreamSegmentName(random.nextLong()),
-                random.nextLong(),
-                random.nextBoolean(),
-                random.nextBoolean(),
-                createAttributes(10),
-                new ImmutableDate()));
+        return new StreamSegmentMapOperation(StreamSegmentInformation.builder()
+                .name(super.getStreamSegmentName(random.nextLong()))
+                .length(MathHelpers.abs(random.nextLong()))
+                .sealed(random.nextBoolean())
+                .deleted(random.nextBoolean())
+                .attributes(createAttributes(10))
+                .build());
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/TransactionMapOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/TransactionMapOperationTests.java
@@ -9,11 +9,10 @@
  */
 package io.pravega.segmentstore.server.logs.operations;
 
-import io.pravega.common.util.ImmutableDate;
+import io.pravega.common.MathHelpers;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.server.ContainerMetadata;
 import java.util.Random;
-
 import org.junit.Assert;
 
 /**
@@ -22,13 +21,13 @@ import org.junit.Assert;
 public class TransactionMapOperationTests extends OperationTestsBase<TransactionMapOperation> {
     @Override
     protected TransactionMapOperation createOperation(Random random) {
-        return new TransactionMapOperation(random.nextLong(), new StreamSegmentInformation(
-                super.getStreamSegmentName(random.nextLong()),
-                random.nextLong(),
-                random.nextBoolean(),
-                random.nextBoolean(),
-                StreamSegmentMapOperationTests.createAttributes(10),
-                new ImmutableDate()));
+        return new TransactionMapOperation(random.nextLong(), StreamSegmentInformation.builder()
+                .name(super.getStreamSegmentName(random.nextLong()))
+                .length(MathHelpers.abs(random.nextLong()))
+                .sealed(random.nextBoolean())
+                .deleted(random.nextBoolean())
+                .attributes(StreamSegmentMapOperationTests.createAttributes(10))
+                .build());
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -152,7 +152,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 appendLength = remainingLength;
                 writtenLength += appendLength;
                 remainingLength = 0;
-                segmentMetadata.setDurableLogLength(writtenLength);
+                segmentMetadata.setLength(writtenLength);
             }
         }
 
@@ -210,13 +210,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         appendData(segmentIds, segmentContents, context);
 
         // Mark everything so far (minus a few bytes) as being written to storage.
-        segmentMetadata.setStorageLength(segmentMetadata.getDurableLogLength() - 100);
+        segmentMetadata.setStorageLength(segmentMetadata.getLength() - 100);
 
         // Now partially merge a second transaction
         final long mergedTxOffset = beginMergeTransaction(mergedTxId, segmentMetadata, segmentContents, context);
 
         // Add one more append after all of this.
-        final long endOfMergedDataOffset = segmentMetadata.getDurableLogLength();
+        final long endOfMergedDataOffset = segmentMetadata.getLength();
         byte[] appendData = new byte[randomAppendLength];
         new Random(0).nextBytes(appendData);
         appendSingleWrite(segmentId, appendData, context);
@@ -226,7 +226,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         // * [0 .. StorageLength): no reads allowed.
         // * [StorageLength .. mergedTxOffset): should be fully available.
         // * [mergedTxOffset .. endOfMergedDataOffset): no reads allowed
-        // * [endOfMergedDataOffset .. DurableLogLength): should be fully available.
+        // * [endOfMergedDataOffset .. Length): should be fully available.
 
         // Verify we are not allowed to read from the range which has already been committed to Storage (invalid arguments).
         for (AtomicLong offset = new AtomicLong(0); offset.get() < segmentMetadata.getStorageLength(); offset.incrementAndGet()) {
@@ -279,7 +279,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         verifyReadResult.accept(segmentMetadata.getStorageLength(), mergedTxOffset);
 
         // Verify that we can read the cached data just after the merged transaction but before the end of the segment.
-        verifyReadResult.accept(endOfMergedDataOffset, segmentMetadata.getDurableLogLength());
+        verifyReadResult.accept(endOfMergedDataOffset, segmentMetadata.getLength());
     }
 
     /**
@@ -380,9 +380,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 UpdateableSegmentMetadata segmentMetadata = context.metadata.getStreamSegmentMetadata(segmentId);
                 byte[] data = getAppendData(segmentMetadata.getName(), segmentId, i, writeCount.incrementAndGet());
 
-                // Make sure we increase the DurableLogLength prior to appending; the ReadIndex checks for this.
-                long offset = segmentMetadata.getDurableLogLength();
-                segmentMetadata.setDurableLogLength(offset + data.length);
+                // Make sure we increase the Length prior to appending; the ReadIndex checks for this.
+                long offset = segmentMetadata.getLength();
+                segmentMetadata.setLength(offset + data.length);
                 context.readIndex.append(segmentId, offset, data);
                 recordAppend(segmentId, data, segmentContents);
                 triggerFutureReadsCallback.run();
@@ -449,13 +449,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
         byte[] appendData = "foo".getBytes();
         UpdateableSegmentMetadata segmentMetadata = context.metadata.getStreamSegmentMetadata(segmentId);
-        long segmentOffset = segmentMetadata.getDurableLogLength();
-        segmentMetadata.setDurableLogLength(segmentOffset + appendData.length);
+        long segmentOffset = segmentMetadata.getLength();
+        segmentMetadata.setLength(segmentOffset + appendData.length);
         context.readIndex.append(segmentId, segmentOffset, appendData);
 
         UpdateableSegmentMetadata transactionMetadata = context.metadata.getStreamSegmentMetadata(transactionId);
-        long transactionOffset = transactionMetadata.getDurableLogLength();
-        transactionMetadata.setDurableLogLength(transactionOffset + appendData.length);
+        long transactionOffset = transactionMetadata.getLength();
+        transactionMetadata.setLength(transactionOffset + appendData.length);
         context.readIndex.append(transactionId, transactionOffset, appendData);
 
         // 1. Appends at wrong offsets.
@@ -508,8 +508,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof IllegalArgumentException);
 
         transactionMetadata.markSealed();
-        long mergeOffset = segmentMetadata.getDurableLogLength();
-        segmentMetadata.setDurableLogLength(mergeOffset + transactionMetadata.getLength());
+        long mergeOffset = segmentMetadata.getLength();
+        segmentMetadata.setLength(mergeOffset + transactionMetadata.getLength());
         context.readIndex.beginMerge(segmentId, mergeOffset, transactionId);
         AssertExtensions.assertThrows(
                 "append did not throw the correct exception when called on a Transaction that was already sealed.",
@@ -568,7 +568,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         long testSegmentId = segmentIds.get(0);
         UpdateableSegmentMetadata sm = context.metadata.getStreamSegmentMetadata(testSegmentId);
         sm.setStorageLength(1024 * 1024);
-        sm.setDurableLogLength(1024 * 1024);
+        sm.setLength(1024 * 1024);
 
         AssertExtensions.assertThrows(
                 "Unexpected exception when attempting to read beyond the Segment length in Storage.",
@@ -688,15 +688,15 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             val handle = context.storage.openWrite(sm.getName()).join();
             context.storage.write(handle, 0, new ByteArrayInputStream(preStorageData), preStorageData.length, TIMEOUT).join();
             sm.setStorageLength(preStorageData.length);
-            sm.setDurableLogLength(preStorageData.length);
+            sm.setLength(preStorageData.length);
         }
 
         // Callback that appends one entry at the end of the given segment id.
         Consumer<Long> appendOneEntry = segmentId -> {
             UpdateableSegmentMetadata sm = context.metadata.getStreamSegmentMetadata(segmentId);
             byte[] data = new byte[appendSize];
-            long offset = sm.getDurableLogLength();
-            sm.setDurableLogLength(offset + data.length);
+            long offset = sm.getLength();
+            sm.setLength(offset + data.length);
             context.readIndex.append(segmentId, offset, data);
         };
 
@@ -765,7 +765,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         // Now update the metadata and indicate that all the post-storage data has been moved to storage.
         segmentIds.forEach(segmentId -> {
             UpdateableSegmentMetadata sm = context.metadata.getStreamSegmentMetadata(segmentId);
-            sm.setStorageLength(sm.getDurableLogLength());
+            sm.setStorageLength(sm.getLength());
         });
 
         // We add one artificial entry, which we'll be touching forever and ever; this forces the CacheManager to
@@ -776,7 +776,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         // Now evict everything (whether by size of by aging out).
         for (int i = 0; i < cachePolicy.getMaxGenerations(); i++) {
             @Cleanup
-            ReadResult result = context.readIndex.read(readSegment.getId(), readSegment.getDurableLogLength() - appendSize, appendSize, TIMEOUT);
+            ReadResult result = context.readIndex.read(readSegment.getId(), readSegment.getLength() - appendSize, appendSize, TIMEOUT);
             result.next();
             context.cacheManager.applyCachePolicy();
         }
@@ -837,7 +837,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         appendSingleWrite(transactionId, transactionWriteData, context);
         val handle = context.storage.openWrite(transactionMetadata.getName()).join();
         context.storage.write(handle, 0, new ByteArrayInputStream(transactionWriteData), transactionWriteData.length, TIMEOUT).join();
-        transactionMetadata.setStorageLength(transactionMetadata.getDurableLogLength());
+        transactionMetadata.setStorageLength(transactionMetadata.getLength());
 
         // Write some data to the parent, and make sure it is more than what we write to the transaction (hence the 10).
         for (int i = 0; i < 10; i++) {
@@ -848,8 +848,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
         // Seal & Begin-merge the transaction (do not seal in storage).
         transactionMetadata.markSealed();
-        long mergeOffset = parentMetadata.getDurableLogLength();
-        parentMetadata.setDurableLogLength(mergeOffset + transactionMetadata.getDurableLogLength());
+        long mergeOffset = parentMetadata.getLength();
+        parentMetadata.setLength(mergeOffset + transactionMetadata.getLength());
         context.readIndex.beginMerge(parentId, mergeOffset, transactionId);
         transactionMetadata.markMerged();
         writtenStream.write(transactionWriteData);
@@ -909,11 +909,11 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         appendSingleWrite(transactionId, writeData, context);
         val transactionWriteHandle = context.storage.openWrite(transactionMetadata.getName()).join();
         context.storage.write(transactionWriteHandle, 0, new ByteArrayInputStream(writeData), writeData.length, TIMEOUT).join();
-        transactionMetadata.setStorageLength(transactionMetadata.getDurableLogLength());
+        transactionMetadata.setStorageLength(transactionMetadata.getLength());
 
         // Seal & Begin-merge the transaction (do not seal in storage).
         transactionMetadata.markSealed();
-        parentMetadata.setDurableLogLength(transactionMetadata.getDurableLogLength());
+        parentMetadata.setLength(transactionMetadata.getLength());
         context.readIndex.beginMerge(parentId, 0, transactionId);
         transactionMetadata.markMerged();
 
@@ -934,7 +934,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         context.storage.seal(transactionWriteHandle, TIMEOUT).join();
         val parentWriteHandle = context.storage.openWrite(parentMetadata.getName()).join();
         context.storage.concat(parentWriteHandle, 0, transactionWriteHandle.getSegmentName(), TIMEOUT).join();
-        parentMetadata.setStorageLength(parentMetadata.getDurableLogLength());
+        parentMetadata.setStorageLength(parentMetadata.getLength());
 
         context.readIndex.completeMerge(parentId, transactionId);
 
@@ -995,9 +995,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     private void appendSingleWrite(long segmentId, byte[] data, TestContext context) {
         UpdateableSegmentMetadata segmentMetadata = context.metadata.getStreamSegmentMetadata(segmentId);
 
-        // Make sure we increase the DurableLogLength prior to appending; the ReadIndex checks for this.
-        long offset = segmentMetadata.getDurableLogLength();
-        segmentMetadata.setDurableLogLength(offset + data.length);
+        // Make sure we increase the Length prior to appending; the ReadIndex checks for this.
+        long offset = segmentMetadata.getLength();
+        segmentMetadata.setLength(offset + data.length);
         context.readIndex.append(segmentId, offset, data);
     }
 
@@ -1009,15 +1009,15 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 byte[] data = getAppendData(sm.getName(), segmentId, i, writeId);
                 writeId++;
 
-                // Make sure we increase the DurableLogLength prior to appending; the ReadIndex checks for this.
+                // Make sure we increase the Length prior to appending; the ReadIndex checks for this.
                 long offset = context.storage.getStreamSegmentInfo(sm.getName(), TIMEOUT).join().getLength();
                 val handle = context.storage.openWrite(sm.getName()).join();
                 context.storage.write(handle, offset, new ByteArrayInputStream(data), data.length, TIMEOUT).join();
 
                 // Update metadata appropriately.
                 sm.setStorageLength(offset + data.length);
-                if (sm.getStorageLength() > sm.getDurableLogLength()) {
-                    sm.setDurableLogLength(sm.getStorageLength());
+                if (sm.getStorageLength() > sm.getLength()) {
+                    sm.setLength(sm.getStorageLength());
                 }
 
                 recordAppend(segmentId, data, segmentContents);
@@ -1056,8 +1056,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         transactionMetadata.markSealed();
 
         // Update parent length.
-        long mergeOffset = parentMetadata.getDurableLogLength();
-        parentMetadata.setDurableLogLength(mergeOffset + transactionMetadata.getDurableLogLength());
+        long mergeOffset = parentMetadata.getLength();
+        parentMetadata.setLength(mergeOffset + transactionMetadata.getLength());
 
         // Do the ReadIndex merge.
         context.readIndex.beginMerge(parentMetadata.getId(), mergeOffset, transactionId);
@@ -1073,7 +1073,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     private void checkReadIndex(String testId, HashMap<Long, ByteArrayOutputStream> segmentContents, TestContext context) throws Exception {
         for (long segmentId : segmentContents.keySet()) {
-            long segmentLength = context.metadata.getStreamSegmentMetadata(segmentId).getDurableLogLength();
+            long segmentLength = context.metadata.getStreamSegmentMetadata(segmentId).getLength();
             byte[] expectedData = segmentContents.get(segmentId).toByteArray();
 
             long expectedCurrentOffset = 0;
@@ -1175,7 +1175,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     private void initializeSegment(long segmentId, TestContext context) {
         UpdateableSegmentMetadata metadata = context.metadata.getStreamSegmentMetadata(segmentId);
-        metadata.setDurableLogLength(0);
+        metadata.setLength(0);
         metadata.setStorageLength(0);
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -440,9 +440,9 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
 
         Function<UpdateableSegmentMetadata, Operation> createAppend = segment -> {
             StreamSegmentAppendOperation append = new StreamSegmentAppendOperation(segment.getId(), data, null);
-            append.setStreamSegmentOffset(segment.getDurableLogLength());
+            append.setStreamSegmentOffset(segment.getLength());
             context.dataSource.recordAppend(append);
-            segment.setDurableLogLength(segment.getDurableLogLength() + data.length);
+            segment.setLength(segment.getLength() + data.length);
             return new CachedStreamSegmentAppendOperation(append);
         };
 
@@ -548,7 +548,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             Assert.assertNotNull("Setup error: No metadata for segment " + segmentId, metadata);
             Assert.assertEquals("Setup error: Not expecting a Transaction segment in the final list: " + segmentId, ContainerMetadata.NO_STREAM_SEGMENT_ID, metadata.getParentId());
 
-            Assert.assertEquals("Metadata does not indicate that all bytes were copied to Storage for segment " + segmentId, metadata.getDurableLogLength(), metadata.getStorageLength());
+            Assert.assertEquals("Metadata does not indicate that all bytes were copied to Storage for segment " + segmentId, metadata.getLength(), metadata.getStorageLength());
             Assert.assertEquals("Metadata.Sealed disagrees with Metadata.SealedInStorage for segment " + segmentId, metadata.isSealed(), metadata.isSealedInStorage());
 
             SegmentProperties sp = context.storage.getStreamSegmentInfo(metadata.getName(), TIMEOUT).join();
@@ -574,10 +574,10 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             // Create the Merge Op
             MergeTransactionOperation op = new MergeTransactionOperation(parentMetadata.getId(), transactionMetadata.getId());
             op.setLength(transactionMetadata.getLength());
-            op.setStreamSegmentOffset(parentMetadata.getDurableLogLength());
+            op.setStreamSegmentOffset(parentMetadata.getLength());
 
             // Update metadata
-            parentMetadata.setDurableLogLength(parentMetadata.getDurableLogLength() + transactionMetadata.getDurableLogLength());
+            parentMetadata.setLength(parentMetadata.getLength() + transactionMetadata.getLength());
             transactionMetadata.markMerged();
 
             // Process the merge op
@@ -602,7 +602,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             UpdateableSegmentMetadata segmentMetadata = context.metadata.getStreamSegmentMetadata(segmentId);
             segmentMetadata.markSealed();
             StreamSegmentSealOperation sealOp = new StreamSegmentSealOperation(segmentId);
-            sealOp.setStreamSegmentOffset(segmentMetadata.getDurableLogLength());
+            sealOp.setStreamSegmentOffset(segmentMetadata.getLength());
             context.dataSource.add(sealOp);
         }
     }
@@ -639,9 +639,9 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
     private void appendData(UpdateableSegmentMetadata segmentMetadata, int appendId, int writeId, HashMap<Long, ByteArrayOutputStream> segmentContents, TestContext context) {
         byte[] data = getAppendData(segmentMetadata.getName(), segmentMetadata.getId(), appendId, writeId);
 
-        // Make sure we increase the DurableLogLength prior to appending; the Writer checks for this.
-        long offset = segmentMetadata.getDurableLogLength();
-        segmentMetadata.setDurableLogLength(offset + data.length);
+        // Make sure we increase the Length prior to appending; the Writer checks for this.
+        long offset = segmentMetadata.getLength();
+        segmentMetadata.setLength(offset + data.length);
         StreamSegmentAppendOperation op = new StreamSegmentAppendOperation(segmentMetadata.getId(), data, null);
         op.setStreamSegmentOffset(offset);
         context.dataSource.recordAppend(op);
@@ -717,7 +717,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
 
     private void initializeSegment(long segmentId, TestContext context) {
         UpdateableSegmentMetadata metadata = context.metadata.getStreamSegmentMetadata(segmentId);
-        metadata.setDurableLogLength(0);
+        metadata.setLength(0);
         metadata.setStorageLength(0);
         context.storage.create(metadata.getName(), TIMEOUT).join();
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3Storage.java
@@ -228,9 +228,12 @@ public class ExtendedS3Storage implements Storage {
 
         AccessControlList acls = client.getObjectAcl(config.getBucket(), config.getRoot() + streamSegmentName);
         boolean canWrite = acls.getGrants().stream().anyMatch((grant) -> grant.getPermission().compareTo(Permission.WRITE) >= 0);
-        StreamSegmentInformation information = new StreamSegmentInformation(streamSegmentName,
-                result.getContentLength(), !canWrite, false,
-                new ImmutableDate(result.getLastModified().toInstant().toEpochMilli()));
+        StreamSegmentInformation information = StreamSegmentInformation.builder()
+                .name(streamSegmentName)
+                .length(result.getContentLength())
+                .sealed(!canWrite)
+                .lastModified(new ImmutableDate(result.getLastModified().toInstant().toEpochMilli()))
+                .build();
 
         LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, streamSegmentName);
         return information;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorage.java
@@ -248,9 +248,12 @@ public class FileSystemStorage implements Storage {
         long traceId = LoggerHelpers.traceEnter(log, "getStreamSegmentInfo", streamSegmentName);
         PosixFileAttributes attrs = Files.readAttributes(Paths.get(config.getRoot(), streamSegmentName),
                 PosixFileAttributes.class);
-        StreamSegmentInformation information = new StreamSegmentInformation(streamSegmentName, attrs.size(),
-                !(attrs.permissions().contains(OWNER_WRITE)), false,
-                new ImmutableDate(attrs.creationTime().toMillis()));
+        StreamSegmentInformation information = StreamSegmentInformation.builder()
+                .name(streamSegmentName)
+                .length(attrs.size())
+                .sealed(!(attrs.permissions().contains(OWNER_WRITE)))
+                .lastModified(new ImmutableDate(attrs.creationTime().toMillis()))
+                .build();
 
         LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, streamSegmentName);
         return information;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/CreateOperation.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.storage.impl.hdfs;
 
 import io.pravega.common.LoggerHelpers;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
@@ -18,7 +17,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
-
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.hadoop.fs.Path;
@@ -84,6 +82,6 @@ class CreateOperation extends FileSystemOperation<String> implements Callable<Se
         }
 
         LoggerHelpers.traceLeave(log, "create", traceId, segmentName);
-        return new StreamSegmentInformation(segmentName, 0, false, false, new ImmutableDate());
+        return StreamSegmentInformation.builder().name(segmentName).build();
     }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/GetInfoOperation.java
@@ -10,14 +10,12 @@
 package io.pravega.segmentstore.storage.impl.hdfs;
 
 import io.pravega.common.LoggerHelpers;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
-
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -62,7 +60,7 @@ class GetInfoOperation extends FileSystemOperation<String> implements Callable<S
                 throw fnf;
             }
 
-            result = new StreamSegmentInformation(segmentName, length, isSealed, false, new ImmutableDate());
+            result = StreamSegmentInformation.builder().name(segmentName).length(length).sealed(isSealed).build();
         } while (result == null);
         LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, segmentName, result);
         return result;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -12,7 +12,6 @@ package io.pravega.segmentstore.storage.mocks;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
@@ -585,7 +584,7 @@ public class InMemoryStorage implements TruncateableStorage, ListenableStorage {
 
         SegmentProperties getInfo() {
             synchronized (this.lock) {
-                return new StreamSegmentInformation(this.name, this.length, this.sealed, false, new ImmutableDate());
+                return StreamSegmentInformation.builder().name(this.name).length(this.length).sealed(this.sealed).build();
             }
         }
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
@@ -14,7 +14,6 @@ import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
@@ -147,7 +146,7 @@ class InProcessMockClientAdapter extends ClientAdapterBase {
         @Override
         public CompletableFuture<SegmentProperties> getStreamSegmentInfo(String streamSegmentName, boolean waitForPendingOps, Duration timeout) {
             if (this.segments.contains(streamSegmentName)) {
-                return CompletableFuture.completedFuture(new StreamSegmentInformation(streamSegmentName, 0, false, false, new ImmutableDate()));
+                return CompletableFuture.completedFuture(StreamSegmentInformation.builder().name(streamSegmentName).build());
             } else {
                 return FutureHelpers.failedFuture(new StreamSegmentNotExistsException(streamSegmentName));
             }


### PR DESCRIPTION
**Change log description**
1. Retired `SegmentMetadata.getDurableLogLength` and replaced all usages with `SegmentProperties.getLength` (`SegmentProperties` is a super interface to `SegmentMetadata`).
2. Made most constructors for `StreamSegmentInformation` private and added a `@Builder` constructor. Made all callsites use this builder to construct, which should reduce the chances of having to do massive changes every time we modify a field on this class.

**Purpose of the change**
Fixes #1911. 
Code cleanup.
Paving the way for #1215.

**What the code does**
Exactly the same thing.

**How to verify it**
Refactoring done by IDE and some by hand. Unit tests must pass.