### PR TITLE
Issue 1688: Close transport connections used by controller client after use.

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -112,7 +112,9 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     @Override
     public void close() {
+        if (this.controller != null) {
+            this.controller.close();
+        }
         clientFactory.close();
     }
-
 }

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -90,6 +90,9 @@ public class StreamManagerImpl implements StreamManager {
 
     @Override
     public void close() {
+        if (this.controller != null) {
+            this.controller.close();
+        }
         if (this.executor != null) {
             this.executor.shutdown();
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -254,4 +254,11 @@ public interface Controller extends AutoCloseable {
      */
     CompletableFuture<PravegaNodeUri> getEndpointForSegment(final String qualifiedSegmentName);
 
+    /**
+     * Closes controller client.
+     * @see java.lang.AutoCloseable#close()
+     */
+    @Override
+    void close();
+
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Stream Controller APIs.
  */
-public interface Controller {
+public interface Controller extends AutoCloseable {
 
     // Controller Apis for administrative action for streams
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -818,7 +818,7 @@ public class ControllerImpl implements Controller {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (!closed.getAndSet(true)) {
             this.channel.shutdownNow(); // Initiates a shutdown of channel.
         }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -429,5 +429,8 @@ public class MockController implements Controller {
         return CompletableFuture.completedFuture(true);
     }
 
+    @Override
+    public void close() throws Exception {
+    }
 }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -430,7 +430,7 @@ public class MockController implements Controller {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
     }
 }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -331,4 +331,8 @@ public class LocalController implements Controller {
     public CompletableFuture<Boolean> isSegmentOpen(Segment segment) {
         return controller.isSegmentValid(segment.getScope(), segment.getStreamName(), segment.getSegmentNumber());
     }
+
+    @Override
+    public void close() throws Exception {
+    }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -333,6 +333,6 @@ public class LocalController implements Controller {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -237,10 +237,8 @@ public class ControllerRestApiTest {
         final String testStream2 = RandomStringUtils.randomAlphanumeric(10);
         URI controllerUri = SETUP_UTILS.getControllerUri();
         @Cleanup("shutdown")
-        InlineExecutor executor = new InlineExecutor();
-        final Controller controller = new ControllerImpl(controllerUri,
-                                                         ControllerImplConfig.builder().retryAttempts(1).build(), executor);
-        try (StreamManager streamManager = new StreamManagerImpl(controller)) {
+        InlineExecutor inlineExecutor = new InlineExecutor();
+        try (StreamManager streamManager = new StreamManagerImpl(createController(controllerUri, inlineExecutor))) {
             log.info("Creating scope: {}", testScope);
             streamManager.createScope(testScope);
 
@@ -259,7 +257,7 @@ public class ControllerRestApiTest {
         final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
         final String reader1 = RandomStringUtils.randomAlphanumeric(10);
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
-        try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, controller);
+        try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor));
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),
                     new HashSet<>(Arrays.asList(testStream1, testStream2)));
@@ -310,5 +308,9 @@ public class ControllerRestApiTest {
         log.info("Get readergroup properties successful");
 
         log.info("Test restApiTests passed successfully!");
+    }
+
+    private Controller createController(URI controllerUri, InlineExecutor executor) {
+        return new ControllerImpl(controllerUri, ControllerImplConfig.builder().retryAttempts(1).build(), executor);
     }
 }


### PR DESCRIPTION
**Change log description**
- Ensure `io.pravega.client.stream.impl.Controller` closes resources (transport connections) after use.

**Purpose of the change**
Fixes #1688 

**What the code does**
- Now Controller api implements autocloseable which enables closing of resources used by controller client.

**How to verify it**
Tests should pass.