### PR TITLE
Issue 1923: (SegmentStore) GetSegmentInfo optimization

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -24,13 +24,13 @@ import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
-import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.OperationLogFactory;
 import io.pravega.segmentstore.server.ReadIndex;
 import io.pravega.segmentstore.server.ReadIndexFactory;
 import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.Writer;
 import io.pravega.segmentstore.server.WriterFactory;
 import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
@@ -51,7 +51,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -299,19 +298,16 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
 
         logRequest("getStreamSegmentInfo", streamSegmentName);
         this.metrics.getInfo();
-        TimeoutTimer timer = new TimeoutTimer(timeout);
-
-        Function<Long, CompletableFuture<SegmentProperties>> metadataRetriever =
-                streamSegmentId -> CompletableFuture.completedFuture(this.metadata.getStreamSegmentMetadata(streamSegmentId).getSnapshot());
 
         if (waitForPendingOps) {
             // We have been instructed to wait for all pending operations to complete. Use an op barrier and wait for it
             // before proceeding.
+            TimeoutTimer timer = new TimeoutTimer(timeout);
             return this.durableLog
                     .operationProcessingBarrier(timer.getRemaining())
-                    .thenComposeAsync(v -> this.segmentMapper.getOrAssignStreamSegmentId(streamSegmentName, timer.getRemaining(), metadataRetriever), this.executor);
+                    .thenComposeAsync(v -> this.segmentMapper.getStreamSegmentInfo(streamSegmentName, timer.getRemaining()), this.executor);
         } else {
-            return this.segmentMapper.getOrAssignStreamSegmentId(streamSegmentName, timer.getRemaining(), metadataRetriever);
+            return this.segmentMapper.getStreamSegmentInfo(streamSegmentName, timeout);
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
@@ -267,6 +267,52 @@ public class StreamSegmentMapper {
 
     //endregion
 
+    //region GetSegmentInfo
+
+    /**
+     * Gets information about a StreamSegment. If the Segment is active, it returns this information directly from the
+     * in-memory Metadata. If the Segment is not active, it fetches the information from Storage and returns it, without
+     * activating the segment in the Metadata or otherwise touching the DurableLog.
+     *
+     * @param streamSegmentName The case-sensitive StreamSegment Name.
+     * @param timeout           Timeout for the Operation.
+     * @return A CompletableFuture that, when complete, will contain a SegmentProperties object with the desired
+     * information. If failed, it will contain the exception that caused the failure.
+     */
+    CompletableFuture<SegmentProperties> getStreamSegmentInfo(String streamSegmentName, Duration timeout) {
+        long streamSegmentId = this.containerMetadata.getStreamSegmentId(streamSegmentName, true);
+        CompletableFuture<SegmentProperties> result;
+        if (isValidStreamSegmentId(streamSegmentId)) {
+            // Looks like the Segment is active and we have it in our Metadata. Return the result from there.
+            SegmentMetadata sm = this.containerMetadata.getStreamSegmentMetadata(streamSegmentId);
+            if (sm.isDeleted()) {
+                result = FutureHelpers.failedFuture(new StreamSegmentNotExistsException(streamSegmentName));
+            } else {
+                result = CompletableFuture.completedFuture(sm.getSnapshot());
+            }
+        } else {
+            // The Segment is not yet active.
+            // First, check to see if we have a pending assignment. If so, piggyback on that.
+            QueuedCallback<SegmentProperties> queuedCallback = checkConcurrentAssignment(streamSegmentName,
+                    id -> CompletableFuture.completedFuture(this.containerMetadata.getStreamSegmentMetadata(id).getSnapshot()));
+
+            if (queuedCallback != null) {
+                result = queuedCallback.result;
+            } else {
+                // Not in metadata and no concurrent assignments. Go to Storage and get what's needed.
+                TimeoutTimer timer = new TimeoutTimer(timeout);
+                result = this.storage
+                        .getStreamSegmentInfo(streamSegmentName, timer.getRemaining())
+                        .thenComposeAsync(si -> retrieveAttributes(si, timer.getRemaining()), this.executor)
+                        .thenApply(si -> si.properties);
+            }
+        }
+
+        return result;
+    }
+
+    //endregion
+
     //region Segment Id Assignment
 
     /**
@@ -304,15 +350,7 @@ public class StreamSegmentMapper {
                 // Even though we have the value in the metadata, we need to be very careful not to invoke this callback
                 // before any other existing callbacks are invoked. As such, verify if we have an existing PendingRequest
                 // for this segment - if so, tag onto it so we invoke these callbacks in the correct order.
-                QueuedCallback<T> queuedCallback = null;
-                synchronized (this.assignmentLock) {
-                    PendingRequest pendingRequest = this.pendingRequests.getOrDefault(streamSegmentName, null);
-                    if (pendingRequest != null) {
-                        queuedCallback = new QueuedCallback<>(thenCompose);
-                        pendingRequest.callbacks.add(queuedCallback);
-                    }
-                }
-
+                QueuedCallback<T> queuedCallback = checkConcurrentAssignment(streamSegmentName, thenCompose);
                 return queuedCallback == null ? thenCompose.apply(streamSegmentId) : queuedCallback.result;
             }
         }
@@ -580,6 +618,29 @@ public class StreamSegmentMapper {
 
             completionMethod.accept(pendingRequest, completionArgument);
         }
+    }
+
+    /**
+     * Attempts to piggyback a task on any existing concurrent assignment, if any such assignment exists.
+     *
+     * @param streamSegmentName The Name of the StreamSegment to attempt to piggyback on.
+     * @param thenCompose       A Function that consumes a StreamSegmentId and returns a CompletableFuture that will indicate
+     *                          when the consumption of that StreamSegmentId is complete. This Function will be invoked
+     *                          synchronously if the StreamSegmentId is already mapped, or async, otherwise, after assignment.
+     * @param <T>               Type of the return value.
+     * @return A QueuedCallback representing the callback object for this task, if it was piggybacked on any existing
+     * assignment. If no assignment was found, returns null.
+     */
+    private <T> QueuedCallback<T> checkConcurrentAssignment(String streamSegmentName, Function<Long, CompletableFuture<T>> thenCompose) {
+        QueuedCallback<T> queuedCallback = null;
+        synchronized (this.assignmentLock) {
+            PendingRequest pendingRequest = this.pendingRequests.getOrDefault(streamSegmentName, null);
+            if (pendingRequest != null) {
+                queuedCallback = new QueuedCallback<>(thenCompose);
+                pendingRequest.callbacks.add(queuedCallback);
+            }
+        }
+        return queuedCallback;
     }
 
     private CompletableFuture<Long> withFailureHandler(CompletableFuture<Long> source, String segmentName) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
@@ -31,7 +31,7 @@ public final class SegmentMetadataComparer {
         String idPrefix = message + " SegmentId " + expected.getId();
         Assert.assertEquals(idPrefix + " getId() mismatch.", expected.getId(), actual.getId());
         Assert.assertEquals(idPrefix + " getParentId() mismatch.", expected.getParentId(), actual.getParentId());
-        Assert.assertEquals(idPrefix + " getName() isDeleted.", expected.isDeleted(), actual.isDeleted());
+        Assert.assertEquals(idPrefix + " isDeleted() mismatch.", expected.isDeleted(), actual.isDeleted());
         Assert.assertEquals(idPrefix + " getStorageLength() mismatch.", expected.getStorageLength(), actual.getStorageLength());
         Assert.assertEquals(idPrefix + " getLength() mismatch.", expected.getLength(), actual.getLength());
         Assert.assertEquals(idPrefix + " getName() mismatch.", expected.getName(), actual.getName());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -179,6 +179,120 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests GetStreamSegmentInfo with various scenarios.
+     */
+    @Test
+    public void testGetStreamSegmentInfo() {
+        final String segmentName = "segment";
+        final long segmentId = 1;
+
+        @Cleanup
+        TestContext context = new TestContext();
+        HashSet<String> storageSegments = new HashSet<>();
+
+        // Segment not exists in Metadata or Storage.
+        setupStorageGetHandler(context, storageSegments, sn -> {
+            throw new CompletionException(new StreamSegmentNotExistsException(sn));
+        });
+        setAttributes(segmentName, segmentId, ATTRIBUTE_COUNT, context);
+        val segmentState = context.stateStore.get(segmentName, TIMEOUT).join();
+        Map<UUID, Long> expectedAttributes = segmentState == null ? null : segmentState.getAttributes();
+
+        AssertExtensions.assertThrows(
+                "getStreamSegmentInfo did not throw correct exception when segment does not exist in Metadata or Storage.",
+                () -> context.mapper.getStreamSegmentInfo(segmentName, TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        // Segment does not exist in Metadata, but does so in Storage.
+        // Since we do not setup an OperationLog, we guarantee that there is no attempt to map this in the metadata.
+        val segmentInfo = StreamSegmentInformation.builder()
+                                                  .name(segmentName)
+                                                  .length(123)
+                                                  .sealed(true)
+                                                  .build();
+        storageSegments.add(segmentName);
+        setupStorageGetHandler(context, storageSegments, sn -> segmentInfo);
+        val inStorageInfo = context.mapper.getStreamSegmentInfo(segmentName, TIMEOUT).join();
+        assertEquals("Unexpected SegmentInfo when Segment exists in Storage.", segmentInfo, inStorageInfo);
+        SegmentMetadataComparer.assertSameAttributes("Unexpected attributes when Segment exists in Storage", expectedAttributes, inStorageInfo);
+        Assert.assertEquals("Not expecting any segments to be mapped.", 0, context.metadata.getAllStreamSegmentIds().size());
+
+        // Segment exists in Metadata (and in Storage too) - here, we set different values in the Metadata to verify that
+        // the info is fetched from there.
+        val sm = context.metadata.mapStreamSegmentId(segmentName, segmentId);
+        sm.setLength(segmentInfo.getLength() + 1);
+        sm.updateAttributes(Collections.singletonMap(UUID.randomUUID(), 12345L));
+        val inMetadataInfo = context.mapper.getStreamSegmentInfo(segmentName, TIMEOUT).join();
+        assertEquals("Unexpected SegmentInfo when Segment exists in Metadata.", sm, inMetadataInfo);
+        SegmentMetadataComparer.assertSameAttributes("Unexpected attributes when Segment exists in Metadata.",
+                sm.getAttributes(), inMetadataInfo);
+
+        // Segment exists in Metadata, but is marked as deleted.
+        sm.markDeleted();
+        AssertExtensions.assertThrows(
+                "getStreamSegmentInfo did not throw correct exception when segment is marked as Deleted in metadata.",
+                () -> context.mapper.getStreamSegmentInfo(segmentName, TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+    }
+
+    /**
+     * Tests GetStreamSegmentInfo when it is invoked in parallel with a Segment assignment.
+     */
+    @Test
+    public void testGetStreamSegmentInfoWithConcurrency() throws Exception {
+        // is driven by the same code for Transactions as well.
+        final String segmentName = "Segment";
+        final long segmentId = 1;
+        final SegmentProperties storageInfo = StreamSegmentInformation.builder().name(segmentName).length(123).sealed(true).build();
+        final long metadataLength = storageInfo.getLength() + 1;
+
+        HashSet<String> storageSegments = new HashSet<>();
+        storageSegments.add(segmentName);
+
+        @Cleanup
+        TestContext context = new TestContext();
+        AtomicInteger storageGetCount = new AtomicInteger();
+        setupStorageGetHandler(context, storageSegments, sn -> {
+            storageGetCount.incrementAndGet();
+            return storageInfo;
+        });
+        setAttributes(segmentName, segmentId, ATTRIBUTE_COUNT, context);
+        val segmentState = context.stateStore.get(segmentName, TIMEOUT).join();
+        Map<UUID, Long> expectedAttributes = segmentState == null ? null : segmentState.getAttributes();
+
+        CompletableFuture<Void> addInvoked = new CompletableFuture<>();
+        context.operationLog.addHandler = op -> {
+            addInvoked.join();
+            // Need to set SegmentId on operation.
+            StreamSegmentMapOperation sop = ((StreamSegmentMapOperation) op);
+            UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(segmentName, segmentId);
+            segmentMetadata.setStorageLength(sop.getLength());
+            segmentMetadata.setLength(metadataLength);
+            segmentMetadata.updateAttributes(sop.getAttributes());
+            if (sop.isSealed()) {
+                segmentMetadata.markSealed();
+            }
+
+            return CompletableFuture.completedFuture(null);
+        };
+
+        // Second call is designed to hit when the first call still tries to assign the id, hence we test normal queueing.
+        context.mapper.getOrAssignStreamSegmentId(segmentName, TIMEOUT, id -> CompletableFuture.completedFuture(null));
+
+        // Concurrently with the map, request a Segment Info.
+        CompletableFuture<SegmentProperties> segmentInfoFuture = context.mapper.getStreamSegmentInfo(segmentName, TIMEOUT);
+        Assert.assertFalse("getSegmentInfo returned a completed future.", segmentInfoFuture.isDone());
+
+        // Release the OperationLog add and verify the Segment Info has been served with information from the Metadata.
+        addInvoked.complete(null);
+        SegmentProperties segmentInfo = segmentInfoFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        val expectedInfo = context.metadata.getStreamSegmentMetadata(segmentId);
+        assertEquals("Unexpected Segment Info returned.", expectedInfo, segmentInfo);
+        SegmentMetadataComparer.assertSameAttributes("Unexpected attributes returned.",
+                expectedInfo.getAttributes(), segmentInfo);
+    }
+
+    /**
      * Tests the ability of the StreamSegmentMapper to generate/return the Id of an existing StreamSegment, as well as
      * retrieving existing attributes.
      */
@@ -682,6 +796,13 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
                 }
             }
         };
+    }
+
+    private void assertEquals(String message, SegmentProperties expected, SegmentProperties actual) {
+        Assert.assertEquals(message + " getName() mismatch.", expected.getName(), actual.getName());
+        Assert.assertEquals(message + " isDeleted() mismatch.", expected.isDeleted(), actual.isDeleted());
+        Assert.assertEquals(message + " getLength() mismatch.", expected.getLength(), actual.getLength());
+        Assert.assertEquals(message + " isSealed() mismatch.", expected.isSealed(), actual.isSealed());
     }
 
     //region TestContext

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -264,7 +264,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
         context.operationLog.addHandler = op -> {
             addInvoked.join();
             // Need to set SegmentId on operation.
-            StreamSegmentMapOperation sop = ((StreamSegmentMapOperation) op);
+            StreamSegmentMapOperation sop = (StreamSegmentMapOperation) op;
             UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(segmentName, segmentId);
             segmentMetadata.setStorageLength(sop.getLength());
             segmentMetadata.setLength(metadataLength);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -268,7 +268,7 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
             UpdateableSegmentMetadata segmentMetadata = context.metadata.mapStreamSegmentId(segmentName, segmentId);
             segmentMetadata.setStorageLength(sop.getLength());
             segmentMetadata.setLength(metadataLength);
-            segmentMetadata.updateAttributes(sop.getAttributes());
+            segmentMetadata.updateAttributes(expectedAttributes);
             if (sop.isSealed()) {
                 segmentMetadata.markSealed();
             }


### PR DESCRIPTION
**Change log description**
Changed the way `StreamSegmentService.getStreamSegmentInfo` works in the case when segments are not currently active. 
- If a segment is active, its info is returned directly from the in-memory Metadata
- If a segment is not active, its info is returned from Tier2 Storage, without activating it. This is different than before, when the Segment was activated prior to returning the result.

Benefits include:
- Shorter latencies for inactive segments by not having to wait on also writing to Tier1
- Not activating a segment simply for a `getInfo` means that fewer segments are currently loaded in memory, thus potentially reducing footprint in a situation when we need to just get info on segments without actually touching them (this may be useful when implementing Retention).

**Purpose of the change**
Fixes #1923.

**What the code does**
See **Change log description**

**How to verify it**
New unit tests added to verify behavior in various scenarios.