### PR TITLE
Issue 1409: Failover System tests with transaction writes, reads triggering scaling/auto-scaling

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -65,6 +65,7 @@ abstract class AbstractFailoverTests {
     static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
     static final int WRITER_MAX_RETRY_ATTEMPTS = 20;
     static final int NUM_EVENTS_PER_TRANSACTION = 50;
+    static final int SCALE_WAIT_ITERATIONS = 12;
 
     final String readerName = "reader";
     Service controllerInstance;
@@ -468,7 +469,7 @@ abstract class AbstractFailoverTests {
     }
 
     void waitForScaling(String scope) {
-        for (int waitCounter = 0; waitCounter < 12; waitCounter++) {
+        for (int waitCounter = 0; waitCounter < SCALE_WAIT_ITERATIONS; waitCounter++) {
             StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).join();
             testState.currentNumOfSegments.set(streamSegments.getSegments().size());
             if (testState.currentNumOfSegments.get() == 2) {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -468,13 +468,13 @@ abstract class AbstractFailoverTests {
     }
 
     void waitForScaling(String scope) throws InterruptedException, ExecutionException {
-        for (int waitCounter = 0; waitCounter < 2; waitCounter++) {
+        for (int waitCounter = 0; waitCounter < 12; waitCounter++) {
             StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
             testState.currentNumOfSegments.set(streamSegments.getSegments().size());
             if (testState.currentNumOfSegments.get() == 2) {
                 log.info("The current number of segments is equal to 2, ScaleOperation did not happen");
                 //Scaling operation did not happen, wait
-                Exceptions.handleInterrupted(() -> Thread.sleep(60000));
+                Exceptions.handleInterrupted(() -> Thread.sleep(10000));
                 throw new AbstractFailoverTests.ScaleOperationNotDoneException();
             }
             if (testState.currentNumOfSegments.get() > 2) {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -475,7 +475,6 @@ abstract class AbstractFailoverTests {
                 log.info("The current number of segments is equal to 2, ScaleOperation did not happen");
                 //Scaling operation did not happen, wait
                 Exceptions.handleInterrupted(() -> Thread.sleep(10000));
-                throw new ScaleOperationNotDoneException();
             }
             if (testState.currentNumOfSegments.get() > 2) {
                 //scale operation successful.
@@ -533,10 +532,7 @@ abstract class AbstractFailoverTests {
         List<URI> segUris = segService.getServiceDetails();
         log.debug("Pravega Segmentstore service  details: {}", segUris);
     }
-
-    static class ScaleOperationNotDoneException extends RuntimeException {
-    }
-
+    
     static class TxnNotCompleteException extends RuntimeException {
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -20,16 +20,20 @@ import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.StreamSegments;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.FutureHelpers;
+import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.services.BookkeeperService;
 import io.pravega.test.system.framework.services.PravegaControllerService;
 import io.pravega.test.system.framework.services.PravegaSegmentStoreService;
 import io.pravega.test.system.framework.services.Service;
 import io.pravega.test.system.framework.services.ZookeeperService;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +49,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
-
 import static java.util.Collections.synchronizedList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -61,6 +64,7 @@ abstract class AbstractFailoverTests {
     static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;
     static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
     static final int WRITER_MAX_RETRY_ATTEMPTS = 20;
+    static final int NUM_EVENTS_PER_TRANSACTION = 50;
 
     final String readerName = "reader";
     Service controllerInstance;
@@ -90,6 +94,8 @@ abstract class AbstractFailoverTests {
         final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
+        final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
+        final AtomicBoolean txnWrite = new AtomicBoolean(false);
     }
 
     void performFailoverTest() {
@@ -183,6 +189,80 @@ abstract class AbstractFailoverTests {
         }
     }
 
+
+    CompletableFuture<Void> startWritingIntoTxn(final EventStreamWriter<Long> writer) {
+        return CompletableFuture.runAsync(() -> {
+            while (!testState.stopWriteFlag.get()) {
+                Transaction<Long> txnDebugReference = null;
+                AtomicBoolean txnIsDone = new AtomicBoolean(false);
+
+                try {
+                    Transaction<Long> transaction = writer.beginTxn(5000, 3600000, 29000);
+                    txnDebugReference = transaction;
+
+                    // Sets a recurrent delayed task to ping the txn. It exits when the
+                    // txn completes and no longer needs pinging
+                    FutureHelpers.loop(() -> !txnIsDone.get(), () -> {
+                        return FutureHelpers.delayedTask(() -> {
+                            if (transaction.checkStatus() == Transaction.Status.OPEN) {
+                                FutureHelpers.runOrFail(() -> {
+                                    transaction.ping(5000);
+                                    return null;
+                                }, new CompletableFuture<Void>());
+                            } else {
+                                txnIsDone.set(true);
+                            }
+
+                            return null;
+                        }, Duration.ofMillis(2000), executorService);
+                    }, executorService);
+
+                    for (int j = 0; j < NUM_EVENTS_PER_TRANSACTION; j++) {
+                        long value = testState.eventData.incrementAndGet();
+                        transaction.writeEvent(String.valueOf(value), value);
+                        log.debug("Writing event: {} into transaction: {}", value, transaction.getTxnId());
+                    }
+                    //commit Txn
+                    transaction.commit();
+                    txnIsDone.set(true);
+
+                    //wait for transaction to get committed
+                    testState.txnStatusFutureList.add(checkTxnStatus(transaction, testState.eventWriteCount));
+                } catch (Throwable e) {
+                    // Given that we have retry logic both in the interaction with controller and
+                    // segment store, we should fail the test case in the presence of any exception
+                    // caught here.
+                    txnIsDone.set(true);
+                    log.warn("Exception while writing events in the transaction: ", e);
+                    if (txnDebugReference != null) {
+                        log.debug("Transaction with id: {}  failed", txnDebugReference.getTxnId());
+                    }
+                    testState.getWriteException.set(e);
+                    return;
+                }
+            }
+        }, executorService);
+    }
+
+    CompletableFuture<Void> checkTxnStatus(Transaction<Long> txn,
+                                                   final AtomicLong eventWriteCount) {
+
+        return Retry.indefinitelyWithExpBackoff("Txn did not get committed").runAsync(() -> {
+            Transaction.Status status = txn.checkStatus();
+            log.debug("Txn id {} status is {}", txn.getTxnId(), status);
+            if (status.equals(Transaction.Status.COMMITTED)) {
+                eventWriteCount.addAndGet(NUM_EVENTS_PER_TRANSACTION);
+                log.info("Event write count: {}", eventWriteCount.get());
+            } else if (status.equals(Transaction.Status.ABORTED)) {
+                log.debug("Transaction with id: {} aborted", txn.getTxnId());
+            } else {
+                throw new TxnNotCompleteException();
+            }
+
+            return CompletableFuture.completedFuture(null);
+        }, executorService);
+    }
+
     CompletableFuture<Void> startReading(final EventStreamReader<Long> reader) {
         return CompletableFuture.runAsync(() -> {
             log.info("Exit flag status: {}, Read count: {}, Write count: {}", testState.stopReadFlag.get(),
@@ -258,9 +338,16 @@ abstract class AbstractFailoverTests {
                         EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
                                 .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
                 writerList.add(tmpWriter);
-                final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
-                FutureHelpers.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
-                writerFutureList.add(writerFuture);
+                if (!testState.txnWrite.get()) {
+                    final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
+                    FutureHelpers.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
+                    writerFutureList.add(writerFuture);
+                } else  {
+                    final CompletableFuture<Void> txnWriteFuture = startWritingIntoTxn(tmpWriter);
+                    FutureHelpers.exceptionListener(txnWriteFuture, t -> log.error("Error while writing events into transaction:", t));
+                    writerFutureList.add(txnWriteFuture);
+                }
+
             }
         }).thenRun(() -> {
             testState.writers.addAll(writerFutureList);
@@ -320,9 +407,15 @@ abstract class AbstractFailoverTests {
                         EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
                                 .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
                 newlyAddedWriterList.add(tmpWriter);
-                final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
-                FutureHelpers.exceptionListener(writerFuture, t -> log.error("Error while writing events :", t));
-                newWritersFutureList.add(writerFuture);
+                if (!testState.txnWrite.get()) {
+                    final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
+                    FutureHelpers.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
+                    newWritersFutureList.add(writerFuture);
+                } else  {
+                    final CompletableFuture<Void> txnWriteFuture = startWritingIntoTxn(tmpWriter);
+                    FutureHelpers.exceptionListener(txnWriteFuture, t -> log.error("Error while writing events into transaction:", t));
+                    newWritersFutureList.add(txnWriteFuture);
+                }
             }
         }).thenRun(() -> {
             testState.writers.addAll(newWritersFutureList);
@@ -374,6 +467,27 @@ abstract class AbstractFailoverTests {
         readerGroupManager.deleteReaderGroup(readerGroupName);
     }
 
+    void waitForScaling(String scope) throws InterruptedException, ExecutionException {
+        for (int waitCounter = 0; waitCounter < 2; waitCounter++) {
+            StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
+            testState.currentNumOfSegments.set(streamSegments.getSegments().size());
+            if (testState.currentNumOfSegments.get() == 2) {
+                log.info("The current number of segments is equal to 2, ScaleOperation did not happen");
+                //Scaling operation did not happen, wait
+                Exceptions.handleInterrupted(() -> Thread.sleep(60000));
+                throw new AbstractFailoverTests.ScaleOperationNotDoneException();
+            }
+            if (testState.currentNumOfSegments.get() > 2) {
+                //scale operation successful.
+                log.info("Current Number of segments is {}", testState.currentNumOfSegments.get());
+                break;
+            }
+        }
+        if (testState.currentNumOfSegments.get() == 2) {
+            Assert.fail("Current number of Segments reduced to less than 2. Failure of test");
+        }
+    }
+
 
     static URI startZookeeperInstance() {
         Service zkService = new ZookeeperService("zookeeper");
@@ -421,6 +535,9 @@ abstract class AbstractFailoverTests {
     }
 
     static class ScaleOperationNotDoneException extends RuntimeException {
+    }
+
+    static class TxnNotCompleteException extends RuntimeException {
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -467,15 +467,15 @@ abstract class AbstractFailoverTests {
         readerGroupManager.deleteReaderGroup(readerGroupName);
     }
 
-    void waitForScaling(String scope) throws InterruptedException, ExecutionException {
+    void waitForScaling(String scope) {
         for (int waitCounter = 0; waitCounter < 12; waitCounter++) {
-            StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).get();
+            StreamSegments streamSegments = controller.getCurrentSegments(scope, AUTO_SCALE_STREAM).join();
             testState.currentNumOfSegments.set(streamSegments.getSegments().size());
             if (testState.currentNumOfSegments.get() == 2) {
                 log.info("The current number of segments is equal to 2, ScaleOperation did not happen");
                 //Scaling operation did not happen, wait
                 Exceptions.handleInterrupted(() -> Thread.sleep(10000));
-                throw new AbstractFailoverTests.ScaleOperationNotDoneException();
+                throw new ScaleOperationNotDoneException();
             }
             if (testState.currentNumOfSegments.get() > 2) {
                 //scale operation successful.

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -11,147 +11,57 @@ package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.admin.impl.StreamManagerImpl;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
-import io.pravega.common.concurrent.FutureHelpers;
-import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
-import io.pravega.test.system.framework.services.BookkeeperService;
 import io.pravega.test.system.framework.services.PravegaControllerService;
 import io.pravega.test.system.framework.services.PravegaSegmentStoreService;
 import io.pravega.test.system.framework.services.Service;
 import io.pravega.test.system.framework.services.ZookeeperService;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-
-import static java.time.Duration.ofSeconds;
-import static java.util.Collections.synchronizedList;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MultiReaderTxnWriterWithFailoverTest {
+public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests {
 
-    private static final String STREAM_NAME = "testMultiReaderWriterTxnStream";
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
-    private static final int NUM_EVENTS_PER_TRANSACTION = 50;
-    private static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
-    private static final int WRITER_MAX_RETRY_ATTEMPTS = 15;
-    //Duration for which the system test waits for writes/reads to happen post failover.
-    //10s (SessionTimeout) + 10s (RebalanceContainers) + 20s (For Container recovery + start) + NetworkDelays
-    private static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;
-    private final List<EventStreamReader<Long>> readerList = synchronizedList(new ArrayList<>());
-    private final List<EventStreamWriter<Long>> writerList = synchronizedList(new ArrayList<>());
-    private final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
-    private ScheduledExecutorService executorService;
-    private ScheduledExecutorService controllerExecutorService;
-    private AtomicBoolean stopReadFlag;
-    private AtomicBoolean stopWriteFlag;
-    private AtomicLong eventData;
-    private AtomicLong eventReadCount;
-    private AtomicLong eventWriteCount;
-    // Error atomic reference
-    private AtomicReference<Throwable> writerErrorRef = new AtomicReference<>();
-    private AtomicReference<Throwable> readerErrorRef = new AtomicReference<>();
-
-    private ConcurrentLinkedQueue<Long> eventsReadFromPravega;
-    private Service controllerInstance = null;
-    private Service segmentStoreInstance = null;
-    private URI controllerURIDirect = null;
-    private Controller controller;
+    private static final String STREAM_NAME = "testMultiReaderWriterTxnStream";
+    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(15 * 60);
     private final String scope = "testMultiReaderWriterTxnScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testMultiReaderWriterTxnReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private ScalingPolicy scalingPolicy = ScalingPolicy.fixed(NUM_READERS);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
             .streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
-    private final String readerName = "reader";
-    private final Retry.RetryWithBackoff retry = Retry.withExpBackoff(10, 10, 40, ofSeconds(1).toMillis());
+    private ClientFactory clientFactory;
+    private ReaderGroupManager readerGroupManager;
 
     @Environment
-    public static void initialize() throws MarathonException, URISyntaxException {
-
-        //1. Start 1 instance of zookeeper
-        Service zkService = new ZookeeperService("zookeeper");
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-
-        //2. Start 3 bookies
-        Service bkService = new BookkeeperService("bookkeeper", zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        //3. start 3 instances of pravega controller
-        Service conService = new PravegaControllerService("controller", zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-        conService.scaleService(3, true);
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega Controller service  details: {}", conUris);
-
-        // Fetch all the RPC endpoints and construct the client URIs.
-        final List<String> uris = conUris.stream().filter(uri -> uri.getPort() == 9092).map(URI::getAuthority)
-                .collect(Collectors.toList());
-
-        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
-        log.info("Controller Service direct URI: {}", controllerURI);
-
-        //4.start 3 instances of pravega segmentstore
-        Service segService = new PravegaSegmentStoreService("segmentstore", zkUri, controllerURI);
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-        segService.scaleService(3, true);
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega Segmentstore service  details: {}", segUris);
-
+    public static void initialize() throws InterruptedException, MarathonException, URISyntaxException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before
@@ -190,309 +100,49 @@ public class MultiReaderTxnWriterWithFailoverTest {
         controller = new ControllerImpl(controllerURIDirect,
                                         ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
                                         controllerExecutorService);
+
+        testState = new TestState();
+        testState.txnWrite.set(true);
         //read and write count variables
-        eventsReadFromPravega = new ConcurrentLinkedQueue<>();
-        stopReadFlag = new AtomicBoolean(false);
-        stopWriteFlag = new AtomicBoolean(false);
-        eventData = new AtomicLong(0); //data used by each of the writers.
-        eventReadCount = new AtomicLong(0); // used by readers to maintain a count of events.
-        eventWriteCount = new AtomicLong(0);
+        testState.writersListComplete.add(0, testState.writersComplete);
+        createScopeAndStream(scope, STREAM_NAME, config, controllerURIDirect);
+        log.info("Scope passed to client factory {}", scope);
+        clientFactory = new ClientFactoryImpl(scope, controller);
+        readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
     }
 
     @After
     public void tearDown() {
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
+        testState.stopReadFlag.set(true);
+        testState.stopWriteFlag.set(true);
+        //interrupt writers and readers threads if they are still running.
+        testState.writers.forEach(future -> future.cancel(true));
+        testState.readers.forEach(future -> future.cancel(true));
+        clientFactory.close(); //close the clientFactory/connectionFactory.
+        readerGroupManager.close();
         executorService.shutdownNow();
         controllerExecutorService.shutdownNow();
-        eventsReadFromPravega.clear();
+        testState.eventsReadFromPravega.clear();
+        //scale the controller and segmentStore back to 1 instance.
+        controllerInstance.scaleService(1, true);
+        segmentStoreInstance.scaleService(1, true);
     }
 
-    @Test(timeout = 600000)
+    @Test
     public void multiReaderTxnWriterWithFailOverTest() throws Exception {
 
-        //create a scope
-        try (StreamManager streamManager = new StreamManagerImpl(controllerURIDirect)) {
-            Boolean createScopeStatus = streamManager.createScope(scope);
-            log.info("Creating scope with scope name {}", scope);
-            log.debug("Create scope status {}", createScopeStatus);
-            //create a stream
-            Boolean createStreamStatus = streamManager.createStream(scope, STREAM_NAME, config);
-            log.debug("Create stream status {}", createStreamStatus);
-        }
+        createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
 
-        //get ClientFactory instance
-        log.info("Scope passed to client factory {}", scope);
-        try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller);
-             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect)) {
+        //run the failover test
+        performFailoverTest();
 
-            log.info("Client factory details {}", clientFactory.toString());
-            //create writers
-            log.info("Creating {} writers", NUM_WRITERS);
-            log.info("Writers writing in the scope {}", scope);
-            for (int i = 0; i < NUM_WRITERS; i++) {
-                log.info("Starting writer{}", i);
-                final EventStreamWriter<Long> writer = clientFactory.createEventWriter(STREAM_NAME,
-                        new JavaSerializer<Long>(),
-                        EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
-                writerList.add(writer);
-            }
+        stopWriters();
+        stopReaders();
+        validateResults(readerGroupManager, readerGroupName);
 
-            //create a reader group
-            log.info("Creating Reader group: {}, with readergroup manager using scope: {}", readerGroupName, scope);
-            readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().startingTime(0).build(),
-                    Collections.singleton(STREAM_NAME));
-            log.info("Reader group name: {}, Reader group scope: {}, Online readers: {}",
-                    readerGroupManager.getReaderGroup(readerGroupName).getGroupName(), readerGroupManager
-                            .getReaderGroup(readerGroupName).getScope(), readerGroupManager
-                            .getReaderGroup(readerGroupName).getOnlineReaders());
+        cleanUp(scope, STREAM_NAME); //cleanup if validation is successful.
 
-            //create readers
-            log.info("Creating {} readers", NUM_READERS);
-            log.info("Scope that is seen by readers {}", scope);
-            //start reading events
-            for (int i = 0; i < NUM_READERS; i++) {
-                log.info("Starting reader: {}, with id: {}", i, readerName+i);
-                final EventStreamReader<Long> reader = clientFactory.createReader(readerName + i,
-                        readerGroupName,
-                        new JavaSerializer<Long>(),
-                        ReaderConfig.builder().build());
-                readerList.add(reader);
-            }
-
-            // start writing asynchronously
-            List<CompletableFuture<Void>> writerFutureList = writerList.stream().map(writer ->
-                    startWritingIntoTxn(eventData, writer, stopWriteFlag, eventWriteCount)).collect(Collectors.toList());
-
-            //start reading asynchronously
-            List<CompletableFuture<Void>> readerFutureList = readerList.stream().map(reader ->
-                    startReading(eventsReadFromPravega, eventWriteCount, eventReadCount, stopReadFlag, reader))
-                    .collect(Collectors.toList());
-
-            //run the failover test
-            performFailoverTest();
-
-            //set the stop write flag to true
-            log.info("Stop write flag status {}", stopWriteFlag);
-            stopWriteFlag.set(true);
-
-            //wait for writers completion
-            log.info("Wait for writers execution to complete");
-            FutureHelpers.allOf(writerFutureList).get();
-
-            //wait for txns to get committed
-            log.info("Wait for txns to complete");
-            FutureHelpers.allOf(txnStatusFutureList).get();
-
-            //set the stop read flag to true
-            log.info("Stop read flag status {}", stopReadFlag);
-            stopReadFlag.set(true);
-
-            //wait for readers completion
-            log.info("Wait for readers execution to complete");
-            FutureHelpers.allOf(readerFutureList).get();
-
-            log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +
-                    "Count: {}", eventWriteCount.get(), eventsReadFromPravega.size());
-            assertEquals(eventWriteCount.get(), eventsReadFromPravega.size());
-            assertEquals(eventWriteCount.get(), new TreeSet<>(eventsReadFromPravega).size()); //check unique events.
-            assertNull(writerErrorRef.get() == null ? "" : writerErrorRef.get().getMessage(), writerErrorRef.get());
-            assertNull(readerErrorRef.get() == null ? "" : readerErrorRef.get().getMessage(), readerErrorRef.get());
-
-            closeReadersAndWriters();
-
-            //delete readergroup
-            log.info("Deleting readergroup {}", readerGroupName);
-            readerGroupManager.deleteReaderGroup(readerGroupName);
-        }
-        //seal the stream
-        CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
-        log.info("Sealing stream {}", STREAM_NAME);
-        assertTrue(sealStreamStatus.get());
-        //delete the stream
-        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
-        log.info("Deleting stream {}", STREAM_NAME);
-        assertTrue(deleteStreamStatus.get());
-
-        //delete the scope
-        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
-        log.info("Deleting scope {}", scope);
-        assertTrue(deleteScopeStatus.get());
         log.info("Test {} succeeds ", "MultiReaderWriterTxnWithFailOver");
-    }
-
-    private void closeReadersAndWriters() {
-        log.info("Closing writers");
-        writerList.forEach(writer -> writer.close());
-        log.info("Closing readers");
-        readerList.forEach(reader -> reader.close());
-    }
-
-    private void performFailoverTest() {
-
-        long currentWriteCount1;
-        long currentReadCount1;
-
-        log.info("Test with 3 controller, segmentstore instances running and without a failover scenario");
-
-        currentWriteCount1 = eventWriteCount.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Read count: {}, write count: {} without any failover", currentReadCount1, currentWriteCount1);
-
-        int sleepTime;
-
-        //check reads and writes after some random time
-        sleepTime = new Random().nextInt(50000) + 3000;
-        log.info("Sleeping for {} ", sleepTime);
-        Exceptions.handleInterrupted(() -> Thread.sleep(sleepTime));
-
-        long currentWriteCount2;
-        long currentReadCount2;
-
-        currentWriteCount2 = eventWriteCount.get();
-        currentReadCount2 = eventReadCount.get();
-
-        log.info("Read count: {}, write count: {} without any failover after sleep before scaling", currentReadCount2, currentWriteCount2);
-
-        //Scale down SSS instances to 2
-        segmentStoreInstance.scaleService(2, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
-        log.info("Scaling down SSS instances from 3 to 2");
-
-        currentWriteCount1 = eventWriteCount.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Read count: {}, write count: {} after SSS failover after sleep", currentReadCount1, currentWriteCount1);
-
-        //Scale down controller instances to 2
-        controllerInstance.scaleService(2, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
-        log.info("Scaling down controller instances from 3 to 2");
-
-        currentWriteCount2 = eventWriteCount.get();
-        currentReadCount2 = eventReadCount.get();
-
-        log.info("Read count: {}, write count: {} after controller failover after sleep", currentReadCount2, currentWriteCount2);
-        //Scale down SSS, controller to 1 instance each.
-        segmentStoreInstance.scaleService(1, true);
-        controllerInstance.scaleService(1, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
-        log.info("Scaling down  to 1 controller, 1 SSS instance");
-
-        currentWriteCount1 = eventWriteCount.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Stop write flag status: {}, stop read flag status: {} ", stopWriteFlag, stopReadFlag);
-        log.info("Event data: {}, read count: {}", eventData.get(), eventReadCount.get());
-        log.info("Read count: {}, write count: {} with SSS and controller failover after sleep", currentReadCount1, currentWriteCount1);
-    }
-
-
-    private CompletableFuture<Void> startWritingIntoTxn(final AtomicLong data, final EventStreamWriter<Long> writer,
-                                                        final AtomicBoolean stopWriteFlag, final AtomicLong eventWriteCount) {
-        return CompletableFuture.runAsync(() -> {
-            while (!stopWriteFlag.get()) {
-                Transaction<Long> txnDebugReference = null;
-                AtomicBoolean txnIsDone = new AtomicBoolean(false);
-
-                try {
-                    Transaction<Long> transaction = writer.beginTxn(5000, 3600000, 29000);
-                    txnDebugReference = transaction;
-
-                    // Sets a recurrent delayed task to ping the txn. It exits when the
-                    // txn completes and no longer needs pinging
-                    FutureHelpers.loop(() -> !txnIsDone.get(), () -> {
-                        return FutureHelpers.delayedTask(() -> {
-                            if (transaction.checkStatus() == Transaction.Status.OPEN) {
-                                FutureHelpers.runOrFail(() -> {
-                                    transaction.ping(5000);
-                                    return null;
-                                }, new CompletableFuture<Void>());
-                            } else {
-                                txnIsDone.set(true);
-                            }
-
-                            return null;
-                        }, Duration.ofMillis(2000), executorService);
-                    }, executorService);
-
-                    for (int j = 0; j < NUM_EVENTS_PER_TRANSACTION; j++) {
-                        long value = data.incrementAndGet();
-                        transaction.writeEvent(String.valueOf(value), value);
-                        log.debug("Writing event: {} into transaction: {}", value, transaction.getTxnId());
-                    }
-                    //commit Txn
-                    transaction.commit();
-                    txnIsDone.set(true);
-
-                    //wait for transaction to get committed
-                    txnStatusFutureList.add(checkTxnStatus(transaction, eventWriteCount));
-                } catch (Throwable e) {
-                    // Given that we have retry logic both in the interaction with controller and
-                    // segment store, we should fail the test case in the presence of any exception
-                    // caught here.
-                    txnIsDone.set(true);
-                    log.warn("Exception while writing events in the transaction: ", e);
-                    if (txnDebugReference != null) {
-                        log.debug("Transaction with id: {}  failed", txnDebugReference.getTxnId());
-                    }
-                    writerErrorRef.set(e);
-                    return;
-                }
-            }
-        }, executorService);
-    }
-
-    private CompletableFuture<Void> checkTxnStatus(Transaction<Long> txn,
-                                                   final AtomicLong eventWriteCount) {
-
-        return Retry.indefinitelyWithExpBackoff("Txn did not get committed").runAsync(() -> {
-            Transaction.Status status = txn.checkStatus();
-            log.debug("Txn id {} status is {}", txn.getTxnId(), status);
-            if (status.equals(Transaction.Status.COMMITTED)) {
-                eventWriteCount.addAndGet(NUM_EVENTS_PER_TRANSACTION);
-                log.info("Event write count: {}", eventWriteCount.get());
-            } else if (status.equals(Transaction.Status.ABORTED)) {
-                log.debug("Transaction with id: {} aborted", txn.getTxnId());
-            } else {
-                throw new TxnNotCompleteException();
-            }
-
-            return CompletableFuture.completedFuture(null);
-        }, executorService);
-    }
-
-    private CompletableFuture<Void> startReading(final ConcurrentLinkedQueue<Long> readResult, final AtomicLong writeCount, final
-    AtomicLong readCount, final AtomicBoolean exitFlag, final EventStreamReader<Long> reader) {
-        return CompletableFuture.runAsync(() -> {
-            log.info("Exit flag status {}", exitFlag);
-            log.info("Read count {} and write count {}", readCount.get(), writeCount);
-            while (!(exitFlag.get() && readCount.get() == writeCount.get())) {
-                log.info("Entering read loop");
-                // exit only if exitFlag is true  and read Count equals write count.
-                try {
-                    final Long longEvent = reader.readNextEvent(SECONDS.toMillis(60)).getEvent();
-                    log.debug("Reading event {}", longEvent);
-                    if (longEvent != null) {
-                        //update if event read is not null.
-                        readResult.add(longEvent);
-                        readCount.incrementAndGet();
-                        log.debug("Event read count {}", readCount);
-                    } else {
-                        log.debug("Read timeout");
-                    }
-                } catch (Throwable e) {
-                    log.error("Test Exception while reading from the stream: ", e);
-                    readerErrorRef.set(e);
-                    return;
-                }
-            }
-
-        }, executorService);
-    }
-
-    private static class TxnNotCompleteException extends RuntimeException {
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -123,6 +123,7 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         executorService.shutdownNow();
         controllerExecutorService.shutdownNow();
         testState.eventsReadFromPravega.clear();
+        testState.txnStatusFutureList.clear();
         //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests {
 
@@ -144,6 +146,6 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
 
         cleanUp(scope, STREAM_NAME); //cleanup if validation is successful.
 
-        log.info("Test {} succeeds ", "MultiReaderWriterTxnWithFailOver");
+        log.info("Test MultiReaderWriterTxnWithFailOver succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -40,7 +39,6 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests {
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -40,7 +39,6 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -11,126 +11,57 @@ package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.admin.impl.StreamManagerImpl;
-import io.pravega.client.netty.impl.ConnectionFactory;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
-import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
-import io.pravega.test.system.framework.services.BookkeeperService;
 import io.pravega.test.system.framework.services.PravegaControllerService;
 import io.pravega.test.system.framework.services.PravegaSegmentStoreService;
 import io.pravega.test.system.framework.services.Service;
 import io.pravega.test.system.framework.services.ZookeeperService;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MultiReaderWriterWithFailOverTest {
+public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
+
     private static final String STREAM_NAME = "testMultiReaderWriterStream";
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
-    private static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
-    private static final int WRITER_MAX_RETRY_ATTEMPTS = 15;
-    private List<EventStreamReader<Long>> readerList = new ArrayList<>();
-    private List<EventStreamWriter<Long>> writerList = new ArrayList<>();
-    private ScheduledExecutorService executorService;
-    private AtomicBoolean stopReadFlag;
-    private AtomicBoolean stopWriteFlag;
-    private AtomicLong eventData;
-    private AtomicLong eventReadCount;
-    private ConcurrentLinkedQueue<Long> eventsReadFromPravega;
-    private Service controllerInstance = null;
-    private Service segmentStoreInstance = null;
-    private URI controllerURIDirect = null;
-    //zk session timeout to detect failure (30s) +
-    // rebalance time to update ownership change (10s) +
-    // time taken to start a segment container
-    private final int sleepTimeAfterFailover = 60000;
+    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(15 * 60);
+    private final String scope = "testMultiReaderWriterScope" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String readerGroupName = "testMultiReaderWriterReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(NUM_READERS);
+    StreamConfiguration config = StreamConfiguration.builder().scope(scope)
+            .streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
+    private ClientFactory clientFactory;
+    private ReaderGroupManager readerGroupManager;
 
     @Environment
     public static void initialize() throws MarathonException, URISyntaxException {
-
-        //1. Start 1 instance of zookeeper
-        Service zkService = new ZookeeperService("zookeeper");
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-
-        //2. Start 3 bookies
-        Service bkService = new BookkeeperService("bookkeeper", zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        //3. start 3 instances of pravega controller
-        Service conService = new PravegaControllerService("controller", zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-        conService.scaleService(3, true);
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega Controller service  details: {}", conUris);
-
-        // Fetch all the RPC endpoints and construct the client URIs.
-        final List<String> uris = conUris.stream().filter(uri -> uri.getPort() == 9092).map(URI::getAuthority)
-                .collect(Collectors.toList());
-
-        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
-        log.info("Controller Service direct URI: {}", controllerURI);
-
-        //4.start 3 instances of pravega segmentstore
-        Service segService = new PravegaSegmentStoreService("segmentstore", zkUri, controllerURI);
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-        segService.scaleService(3, true);
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega Segmentstore service  details: {}", segUris);
-
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before
@@ -161,284 +92,57 @@ public class MultiReaderWriterWithFailOverTest {
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
 
-        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1, "MultiReaderWriterWithFailOverTest");
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1, "MultiReaderWriterWithFailOverTest-main");
+
+        controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
+                "MultiReaderWriterWithFailoverTest-controller");
+        //get Controller Uri
+        controller = new ControllerImpl(controllerURIDirect,
+                ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
+                controllerExecutorService);
+
+        testState = new TestState();
+        //read and write count variables
+        testState.writersListComplete.add(0, testState.writersComplete);
+        createScopeAndStream(scope, STREAM_NAME, config, controllerURIDirect);
+        log.info("Scope passed to client factory {}", scope);
+        clientFactory = new ClientFactoryImpl(scope, controller);
+        readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
 
     }
 
     @After
     public void tearDown() {
+        testState.stopReadFlag.set(true);
+        testState.stopWriteFlag.set(true);
+        //interrupt writers and readers threads if they are still running.
+        testState.writers.forEach(future -> future.cancel(true));
+        testState.readers.forEach(future -> future.cancel(true));
+        clientFactory.close(); //close the clientFactory/connectionFactory.
+        readerGroupManager.close();
+        executorService.shutdownNow();
+        controllerExecutorService.shutdownNow();
+        testState.eventsReadFromPravega.clear();
+        //scale the controller and segmentStore back to 1 instance.
         controllerInstance.scaleService(1, true);
         segmentStoreInstance.scaleService(1, true);
-        executorService.shutdownNow();
     }
 
-    @Test(timeout = 600000)
+    @Test
     public void multiReaderWriterWithFailOverTest() throws Exception {
 
-        String scope = "testMultiReaderWriterScope" + new Random().nextInt(Integer.MAX_VALUE);
-        String readerGroupName = "testMultiReaderWriterReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
-        ScalingPolicy scalingPolicy = ScalingPolicy.fixed(NUM_READERS);
-        StreamConfiguration config = StreamConfiguration.builder().scope(scope)
-                .streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
-        //get Controller Uri
-        URI controllerUri = controllerURIDirect;
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
-        Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(),
-                executorService);
+        createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
 
-        eventsReadFromPravega = new ConcurrentLinkedQueue<>();
-        stopReadFlag = new AtomicBoolean(false);
-        stopWriteFlag = new AtomicBoolean(false);
-        eventData = new AtomicLong(0); //data used by each of the writers.
-        eventReadCount = new AtomicLong(0); // used by readers to maintain a count of events.
+        //run the failover test
+        performFailoverTest();
 
-        //create a scope
-        try (StreamManager streamManager = new StreamManagerImpl(controllerUri)) {
-            Boolean createScopeStatus = streamManager.createScope(scope);
-            log.info("Creating scope with scope name {}", scope);
-            log.debug("Create scope status {}", createScopeStatus);
-            //create a stream
-            Boolean createStreamStatus = streamManager.createStream(scope, STREAM_NAME, config);
-            log.debug("Create stream status {}", createStreamStatus);
-        }
+        stopWriters();
+        stopReaders();
+        validateResults(readerGroupManager, readerGroupName);
 
-        //get ClientFactory instance
-        log.info("Scope passed to client factory {}", scope);
-        try (ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
-             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerUri)) {
+        cleanUp(scope, STREAM_NAME); //cleanup if validation is successful.
 
-            log.info("Client factory details {}", clientFactory.toString());
-            //create writers
-            log.info("Creating {} writers", NUM_WRITERS);
-            log.info("Writers writing in the scope {}", scope);
-            for (int i = 0; i < NUM_WRITERS; i++) {
-                log.info("Starting writer{}", i);
-                final EventStreamWriter<Long> writer = clientFactory.createEventWriter(STREAM_NAME,
-                        new JavaSerializer<Long>(),
-                        EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
-                writerList.add(writer);
-            }
-
-            //create a reader group
-            log.info("Creating Reader group : {}", readerGroupName);
-            log.info("Scope passed to readergroup manager {}", scope);
-
-            readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().startingTime(0).build(),
-                    Collections.singleton(STREAM_NAME));
-            log.info("Reader group name {} ", readerGroupManager.getReaderGroup(readerGroupName).getGroupName());
-            log.info("Reader group scope {}", readerGroupManager.getReaderGroup(readerGroupName).getScope());
-            log.info("Online readers {}", readerGroupManager.getReaderGroup(readerGroupName).getOnlineReaders());
-
-            //create readers
-            log.info("Creating {} readers", NUM_READERS);
-            String readerName = "reader" + new Random().nextInt(Integer.MAX_VALUE);
-            log.info("Scope that is seen by readers {}", scope);
-            //start reading events
-            for (int i = 0; i < NUM_READERS; i++) {
-                log.info("Starting reader{}", i);
-                log.info("Creating reader with id {}", readerName + i);
-                final EventStreamReader<Long> reader = clientFactory.createReader(readerName + i,
-                        readerGroupName,
-                        new JavaSerializer<Long>(),
-                        ReaderConfig.builder().build());
-                readerList.add(reader);
-            }
-
-            // start writing asynchronously
-            List<CompletableFuture<Void>> writerFutureList = new ArrayList<>();
-            writerList.forEach(writer -> {
-                CompletableFuture<Void> writerFuture = startWriting(eventData, writer, stopWriteFlag);
-                writerFutureList.add(writerFuture);
-            });
-
-            //start reading asynchronously
-            List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
-            readerList.forEach(reader -> {
-                CompletableFuture<Void> readerFuture = startReading(eventsReadFromPravega, eventData, eventReadCount, stopReadFlag, reader);
-                readerFutureList.add(readerFuture);
-            });
-
-            //perform the scaling operations
-            performFailoverTest();
-
-            //set the stop write flag to true
-            log.info("Stop write flag status {}", stopWriteFlag);
-            stopWriteFlag.set(true);
-
-            //wait for writers completion
-            log.info("Wait for writers execution to complete");
-            FutureHelpers.allOf(writerFutureList).get();
-
-            //set the stop read flag to true
-            log.info("Stop read flag status {}", stopReadFlag);
-            stopReadFlag.set(true);
-
-            //wait for readers completion
-            log.info("Wait for readers execution to complete");
-            FutureHelpers.allOf(readerFutureList).get();
-
-            log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +
-                    "Count: {}", eventData.get(), eventsReadFromPravega.size());
-            assertEquals(eventData.get(), eventsReadFromPravega.size());
-            assertEquals(eventData.get(), new TreeSet<>(eventsReadFromPravega).size()); //check unique events.
-
-            cleanUp();
-
-            //delete readergroup
-            log.info("Deleting readergroup {}", readerGroupName);
-            readerGroupManager.deleteReaderGroup(readerGroupName);
-        }
-        //seal the stream
-        CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, STREAM_NAME);
-        log.info("Sealing stream {}", STREAM_NAME);
-        assertTrue(sealStreamStatus.get());
-        //delete the stream
-        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, STREAM_NAME);
-        log.info("Deleting stream {}", STREAM_NAME);
-        assertTrue(deleteStreamStatus.get());
-
-        //delete the scope
-        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
-        log.info("Deleting scope {}", scope);
-        assertTrue(deleteScopeStatus.get());
         log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
-    }
-
-    private void cleanUp() {
-        log.info("Closing writers");
-        writerList.forEach(writer -> writer.close());
-        log.info("Closing readers");
-        readerList.forEach(reader -> reader.close());
-    }
-
-    private void performFailoverTest() {
-
-        long currentWriteCount1;
-        long currentReadCount1;
-
-        log.info("Test with 3 controller, segmentstore instances running and without a failover scenario");
-
-        currentWriteCount1 = eventData.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Read count without any failover {}", currentReadCount1);
-        log.info("Write count without any failover {}", currentWriteCount1);
-
-        int sleepTime;
-
-        //check reads and writes after some random time
-        sleepTime = new Random().nextInt(50000) + 3000;
-        log.info("Sleeping for {} ", sleepTime);
-        Exceptions.handleInterrupted(() -> Thread.sleep(sleepTime));
-
-        long currentWriteCount2;
-        long currentReadCount2;
-
-        currentWriteCount2 = eventData.get();
-        currentReadCount2 = eventReadCount.get();
-
-        log.info("Read count without any failover after sleep before scaling  {}", currentReadCount2);
-        log.info("Write count without any failover after sleep before scaling {}", currentWriteCount2);
-
-        //ensure writes are happening
-        assertTrue(currentWriteCount2 > currentWriteCount1);
-        //ensure reads are happening
-        assertTrue(currentReadCount2 > currentReadCount1);
-
-        //Scale down SSS instances to 2
-        segmentStoreInstance.scaleService(2, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(sleepTimeAfterFailover));
-        log.info("Scaling down SSS instances from 3 to 2");
-
-        currentWriteCount1 = eventData.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Read count after SSS failover after sleep  {}", currentReadCount1);
-        log.info("Write count after SSS failover after sleep {}", currentWriteCount1);
-
-        //ensure writes are happening
-        assertTrue(currentWriteCount1 > currentWriteCount2);
-        //ensure reads are happening
-        assertTrue(currentReadCount1 > currentReadCount2);
-
-        //Scale down controller instances to 2
-        controllerInstance.scaleService(2, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(sleepTimeAfterFailover));
-        log.info("Scaling down controller instances from 3 to 2");
-
-        currentWriteCount2 = eventData.get();
-        currentReadCount2 = eventReadCount.get();
-
-        log.info("Read count after controller failover after sleep  {}", currentReadCount2);
-        log.info("Write count after controller failover after sleep  {}", currentWriteCount2);
-
-        //ensure writes are happening
-        assertTrue(currentWriteCount2 > currentWriteCount1);
-        //ensure reads are happening
-        assertTrue(currentReadCount2 > currentReadCount1);
-
-        //Scale down SSS, controller to 1 instance each.
-        segmentStoreInstance.scaleService(1, true);
-        controllerInstance.scaleService(1, true);
-        Exceptions.handleInterrupted(() -> Thread.sleep(sleepTimeAfterFailover));
-        log.info("Scaling down  to 1 controller, 1 SSS instance");
-
-        currentWriteCount1 = eventData.get();
-        currentReadCount1 = eventReadCount.get();
-
-        log.info("Stop write flag status {}", stopWriteFlag);
-        log.info("Stop read flag status {}", stopReadFlag);
-        log.info("Event data {}", eventData.get());
-        log.info("Read count {}", eventReadCount.get());
-        log.info("Read count with SSS and controller failover after sleep {}", currentReadCount1);
-        log.info("Write count with SSS and controller failover after sleep {} ", currentWriteCount1);
-    }
-
-    private CompletableFuture<Void> startWriting(final AtomicLong data, final EventStreamWriter<Long> writer,
-                                                 final AtomicBoolean stopWriteFlag) {
-        return CompletableFuture.runAsync(() -> {
-            while (!stopWriteFlag.get()) {
-                try {
-                    long value = data.incrementAndGet();
-                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
-                    log.debug("Event write count before write call {}", value);
-                    writer.writeEvent(String.valueOf(value), value);
-                    log.debug("Event write count before flush {}", value);
-                    writer.flush();
-                    log.debug("Writing event {}", value);
-                } catch (Throwable e) {
-                    log.error("Test exception writing events: ", e);
-                }
-            }
-            log.info("Closing the writers.Stop write flag status: {}", stopWriteFlag.get());
-        }, executorService);
-    }
-
-    private CompletableFuture<Void> startReading(final ConcurrentLinkedQueue<Long> readResult, final AtomicLong writeCount, final
-    AtomicLong readCount, final AtomicBoolean exitFlag, final EventStreamReader<Long> reader) {
-        return CompletableFuture.runAsync(() -> {
-            log.info("Exit flag status {}", exitFlag.get());
-            log.info("Read count {} and write count {}", readCount.get(), writeCount.get());
-            while (!(exitFlag.get() && readCount.get() == writeCount.get())) {
-                log.info("Entering read loop");
-                // exit only if exitFlag is true  and read Count equals write count.
-                try {
-                    final Long longEvent = reader.readNextEvent(SECONDS.toMillis(60)).getEvent();
-                    log.debug("Reading event {}", longEvent);
-                    if (longEvent != null) {
-                        //update if event read is not null.
-                        readResult.add(longEvent);
-                        readCount.incrementAndGet();
-                        log.debug("Event read count {}", readCount);
-                    } else {
-                        log.debug("Read timeout");
-                    }
-                } catch (Throwable e) {
-                    log.error("Test Exception while reading from the stream: ", e);
-                }
-            }
-            log.info("Closing the readers.Stop read flag status: {}", exitFlag.get());
-        }, executorService);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
 
@@ -143,6 +145,6 @@ public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
 
         cleanUp(scope, STREAM_NAME); //cleanup if validation is successful.
 
-        log.info("Test {} succeeds ", "MultiReaderWriterWithFailOver");
+        log.info("Test MultiReaderWriterWithFailOver succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -53,7 +53,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
     private final String scope = "testReadTxnWriteAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadTxnWriteAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
-    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1); // auto scaling is not enabled.
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
             .streamName(AUTO_SCALE_STREAM).scalingPolicy(scalingPolicy).build();
     private ClientFactory clientFactory;

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class ReadTxnWriteAutoScaleFailoverTest extends AbstractFailoverTests {
+public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests {
 
     private static final int INIT_NUM_WRITERS = 2;
     private static final int ADD_NUM_WRITERS = 2;
@@ -51,11 +51,11 @@ public class ReadTxnWriteAutoScaleFailoverTest extends AbstractFailoverTests {
     //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
-    private final String scope = "testReadTxnWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
-    private final String readerGroupName = "testReadTxnWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String scope = "testReadTxnWriteAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String readerGroupName = "testReadTxnWriteAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1); // auto scaling is not enabled.
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
-            .streamName(SCALE_STREAM).scalingPolicy(scalingPolicy).build();
+            .streamName(AUTO_SCALE_STREAM).scalingPolicy(scalingPolicy).build();
     private ClientFactory clientFactory;
     private ReaderGroupManager readerGroupManager;
 
@@ -97,9 +97,9 @@ public class ReadTxnWriteAutoScaleFailoverTest extends AbstractFailoverTests {
 
         //num. of readers + num. of writers + 1 to run checkScale operation
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS + 1,
-                "ReadTxnWriteAndScaleWithFailoverTest-main");
+                "ReadTxnWriteAutoScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
-                "ReadTxnWriteAndScaleWithFailoverTest-controller");
+                "ReadTxnWriteAutoScaleWithFailoverTest-controller");
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect,
                 ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
@@ -108,7 +108,7 @@ public class ReadTxnWriteAutoScaleFailoverTest extends AbstractFailoverTests {
         testState.writersListComplete.add(0, testState.writersComplete);
         testState.writersListComplete.add(1, testState.newWritersComplete);
         testState.txnWrite.set(true);
-        createScopeAndStream(scope, SCALE_STREAM, config, controllerURIDirect);
+        createScopeAndStream(scope, AUTO_SCALE_STREAM, config, controllerURIDirect);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
@@ -165,6 +165,7 @@ public class ReadTxnWriteAutoScaleFailoverTest extends AbstractFailoverTests {
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
+        log.info("Test {} succeeds ", "ReadTxnWriteAutoScaleWithFailover");
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -165,7 +165,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
-        log.info("Test {} succeeds ", "ReadTxnWriteAutoScaleWithFailover");
+        log.info("Test ReadTxnWriteAutoScaleWithFailover succeeds");
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -7,6 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
+
 package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
@@ -16,8 +17,10 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
+import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.services.PravegaControllerService;
@@ -26,7 +29,7 @@ import io.pravega.test.system.framework.services.Service;
 import io.pravega.test.system.framework.services.ZookeeperService;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,43 +37,44 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests {
+public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 
-    private static final int INIT_NUM_WRITERS = 2;
-    private static final int ADD_NUM_WRITERS = 2;
-    private static final int NUM_READERS = 2;
-    private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
-
+    private static final int NUM_READERS = 5;
+    private static final int NUM_WRITERS = 5;
     //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
-
-    private final String scope = "testReadWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
-    private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
-    private final ScalingPolicy scalingPolicy = ScalingPolicy.byEventRate(1, 2, 2);
+    private final String scope = "testReadTxnWriteAndScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String readerGroupName = "testReadTxnWriteAndScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1); // auto scaling is not enabled.
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
-            .streamName(AUTO_SCALE_STREAM).scalingPolicy(scalingPolicy).build();
+            .streamName(SCALE_STREAM).scalingPolicy(scalingPolicy).build();
     private ClientFactory clientFactory;
     private ReaderGroupManager readerGroupManager;
 
     @Environment
-    public static void initialize() throws MarathonException, URISyntaxException {
+    public static void initialize() throws InterruptedException, MarathonException, URISyntaxException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
         URI controllerUri = startPravegaControllerInstances(zkUri);
         startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
+
     @Before
     public void setup() {
-        // Get zk details to verify if controller, SSS are running
+        // Get zk details to verify if controller, segmentstore are running
         Service zkService = new ZookeeperService("zookeeper");
         List<URI> zkUris = zkService.getServiceDetails();
         log.debug("Zookeeper service details: {}", zkUris);
@@ -95,49 +99,29 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
 
-        //executor service
-        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + TOTAL_NUM_WRITERS + 1,
-                                                                        "ReadWriteAndAutoScaleWithFailoverTest-main");
+        //num. of readers + num. of writers + 1 to run checkScale operation
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1,
+                "ReadTxnWriteAndScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
-                                                                                  "ReadWriteAndAutoScaleWithFailoverTest-controller");
+                "ReadTxnWriteAndScaleWithFailoverTest-controller");
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect,
-                                        ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
-                                        controllerExecutorService);
+                ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
+                controllerExecutorService);
         testState = new TestState();
         testState.writersListComplete.add(0, testState.writersComplete);
-        testState.writersListComplete.add(1, testState.newWritersComplete);
+        testState.txnWrite.set(true);
 
-        createScopeAndStream(scope, AUTO_SCALE_STREAM, config, controllerURIDirect);
+        createScopeAndStream(scope, SCALE_STREAM, config, controllerURIDirect);
         log.info("Scope passed to client factory {}", scope);
-
         clientFactory = new ClientFactoryImpl(scope, controller);
         readerGroupManager = ReaderGroupManager.withScope(scope, controllerURIDirect);
     }
 
-    @After
-    public void tearDown() {
-        testState.stopReadFlag.set(true);
-        testState.stopWriteFlag.set(true);
-        //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
-        clientFactory.close();
-        readerGroupManager.close();
-        executorService.shutdownNow();
-        controllerExecutorService.shutdownNow();
-        testState.eventsReadFromPravega.clear();
-        //scale the controller and segmentStore back to 1 instance.
-        controllerInstance.scaleService(1, true);
-        segmentStoreInstance.scaleService(1, true);
-    }
-
-
     @Test
-    public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
-
-        createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
-        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
+    public void readTxnWriteScaleWithFailoverTest() throws Exception {
+        createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
 
         //run the failover test before scaling
         performFailoverTest();
@@ -147,14 +131,38 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         segmentStoreInstance.scaleService(3, true);
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-        addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+        //scale manually
+        log.debug("Number of Segments before manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
+                .get().getSegments().size());
+
+        Map<Double, Double> keyRanges = new HashMap<>();
+        keyRanges.put(0.0, 0.5);
+        keyRanges.put(0.5, 1.0);
+
+        CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
+                Collections.singletonList(0),
+                keyRanges,
+                executorService).getFuture();
+        FutureHelpers.exceptionListener(scaleStatus, t -> log.error("Scale Operation completed with an error", t));
 
         //run the failover test while scaling
         performFailoverTest();
 
-        waitForScaling(scope);
+        //do a get on scaleStatus
+        if (FutureHelpers.await(scaleStatus)) {
+            log.info("Scale operation has completed: {}", scaleStatus.get());
+            if (!scaleStatus.get()) {
+                log.error("Scale operation did not complete", scaleStatus.get());
+                Assert.fail("Scale operation did not complete successfully");
+            }
+        } else {
+            Assert.fail("Scale operation threw an exception");
+        }
 
-        //bring the instances back to 3 before performing failover
+        log.debug("Number of Segments post manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
+                .get().getSegments().size());
+
+        //bring the instances back to 3 before performing failover after scaling
         controllerInstance.scaleService(3, true);
         segmentStoreInstance.scaleService(3, true);
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
@@ -166,8 +174,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         stopReaders();
         validateResults(readerGroupManager, readerGroupName);
 
-        cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
+        cleanUp(scope, SCALE_STREAM); //cleanup if validation is successful.
+        log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");
     }
-
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 
@@ -136,8 +138,11 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
                 .get().getSegments().size());
 
         Map<Double, Double> keyRanges = new HashMap<>();
-        keyRanges.put(0.0, 0.5);
-        keyRanges.put(0.5, 1.0);
+        keyRanges.put(0.0, 0.2);
+        keyRanges.put(0.2, 0.4);
+        keyRanges.put(0.4, 0.6);
+        keyRanges.put(0.6, 0.8);
+        keyRanges.put(0.8, 1.0);
 
         CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
                 Collections.singletonList(0),
@@ -175,7 +180,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, SCALE_STREAM); //cleanup if validation is successful.
-        log.info("Test {} succeeds ", "ReadTxnWriteScaleWithFailover");
+        log.info("Test ReadTxnWriteScaleWithFailover succeeds");
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -31,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -48,7 +47,6 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -55,8 +55,8 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
     //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
-    private final String scope = "testReadTxnWriteAndScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
-    private final String readerGroupName = "testReadTxnWriteAndScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String scope = "testReadTxnWriteScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
+    private final String readerGroupName = "testReadTxnWriteScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);
     private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1); // auto scaling is not enabled.
     private final StreamConfiguration config = StreamConfiguration.builder().scope(scope)
             .streamName(SCALE_STREAM).scalingPolicy(scalingPolicy).build();
@@ -101,9 +101,9 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 
         //num. of readers + num. of writers + 1 to run checkScale operation
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 1,
-                "ReadTxnWriteAndScaleWithFailoverTest-main");
+                "ReadTxnWriteScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
-                "ReadTxnWriteAndScaleWithFailoverTest-controller");
+                "ReadTxnWriteScaleWithFailoverTest-controller");
         //get Controller Uri
         controller = new ControllerImpl(controllerURIDirect,
                 ControllerImplConfig.builder().maxBackoffMillis(5000).build(),
@@ -175,7 +175,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, SCALE_STREAM); //cleanup if validation is successful.
-        log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");
+        log.info("Test {} succeeds ", "ReadTxnWriteScaleWithFailover");
     }
 
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -41,7 +40,6 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests {
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests {
 
@@ -167,6 +169,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
-        log.info("Test {} succeeds ", "ReadWriteAndAutoScaleWithFailover");
+        log.info("Test ReadWriteAndAutoScaleWithFailover succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -167,7 +167,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, AUTO_SCALE_STREAM); //cleanup if validation is successful.
+        log.info("Test {} succeeds ", "ReadWriteAndAutoScaleWithFailover");
     }
-
-
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -31,6 +31,7 @@ import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
@@ -154,8 +156,11 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
                 .get().getSegments().size());
 
         Map<Double, Double> keyRanges = new HashMap<>();
-        keyRanges.put(0.0, 0.5);
-        keyRanges.put(0.5, 1.0);
+        keyRanges.put(0.0, 0.2);
+        keyRanges.put(0.2, 0.4);
+        keyRanges.put(0.4, 0.6);
+        keyRanges.put(0.6, 0.8);
+        keyRanges.put(0.8, 1.0);
 
         CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
                 Collections.singletonList(0),
@@ -193,6 +198,6 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         validateResults(readerGroupManager, readerGroupName);
 
         cleanUp(scope, SCALE_STREAM); //cleanup if validation is successful.
-        log.info("Test {} succeeds ", "ReadWriteAndScaleWithFailover");
+        log.info("Test ReadWriteAndScaleWithFailover succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -31,7 +31,6 @@ import mesosphere.marathon.client.utils.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -48,7 +47,6 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-@Ignore
 @RunWith(SystemTestRunner.class)
 public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 


### PR DESCRIPTION
**Change log description**
Two new failover system test cases with  txn writes and reads  and triggering scaling/auto-scaling are added.
Failover is performed before, during, after scaling/auto-scaling.
Failover consists of the following :
a. segmentstore failover
b. controller failover
c. segmentstore and controller failover
Currently, `multireaderwriterwithfailovertest` and `multireadertxnwriterwithfailovertest`   doesn't match with the other failover tests. They need to be modified.
**Purpose of the change**
1. Adding new system test cases with failover .
2. Using `AbstractFailoverTests` in all the failover tests to create uniformity across all the failover tests.

**What the code does**
Fixes #1409 

**How to verify it**
System tests should pass