### PR TITLE
Issue 2003 : Disable automatic checkpointing in EndToEndTxnWithScaleTest 

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithScaleTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithScaleTest.java
@@ -134,7 +134,8 @@ public class EndToEndTxnWithScaleTest {
         transaction.commit();
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory, connectionFactory);
-        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().build(), Collections.singleton("test"));
+        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().disableAutomaticCheckpoints().build(),
+                Collections.singleton("test"));
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
                 ReaderConfig.builder().build());


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Disable automatic checkpointing in EndToEndTxnWIthScaleTest.
**Purpose of the change**
Fixes #2003 
**What the code does**
Fixes flaky integration test.
**How to verify it**
Tests should pass.