### PR TITLE
Issue 2019: Removing unneeded and flaky unit tests

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -730,19 +730,14 @@ class BookKeeperLog implements DurableDataLog {
      */
     @SneakyThrows(DurableDataLogException.class) // Because this is an arg to SequentialAsyncProcessor, which wants a Runnable.
     private void rollover() {
-        long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "rollover");
-        val wl = getWriteLedger();
-        if (wl == null) {
-            if (!this.closed.get()) {
-                throw new IllegalStateException("WriteLedger is null but BookKeeperLog is not closed.");
-            }
-
-            // BookKeeperLog is closed.
-            LoggerHelpers.traceLeave(log, this.traceObjectId, "rollover", traceId, false);
+        if (this.closed.get()) {
+            // BookKeeperLog is closed; no point in running this.
             return;
         }
 
-        if (!wl.ledger.isClosed() && wl.ledger.getLength() < this.config.getBkLedgerMaxSize()) {
+        long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "rollover");
+        val l = getWriteLedger().ledger;
+        if (!l.isClosed() && l.getLength() < this.config.getBkLedgerMaxSize()) {
             // Nothing to do. Trigger the write processor just in case this rollover was invoked because the write
             // processor got a pointer to a LedgerHandle that was just closed by a previous run of the rollover processor.
             this.writeProcessor.runAsync();


### PR DESCRIPTION
**Change log description**
Removed the following unit tests from `BookKeeperLogTests`
- `testAutoCloseOnZooKeeperFailure`
- `testAppendTransientZooKeeperFailure`

These were causing sporadic build failures due to timeouts since they were stopping and then quickly restarting ZooKeeper during the test. In case that didn't work out it would be possible for the unit test to not complete due to the ZK clients (ours, and the one in BK) endlessly trying to reconnect.

These unit tests do not test anything in addition to what their siblings do (the ones that stop/start BookKeeper) and rely on BookKeeper's internal mechanism for ZK reconnection to succeed. 

Also changed:
- Do not perform rollover in BookKeeperLog if the instance is closed. This was caught up in one of these failed runs and it would have been possible since the Rollover Processor is running asynchronously and a call to `close` would not necessarily stop one from executing.

**Purpose of the change**
Fixes #2019 

**What the code does**
Removes two unit tests.

**How to verify it**
Travis and Jenkins tests must succeed. Verify in Jenkins using branch builder.