### PR TITLE
Issue 2040: Reduced bookie count in SegmentStore integration test

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -39,7 +39,7 @@ import org.junit.Before;
 public class ExtendedS3IntegrationTest extends StreamSegmentStoreTestBase {
     //region Test Configuration and Setup
 
-    private static final int BOOKIE_COUNT = 3;
+    private static final int BOOKIE_COUNT = 1;
     private String endpoint;
     private BookKeeperRunner bookkeeper = null;
     private String baseDir;

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.Before;
 public class FileSystemIntegrationTest extends StreamSegmentStoreTestBase {
     //region Test Configuration and Setup
 
-    private static final int BOOKIE_COUNT = 3;
+    private static final int BOOKIE_COUNT = 1;
     private File baseDir = null;
     private BookKeeperRunner bookkeeper = null;
     /**

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -34,7 +34,7 @@ import org.junit.Before;
 public class HDFSIntegrationTest extends StreamSegmentStoreTestBase {
     //region Test Configuration and Setup
 
-    private static final int BOOKIE_COUNT = 3;
+    private static final int BOOKIE_COUNT = 1;
     private File baseDir = null;
     private MiniDFSCluster hdfsCluster = null;
     private BookKeeperRunner bookkeeper = null;


### PR DESCRIPTION
**Change log description**
Reduced the number of bookies in integration tests from 3 to 1. Since they're all in process, there's no point in over-replicating the data, which just slows things down.

**Purpose of the change**
Fixes #2040.

**What the code does**
Nothing different.

**How to verify it**
Build must pass.