### PR TITLE
Issue 1959: Sporadic build failure in new StreamMetadataTasksTest.updateStreamTest

### DIFF
--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -213,10 +213,7 @@ public class StreamMetadataTasksTest {
         AtomicReference<State> streamState = new AtomicReference<>(State.ACTIVE);
         FutureHelpers.loop(() -> streamState.get().equals(State.ACTIVE),
                 () -> streamStorePartialMock.getState(SCOPE, stream1, true, null, executor)
-                        .thenAccept(state -> {
-                            streamState.set(state);
-
-                        }), executor).join();
+                        .thenAccept(streamState::set), executor).join();
 
         StreamConfiguration streamConfiguration2 = StreamConfiguration.builder()
                 .scope(SCOPE)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -206,6 +207,17 @@ public class StreamMetadataTasksTest {
 
         CompletableFuture<UpdateStreamStatus.Status> updateOperationFuture1 = streamMetadataTasks.updateStream(SCOPE, stream1,
                 streamConfiguration1, null);
+
+        // ensure that previous updatestream has posted the event and set status to updating,
+        // only then call second updateStream
+        AtomicReference<State> streamState = new AtomicReference<>(State.ACTIVE);
+        FutureHelpers.loop(() -> streamState.get().equals(State.ACTIVE),
+                () -> streamStorePartialMock.getState(SCOPE, stream1, true, null, executor)
+                        .thenAccept(state -> {
+                            streamState.set(state);
+
+                        }), executor).join();
+
 
         StreamConfiguration streamConfiguration2 = StreamConfiguration.builder()
                 .scope(SCOPE)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -218,7 +218,6 @@ public class StreamMetadataTasksTest {
 
                         }), executor).join();
 
-
         StreamConfiguration streamConfiguration2 = StreamConfiguration.builder()
                 .scope(SCOPE)
                 .streamName(stream1)


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
StreamMetadataTasksTest.updatestream test has a test to concurrently call two updatestream api calls. 
The problem is since both of them are processed asynchronously, second one can be processed before the first, hence breaking the expectations in the test. 
Hence we need to make sure that the first one has started processing before we post the second one to ensure guaranteed order of processing so test can verify correctly. 

**Purpose of the change**
Fixes #1959 

**What the code does**
After making first updateStream call, the test waits to see stream state being set to UPDATING ("first step" of update workflow) before making second update stream call.
This will ensure that first workflow is executed before second.. and test's expectation of first to succeed while second to fail with "conflict" holds true. 

**How to verify it**
The unit test in question to pass consistently. 