### PR TITLE
Issue 1992: Unread bytes bug fix and test

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -188,6 +188,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
     public long unreadBytes() {
         @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
+        synchronizer.fetchUpdates();
         Map<Stream, Map<Segment, Long>> positions = synchronizer.getState().getPositions();
         SegmentMetadataClientFactory metaFactory = new SegmentMetadataClientFactoryImpl(controller, connectionFactory);
         

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupUnreadBytesTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupUnreadBytesTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReaderGroupUnreadBytesTest {
+
+    private final int controllerPort = TestUtils.getAvailableListenPort();
+    private final String serviceHost = "localhost";
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final int containerCount = 4;
+    private TestingServer zkTestServer;
+    private PravegaConnectionListener server;
+    private ControllerWrapper controllerWrapper;
+    private ServiceBuilder serviceBuilder;
+    private ScheduledExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+
+        server = new PravegaConnectionListener(false, servicePort, store);
+        server.startListening();
+
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                containerCount);
+        controllerWrapper.awaitRunning();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        controllerWrapper.close();
+        server.close();
+        serviceBuilder.close();
+        zkTestServer.close();
+    }
+
+    @Test(timeout = 40000)
+    public void testSegmentNotifications() throws Exception {
+        StreamConfiguration config = StreamConfiguration.builder()
+                .scope("test")
+                .streamName("test")
+                .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                .build();
+        Controller controller = controllerWrapper.getController();
+        controllerWrapper.getControllerService().createScope("test").get();
+        controller.createStream(config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl("test", controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter("test", new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        writer.writeEvent("0", "fpj was here").get();
+        writer.writeEvent("0", "fpj was here").get();
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
+                connectionFactory);
+        ReaderGroup readerGroup = groupManager.createReaderGroup("group", ReaderGroupConfig
+                .builder().disableAutomaticCheckpoints().build(), Collections
+                .singleton("test"));
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader("readerId", "group", new JavaSerializer<>(),
+                ReaderConfig.builder().build());
+
+
+        EventRead<String> firstEvent = reader.readNextEvent(15000);
+        EventRead<String> secondEvent = reader.readNextEvent(15000);
+        assertNotNull(firstEvent);
+        assertEquals("fpj was here", firstEvent.getEvent());
+        assertNotNull(secondEvent);
+        assertEquals("fpj was here", secondEvent.getEvent());
+
+        long unreadBytes = readerGroup.getMetrics().unreadBytes();
+        assertTrue(unreadBytes == 0);
+        writer.writeEvent("0", "fpj was here").get();
+
+        unreadBytes = readerGroup.getMetrics().unreadBytes();
+        assertTrue(unreadBytes > 0);
+    }
+}


### PR DESCRIPTION
**Change log description**
* Adds a call to fetchUpdates to ReaderGroupImpl.unreadBytes. This call populates the state of the synchronizer after creation.
* Adds an integration test to exercise the unreadBytes call.

**Purpose of the change**
Fixes #1992

**What the code does**
It adds a call to populate the state of the synchronizer after creation and an integration test to exercise unreadBytes.

The test added does not pass currently, though. The problem I am observing is that the values returned do not match my expectation. Specifically, the computation of the bytes read is return zero during that test case, even though I am reading events. The expectation seems to be that the bytes read values, determined by the assigned and unassigned segment structures in the reader group state, only changes after segment assignments. I have even tried triggering a checkpoint to see if it works.

**Please do not merge until this issue is resolved.**

**How to verify it**
Build, tests need to pass.