### PR TITLE
Issue 1971: Builder call to disable checkpoints

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -29,15 +29,26 @@ public class ReaderGroupConfig implements Serializable {
        private long automaticCheckpointIntervalMillis = 120000;
 
        /**
-         * Returns a config builder that started at  a given time.
+         * Returns a config builder that started at a given time.
          *
          * @param time A time to create sequence at.
-         * @return Sequence instance.
+         * @return Reader group config builder.
          */
        public ReaderGroupConfigBuilder startingTime(long time) {
            startingPosition = Sequence.create(time, 0);
            return this;
        }
-   }
 
+       /**
+        * Disables automatic checkpointing. Checkpoints need to be
+        * generated manually, {@see ReaderGroup#checkpoint}.
+        *
+        * @return Reader group config builder.
+        */
+
+       public ReaderGroupConfigBuilder disableAutomaticCheckpoints() {
+           this.automaticCheckpointIntervalMillis = -1;
+           return this;
+       }
+   }
 }

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -10,6 +10,7 @@
 package io.pravega.client.stream;
 
 import java.io.Serializable;
+import java.util.concurrent.ScheduledExecutorService;
 
 import lombok.Builder;
 import lombok.Data;
@@ -41,7 +42,9 @@ public class ReaderGroupConfig implements Serializable {
 
        /**
         * Disables automatic checkpointing. Checkpoints need to be
-        * generated manually, {@see ReaderGroup#checkpoint}.
+        * generated manually, see this method:
+        *
+        * {@link ReaderGroup#initiateCheckpoint(String, ScheduledExecutorService)}.
         *
         * @return Reader group config builder.
         */

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -80,7 +80,8 @@ public class CheckpointTest {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
         MockClientFactory clientFactory = streamManager.getClientFactory();
-        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().startingPosition(Sequence.MIN_VALUE).automaticCheckpointIntervalMillis(-1).build();
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().startingPosition(Sequence.MIN_VALUE)
+                                                                    .disableAutomaticCheckpoints().build();
         streamManager.createScope(scope);
         streamManager.createStream(scope, streamName, StreamConfiguration.builder()
                                                                          .scope(scope)

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -232,7 +232,8 @@ public class ReadTest {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
         MockClientFactory clientFactory = streamManager.getClientFactory();
-        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().startingPosition(Sequence.MIN_VALUE).automaticCheckpointIntervalMillis(-1).build();
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().startingPosition(Sequence.MIN_VALUE)
+                                                                   .disableAutomaticCheckpoints().build();
         streamManager.createScope(scope);
         streamManager.createStream(scope, streamName, null);
         streamManager.createReaderGroup(readerGroup, groupConfig, Collections.singleton(streamName));

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -144,7 +144,7 @@ public class ReaderGroupNotificationTest {
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
                 connectionFactory);
         ReaderGroup readerGroup = groupManager.createReaderGroup("reader", ReaderGroupConfig
-                .builder().automaticCheckpointIntervalMillis(-1).build(), Collections
+                .builder().disableAutomaticCheckpoints().build(), Collections
                 .singleton("test"));
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
@@ -126,7 +126,7 @@ public class EndToEndWithScaleTest {
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
                 connectionFactory);
-        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().automaticCheckpointIntervalMillis(-1).
+        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().disableAutomaticCheckpoints().
                 build(), Collections.singleton("test"));
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),


### PR DESCRIPTION
**Change log description**
* Adds a builder call to disable automatic checkpoints. Automatic checkpointing is enabled by default.

**Purpose of the change**
Fixes #1971 

**What the code does**
It adds a call to `ReaderGroupConfigBuilder` to disable automatic checkpointing. Previously, we required the application to set the interval to -1.

**How to verify it**
Build and run unit tests.
