### PR TITLE
Issue 1953: Extended S3 Storage uses ECS namespace from the config

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageFactory.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageFactory.java
@@ -41,7 +41,8 @@ public class ExtendedS3StorageFactory implements StorageFactory {
     public Storage createStorageAdapter() {
         S3Config s3Config = new S3Config(config.getUrl())
                 .withIdentity(config.getAccessKey())
-                .withSecretKey(config.getSecretKey());
+                .withSecretKey(config.getSecretKey())
+                .withNamespace(config.getNamespace());
 
         S3JerseyClient client = new S3JerseyClient(s3Config);
         return new ExtendedS3Storage(client, this.config, this.executor);


### PR DESCRIPTION
**Change log description**
- Use namespace while creating a S3 client.

**Purpose of the change**
Fixes #1953. Uses ECS namespace config while creating S3 client.

**What the code does**
Use namespace while creating a S3 client.

**How to verify it**
Works with ECS configured with namespaces.