### PR TITLE
Issue 1997: BookKeeperLog uses a Retry-with-Backoff

### DIFF
--- a/common/src/test/java/io/pravega/common/concurrent/SequentialAsyncProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/SequentialAsyncProcessorTests.java
@@ -9,12 +9,16 @@
  */
 package io.pravega.common.concurrent;
 
+import io.pravega.common.ExceptionHelpers;
+import io.pravega.common.util.RetriesExhaustedException;
+import io.pravega.common.util.Retry;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -44,13 +48,18 @@ public class SequentialAsyncProcessorTests extends ThreadPooledTestSuite {
         val count = new AtomicInteger();
         val wasInvoked = new Semaphore(0);
         val waitOn = new CompletableFuture<Void>();
+        val retry = Retry.withExpBackoff(1, 2, 3)
+                         .retryWhen(t -> true)
+                         .throwingOn(Exception.class);
+        val error = new AtomicReference<Throwable>();
         val p = new SequentialAsyncProcessor(
                 () -> {
                     count.incrementAndGet();
                     wasInvoked.release();
                     waitOn.join();
                 },
-                (ex, c) -> true,
+                retry,
+                error::set,
                 executorService());
 
         // Invoke it a number of times.
@@ -76,24 +85,31 @@ public class SequentialAsyncProcessorTests extends ThreadPooledTestSuite {
         final int expectedCount = 2;
         val count = new AtomicInteger();
         val finished = new CompletableFuture<Void>();
+        val retry = Retry.withExpBackoff(1, 2, expectedCount)
+                         .retryWhen(t -> {
+                             if (count.get() >= expectedCount) {
+                                 finished.complete(null);
+                             }
+                             return ExceptionHelpers.getRealException(t) instanceof IntentionalException;
+                         })
+                         .throwingOn(Exception.class);
+        val error = new CompletableFuture<Throwable>();
         val p = new SequentialAsyncProcessor(
                 () -> {
                     count.incrementAndGet();
                     throw new IntentionalException();
                 },
-                (ex, c) -> {
-                    boolean done = count.get() >= expectedCount;
-                    if (done) {
-                        finished.complete(null);
-                    }
-                    return !done;
-                },
+                retry,
+                error::complete,
                 executorService());
 
         // Invoke it once.
         p.runAsync();
 
         finished.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        val finalException = ExceptionHelpers.getRealException(error.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
         Assert.assertEquals("Unexpected number of final invocations.", expectedCount, count.get());
+        Assert.assertTrue("Unexpected final error callback.", finalException instanceof RetriesExhaustedException
+                && ExceptionHelpers.getRealException(finalException.getCause()) instanceof IntentionalException);
     }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -20,6 +20,7 @@ import io.pravega.common.concurrent.SequentialAsyncProcessor;
 import io.pravega.common.util.ArrayView;
 import io.pravega.common.util.CloseableIterator;
 import io.pravega.common.util.RetriesExhaustedException;
+import io.pravega.common.util.Retry;
 import io.pravega.segmentstore.storage.DataLogInitializationException;
 import io.pravega.segmentstore.storage.DataLogNotAvailableException;
 import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
@@ -122,10 +123,29 @@ class BookKeeperLog implements DurableDataLog {
         this.logNodePath = HierarchyUtils.getPath(this.containerId, this.config.getZkHierarchyDepth());
         this.traceObjectId = String.format("Log[%d]", this.containerId);
         this.writes = new WriteQueue();
-        this.writeProcessor = new SequentialAsyncProcessor(this::processWritesSync, this::handleWriteProcessorFailures, this.executorService);
-        this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, this::handleRolloverFailure, this.executorService);
+        val retry = createRetryPolicy(this.config.getMaxWriteAttempts(), this.config.getBkWriteTimeoutMillis());
+        this.writeProcessor = new SequentialAsyncProcessor(this::processWritesSync, retry, this::handleWriteProcessorFailures, this.executorService);
+        this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, retry, this::handleRolloverFailure, this.executorService);
         this.metrics = new BookKeeperMetrics.BookKeeperLog(this.containerId);
         this.metricReporter = this.executorService.scheduleWithFixedDelay(this::reportMetrics, REPORT_INTERVAL, REPORT_INTERVAL, TimeUnit.MILLISECONDS);
+    }
+
+    private Retry.RetryAndThrowBase<Exception> createRetryPolicy(int maxWriteAttempts, int writeTimeout) {
+        int initialDelay = writeTimeout / maxWriteAttempts;
+        int maxDelay = writeTimeout * maxWriteAttempts;
+        return Retry.withExpBackoff(initialDelay, 2, maxWriteAttempts, maxDelay)
+                    .retryWhen(ex -> true) // Retry for every exception.
+                    .throwingOn(Exception.class);
+    }
+
+    private void handleWriteProcessorFailures(Throwable exception) {
+        log.warn("{}: Too many write processor failures; closing.", this.traceObjectId, exception);
+        close();
+    }
+
+    private void handleRolloverFailure(Throwable exception) {
+        log.warn("{}: Too many rollover failures; closing.", this.traceObjectId, exception);
+        close();
     }
 
     //endregion
@@ -285,24 +305,6 @@ class BookKeeperLog implements DurableDataLog {
         } else if (!processPendingWrites() && !this.closed.get()) {
             // We were not able to complete execution of all writes. Try again.
             this.writeProcessor.runAsync();
-        }
-    }
-
-    /**
-     * Handles a failure from the WriteProcessor.
-     *
-     * @param exception    The causing exception.
-     * @param failureCount The number of consecutive failures.
-     * @return True if the WriteProcessor should be reinvoked, false otherwise.
-     */
-    private boolean handleWriteProcessorFailures(Throwable exception, int failureCount) {
-        log.error("{}: processWritesSync (attempt {}/{}) failed.", this.traceObjectId, failureCount, this.config.getMaxWriteAttempts(), exception);
-        if (failureCount >= this.config.getMaxWriteAttempts()) {
-            log.warn("{}: Too many write processor failures; closing.", this.traceObjectId);
-            close();
-            return false;
-        } else {
-            return true;
         }
     }
 
@@ -725,9 +727,9 @@ class BookKeeperLog implements DurableDataLog {
      *
      * NOTE: this method is not thread safe and is not meant to be executed concurrently. It should only be invoked as
      * part of the Rollover Processor.
-     * @throws DurableDataLogException If an Exception happened during rollover.
      */
-    private void rollover() throws DurableDataLogException {
+    @SneakyThrows(DurableDataLogException.class) // Because this is an arg to SequentialAsyncProcessor, which wants a Runnable.
+    private void rollover() {
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "rollover");
         val l = getWriteLedger().ledger;
         if (!l.isClosed() && l.getLength() < this.config.getBkLedgerMaxSize()) {
@@ -764,8 +766,8 @@ class BookKeeperLog implements DurableDataLog {
                 this.logMetadata = metadata;
             }
 
-            // Close the old ledger. This must be done outside of the lock, otherwise the pending writes (and their callbacks
-            // will be invoked within the lock, thus likely candidates for deadlocks).
+            // Close the old ledger. This must be done outside of the lock, otherwise the pending writes (and their callbacks)
+            // will be invoked within the lock, thus likely candidates for deadlocks.
             Ledgers.close(oldLedger);
             log.info("{}: Rollover: swapped ledger and metadata pointers (Old = {}, New = {}) and closed old ledger.",
                     this.traceObjectId, oldLedger.getId(), newLedger.getId());
@@ -774,24 +776,6 @@ class BookKeeperLog implements DurableDataLog {
             // ledger length. Invoke the Write Processor to execute them.
             this.writeProcessor.runAsync();
             LoggerHelpers.traceLeave(log, this.traceObjectId, "rollover", traceId, true);
-        }
-    }
-
-    /**
-     * Handles a failure from the Rollover Processor.
-     *
-     * @param exception    The causing exception.
-     * @param failureCount The number of consecutive failures.
-     * @return True if the RolloverProcessor should be reinvoked, false otherwise.
-     */
-    private boolean handleRolloverFailure(Throwable exception, int failureCount) {
-        log.error("{}: Rollover failure (attempt {}/{}); log may be unusable.", this.traceObjectId, failureCount, this.config.getMaxWriteAttempts(), exception);
-        if (failureCount >= this.config.getMaxWriteAttempts()) {
-            log.warn("{}: Too many rollover failures; closing.", this.traceObjectId);
-            close();
-            return false;
-        } else {
-            return true;
         }
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
@@ -14,7 +14,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Builder;
 import lombok.Cleanup;
@@ -49,7 +51,7 @@ public class BookKeeperServiceRunner implements AutoCloseable {
     private final List<Integer> bookiePorts;
     private final List<BookieServer> servers = new ArrayList<>();
     private final AtomicReference<ZooKeeperServiceRunner> zkServer = new AtomicReference<>();
-    private final List<File> tempDirs = new ArrayList<>();
+    private final HashMap<Integer, File> tempDirs = new HashMap<>();
     private final AtomicReference<Thread> cleanup = new AtomicReference<>();
 
     //endregion
@@ -59,10 +61,7 @@ public class BookKeeperServiceRunner implements AutoCloseable {
     @Override
     public void close() throws Exception {
         try {
-            for (BookieServer bs : this.servers) {
-                bs.shutdown();
-            }
-
+            this.servers.stream().filter(Objects::nonNull).forEach(BookieServer::shutdown);
             if (this.zkServer.get() != null) {
                 this.zkServer.get().close();
             }
@@ -86,29 +85,30 @@ public class BookKeeperServiceRunner implements AutoCloseable {
     //region BookKeeper operations
 
     /**
-     * Suspends the BookieService with the given index (does not stop it).
+     * Stops the BookieService with the given index.
      *
      * @param bookieIndex The index of the bookie to stop.
-     * @throws ArrayIndexOutOfBoundsException If bookieIndex is invalid.
      */
-    public void suspendBookie(int bookieIndex) {
+    public void stopBookie(int bookieIndex) {
         Preconditions.checkState(this.servers.size() > 0, "No Bookies initialized. Call startAll().");
+        Preconditions.checkState(this.servers.get(0) != null, "Bookie already stopped.");
         val bk = this.servers.get(bookieIndex);
-        bk.suspendProcessing();
-        log.info("Bookie {} suspended.", bookieIndex);
+        bk.shutdown();
+        this.servers.set(bookieIndex, null);
+        log.info("Bookie {} stopped.", bookieIndex);
     }
 
     /**
-     * Resumes the BookieService with the given index.
+     * Restarts the BookieService with the given index.
      *
-     * @param bookieIndex The index of the bookie to start.
-     * @throws ArrayIndexOutOfBoundsException If bookieIndex is invalid.
+     * @param bookieIndex The index of the bookie to restart.
+     * @throws Exception If an exception occurred.
      */
-    public void resumeBookie(int bookieIndex) {
+    public void startBookie(int bookieIndex) throws Exception {
         Preconditions.checkState(this.servers.size() > 0, "No Bookies initialized. Call startAll().");
-        val bk = this.servers.get(bookieIndex);
-        bk.resumeProcessing();
-        log.info("Bookie {} resumed.", bookieIndex);
+        Preconditions.checkState(this.servers.get(0) == null, "Bookie already running.");
+        this.servers.set(bookieIndex, runBookie(this.bookiePorts.get(bookieIndex)));
+        log.info("Bookie {} stopped.", bookieIndex);
     }
 
     /**
@@ -159,8 +159,7 @@ public class BookKeeperServiceRunner implements AutoCloseable {
         }
 
         initializeZookeeper();
-        val baseConf = new ServerConfiguration();
-        runBookies(baseConf);
+        runBookies();
     }
 
     private void initializeZookeeper() throws Exception {
@@ -186,40 +185,49 @@ public class BookKeeperServiceRunner implements AutoCloseable {
         zkc.create(znodePath.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
 
-    private void runBookies(ServerConfiguration baseConf) throws Exception {
+    private void runBookies() throws Exception {
         log.info("Starting Bookie(s) ...");
-        // Create Bookie Servers (B1, B2, B3)
         for (int bkPort : this.bookiePorts) {
-            val tmpDir = IOUtils.createTempDir("bookie_" + bkPort, "test");
+            this.servers.add(runBookie(bkPort));
+        }
+    }
+
+    private BookieServer runBookie(int bkPort) throws Exception {
+        // Attempt to reuse an existing data directory. This is useful in case of stops & restarts, when we want to perserve
+        // already committed data.
+        File tmpDir = this.tempDirs.getOrDefault(bkPort, null);
+        if (tmpDir == null) {
+            tmpDir = IOUtils.createTempDir("bookie_" + bkPort, "test");
             tmpDir.deleteOnExit();
-            this.tempDirs.add(tmpDir);
+            this.tempDirs.put(bkPort, tmpDir);
             log.info("Created " + tmpDir);
             if (!tmpDir.delete() || !tmpDir.mkdir()) {
                 throw new IOException("Couldn't create bookie dir " + tmpDir);
             }
-
-            // override settings
-            val conf = new ServerConfiguration(baseConf);
-            conf.setBookiePort(bkPort);
-            conf.setZkServers(LOOPBACK_ADDRESS.getHostAddress() + ":" + this.zkPort);
-            conf.setJournalDirName(tmpDir.getPath());
-            conf.setLedgerDirNames(new String[]{ tmpDir.getPath() });
-            conf.setAllowLoopback(true);
-            conf.setJournalAdaptiveGroupWrites(false);
-            conf.setZkLedgersRootPath(ledgersPath);
-
-            log.info("Starting Bookie at port " + bkPort);
-            val bs = new BookieServer(conf);
-            this.servers.add(bs);
-            bs.start();
         }
+
+        val conf = new ServerConfiguration();
+        conf.setBookiePort(bkPort);
+        conf.setZkServers(LOOPBACK_ADDRESS.getHostAddress() + ":" + this.zkPort);
+        conf.setJournalDirName(tmpDir.getPath());
+        conf.setLedgerDirNames(new String[]{tmpDir.getPath()});
+        conf.setAllowLoopback(true);
+        conf.setJournalAdaptiveGroupWrites(false);
+        conf.setZkLedgersRootPath(ledgersPath);
+
+        log.info("Starting Bookie at port " + bkPort);
+        val bs = new BookieServer(conf);
+        bs.start();
+        return bs;
     }
 
     private void cleanupDirectories() throws IOException {
-        for (File dir : this.tempDirs) {
+        for (File dir : this.tempDirs.values()) {
             log.info("Cleaning up " + dir);
             FileUtils.deleteDirectory(dir);
         }
+
+        this.tempDirs.clear();
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Write.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Write.java
@@ -173,6 +173,12 @@ class Write {
         }
 
         endAttempt();
+        WriteLedger ledger = this.writeLedger.get();
+        if (ledger != null && ledger.isRolledOver()) {
+            // Rollovers aren't really failures (they're caused by us). In that case, do not count this failure as an attempt.
+            this.attemptCount.updateAndGet(v -> Math.max(0, v - 1));
+        }
+
         if (complete) {
             this.result.completeExceptionally(this.failureCause.get());
         }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
-import ch.qos.logback.classic.LoggerContext;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.FutureHelpers;
 import io.pravega.common.util.ByteArraySegment;
@@ -47,7 +46,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.slf4j.LoggerFactory;
 
 /**
  * Unit tests for BookKeeperLog. These require that a compiled BookKeeper distribution exists on the local
@@ -77,9 +75,6 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
      */
     @BeforeClass
     public static void setUpBookKeeper() throws Exception {
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        context.reset();
-
         // Pick a random port to reduce chances of collisions during concurrent test executions.
         BK_PORT.set(TestUtils.getAvailableListenPort());
         val bookiePorts = new ArrayList<Integer>();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -60,7 +60,7 @@ public class BookKeeperLogTests extends DurableDataLogTestBase {
     private static final int WRITE_COUNT = 500;
     private static final int BOOKIE_COUNT = 1;
     private static final int THREAD_POOL_SIZE = 20;
-    private static final int MAX_WRITE_ATTEMPTS = 5;
+    private static final int MAX_WRITE_ATTEMPTS = 3;
     private static final int MAX_LEDGER_SIZE = WRITE_MAX_LENGTH * Math.max(10, WRITE_COUNT / 20);
 
     private static final AtomicReference<BookKeeperServiceRunner> BK_SERVICE = new AtomicReference<>();


### PR DESCRIPTION
**Change log description**
- Updated `BookKeeperLog`'s WriteProcessor and RolloverProcessor to use a retry-with-backoff when they encounter errors.
- Updated `SequentialAsyncProcessor` to use a standard retry policy instead of the mechanism it had previously.
- Not counting write failures due to rollovers as "failed attempts", since they were caused by an action by us.
- BookKeeperLog unit tests: actually stopping Bookies completely (instead of just stopping their Netty interfaces). This more closely resembles a real-life failure.

**Purpose of the change**
Fixes #1997.

**What the code does**
See Change Log Description.

**How to verify it**
Verify that the build passes consistently.