### PR TITLE
Issue 1939: NPE during shutdown of ControllerNameResolver

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
@@ -188,7 +188,9 @@ public class ControllerResolverFactory extends NameResolver.Factory {
         public void shutdown() {
             if (!shutdown) {
                 log.info("Shutting down ControllerNameResolver");
-                this.scheduledExecutor.shutdownNow();
+                if (this.scheduledExecutor != null) {
+                    this.scheduledExecutor.shutdownNow();
+                }
                 shutdown = true;
             }
         }


### PR DESCRIPTION
**Change log description**
Check for null before ControllerNameResolver#shutdown.

**Purpose of the change**
Fixes #1939 

**What the code does**
Additional null check since an executor is not used in the direct scheme(tcp://) for controller, but is used only in a discover scheme (pravega://)

**How to verify it**
Tests should pass.