### PR TITLE
Issue 2054: (Bugfix) Additional health check is causing the failover tests to timeout/fail.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -45,7 +45,6 @@ public class RemoteSequential implements TestExecutor {
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {
-
         log.debug("Starting test execution for method: {}", testMethod);
 
         String className = testMethod.getDeclaringClass().getName();
@@ -85,7 +84,7 @@ public class RemoteSequential implements TestExecutor {
 
     private CompletableFuture<Void> waitForJobCompletion(final String jobId) {
         return Futures.loop(() -> isTestRunning(jobId),
-                () -> Futures.delayedFuture(Duration.ofSeconds(3), executorService),
+                () -> Futures.delayedFuture(Duration.ofSeconds(10), executorService),
                 executorService);
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -118,8 +118,8 @@ public class RemoteSequential implements TestExecutor {
                 className + "#" + methodName + " > server.log 2>&1" +
                 "; exit $?");
 
-        run.setCpus(0.5);
-        run.setMem(64.0);
+        run.setCpus(1.5); //CPU shares.
+        run.setMem(512.0); //amount of memory required for running test in MB.
         run.setDisk(50.0);
         run.setEnv(env);
         run.setMaxLaunchDelay(3600);

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -45,7 +45,7 @@ public class RemoteSequential implements TestExecutor {
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {
-        Exceptions.handleInterrupted(() -> TimeUnit.MINUTES.sleep(1)); //wait for a minute before starting tests.
+        Exceptions.handleInterrupted(() -> TimeUnit.SECONDS.sleep(30)); //wait for a minute before starting tests.
         // This will be removed once issue https://github.com/pravega/pravega/issues/1665 is resolved.
         log.debug("Starting test execution for method: {}", testMethod);
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -45,6 +45,8 @@ public class RemoteSequential implements TestExecutor {
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {
+        Exceptions.handleInterrupted(() -> TimeUnit.MINUTES.sleep(1)); //wait for a minute before starting tests.
+        // This will be removed once issue https://github.com/pravega/pravega/issues/1665 is resolved.
         log.debug("Starting test execution for method: {}", testMethod);
 
         String className = testMethod.getDeclaringClass().getName();

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -45,7 +45,7 @@ public class RemoteSequential implements TestExecutor {
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {
-        Exceptions.handleInterrupted(() -> TimeUnit.SECONDS.sleep(30)); //wait for a minute before starting tests.
+        Exceptions.handleInterrupted(() -> TimeUnit.SECONDS.sleep(60));
         // This will be removed once issue https://github.com/pravega/pravega/issues/1665 is resolved.
         log.debug("Starting test execution for method: {}", testMethod);
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/BookkeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/BookkeeperService.java
@@ -110,7 +110,7 @@ public class BookkeeperService extends MarathonBasedService {
         app.setEnv(map);
         //healthchecks
         List<HealthCheck> healthCheckList = new ArrayList<>();
-        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, BK_PORT));
+        healthCheckList.add(setHealthCheck(300, "TCP", false, 60, 20, 0, BK_PORT));
         app.setHealthChecks(healthCheckList);
 
         return app;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -132,7 +132,7 @@ public abstract class MarathonBasedService implements Service {
 
     CompletableFuture<Void> waitUntilServiceRunning() {
         return Futures.loop(() -> !isRunning(), //condition
-                () -> Futures.delayedFuture(Duration.ofSeconds(5), executorService),
+                () -> Futures.delayedFuture(Duration.ofSeconds(20), executorService),
                 executorService);
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -45,12 +45,11 @@ import static io.pravega.test.system.framework.TestFrameworkException.Type.Reque
 @Slf4j
 public abstract class MarathonBasedService implements Service {
 
-    static final boolean FORCE_IMAGE = false;
     static final int ZKSERVICE_ZKPORT = 2181;
-    static final String CONTAINER_TYPE = "DOCKER";
-    static final String IMAGE_PATH = System.getProperty("dockerImageRegistry");
+    static final String CONTAINER_TYPE = "MESOS";
+    //TODO: Revert this change once the jenkins job is reconfigured.
+    static final String IMAGE_PATH = "devops-repo.isus.emc.com:8116";
     static final String PRAVEGA_VERSION = System.getProperty("imageVersion");
-    static final String NETWORK_TYPE = "HOST";
     private static final String TCP = "tcp://";
     final String id;
     final Marathon marathonClient;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -47,8 +47,7 @@ public abstract class MarathonBasedService implements Service {
 
     static final int ZKSERVICE_ZKPORT = 2181;
     static final String CONTAINER_TYPE = "MESOS";
-    //TODO: Revert this change once the jenkins job is reconfigured.
-    static final String IMAGE_PATH = "devops-repo.isus.emc.com:8116";
+    static final String IMAGE_PATH = System.getProperty("dockerImageRegistry");
     static final String PRAVEGA_VERSION = System.getProperty("imageVersion");
     private static final String TCP = "tcp://";
     final String id;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -73,7 +73,8 @@ public abstract class MarathonBasedService implements Service {
             log.debug("App Details: {}", app);
             //app is not running until the desired instance count is equal to the number of task/docker containers
             // and the state of application is healthy.
-            if (app.getApp().getTasksRunning().intValue() == app.getApp().getInstances().intValue()) {
+            if ((app.getApp().getTasksRunning().intValue() == app.getApp().getInstances().intValue())
+                    && app.getApp().getTasksRunning().intValue() == app.getApp().getTasksHealthy().intValue()) {
                 log.info("App {} is running", this.id);
                 return true;
             } else {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -45,7 +45,7 @@ import static io.pravega.test.system.framework.TestFrameworkException.Type.Reque
 @Slf4j
 public abstract class MarathonBasedService implements Service {
 
-    static final boolean FORCE_IMAGE = true;
+    static final boolean FORCE_IMAGE = false;
     static final int ZKSERVICE_ZKPORT = 2181;
     static final String CONTAINER_TYPE = "DOCKER";
     static final String IMAGE_PATH = System.getProperty("dockerImageRegistry");
@@ -74,8 +74,7 @@ public abstract class MarathonBasedService implements Service {
             log.debug("App Details: {}", app);
             //app is not running until the desired instance count is equal to the number of task/docker containers
             // and the state of application is healthy.
-            if ((app.getApp().getTasksRunning().intValue() == app.getApp().getInstances().intValue())
-                    && app.getApp().getTasksRunning().intValue() == app.getApp().getTasksHealthy().intValue()) {
+            if (app.getApp().getTasksRunning().intValue() == app.getApp().getInstances().intValue()) {
                 log.info("App {} is running", this.id);
                 return true;
             } else {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
@@ -39,7 +39,7 @@ public class PravegaControllerService extends MarathonBasedService {
     private static final int REST_PORT = 10080;
     private final URI zkUri;
     private int instances = 1;
-    private double cpu = 0.1;
+    private double cpu = 0.5;
     private double mem = 700;
 
     public PravegaControllerService(final String id, final URI zkUri) {
@@ -117,7 +117,7 @@ public class PravegaControllerService extends MarathonBasedService {
         app.setPortDefinitions(Arrays.asList(createPortDefinition(CONTROLLER_PORT), createPortDefinition(REST_PORT)));
         app.setRequirePorts(true);
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 30, 0, CONTROLLER_PORT));
+        healthCheckList.add(setHealthCheck(300, "TCP", false, 60, 20, 0, CONTROLLER_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
         String controllerSystemProperties = "-Xmx512m" +

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
@@ -14,7 +14,6 @@ import io.pravega.test.system.framework.Utils;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,8 +25,6 @@ import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.Container;
 import mesosphere.marathon.client.model.v2.Docker;
 import mesosphere.marathon.client.model.v2.HealthCheck;
-import mesosphere.marathon.client.model.v2.Parameter;
-import mesosphere.marathon.client.model.v2.Volume;
 import mesosphere.marathon.client.MarathonException;
 
 import static io.pravega.test.system.framework.TestFrameworkException.Type.InternalError;
@@ -114,27 +111,17 @@ public class PravegaControllerService extends MarathonBasedService {
         app.setContainer(new Container());
         app.getContainer().setType(CONTAINER_TYPE);
         app.getContainer().setDocker(new Docker());
-        //set volume
-        Collection<Volume> volumeCollection = new ArrayList<Volume>();
-        volumeCollection.add(createVolume("/tmp/logs", "/mnt/logs", "RW"));
-        app.getContainer().setVolumes(volumeCollection);
         app.getContainer().getDocker().setImage(IMAGE_PATH + "/nautilus/pravega:" + PRAVEGA_VERSION);
-        app.getContainer().getDocker().setNetwork(NETWORK_TYPE);
-        app.getContainer().getDocker().setForcePullImage(FORCE_IMAGE);
-        //set docker container parameters
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
-        List<Parameter> parameterList = new ArrayList<>();
-        Parameter element1 = new Parameter("env", "JAVA_OPTS=-Xmx512m");
-        parameterList.add(element1);
-        app.getContainer().getDocker().setParameters(parameterList);
         //set port
         app.setPortDefinitions(Arrays.asList(createPortDefinition(CONTROLLER_PORT), createPortDefinition(REST_PORT)));
         app.setRequirePorts(true);
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "TCP", false, 60, 20, 0, CONTROLLER_PORT));
+        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, CONTROLLER_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
-        String controllerSystemProperties = setSystemProperty("ZK_URL", zk) +
+        String controllerSystemProperties = "-Xmx512m" +
+                setSystemProperty("ZK_URL", zk) +
                 setSystemProperty("CONTROLLER_RPC_PUBLISHED_HOST", this.id + ".marathon.mesos") +
                 setSystemProperty("CONTROLLER_RPC_PUBLISHED_PORT", String.valueOf(CONTROLLER_PORT)) +
                 setSystemProperty("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT)) +

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
@@ -117,7 +117,7 @@ public class PravegaControllerService extends MarathonBasedService {
         app.setPortDefinitions(Arrays.asList(createPortDefinition(CONTROLLER_PORT), createPortDefinition(REST_PORT)));
         app.setRequirePorts(true);
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, CONTROLLER_PORT));
+        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 30, 0, CONTROLLER_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
         String controllerSystemProperties = "-Xmx512m" +

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -39,7 +39,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
     private static final java.lang.String KEY_VALUE_SEPARATOR = "::";
     private final URI zkUri;
     private int instances = 1;
-    private double cpu = 0.1;
+    private double cpu = 0.5;
     private double mem = 1000.0;
     private final URI conUri;
 
@@ -110,7 +110,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         app.setRequirePorts(true);
         //healthchecks
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 30, 0, SEGMENTSTORE_PORT));
+        healthCheckList.add(setHealthCheck(300, "TCP", false, 60, 20, 0, SEGMENTSTORE_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -40,7 +40,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
     private final URI zkUri;
     private int instances = 1;
     private double cpu = 0.5;
-    private double mem = 1000.0;
+    private double mem = 1280.0;
     private final URI conUri;
 
     public PravegaSegmentStoreService(final String id, final URI zkUri, final URI conUri) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -123,7 +123,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         getCustomEnvVars(map, SEGMENTSTORE_EXTRA_ENV);
 
         //Properties set to override defaults for system tests
-        String hostSystemProperties = "-Xmx900m" +
+        String hostSystemProperties = "-Xmx1024m" +
                 setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -15,7 +15,6 @@ import io.pravega.test.system.framework.Utils;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +26,6 @@ import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.Container;
 import mesosphere.marathon.client.model.v2.Docker;
 import mesosphere.marathon.client.model.v2.HealthCheck;
-import mesosphere.marathon.client.model.v2.Parameter;
-import mesosphere.marathon.client.model.v2.Volume;
 import mesosphere.marathon.client.MarathonException;
 
 import static io.pravega.test.system.framework.TestFrameworkException.Type.InternalError;
@@ -106,24 +103,14 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         app.setContainer(new Container());
         app.getContainer().setType(CONTAINER_TYPE);
         app.getContainer().setDocker(new Docker());
-        //set volume
-        Collection<Volume> volumeCollection = new ArrayList<Volume>();
-        volumeCollection.add(createVolume("/tmp/logs", "/mnt/logs", "RW"));
-        app.getContainer().setVolumes(volumeCollection);
         //set the image and network
         app.getContainer().getDocker().setImage(IMAGE_PATH + "/nautilus/pravega:" + PRAVEGA_VERSION);
-        app.getContainer().getDocker().setNetwork(NETWORK_TYPE);
-        app.getContainer().getDocker().setForcePullImage(FORCE_IMAGE);
-        List<Parameter> parameterList = new ArrayList<>();
-        Parameter element1 = new Parameter("env", "JAVA_OPTS=-Xmx900m");
-        parameterList.add(element1);
-        app.getContainer().getDocker().setParameters(parameterList);
         //set port
         app.setPortDefinitions(Arrays.asList(createPortDefinition(SEGMENTSTORE_PORT)));
         app.setRequirePorts(true);
         //healthchecks
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "TCP", false, 60, 20, 0, SEGMENTSTORE_PORT));
+        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, SEGMENTSTORE_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
@@ -136,7 +123,8 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         getCustomEnvVars(map, SEGMENTSTORE_EXTRA_ENV);
 
         //Properties set to override defaults for system tests
-        String hostSystemProperties = setSystemProperty("autoScale.muteInSeconds", "120") +
+        String hostSystemProperties = "-Xmx900m" +
+                setSystemProperty("autoScale.muteInSeconds", "120") +
                 setSystemProperty("autoScale.cooldownInSeconds", "120") +
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -40,7 +40,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
     private final URI zkUri;
     private int instances = 1;
     private double cpu = 0.5;
-    private double mem = 1280.0;
+    private double mem = 1741.0;
     private final URI conUri;
 
     public PravegaSegmentStoreService(final String id, final URI zkUri, final URI conUri) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -110,7 +110,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
         app.setRequirePorts(true);
         //healthchecks
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
-        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, SEGMENTSTORE_PORT));
+        healthCheckList.add(setHealthCheck(900, "MESOS_TCP", false, 60, 30, 0, SEGMENTSTORE_PORT));
         app.setHealthChecks(healthCheckList);
         //set env
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/ZookeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/ZookeeperService.java
@@ -84,9 +84,8 @@ public class ZookeeperService extends MarathonBasedService {
         app.getContainer().setType(CONTAINER_TYPE);
         app.getContainer().setDocker(new Docker());
         app.getContainer().getDocker().setImage(ZK_IMAGE);
-        app.getContainer().getDocker().setNetwork(NETWORK_TYPE);
         List<HealthCheck> healthCheckList = new ArrayList<>();
-        final HealthCheck hc = setHealthCheck(900, "TCP", false, 60, 20, 0, ZKSERVICE_ZKPORT);
+        final HealthCheck hc = setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, ZKSERVICE_ZKPORT);
         healthCheckList.add(hc);
         app.setHealthChecks(healthCheckList);
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/ZookeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/ZookeeperService.java
@@ -85,7 +85,7 @@ public class ZookeeperService extends MarathonBasedService {
         app.getContainer().setDocker(new Docker());
         app.getContainer().getDocker().setImage(ZK_IMAGE);
         List<HealthCheck> healthCheckList = new ArrayList<>();
-        final HealthCheck hc = setHealthCheck(900, "MESOS_TCP", false, 60, 20, 0, ZKSERVICE_ZKPORT);
+        final HealthCheck hc = setHealthCheck(300, "TCP", false, 60, 20, 0, ZKSERVICE_ZKPORT);
         healthCheckList.add(hc);
         app.setHealthChecks(healthCheckList);
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -51,9 +51,9 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     private static final int ADD_NUM_WRITERS = 2;
     private static final int NUM_READERS = 2;
     private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
-    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(20 * 60);
+    public Timeout globalTimeout = Timeout.seconds(25 * 60);
     private final String scope = "testReadTxnWriteAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String stream = "testReadTxnWriteAutoScaleStream";
     private final String readerGroupName = "testReadTxnWriteAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -56,9 +56,9 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 
     private static final int NUM_READERS = 5;
     private static final int NUM_WRITERS = 5;
-    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(22 * 60);
+    public Timeout globalTimeout = Timeout.seconds(25 * 60);
     private final String scope = "testReadTxnWriteScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String stream = "testReadTxnWriteScaleStream";
     private final String readerGroupName = "testReadTxnWriteScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -51,9 +51,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     private static final int NUM_READERS = 2;
     private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
 
-    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(15 * 60);
+    public Timeout globalTimeout = Timeout.seconds(25 * 60);
 
     private final String scope = "testReadWriteAndAutoScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -56,9 +56,9 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
 
-    //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(15 * 60);
+    public Timeout globalTimeout = Timeout.seconds(25 * 60);
 
     private final String scope = "testReadWriteAndScaleScope" + new Random().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndScaleReaderGroup" + new Random().nextInt(Integer.MAX_VALUE);


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>
**Change log description**
- Ensure pravega docker images run on a mesos containerizer.
- Increase resources provided to test and pravega containers.

**Purpose of the change**
Fixes #2054 

**What the code does**
- Ensure the we use mesos containerizer to obtain better performance on a mesos cluster.
- Ensure the tests pass on the latest marathon 1.5.

**How to verify it**
Tests should pass.

Update: Tested it on the latest cluster with marathon 1.5.0. The framework is behaving as expected. 