### PR TITLE
Issue 1973: Update code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers. This code additionally applies to situations of inappropriate conduct when the project is perceived as having enabled such a situation. For example, when it can be established that the people involved in an incident have met through the project communication media
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers. This code additionally applies to situations of inappropriate conduct when the project is perceived as having enabled such a situation. For example, when it can be established that the people involved in an incident have met through the project communication media
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers. This code additionally applies to situations of inappropriate conduct when the project is perceived as having enabled such a situation. For example, when it can be established that the people involved in an incident have met through the project communication media.
 
 ## Enforcement
 


### PR DESCRIPTION
**Change log description**
Adds language to the code of conduct to enable it to apply to things that take place outside of official Pravega spaces, but occurred as a result of the individuals involved interactions with Pravega.

**Purpose of the change**
Fixes #1973 

**What the code does**
No code changes.

**How to verify it**
Manual inspection.