### PR TITLE
Issue 1995: Stream cut API reader side

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -131,7 +131,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener {
      * A stream cut corresponds to a position in the stream, and it can be used by
      * the application as reference to such a position.
      *
-     * @return
+     * @return Map of streams that this group is reading from to the corresponding cuts.
      */
     Map<Stream, StreamCut> getStreamCuts();
 }

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -10,8 +10,10 @@
 package io.pravega.client.stream;
 
 import io.pravega.client.ClientFactory;
+import io.pravega.client.stream.impl.StreamCut;
 import io.pravega.client.stream.notifications.ReaderGroupNotificationListener;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -123,4 +125,13 @@ public interface ReaderGroup extends ReaderGroupNotificationListener {
      * @return Set of streams for this group.
      */
     Set<String> getStreamNames();
+
+    /**
+     * Returns a stream cut for each stream that this reader group is reading from.
+     * A stream cut corresponds to a position in the stream, and it can be used by
+     * the application as reference to such a position.
+     *
+     * @return
+     */
+    Map<Stream, StreamCut> getStreamCuts();
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -225,4 +225,21 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         checkNotNull(executor, "executor");
         return this.notifierFactory.getEndOfDataNotifier(executor);
     }
+
+    @Override
+    public Map<Stream, StreamCut> getStreamCuts() {
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
+        synchronizer.fetchUpdates();
+        ReaderGroupState state = synchronizer.getState();
+        Map<Stream, Map<Segment, Long>> positions = state.getPositions();
+        HashMap<Stream, StreamCut> cuts = new HashMap<>();
+
+        for (Entry<Stream, Map<Segment, Long>> streamPosition : positions.entrySet()) {
+            StreamCut position = new StreamCut(streamPosition.getKey(), streamPosition.getValue());
+            cuts.put(streamPosition.getKey(), position);
+        }
+
+        return cuts;
+    }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
@@ -9,9 +9,11 @@
  */
 package io.pravega.client.stream.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Stream;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -29,5 +31,14 @@ public class StreamCut implements Serializable {
     private final Stream stream;
     @Getter(value = AccessLevel.PACKAGE)
     private final Map<Segment, Long> positions;
-    
+
+    @VisibleForTesting
+    public boolean validate(List<String> segmentNames) {
+        boolean containsAll = true;
+        for(Segment s: positions.keySet()) {
+            containsAll = containsAll && segmentNames.contains(s.getScopedName());
+        }
+
+        return containsAll;
+    }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
@@ -35,8 +35,8 @@ public class StreamCut implements Serializable {
 
     @VisibleForTesting
     public boolean validate(Set<String> segmentNames) {
-        for(Segment s: positions.keySet()) {
-            if(segmentNames.contains(s.getScopedName())) {
+        for (Segment s: positions.keySet()) {
+            if (segmentNames.contains(s.getScopedName())) {
                 return false;
             }
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
@@ -36,7 +36,7 @@ public class StreamCut implements Serializable {
     @VisibleForTesting
     public boolean validate(Set<String> segmentNames) {
         for (Segment s: positions.keySet()) {
-            if (segmentNames.contains(s.getScopedName())) {
+            if (!segmentNames.contains(s.getScopedName())) {
                 return false;
             }
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCut.java
@@ -13,8 +13,9 @@ import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Stream;
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
@@ -33,12 +34,13 @@ public class StreamCut implements Serializable {
     private final Map<Segment, Long> positions;
 
     @VisibleForTesting
-    public boolean validate(List<String> segmentNames) {
-        boolean containsAll = true;
+    public boolean validate(Set<String> segmentNames) {
         for(Segment s: positions.keySet()) {
-            containsAll = containsAll && segmentNames.contains(s.getScopedName());
+            if(segmentNames.contains(s.getScopedName())) {
+                return false;
+            }
         }
 
-        return containsAll;
+        return true;
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -15,8 +15,6 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
-import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -32,7 +30,6 @@ import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamCut;
 import io.pravega.client.stream.impl.StreamImpl;
-import io.pravega.common.util.ReusableLatch;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
@@ -42,7 +39,6 @@ import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.generic.GenericData;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
@@ -51,10 +47,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -158,7 +153,7 @@ public class StreamCutsTest {
 
         reader.readNextEvent(15000);
         cuts = readerGroup.getStreamCuts();
-        ArrayList<String> segmentNames = new ArrayList<>();
+        HashSet<String> segmentNames = new HashSet<>();
         segmentNames.add("test/test/1");
         segmentNames.add("test/test/2");
         validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
@@ -202,7 +197,7 @@ public class StreamCutsTest {
         validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
     }
 
-    private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, List<String> segmentNames) {
+    private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, Set<String> segmentNames) {
         Set<String> streamNames = group.getStreamNames();
         cuts.forEach((s, c) -> {
                 assertTrue(streamNames.contains(s.getStreamName()));

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -138,7 +138,7 @@ public class StreamCutsTest {
         assertEquals("fpj was here again", secondEvent.getEvent());
 
         Map<Stream, StreamCut> cuts = readerGroup.getStreamCuts();
-        validateCuts(readerGroup, cuts, Collections.singletonList("test/test/0"));
+        validateCuts(readerGroup, cuts, Collections.singleton("test/test/0"));
 
         // Scale the stream to verify that we get more segments in the cut.
         Stream stream = new StreamImpl("test", "test");
@@ -156,7 +156,7 @@ public class StreamCutsTest {
         HashSet<String> segmentNames = new HashSet<>();
         segmentNames.add("test/test/1");
         segmentNames.add("test/test/2");
-        validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
+        validateCuts(readerGroup, cuts, Collections.unmodifiableSet(segmentNames));
 
         // Scale down to verify that the number drops back.
         map = new HashMap<>();
@@ -173,7 +173,7 @@ public class StreamCutsTest {
         reader.readNextEvent(15000);
 
         cuts = readerGroup.getStreamCuts();
-        validateCuts(readerGroup, cuts, Collections.singletonList("test/test/3"));
+        validateCuts(readerGroup, cuts, Collections.singleton("test/test/3"));
 
         // Scale up to 4 segments again.
         map = new HashMap<>();
@@ -189,12 +189,12 @@ public class StreamCutsTest {
         reader.readNextEvent(15000);
 
         cuts = readerGroup.getStreamCuts();
-        segmentNames = new ArrayList<>();
+        segmentNames = new HashSet<>();
         segmentNames.add("test/test/4");
         segmentNames.add("test/test/5");
         segmentNames.add("test/test/6");
         segmentNames.add("test/test/7");
-        validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
+        validateCuts(readerGroup, cuts, Collections.unmodifiableSet(segmentNames));
     }
 
     private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, Set<String> segmentNames) {

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.Checkpoint;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.StreamCut;
+import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.common.util.ReusableLatch;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericData;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class StreamCutsTest {
+
+    private final int controllerPort = TestUtils.getAvailableListenPort();
+    private final String serviceHost = "localhost";
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final int containerCount = 4;
+    private TestingServer zkTestServer;
+    private PravegaConnectionListener server;
+    private ControllerWrapper controllerWrapper;
+    private ServiceBuilder serviceBuilder;
+    private ScheduledExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+
+        server = new PravegaConnectionListener(false, servicePort, store);
+        server.startListening();
+
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                containerCount);
+        controllerWrapper.awaitRunning();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        controllerWrapper.close();
+        server.close();
+        serviceBuilder.close();
+        zkTestServer.close();
+    }
+
+    @Test(timeout = 40000)
+    public void testReaderGroupCuts() throws Exception {
+        StreamConfiguration config = StreamConfiguration.builder()
+                .scope("test")
+                .streamName("test")
+                .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                .build();
+        Controller controller = controllerWrapper.getController();
+        controllerWrapper.getControllerService().createScope("test").get();
+        controller.createStream(config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl("test", controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter("test", new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        writer.writeEvent("0", "fpj was here").get();
+        writer.writeEvent("0", "fpj was here again").get();
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
+                connectionFactory);
+        ReaderGroup readerGroup = groupManager.createReaderGroup("cuts", ReaderGroupConfig
+                .builder().disableAutomaticCheckpoints().build(), Collections
+                .singleton("test"));
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader("readerId", "cuts", new JavaSerializer<>(),
+                ReaderConfig.builder().build());
+
+        EventRead<String> firstEvent = reader.readNextEvent(15000);
+        EventRead<String> secondEvent = reader.readNextEvent(15000);
+        assertNotNull(firstEvent);
+        assertEquals("fpj was here", firstEvent.getEvent());
+        assertNotNull(secondEvent);
+        assertEquals("fpj was here again", secondEvent.getEvent());
+
+        Map<Stream, StreamCut> cuts = readerGroup.getStreamCuts();
+        validateCuts(readerGroup, cuts, Collections.singletonList("test/test/0"));
+
+        // Scale the stream to verify that we get more segments in the cut.
+        Stream stream = new StreamImpl("test", "test");
+        Map<Double, Double> map = new HashMap<>();
+        map.put(0.0, 0.5);
+        map.put(0.5, 1.0);
+        Boolean result = controller.scaleStream(stream, Collections.singletonList(0), map, executor).getFuture().get();
+        assertTrue(result);
+        log.info("Finished 1st scaling");
+        writer.writeEvent("0", "fpj was here again").get();
+        writer.writeEvent("1", "fpj was here again").get();
+
+        reader.readNextEvent(15000);
+        cuts = readerGroup.getStreamCuts();
+        ArrayList<String> segmentNames = new ArrayList<>();
+        segmentNames.add("test/test/1");
+        segmentNames.add("test/test/2");
+        validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
+
+        // Scale down to verify that the number drops back.
+        map = new HashMap<>();
+        map.put(0.0, 1.0);
+        ArrayList<Integer> toSeal = new ArrayList<>();
+        toSeal.add(1);
+        toSeal.add(2);
+        result = controller.scaleStream(stream, Collections.unmodifiableList(toSeal), map, executor).getFuture().get();
+        assertTrue(result);
+        log.info("Finished 2nd scaling");
+        writer.writeEvent("0", "fpj was here again").get();
+
+        reader.readNextEvent(15000);
+        reader.readNextEvent(15000);
+
+        cuts = readerGroup.getStreamCuts();
+        validateCuts(readerGroup, cuts, Collections.singletonList("test/test/3"));
+
+        // Scale up to 4 segments again.
+        map = new HashMap<>();
+        map.put(0.0, 0.25);
+        map.put(0.25, 0.5);
+        map.put(0.5, 0.75);
+        map.put(0.75, 1.0);
+        result = controller.scaleStream(stream, Collections.singletonList(3), map, executor).getFuture().get();
+        assertTrue(result);
+        log.info("Finished 3rd scaling");
+        writer.writeEvent("0", "fpj was here again").get();
+
+        reader.readNextEvent(15000);
+
+        cuts = readerGroup.getStreamCuts();
+        segmentNames = new ArrayList<>();
+        segmentNames.add("test/test/4");
+        segmentNames.add("test/test/5");
+        segmentNames.add("test/test/6");
+        segmentNames.add("test/test/7");
+        validateCuts(readerGroup, cuts, Collections.unmodifiableList(segmentNames));
+    }
+
+    private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, List<String> segmentNames) {
+        Set<String> streamNames = group.getStreamNames();
+        cuts.forEach((s, c) -> {
+                assertTrue(streamNames.contains(s.getStreamName()));
+                assertTrue(c.validate(segmentNames));
+        });
+    }
+}


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Adds a reader group call to obtain a stream cut.


**Purpose of the change**
Fixes #1995

**What the code does**
Adds a new API call to `ReaderGroup` and a corresponding implementation in `ReaderGroupImpl`. It adds an integration test case to check for a correct implementation.

**How to verify it**
Run tests.