### PR TITLE
Issue 1961: (BugFix) Use correct overload of IOUtils.copyBytes in HDFSStorage

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/WriteOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/WriteOperation.java
@@ -17,7 +17,6 @@ import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.hdfs.protocol.AclException;
@@ -76,7 +75,12 @@ public class WriteOperation extends FileSystemOperation<HDFSSegmentHandle> imple
                 return;
             }
 
-            IOUtils.copyBytes(this.data, stream, this.length);
+            // We need to be very careful with IOUtils.copyBytes. There are many overloads with very similar signatures.
+            // There is a difference between (InputStream, OutputStream, int, boolean) and (InputStream, OutputStream, long, boolean),
+            // in that the one with "int" uses the third arg as a buffer size, and the one with "long" uses it as the number
+            // of bytes to copy.
+            IOUtils.copyBytes(this.data, stream, (long) this.length, false);
+
             stream.flush();
             lastFile.increaseLength(this.length);
         } catch (FileNotFoundException | AclException ex) {


### PR DESCRIPTION
**Change log description**
Fixed a bug in `WriteOperation` where it was using the wrong overload of `IOUtils.copyBytes`. The previous call was passing "length" as buffer size, thus causing the method to copy the entire `InputStream` as opposed from just how much we wanted.

Updated `StorageTestBase` to test for this case as well.

**Purpose of the change**
Fixes #1961 .

**What the code does**
Uses the correct overload of `IOUtils.copyBytes`.

**How to verify it**
Unit test updated to check this particular case. Also can verify the correct overload is used.