### PR TITLE
Issue 2042: Ensure only one reader aquires a segment.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -293,6 +293,7 @@ public class ReaderGroupStateManager {
         AtomicReference<Map<Segment, Long>> result = new AtomicReference<>();
         AtomicBoolean reinitRequired = new AtomicBoolean(false);
         sync.updateState(state -> {
+            result.set(Collections.emptyMap());
             if (!state.isReaderOnline(readerId)) {
                 reinitRequired.set(true);
                 return null;
@@ -302,7 +303,6 @@ public class ReaderGroupStateManager {
             }
             int toAcquire = calculateNumSegmentsToAcquire(state);
             if (toAcquire == 0) {
-                result.set(Collections.emptyMap());
                 return null;
             }
             Map<Segment, Long> unassignedSegments = state.getUnassignedSegments();


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <Tom.Kaitchuck@emc.com>

**Change log description**
Ensure only one reader acquires a segment.

**Purpose of the change**
Fixes #2042 .
The acquireSegment logic is broken. It has two possible early return paths in the update function. However these do not reset the result variable. This has the effect of keeping the result from a previous iteration of update.

**What the code does**
It now resets the result immediately, so that regardless of where the function returns nothing is carried over from the previous iteration.

**How to verify it**
No tests, are added here. But as this is a pattern, I've filed #2043 to cover this pattern. Once this change is made it will be easy to prevent this pattern all together, and add tests for it.