### PR TITLE
Issue 2050: SelfTester reports operations per second

### DIFF
--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
@@ -88,11 +88,17 @@ public class TestState {
     //region Properties
 
     /**
+     * Gets the throughput measured in Operations per Second.
+     */
+    double getOperationsPerSecond() {
+        return this.successfulOperationCount.get() / getElapsedSeconds();
+    }
+
+    /**
      * Gets the throughput since the last time reset() was called in Bytes/Second.
      */
     double getThroughput() {
-        double durationSeconds = (this.lastAppendTime.get() - this.startTimeNanos.get()) / NANOS_PER_SECOND;
-        return this.producedLength.get() / durationSeconds;
+        return this.producedLength.get() / getElapsedSeconds();
     }
 
     /**
@@ -226,6 +232,10 @@ public class TestState {
      */
     LatencyCollection getDurations(OperationType operationType) {
         return this.durations.get(operationType);
+    }
+
+    private double getElapsedSeconds() {
+        return (this.lastAppendTime.get() - this.startTimeNanos.get()) / NANOS_PER_SECOND;
     }
 
     //endregion


### PR DESCRIPTION
**Change log description**
SelfTester reports operations per second, in addition to all other metrics it used to report.

**Purpose of the change**
Fixes #2050. Needed for performance benchmarks.

**What the code does**
SelfTester reports new metric.

**How to verify it**
Sample output (check out newly added `Ops = <instant>/<overall>`):
(disregard actual numbers; this was done on a dev machine without controlling for the environment)
```
0:00:01.779 [SelfTest]: Started.
0:00:02.780 [Reporter]: (warmup); Ops = 0/35646; Data: 3.4 MB; TPut: 0.0/3.4 MB/s; TPools (Q/T/S): S = 4/5/30, T = 0/1/80, FJ = 0/0/0.
0:00:03.787 [Reporter]: (warmup); Ops = 141111/88882; Data: 17.0 MB; TPut: 13.5/8.5 MB/s; TPools (Q/T/S): S = 4/6/30, T = 115/1/80, FJ = 0/0/0.
0:00:04.787 [Reporter]: 162296/2000000; Ops = 0/175216; Data: 15.5 MB; TPut: 0.0/16.7 MB/s; TPools (Q/T/S): S = 7/6/30, T = 0/1/80, FJ = 0/0/0.
0:00:05.790 [Reporter]: 345077/2000000; Ops = 182237/178867; Data: 32.9 MB; TPut: 17.4/17.1 MB/s; TPools (Q/T/S): S = 7/5/30, T = 3373/1/80, FJ = 0/0/0.
0:00:06.791 [Reporter]: 502726/2000000; Ops = 157586/171630; Data: 47.9 MB; TPut: 15.0/16.4 MB/s; TPools (Q/T/S): S = 5/4/30, T = 2/1/80, FJ = 0/0/0.
0:00:07.791 [Reporter]: 622617/2000000; Ops = 119862/159180; Data: 59.4 MB; TPut: 11.4/15.2 MB/s; TPools (Q/T/S): S = 4/7/30, T = 0/1/80, FJ = 0/0/0.
0:00:08.791 [Reporter]: 801043/2000000; Ops = 178368/165605; Data: 76.4 MB; TPut: 17.0/15.8 MB/s; TPools (Q/T/S): S = 4/4/30, T = 0/1/80, FJ = 0/0/0.
0:00:09.792 [Reporter]: 951885/2000000; Ops = 150808/160508; Data: 90.8 MB; TPut: 14.4/15.3 MB/s; TPools (Q/T/S): S = 4/5/30, T = 0/1/80, FJ = 0/0/0.
0:00:10.792 [Reporter]: 1168886/2000000; Ops = 216937/168651; Data: 111.5 MB; TPut: 20.7/16.1 MB/s; TPools (Q/T/S): S = 5/5/30, T = 0/1/80, FJ = 0/0/0.
0:00:11.792 [Reporter]: 1323422/2000000; Ops = 154484/167295; Data: 126.2 MB; TPut: 14.7/16.0 MB/s; TPools (Q/T/S): S = 4/4/30, T = 0/1/80, FJ = 0/0/0.
0:00:12.792 [Reporter]: 1499627/2000000; Ops = 176159/167904; Data: 143.0 MB; TPut: 16.8/16.0 MB/s; TPools (Q/T/S): S = 4/5/30, T = 22/2/80, FJ = 0/0/0.
0:00:13.796 [Reporter]: 1628384/2000000; Ops = 128292/163971; Data: 155.3 MB; TPut: 12.2/15.6 MB/s; TPools (Q/T/S): S = 5/3/30, T = 0/2/80, FJ = 0/0/0.
0:00:14.797 [Reporter]: 1822285/2000000; Ops = 193810/166640; Data: 173.8 MB; TPut: 18.5/15.9 MB/s; TPools (Q/T/S): S = 4/5/30, T = 194/3/80, FJ = 0/0/0.
0:00:15.797 [Reporter]: 1992634/2000000; Ops = 170307/166946; Data: 190.0 MB; TPut: 16.2/15.9 MB/s; TPools (Q/T/S): S = 5/4/30, T = 1/2/80, FJ = 0/0/0.
0:00:15.982 [Reporter]: 2009996/2000000; Ops = 93908/166099; Data: 191.7 MB; TPut: 9.0/15.8 MB/s; TPools (Q/T/S): S = 5/1/30, T = 0/1/80, FJ = 0/0/0.
```