### PR TITLE
Issue 2075: PravegaRequestProcessor.commitTransaction should handle SegmentAlreadyMergedException

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentMergedException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -454,7 +455,21 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 .thenAccept(v -> connection.send(new TransactionCommitted(requestId, commitTx.getSegment(), commitTx.getTxid())));
 
         CompletableFuture.allOf(seal, merge)
-                .exceptionally(e -> handleException(requestId, transactionName, "Commit transaction", e));
+                .exceptionally(e -> {
+                    final Throwable cause;
+                    if (e instanceof CompletionException) {
+                        cause = e.getCause();
+                    } else {
+                        cause = e;
+                    }
+                    if (cause instanceof StreamSegmentMergedException) {
+                        log.warn("Stream segment is already merged '{}'.", transactionName);
+                        connection.send(new TransactionCommitted(requestId, commitTx.getSegment(), commitTx.getTxid()));
+                        return null;
+                    } else {
+                        return handleException(requestId, transactionName, "Commit transaction", e);
+                    }
+                });
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -463,7 +463,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                         cause = e;
                     }
                     if (cause instanceof StreamSegmentMergedException) {
-                        log.warn("Stream segment is already merged '{}'.", transactionName);
+                        log.info("Stream segment is already merged '{}'.", transactionName);
                         connection.send(new TransactionCommitted(requestId, commitTx.getSegment(), commitTx.getTxid()));
                         return null;
                     } else {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -456,13 +456,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         CompletableFuture.allOf(seal, merge)
                 .exceptionally(e -> {
-                    final Throwable cause;
-                    if (e instanceof CompletionException) {
-                        cause = e.getCause();
-                    } else {
-                        cause = e;
-                    }
-                    if (cause instanceof StreamSegmentMergedException) {
+                    if (Exceptions.unwrap(e) instanceof StreamSegmentMergedException) {
                         log.info("Stream segment is already merged '{}'.", transactionName);
                         connection.send(new TransactionCommitted(requestId, commitTx.getSegment(), commitTx.getTxid()));
                         return null;


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
In commitTransaction, we are bow capturing SegmentAlreadyMergedException and treating this as idempotent operation and returning TransactionCommitted in response. 
**Purpose of the change**
Fixes issue 2075
**What the code does**

**How to verify it**
