### PR TITLE
Issue 1964: Sporadic build failure ZkCheckpointStoreConnectivityTest

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -99,7 +99,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NoNodeException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (Exception e) {
             throw new CheckpointStoreException(e);
@@ -162,7 +163,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NoNodeException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (CheckpointStoreException e) {
             throw e;
@@ -190,7 +192,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NoNodeException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (CheckpointStoreException e) {
             throw e;
@@ -267,7 +270,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NodeExistsException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NodeExists, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (Exception e) {
             throw new CheckpointStoreException(e);
@@ -283,7 +287,8 @@ class ZKCheckpointStore implements CheckpointStore {
             // Its ok if the node is already deleted, mask this exception.
         } catch (KeeperException.NotEmptyException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NodeNotEmpty, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (Exception e) {
             throw new CheckpointStoreException(e);
@@ -297,7 +302,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NoNodeException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (Exception e) {
             throw new CheckpointStoreException(e);
@@ -327,7 +333,8 @@ class ZKCheckpointStore implements CheckpointStore {
 
         } catch (KeeperException.NoNodeException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException e) {
+        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
+                | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
         } catch (Exception e) {
             throw new CheckpointStoreException(e);

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
@@ -33,7 +33,7 @@ public class ZkCheckpointStoreConnectivityTest {
 
     @Before
     public void setup() throws Exception {
-        cli = CuratorFrameworkFactory.newClient("localhost:0000", 1, 1, (r, e, s) -> false);
+        cli = CuratorFrameworkFactory.newClient("localhost:0000", 10000, 1, (r, e, s) -> false);
         cli.start();
         checkpointStore = CheckpointStoreFactory.createZKStore(cli);
     }


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
Throwing connectivity exception in case of zk session expiry.
In the test code, increased the session expiry time.

**Purpose of the change**
Fixes issue 1964

**What the code does**
Transforms zk session expiry exception into store.connectivity excepiton

**How to verify it**
Said test should pass consistently
