### PR TITLE
Issue 2054: Ensure Bookkeeper port is mentioned in marathon healthCheck.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/BookkeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/BookkeeperService.java
@@ -120,7 +120,7 @@ public class BookkeeperService extends MarathonBasedService {
         app.setEnv(map);
         //healthchecks
         List<HealthCheck> healthCheckList = new ArrayList<>();
-        healthCheckList.add(setHealthCheck(900, "TCP", false, 60, 20, 0));
+        healthCheckList.add(setHealthCheck(900, "TCP", false, 60, 20, 0, BK_PORT));
         app.setHealthChecks(healthCheckList);
 
         return app;


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure bookkeeper port is mentioned while setting the health check for bookkeeper service.

**Purpose of the change**
Fixes #2054 

**What the code does**
Add port to Bookkeeper service healthcheck.

**How to verify it**
Tests on mesos should pass.