### PR TITLE
Issue 2057 : (Bugfix) Remove redundant close() call in ConnectionFactoryImpl .

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -127,7 +127,6 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                         connectionComplete.complete(handler);
                     } else {
                         connectionComplete.completeExceptionally(new ConnectionFailedException(future.cause()));
-                        future.channel().close(); // close channel in case of failure.
                     }
                 }
             });


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Removes redundant `channel.close()` call incase the bootstrap.connect() operation fails.

**Purpose of the change**
Fixes #2057 

**What the code does**
Removes the redundant `close()` method call.

**How to verify it**
Tests should pass.