### PR TITLE
Issue 2066: Compiler warnings

### DIFF
--- a/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
@@ -75,18 +75,18 @@ public class FuturesTests {
     public void testExceptionallyCompose() {
         // When applied to a CompletableFuture that completes normally.
         val successfulFuture = new CompletableFuture<Integer>();
-        val f1 = Futures.exceptionallyCompose(successfulFuture, ex -> CompletableFuture.completedFuture(2));
+        val f1 = Futures.<Integer>exceptionallyCompose(successfulFuture, ex -> CompletableFuture.completedFuture(2));
         successfulFuture.complete(1);
         Assert.assertEquals("Unexpected completion value for successful future.", 1, (int) f1.join());
 
         // When applied to a CompletableFuture that completes exceptionally.
         val failedFuture = new CompletableFuture<Integer>();
-        val f2 = Futures.exceptionallyCompose(failedFuture, ex -> CompletableFuture.completedFuture(2));
+        val f2 = Futures.<Integer>exceptionallyCompose(failedFuture, ex -> CompletableFuture.completedFuture(2));
         failedFuture.completeExceptionally(new IntentionalException());
         Assert.assertEquals("Unexpected completion value for failed future that handled the exception.", 2, (int) f2.join());
 
         // When applied to a CompletableFuture that completes exceptionally and the handler also throws.
-        val f3 = Futures.exceptionallyCompose(failedFuture, ex -> {
+        val f3 = Futures.<Integer>exceptionallyCompose(failedFuture, ex -> {
             throw new IntentionalException();
         });
         AssertExtensions.assertThrows(

--- a/common/src/test/java/io/pravega/common/io/FixedByteArrayOutputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/FixedByteArrayOutputStreamTests.java
@@ -23,8 +23,6 @@ import io.pravega.test.common.AssertExtensions;
 public class FixedByteArrayOutputStreamTests {
     /**
      * Tests that FixedByteArrayOutputStream works as advertised.
-     *
-     * @throws IOException
      */
     @Test
     public void testWrite() throws IOException {

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -131,8 +131,6 @@ public class ByteArraySegmentTests {
 
     /**
      * Tests the functionality of getReader (the ability to return an InputStream from a sub-segment of the main buffer).
-     *
-     * @throws IOException
      */
     @Test
     public void testGetReader() throws IOException {
@@ -155,8 +153,6 @@ public class ByteArraySegmentTests {
 
     /**
      * Tests the functionality of getWriter (the ability to return an OutputStream that can be used to write to the main buffer).
-     *
-     * @throws IOException
      */
     @Test
     public void testGetWriter() throws IOException {
@@ -207,8 +203,6 @@ public class ByteArraySegmentTests {
 
     /**
      * Tests the behavior of the ByteArraySegment in read-only mode.
-     *
-     * @throws Exception
      */
     @Test
     public void testReadOnly() throws Exception {

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -48,7 +48,7 @@ public enum AttributeUpdateType {
      * Any updates will replace the current attribute value, but only if the existing value matches
      * an expected value. If the value is different the update will fail. This can be used to
      * perform compare and set operations. The value {io.pravega.segmentstore.server.SegmentMetadata.NULL_ATTRIBUTE_VALUE}
-     * is used to indicate a non value. IE: to remove the attribute or if the value is expected not to
+     * is used to indicate a non value, i.e., to remove the attribute or if the value is expected not to
      * exist.
      */
     ReplaceIfEquals((byte) 4);

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -47,8 +47,8 @@ public enum AttributeUpdateType {
     /**
      * Any updates will replace the current attribute value, but only if the existing value matches
      * an expected value. If the value is different the update will fail. This can be used to
-     * perform compare and set operations. The value {@link SegmentMetadata#NULL_ATTRIBUTE_VALUE} is
-     * used to indicate a non value. IE: to remove the attribute or if the value is expected not to
+     * perform compare and set operations. The value {io.pravega.segmentstore.server.SegmentMetadata.NULL_ATTRIBUTE_VALUE}
+     * is used to indicate a non value. IE: to remove the attribute or if the value is expected not to
      * exist.
      */
     ReplaceIfEquals((byte) 4);

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
@@ -69,7 +69,7 @@ public class StreamSegmentInformation implements SegmentProperties {
     }
 
     /**
-     * Creates a new StreamSegmentInformationBuilder with information already populated from the given SegmentpProperties.
+     * Creates a new StreamSegmentInformationBuilder with information already populated from the given SegmentProperties.
      *
      * @param base The SegmentProperties to use as a base.
      * @return The Builder.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -239,17 +239,10 @@ public final class ServiceStarter {
 
         try {
             serviceStarter.get().start();
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    try {
-                        log.info("Caught interrupt signal...");
-                        serviceStarter.get().shutdown();
-                    } catch (Exception e) {
-                        // do nothing
-                    }
-                }
-            });
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                log.info("Caught interrupt signal...");
+                serviceStarter.get().shutdown();
+            }));
 
             Thread.sleep(Long.MAX_VALUE);
         } catch (InterruptedException ex) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
@@ -33,7 +33,6 @@ class ZKSegmentContainerManager implements SegmentContainerManager {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final Cluster cluster;
     private final ZKSegmentContainerMonitor containerMonitor;
-    private final ScheduledExecutorService executor;
 
     /**
      * Creates a new instance of the ZKSegmentContainerManager class.
@@ -48,10 +47,8 @@ class ZKSegmentContainerManager implements SegmentContainerManager {
         Preconditions.checkNotNull(containerRegistry, "containerRegistry");
         Preconditions.checkNotNull(zkClient, "zkClient");
         this.host = Preconditions.checkNotNull(pravegaServiceEndpoint, "pravegaServiceEndpoint");
-        this.executor = Preconditions.checkNotNull(executor, "executor");
-
         this.cluster = new ClusterZKImpl(zkClient, ClusterType.HOST);
-        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint, this.executor);
+        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint, executor);
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -173,7 +173,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
      * Appends are opportunistically batched here. i.e. If many are waiting they are combined into a single append and
      * that is written.
      */
-    public void performNextWrite() {
+    private void performNextWrite() {
         Append append = getNextAppend();
         if (append == null) {
             return;
@@ -251,8 +251,9 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private void handleAppendResult(final Append append, Throwable exception) {
         try {
             boolean conditionalFailed = exception != null && (Exceptions.unwrap(exception) instanceof BadOffsetException);
-            long previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
+            long previousEventNumber;
             synchronized (lock) {
+                previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
                 Preconditions.checkState(outstandingAppend == append,
                         "Synchronization error in: %s.", AppendProcessor.this.getClass().getName());
                 outstandingAppend = null;

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -27,7 +27,6 @@ import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.protocol.netty.WireCommands;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -57,15 +57,12 @@ public class AutoScaleProcessor {
     private final AtomicReference<EventStreamWriter<AutoScaleEvent>> writer;
     private final EventWriterConfig writerConfig;
     private final AutoScalerConfig configuration;
-    private final Executor executor;
     private final ScheduledExecutorService maintenanceExecutor;
 
     AutoScaleProcessor(AutoScalerConfig configuration,
-                       Executor executor,
                        ScheduledExecutorService maintenanceExecutor) {
         this.configuration = configuration;
         this.maintenanceExecutor = maintenanceExecutor;
-        this.executor = executor;
 
         serializer = new JavaSerializer<>();
         writerConfig = EventWriterConfig.builder().build();
@@ -86,8 +83,8 @@ public class AutoScaleProcessor {
     }
 
     @VisibleForTesting
-    AutoScaleProcessor(EventStreamWriter<AutoScaleEvent> writer, AutoScalerConfig configuration, Executor executor, ScheduledExecutorService maintenanceExecutor) {
-        this(configuration, executor, maintenanceExecutor);
+    AutoScaleProcessor(EventStreamWriter<AutoScaleEvent> writer, AutoScalerConfig configuration, ScheduledExecutorService maintenanceExecutor) {
+        this(configuration, maintenanceExecutor);
         this.writer.set(writer);
         this.initialized.set(true);
         maintenanceExecutor.scheduleAtFixedRate(cache::cleanUp, 0, configuration.getCacheCleanup().getSeconds(), TimeUnit.SECONDS);
@@ -95,9 +92,8 @@ public class AutoScaleProcessor {
 
     @VisibleForTesting
     AutoScaleProcessor(AutoScalerConfig configuration, ClientFactory cf,
-                       Executor executor,
                        ScheduledExecutorService maintenanceExecutor) {
-        this(configuration, executor, maintenanceExecutor);
+        this(configuration, maintenanceExecutor);
         clientFactory.set(cf);
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
@@ -44,14 +44,13 @@ public class SegmentStatsFactory implements AutoCloseable {
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store,
                                                            ClientFactory clientFactory,
                                                            AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory,
-                executor, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store,
                 executor, maintenanceExecutor);
     }
 
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store, AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, executor, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store, executor, maintenanceExecutor);
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorder.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorder.java
@@ -24,7 +24,6 @@ public interface SegmentStatsRecorder {
      * Method to notify segment sealed events.
      *
      * @param streamSegmentName segment.
-     * @param streamSegmentName
      */
     void sealSegment(String streamSegmentName);
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -38,18 +38,15 @@ public class AutoScaleProcessorTest {
     private static final String STREAM2 = "stream2";
     private static final String STREAM3 = "stream3";
     private static final String STREAM4 = "stream4";
-    ExecutorService executor;
     ScheduledExecutorService maintenanceExecutor;
 
     @Before
     public void setup() {
-        executor = Executors.newSingleThreadExecutor();
         maintenanceExecutor = Executors.newSingleThreadScheduledExecutor();
     }
 
     @After
     public void teardown() {
-        executor.shutdown();
         maintenanceExecutor.shutdown();
     }
 
@@ -91,7 +88,7 @@ public class AutoScaleProcessorTest {
                         .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
                         .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
                         .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executor, maintenanceExecutor);
+                maintenanceExecutor);
 
         String streamSegmentName1 = Segment.getScopedName(SCOPE, STREAM1, 0);
         String streamSegmentName2 = Segment.getScopedName(SCOPE, STREAM2, 0);
@@ -139,7 +136,7 @@ public class AutoScaleProcessorTest {
                 .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
                 .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
                 .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executor, maintenanceExecutor);
+                maintenanceExecutor);
         String streamSegmentName1 = Segment.getScopedName(SCOPE, STREAM1, 0);
         monitor.notifyCreated(streamSegmentName1, WireCommands.CreateSegment.IN_EVENTS_PER_SEC, 10);
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -19,7 +19,6 @@ import io.pravega.shared.protocol.netty.WireCommands;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -13,8 +13,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.server.EvictableMetadata;
-import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -216,7 +217,9 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
 
     @Override
     public Collection<Long> getAllStreamSegmentIds() {
-        return this.metadataById.keySet();
+        synchronized (this.lock) {
+            return new HashSet<>(this.metadataById.keySet());
+        }
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -111,7 +111,7 @@ class DataFrameBuilder<T extends LogItem> implements AutoCloseable {
      * written to the DataFrame will be discarded. Note that if a LogItem spans multiple DataFrames, in case of failure,
      * the content serialized to already committed DataFrames will not be discarded. That case will have to be dealt with
      * upon reading DataFrames from the DataFrameLog.
-     * <p/>
+     *
      * Any exceptions that resulted from the Data Frame failing to commit will be routed through the dataFrameCommitFailureCallback
      * callback, as well as being thrown from this exception.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
@@ -38,7 +38,6 @@ class DataFrameReader<T extends LogItem> implements CloseableIterator<DataFrameR
     //region Members
 
     private final FrameEntryEnumerator frameContentsEnumerator;
-    private final String traceObjectId;
     private final LogItemFactory<T> logItemFactory;
     private long lastReadSequenceNumber;
     private int readEntryCount;
@@ -60,8 +59,7 @@ class DataFrameReader<T extends LogItem> implements CloseableIterator<DataFrameR
     DataFrameReader(DurableDataLog log, LogItemFactory<T> logItemFactory, int containerId) throws DurableDataLogException {
         Preconditions.checkNotNull(log, "log");
         Preconditions.checkNotNull(logItemFactory, "logItemFactory");
-        this.traceObjectId = String.format("DataFrameReader[%d]", containerId);
-        this.frameContentsEnumerator = new FrameEntryEnumerator(log, traceObjectId);
+        this.frameContentsEnumerator = new FrameEntryEnumerator(log, String.format("DataFrameReader[%d]", containerId));
         this.lastReadSequenceNumber = Operation.NO_SEQUENCE_NUMBER;
         this.logItemFactory = logItemFactory;
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -63,7 +63,6 @@ public class DurableLog extends AbstractService implements OperationLog {
 
     private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(30);
     private final String traceObjectId;
-    private final DurableLogConfig config;
     private final LogItemFactory<Operation> operationFactory;
     private final SequencedItemList<Operation> inMemoryOperationLog;
     private final DurableDataLog durableDataLog;
@@ -97,7 +96,6 @@ public class DurableLog extends AbstractService implements OperationLog {
         Preconditions.checkNotNull(readIndex, "readIndex");
         Preconditions.checkNotNull(executor, "executor");
 
-        this.config = config;
         this.durableDataLog = dataFrameLogFactory.createDurableDataLog(metadata.getContainerId());
         assert this.durableDataLog != null : "dataFrameLogFactory created null durableDataLog.";
 
@@ -107,7 +105,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         this.operationFactory = new OperationFactory();
         this.inMemoryOperationLog = createInMemoryLog();
         this.memoryStateUpdater = new MemoryStateUpdater(this.inMemoryOperationLog, readIndex, this::triggerTailReads);
-        MetadataCheckpointPolicy checkpointPolicy = new MetadataCheckpointPolicy(this.config, this::queueMetadataCheckpoint, this.executor);
+        MetadataCheckpointPolicy checkpointPolicy = new MetadataCheckpointPolicy(config, this::queueMetadataCheckpoint, this.executor);
         this.operationProcessor = new OperationProcessor(this.metadata, this.memoryStateUpdater, this.durableDataLog, checkpointPolicy, executor);
         Services.onStop(this.operationProcessor, this::queueStoppedHandler, this::queueFailedHandler, this.executor);
         this.tailReads = new HashSet<>();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
@@ -199,13 +199,13 @@ class OperationMetadataUpdater implements ContainerMetadata {
 
     /**
      * Phase 1/2 of processing a Operation.
-     * <p/>
+     *
      * If the given operation is a StorageOperation, the Operation is validated against the base Container Metadata and
      * the pending UpdateTransaction and it is updated accordingly (if needed).
-     * <p/>
+     *
      * If the given operation is a MetadataCheckpointOperation, the current state of the metadata (including pending
      * UpdateTransactions) is serialized to it.
-     * <p/>
+     *
      * For all other kinds of MetadataOperations (i.e., StreamSegmentMapOperation, TransactionMapOperation) this method only
      * does anything if the base Container Metadata is in Recovery Mode (in which case the given MetadataOperation) is
      * recorded in the pending UpdateTransaction.
@@ -226,7 +226,7 @@ class OperationMetadataUpdater implements ContainerMetadata {
 
     /**
      * Phase 2/2 of processing an Operation. The Operation's effects are reflected in the pending UpdateTransaction.
-     * <p/>
+     *
      * This method only has an effect on StorageOperations. It does nothing for MetadataOperations, regardless of whether
      * the base Container Metadata is in Recovery Mode or not.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
@@ -20,10 +20,9 @@ import java.time.Duration;
 public interface AsyncReadResultHandler {
     /**
      * Determines whether the AsyncReadResultProcessor should request data for the given ReadResultEntryType and Offset.
-     * <p/>
+     *
      * This method will only be invoked on those ReadResultEntries that do not currently have data available for consumption,
      * such as StorageReadResultEntry or FutureReadResultEntry.
-     * <p/>
      * If a call to this method returns false, the AsyncReadResultProcessor, as well as the underlying ReadResult, will be closed.
      *
      * @param entryType           The Type of the ReadResultEntry to process.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * for each ReadResultEntry returned by the result. This class is suitable for handling long-poll reads, as it does not
  * hog any threads while waiting for such future reads to become available. It only uses (a thread from) the Executor
  * when the data for a read becomes available, at which point it executes the handler on such a thread.
- * <p/>
+ *
  * The AsyncReadResultProcessor stops when any of the following conditions occur
  * <ul>
  * <li> The ReadResult reaches the end (hasNext() == false)

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheManager.java
@@ -29,10 +29,10 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Manages the lifecycle of Cache Entries. Decides which entries are to be kept in memory and which are eligible for
  * removal.
- * <p/>
+ *
  * Entry Management is indirect, and doesn't deal with them directly. Also, the management needs to be done across multiple
  * CacheManager Clients, and a common scheme needs to be used to instruct each such client when it's time to evict unused entries.
- * <p/>
+ *
  * The CacheManager holds two reference numbers: the current generation and the oldest generation. Every new Cache Entry
  * (in the clients) that is generated or updated gets assigned the current generation. As the CacheManager determines that
  * there are too many Cache Entries or that the maximum size has been exceeded, it will increment the oldest generation.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexEntry.java
@@ -88,7 +88,7 @@ abstract class ReadIndexEntry implements SortedIndex.IndexEntry {
     abstract boolean isDataEntry();
 
     @Override
-    public String toString() {
+    public synchronized String toString() {
         return String.format("Offset = %d, Length = %d, Gen = %d", this.streamSegmentOffset, getLength(), this.generation);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
@@ -130,7 +130,7 @@ class StreamSegmentReadResult implements ReadResult {
     /**
      * Gets the next ReadResultEntry that exists in the ReadResult. This will return null if hasNext() indicates false
      * (as opposed from throwing a NoSuchElementException, like a general iterator).
-     * <p/>
+     *
      * Notes:
      * <ul>
      * <li> Calls to next() will block until the ReadResultEntry.getContent() for the previous call to next() has been completed (normally or exceptionally).

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogReader.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogReader.java
@@ -108,7 +108,6 @@ class LogReader implements CloseableIterator<DurableDataLog.ReadItem, DurableDat
         return new LogReader.ReadItem(this.currentLedger.reader.nextElement(), this.currentLedger.metadata);
     }
 
-    @SneakyThrows
     private void openNextLedger(LedgerAddress address) throws DurableDataLogException {
         if (address == null) {
             // We have reached the end.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/LogAddress.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/LogAddress.java
@@ -12,7 +12,7 @@ package io.pravega.segmentstore.storage;
 /**
  * Represents the base for an addressing scheme inside a DurableDataLog. This can be used for accurately locating where
  * DataFrames are stored inside a DurableDataLog.
- * <p/>
+ *
  * Subclasses would be specific to DurableDataLog implementations.
  */
 public abstract class LogAddress {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -421,7 +421,9 @@ public class InMemoryStorage implements SyncStorage {
 
         @Override
         public String toString() {
-            return String.format("%s: Length = %d, Sealed = %s", this.name, this.length, this.sealed);
+            synchronized (this.lock) {
+                return String.format("%s: Length = %d, Sealed = %s", this.name, this.length, this.sealed);
+            }
         }
 
         @Data

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
@@ -690,7 +690,7 @@ public class RollingStorage implements SyncStorage {
     }
 
     @SneakyThrows(StreamingException.class)
-    private void checkTruncatedSegment(StreamingException ex, RollingSegmentHandle handle, SegmentChunk segmentChunk) throws StreamSegmentTruncatedException {
+    private void checkTruncatedSegment(StreamingException ex, RollingSegmentHandle handle, SegmentChunk segmentChunk) {
         if (ex != null && (Exceptions.unwrap(ex) instanceof StreamSegmentNotExistsException) || !segmentChunk.exists()) {
             // We ran into a SegmentChunk that does not exist (either marked as such or due to a failed read).
             segmentChunk.markInexistent();

--- a/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
@@ -99,8 +99,6 @@ public class ErrorInjector<T extends Throwable> {
 
     /**
      * Generates an exception of type T if the count trigger activates.
-     *
-     * @throws T
      */
     private T generateExceptionIfNecessary() {
         this.lastCycleException = null;


### PR DESCRIPTION
**Change log description**
Fixed a number of compiler warnings reported by Intellij using various rules enabled. Sample changes include:
- Unused class-level fields
- Class-level fields that can be converted to local variables
- Casting warnings
- Javadoc warnings
- Accessing class-level fields outside of their declared guards (concurrency).

**Purpose of the change**
Fixes #2066.

**What the code does**
Better looking code.

**How to verify it**
Build & tests must pass.
