### PR TITLE
Issue 2064: Removed uses of deprecated RandomStringUtils.

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -36,6 +36,7 @@ import io.pravega.controller.server.rest.generated.model.StreamState;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
 import io.pravega.test.common.InlineExecutor;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.integration.utils.SetupUtils;
 import java.net.URI;
 import java.util.Arrays;
@@ -50,7 +51,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.RandomStringUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -113,8 +113,8 @@ public class ControllerRestApiTest {
         assertEquals("Ping test", OK.getStatusCode(), response.getStatus());
         log.info("REST Server is running. Ping successful.");
 
-        final String scope1 = RandomStringUtils.randomAlphanumeric(10);
-        final String stream1 = RandomStringUtils.randomAlphanumeric(10);
+        final String scope1 = TestUtils.randomAlphanumeric(10);
+        final String stream1 = TestUtils.randomAlphanumeric(10);
 
         // TEST CreateScope POST http://controllerURI:Port/v1/scopes
         resourceURl = new StringBuilder(restServerURI).append("/v1/scopes").toString();
@@ -232,9 +232,9 @@ public class ControllerRestApiTest {
 
         // Test reader groups APIs.
         // Prepare the streams and readers using the admin client.
-        final String testScope = RandomStringUtils.randomAlphanumeric(10);
-        final String testStream1 = RandomStringUtils.randomAlphanumeric(10);
-        final String testStream2 = RandomStringUtils.randomAlphanumeric(10);
+        final String testScope = TestUtils.randomAlphanumeric(10);
+        final String testStream1 = TestUtils.randomAlphanumeric(10);
+        final String testStream2 = TestUtils.randomAlphanumeric(10);
         URI controllerUri = SETUP_UTILS.getControllerUri();
         @Cleanup("shutdown")
         InlineExecutor inlineExecutor = new InlineExecutor();
@@ -253,10 +253,10 @@ public class ControllerRestApiTest {
             streamManager.createStream(testScope, testStream2, streamConf2);
         }
 
-        final String readerGroupName1 = RandomStringUtils.randomAlphanumeric(10);
-        final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
-        final String reader1 = RandomStringUtils.randomAlphanumeric(10);
-        final String reader2 = RandomStringUtils.randomAlphanumeric(10);
+        final String readerGroupName1 = TestUtils.randomAlphanumeric(10);
+        final String readerGroupName2 = TestUtils.randomAlphanumeric(10);
+        final String reader1 = TestUtils.randomAlphanumeric(10);
+        final String reader2 = TestUtils.randomAlphanumeric(10);
         try (ClientFactory clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor));
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, controllerUri)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().startingTime(0).build(),

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -125,7 +124,7 @@ public class MultiReadersEndToEndTest {
             log.info("Wrote {} events", NUM_TEST_EVENTS);
         });
 
-        final String readerGroupName = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10).toLowerCase();
+        final String readerGroupName = "testreadergroup" + TestUtils.randomAlphanumeric(10).toLowerCase();
 
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SETUP_UTILS.getScope(),

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -18,6 +18,7 @@ import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.impl.StreamSegments;
 import io.pravega.client.stream.impl.TxnSegments;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.services.BookkeeperService;
@@ -35,7 +36,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -120,8 +120,8 @@ public class ControllerFailoverTest {
 
     @Test(timeout = 180000)
     public void failoverTest() throws URISyntaxException, InterruptedException {
-        String scope = "testFailoverScope" + RandomStringUtils.randomAlphabetic(5);
-        String stream = "testFailoverStream" + RandomStringUtils.randomAlphabetic(5);
+        String scope = "testFailoverScope" + TestUtils.randomAlphabetic(5);
+        String stream = "testFailoverStream" + TestUtils.randomAlphabetic(5);
         int initialSegments = 2;
         List<Integer> segmentsToSeal = Collections.singletonList(0);
         Map<Double, Double> newRangesToCreate = new HashMap<>();

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -36,6 +36,7 @@ import io.pravega.controller.server.rest.generated.model.StreamState;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
 import io.pravega.test.common.InlineExecutor;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.services.BookkeeperService;
@@ -58,7 +59,6 @@ import javax.ws.rs.core.Response;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.Assert;
 import org.junit.Test;
@@ -155,8 +155,8 @@ public class ControllerRestApiTest {
         assertEquals("Ping test", OK.getStatusCode(), response.getStatus());
         log.info("REST Server is running. Ping successful.");
 
-        final String scope1 = RandomStringUtils.randomAlphanumeric(10);
-        final String stream1 = RandomStringUtils.randomAlphanumeric(10);
+        final String scope1 = TestUtils.randomAlphanumeric(10);
+        final String stream1 = TestUtils.randomAlphanumeric(10);
 
         // TEST CreateScope POST http://controllerURI:Port/v1/scopes
         resourceURl = new StringBuilder(restServerURI).append("/v1/scopes").toString();
@@ -274,9 +274,9 @@ public class ControllerRestApiTest {
 
         // Test reader groups APIs.
         // Prepare the streams and readers using the admin client.
-        final String testScope = RandomStringUtils.randomAlphanumeric(10);
-        final String testStream1 = RandomStringUtils.randomAlphanumeric(10);
-        final String testStream2 = RandomStringUtils.randomAlphanumeric(10);
+        final String testScope = TestUtils.randomAlphanumeric(10);
+        final String testStream1 = TestUtils.randomAlphanumeric(10);
+        final String testStream2 = TestUtils.randomAlphanumeric(10);
         URI controllerUri = ctlURIs.get(0);
         try (StreamManager streamManager = new StreamManagerImpl(controllerUri)) {
             log.info("Creating scope: {}", testScope);
@@ -293,10 +293,10 @@ public class ControllerRestApiTest {
             streamManager.createStream(testScope, testStream2, streamConf2);
         }
 
-        final String readerGroupName1 = RandomStringUtils.randomAlphanumeric(10);
-        final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
-        final String reader1 = RandomStringUtils.randomAlphanumeric(10);
-        final String reader2 = RandomStringUtils.randomAlphanumeric(10);
+        final String readerGroupName1 = TestUtils.randomAlphanumeric(10);
+        final String readerGroupName2 = TestUtils.randomAlphanumeric(10);
+        final String reader1 = TestUtils.randomAlphanumeric(10);
+        final String reader2 = TestUtils.randomAlphanumeric(10);
         @Cleanup("shutdown")
         InlineExecutor executor = new InlineExecutor();
         Controller controller = new ControllerImpl(controllerUri, ControllerImplConfig.builder().build(), executor);

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -14,6 +14,7 @@ import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.common.util.Retry;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.services.PravegaControllerService;
@@ -29,7 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -141,37 +141,37 @@ public class MultiControllerTest {
 
         log.info("Test tcp:// with all 3 controller instances running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDirect).get());
         log.info("Test pravega:// with all 3 controller instances running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDiscover).get());
 
         controllerServiceInstance1.stop();
         log.info("Test tcp:// with 2 controller instances running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDirect).get());
         log.info("Test pravega:// with 2 controller instances running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDiscover).get());
 
         controllerServiceInstance2.stop();
         log.info("Test tcp:// with only 1 controller instance running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDirect).get());
         log.info("Test pravega:// with only 1 controller instance running");
         Assert.assertTrue(createScopeWithSimpleRetry(
-                "scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover).get());
+                "scope" + TestUtils.randomAlphanumeric(10), controllerURIDiscover).get());
 
         // All APIs should throw exception and fail.
         controllerServiceInstance3.stop();
         log.info("Test tcp:// with no controller instances running");
         AssertExtensions.assertThrows("Should throw RetriesExhaustedException",
-                createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDirect),
+                createScope("scope" + TestUtils.randomAlphanumeric(10), controllerURIDirect),
                 throwable -> throwable instanceof RetriesExhaustedException);
 
         log.info("Test pravega:// with no controller instances running");
         AssertExtensions.assertThrows("Should throw RetriesExhaustedException",
-                createScope("scope" + RandomStringUtils.randomAlphanumeric(10), controllerURIDiscover),
+                createScope("scope" + TestUtils.randomAlphanumeric(10), controllerURIDiscover),
                 throwable -> throwable instanceof RetriesExhaustedException);
 
         log.info("multiControllerTest execution completed");

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -21,6 +21,7 @@ import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.services.BookkeeperService;
@@ -37,7 +38,6 @@ import java.util.UUID;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -152,8 +152,8 @@ public class MultiSegmentStoreTest {
         List<URI> ctlURIs = this.controllerInstance.getServiceDetails();
         URI controllerUri = ctlURIs.get(0);
 
-        String scope = "testscope" + RandomStringUtils.randomAlphanumeric(10);
-        String stream = "teststream" + RandomStringUtils.randomAlphanumeric(10);
+        String scope = "testscope" + TestUtils.randomAlphanumeric(10);
+        String stream = "teststream" + TestUtils.randomAlphanumeric(10);
 
         @Cleanup
         StreamManager streamManager = StreamManager.create(controllerUri);
@@ -184,7 +184,7 @@ public class MultiSegmentStoreTest {
         writer.flush();
 
         log.info("Invoking reader with controller URI: {}", controllerUri);
-        final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
+        final String readerGroup = "testreadergroup" + TestUtils.randomAlphanumeric(10);
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerUri);
         groupManager.createReaderGroup(readerGroup, ReaderGroupConfig.builder().startingTime(0).build(),
                                        Collections.singleton(stream));

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.concurrent.GuardedBy;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -33,6 +34,7 @@ public class TestUtils {
      * random from this string.
      */
     private static final char[] ALPHANUMERIC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+    @GuardedBy("RANDOM")
     private static final Random RANDOM = new Random(0);
 
     /**

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -9,12 +9,11 @@
  */
 package io.pravega.test.common;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility class for Tests.
@@ -28,6 +27,13 @@ public class TestUtils {
     // We use a random start position here to avoid ports conflicts when this method is executed from multiple processes
     // in parallel. This is needed since the processes will contend for the same port sequence.
     private static final AtomicInteger NEXT_PORT = new AtomicInteger(new Random().nextInt(MAX_PORT_COUNT));
+
+    /**
+     * We use this as a source of alphanumeric characters when generating random strings. Characters will be selected at
+     * random from this string.
+     */
+    private static final char[] ALPHANUMERIC_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+    private static final Random RANDOM = new Random(0);
 
     /**
      * A helper method to get a random free port.
@@ -47,5 +53,44 @@ public class TestUtils {
         }
         throw new IllegalStateException(
                 String.format("Could not assign port in range %d - %d", BASE_PORT, MAX_PORT_COUNT + BASE_PORT));
+    }
+
+    /**
+     * Generates a new alphanumeric String of the given length.
+     *
+     * @param length The length of the String.
+     * @return The new String.
+     */
+    public static String randomAlphanumeric(int length) {
+        return randomString(length, 0, ALPHANUMERIC_CHARS.length);
+    }
+
+    /**
+     * Generates a new String containing only letters of the given length.
+     *
+     * @param length The length of the String.
+     * @return The new String.
+     */
+    public static String randomAlphabetic(int length) {
+        return randomString(length, 10, ALPHANUMERIC_CHARS.length);
+    }
+
+    /**
+     * Generates a new String of the given length containing only characters of the given range.
+     *
+     * @param length              The length of the String.
+     * @param lowerIndexInclusive The first Index (inclusive) in ALPHANUMERIC_CHARS to select characters from.
+     * @param upperIndexExclusive The last index (exclusive) in ALPHANUMERIC_CHARS to select characters from.
+     * @return The new String.
+     */
+    private static String randomString(int length, int lowerIndexInclusive, int upperIndexExclusive) {
+        char[] data = new char[length];
+        for (int i = 0; i < length; i++) {
+            synchronized (RANDOM) {
+                data[i] = ALPHANUMERIC_CHARS[lowerIndexInclusive + RANDOM.nextInt(upperIndexExclusive - lowerIndexInclusive)];
+            }
+        }
+
+        return new String(data);
     }
 }

--- a/test/testcommon/src/test/java/io/pravega/test/common/TestUtilsTest.java
+++ b/test/testcommon/src/test/java/io/pravega/test/common/TestUtilsTest.java
@@ -9,8 +9,6 @@
  */
 package io.pravega.test.common;
 
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -20,14 +18,18 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.junit.Assert;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test class to verify correctness of utility methods.
+ * Unit test for the TestUtils class.
  */
-public class UtilityMethodsTest {
+public class TestUtilsTest {
 
     /**
      * Test to verify correctness of getAvailableListenPort() method.
@@ -53,5 +55,28 @@ public class UtilityMethodsTest {
         }
         assertEquals(threadCount, futures.size());
         executorService.shutdown();
+    }
+
+    @Test(timeout = 10000)
+    public void testRandomAlphanumeric() {
+        testGetString(TestUtils::randomAlphanumeric, c -> Character.isDigit(c) || Character.isAlphabetic(c));
+    }
+
+    @Test(timeout = 10000)
+    public void testRandomAlphabetic() {
+        testGetString(TestUtils::randomAlphabetic, Character::isAlphabetic);
+    }
+
+    private void testGetString(Function<Integer, String> generateString, Predicate<Character> verifyChar) {
+        final int maxLength = 200;
+        for (int length = 0; length < maxLength; length++) {
+            String s = generateString.apply(length);
+            Assert.assertEquals("Unexpected length.", length, s.length());
+            for (int i = 0; i < length; i++) {
+                char c = s.charAt(i);
+                Assert.assertTrue(String.format("Unexpected character '%s' at index %d (length = %d).", c, i, length),
+                        verifyChar.test(c));
+            }
+        }
     }
 }


### PR DESCRIPTION
**Change log description**
Removed uses of `RandomStringUtils` (deprecated) and replaced with simple, in-house, random string generator. 

A custom-built method was preferred over the recommendation in `RandomStringUtils` since the alternative would have been the need to pull yet another dependency into our project just for one method (org.apache.commons.text).

**Purpose of the change**
Fixes #2064.

**What the code does**
This seems to affect system tests code only. Replaced uses of deprecated library call with call in `TestUtils`.

**How to verify it**
System tests must pass (since they're the only ones affected).
