### PR TITLE
Issue 1982: Fix ReaderGroupNotificationTest and EndToEndWithScaleTest failure

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -144,7 +144,7 @@ public class ReaderGroupNotificationTest {
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
                 connectionFactory);
         ReaderGroup readerGroup = groupManager.createReaderGroup("reader", ReaderGroupConfig
-                .builder().build(), Collections
+                .builder().automaticCheckpointIntervalMillis(-1).build(), Collections
                 .singleton("test"));
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
@@ -124,8 +124,10 @@ public class EndToEndWithScaleTest {
         assertTrue(result);
         writer.writeEvent("0", "txntest2").get();
         @Cleanup
-        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory, connectionFactory);
-        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().build(), Collections.singleton("test"));
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
+                connectionFactory);
+        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().automaticCheckpointIntervalMillis(-1).
+                build(), Collections.singleton("test"));
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
                 ReaderConfig.builder().build());


### PR DESCRIPTION
**Change log description**
Disable automatic checkpointing for ReaderGroup as it is not required by the tests.
**Purpose of the change**
Fixes #1982 , #1983 
**What the code does**
Fixes flaky integration tests.
**How to verify it**
Tests should pass.