### PR TITLE
Issue 2005: Update bookkeeper to 4.5.0

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -23,8 +23,9 @@ RUN wget http://www.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bo
 &&  tar xvzf  bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
 &&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bk_all
 
+# zookeeper-3.5.3-beta.tar.gz is actually not compressed even though it is published as .tar.gz, so not using -z flag to untar
 RUN wget http://www.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
-&&  tar xvzf zookeeper-$ZOOKEEPER_VERSION.tar.gz \
+&&  tar xvf zookeeper-$ZOOKEEPER_VERSION.tar.gz \
 &&  mv zookeeper-$ZOOKEEPER_VERSION /opt/zk
 
 ENV bookiePort 3181

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -16,15 +16,16 @@ RUN apt-get update \
 &&  mkdir -p /opt \
 &&  cd /opt
 
-RUN wget http://www.apache.org/dist/bookkeeper/bookkeeper-4.4.0/bookkeeper-server-4.4.0-bin.tar.gz \
-&& tar xvzf  bookkeeper-server-4.4.0-bin.tar.gz \
-&& mkdir -p /opt/bk_all \
-&& mv bookkeeper-server-4.4.0/ /opt/bk_all/
+ENV BOOKKEEPER_VERSION=4.5.0 \
+    ZOOKEEPER_VERSION=3.5.3-beta
 
-RUN wget http://www.apache.org/dist/zookeeper/zookeeper-3.5.1-alpha/zookeeper-3.5.1-alpha.tar.gz \
-&& tar xvzf  zookeeper-3.5.1-alpha.tar.gz \
-&& mkdir -p /opt/zk \
-&& mv zookeeper-3.5.1-alpha/ /opt/zk/
+RUN wget http://www.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
+&&  tar xvzf  bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
+&&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bk_all
+
+RUN wget http://www.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
+&&  tar xvzf zookeeper-$ZOOKEEPER_VERSION.tar.gz \
+&&  mv zookeeper-$ZOOKEEPER_VERSION /opt/zk
 
 ENV bookiePort 3181
 

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -9,6 +9,9 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+ZK_HOME=/opt/zk
+BK_HOME=/opt/bk_all
+
 PORT0=${PORT0:-$bookiePort}
 PORT0=${PORT0:-3181}
 ZK_URL=${ZK_URL:-127.0.0.1:2181}
@@ -31,28 +34,28 @@ echo "ZK_URL is $ZK_URL"
 echo "BK_DIR is $BK_DIR"
 echo "BK_LEDGERS_PATH is $BK_LEDGERS_PATH"
 
-sed -i 's/3181/'$PORT0'/' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-sed -i "s/localhost:2181/${ZK_URL}/" /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-sed -i 's|journalDirectory=/tmp/bk-txn|journalDirectory='${BK_DIR}'/journal|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-sed -i 's|ledgerDirectories=/tmp/bk-data|ledgerDirectories='${BK_DIR}'/ledgers|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-sed -i 's|indexDirectories=/tmp/data/bk/ledgers|indexDirectories='${BK_DIR}'/index|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-sed -i 's|# zkLedgersRootPath=/ledgers|zkLedgersRootPath='${BK_LEDGERS_PATH}'|' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
+sed -i 's/3181/'$PORT0'/' ${BK_HOME}/conf/bk_server.conf
+sed -i "s/localhost:2181/${ZK_URL}/" ${BK_HOME}/conf/bk_server.conf
+sed -i 's|journalDirectory=/tmp/bk-txn|journalDirectory='${BK_DIR}'/journal|' ${BK_HOME}/conf/bk_server.conf
+sed -i 's|ledgerDirectories=/tmp/bk-data|ledgerDirectories='${BK_DIR}'/ledgers|' ${BK_HOME}/conf/bk_server.conf
+sed -i 's|indexDirectories=/tmp/data/bk/ledgers|indexDirectories='${BK_DIR}'/index|' ${BK_HOME}/conf/bk_server.conf
+sed -i 's|# zkLedgersRootPath=/ledgers|zkLedgersRootPath='${BK_LEDGERS_PATH}'|' ${BK_HOME}/conf/bk_server.conf
 
-sed -i '/autoRecoveryDaemonEnabled/d' /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
-echo autoRecoveryDaemonEnabled=${BK_AUTORECOVERY} >> /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
+sed -i '/autoRecoveryDaemonEnabled/d' ${BK_HOME}/conf/bk_server.conf
+echo autoRecoveryDaemonEnabled=${BK_AUTORECOVERY} >> ${BK_HOME}/conf/bk_server.conf
 
 echo "wait for zookeeper"
-until /opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL ls /; do sleep 2; done
+until ${ZK_HOME}/bin/zkCli.sh -server $ZK_URL ls /; do sleep 2; done
 
 echo "create the zk root"
-/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}
-/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}
-/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}
 
 echo "format the bookie"
 # format bookie
-BOOKIE_CONF=/opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf /opt/bk_all/bookkeeper-server-4.4.0/bin/bookkeeper shell metaformat -nonInteractive
+BOOKIE_CONF=${BK_HOME}/conf/bk_server.conf ${BK_HOME}/bin/bookkeeper shell metaformat -nonInteractive
 
 echo "start a new bookie"
 # start bookie,
-SERVICE_PORT=$PORT0 /opt/bk_all/bookkeeper-server-4.4.0/bin/bookkeeper bookie --conf /opt/bk_all/bookkeeper-server-4.4.0/conf/bk_server.conf
+SERVICE_PORT=$PORT0 ${BK_HOME}/bin/bookkeeper bookie --conf ${BK_HOME}/conf/bk_server.conf

--- a/docker/compose/Readme.md
+++ b/docker/compose/Readme.md
@@ -1,12 +1,12 @@
-#
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
+<!--
+Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
 # docker-compose
 
 Docker compose can be used to quickly spin up a Pravega cluster to use for testing or development. Unlike 


### PR DESCRIPTION
**Change log description**
This updates the bookkeeper docker image to be based on 4.5.0 to match the version of the 
 bookkeeper dependency.  This also updates the version of zookeeper in the bookkeeper container to 3.5.3-beta, since that is what bookkeeper 4.5.0 uses.
Additionally, I moved the BK and ZK in the containers to be one level higher so there are no version numbers in the paths which would require more changes anytime the versions change:
`/opt/bk_all/bookkeeper-server-<version>` -> `/opt/bk_all`
`/opt/zk/zookeeper-<version>` -> `/opt/zk`

**Purpose of the change**
Bring the versions of bookkeeper and zookeeper in the containers in line with what is used by the code.

**How to verify it**
Build and deploy (docker-compose is a quick way to get things up)