### PR TITLE
Issue 1929: Maven publishing fix

### DIFF
--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -12,8 +12,8 @@ import java.util.regex.Matcher
 
 plugins.withId('application') {
     configurations.archives.with {
-        artifacts.remove artifacts.find { it.archiveTask.is distZip }
-        artifacts.remove artifacts.find { it.archiveTask.is distTar }
+        artifacts.remove artifacts.find { it.hasProperty('archiveTask') && it.archiveTask.is(distZip) }
+        artifacts.remove artifacts.find { it.hasProperty('archiveTask') && it.archiveTask.is(distTar) }
     }
 
     task pathingJar(type: Jar) {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -34,6 +34,17 @@ plugins.withId('java') {
         classifier = 'sources'
         from sourceSets.main.java
     }
+    artifacts { archives sourceJar }
+
+    task generateJavadoc(type: Javadoc) {
+        source = sourceSets.main.allJava
+        failOnError = false
+    }
+    task javadocJar(type: Jar) {
+        classifier = 'javadoc'
+        from generateJavadoc
+    }
+    artifacts { archives javadocJar }
 
     task testJar(type: Jar) {
         classifier = 'tests'


### PR DESCRIPTION
**Change log description**
* Fixes the build for publishing artifacts to maven central.

* Adds source and javadocs jars as they are required by maven central.

*  Fixes the version specifier format  (it does not allow `2.+`) and sets the mockito version to 2.10.0.

**Purpose of the change**
Allow the artifacts to be uploaded to maven central and be released.

I used these changes locally on the release branch in order to publish the 0.1.0 release of pravega to maven central.

Fixes #1929 