### PR TITLE
Issue 1925: StreamManagerImpl gives ArrayIndexOutOfBoundsException for invalid URI [Port Missing in URI

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
@@ -65,6 +65,7 @@ public class ControllerResolverFactory extends NameResolver.Factory {
         final String authority = targetUri.getAuthority();
         final List<InetSocketAddress> addresses = Splitter.on(',').splitToList(authority).stream().map(host -> {
             final String[] strings = host.split(":");
+            Preconditions.checkArgument(strings.length == 2, "URI should have both address and port");
             return InetSocketAddress.createUnresolved(strings[0], Integer.valueOf(strings[1]));
         }).collect(Collectors.toList());
 


### PR DESCRIPTION
**Change log description**
StreamManager.create(URI) gives array out of bound exception if Port is missing in URI.
Added precondition check to ensure that both ip and port are present in the uri. 

**Purpose of the change**
Fixes #1925.

**What the code does**
Adds a precondition check. 

**How to verify it**
All exiting tests should continue to pass. 