### PR TITLE
Issue 2016: Sporadic test failure EndToEndTruncationTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -131,7 +131,7 @@ public class EndToEndTruncationTest {
         streamCutPositions.put(3, 0L);
         streamCutPositions.put(4, 0L);
 
-        controller.truncateStream(stream.getStreamName(), stream.getStreamName(), streamCutPositions);
+        controller.truncateStream(stream.getStreamName(), stream.getStreamName(), streamCutPositions).join();
 
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory,
@@ -142,6 +142,7 @@ public class EndToEndTruncationTest {
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
                 ReaderConfig.builder().build());
+
         EventRead<String> event = reader.readNextEvent(10000);
         assertNotNull(event);
         assertEquals("truncationTest2", event.getEvent());


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
The test fails sporadically because we start truncation but do not wait for truncation to complete. 

**What the code does**
Adds a wait on future. 

**How to verify it**
Test should pass consistently. 