### PR TITLE
Issue 1967: Missing Getter import

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
 @Data
 @Builder


### PR DESCRIPTION
**Change log description**
* Adds missing import to ReaderGroupConfig.

**Purpose of the change**
Fixes #1967 

**What the code does**
Adds missing `lombok.Getter` import.

**How to verify it**
Build.
