### PR TITLE
Issue 2038 : Use correct error message template for Preconditions.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -413,7 +413,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      */
     @Override
     public void write(PendingEvent event) {
-        checkState(!state.isAlreadySealed(), "Segment: {} is already sealed", segmentName);
+        checkState(!state.isAlreadySealed(), "Segment: %s is already sealed", segmentName);
         synchronized (writeOrderLock) {
             ClientConnection connection;
             try {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -350,7 +350,7 @@ public class ReaderGroupState implements Revisioned {
         @Override
         void update(ReaderGroupState state) {
             Map<Segment, Long> assigned = state.assignedSegments.get(readerId);
-            Preconditions.checkState(assigned != null, "{} is not part of the readerGroup", readerId);
+            Preconditions.checkState(assigned != null, "%s is not part of the readerGroup", readerId);
             if (assigned.remove(segment) == null) {
                 throw new IllegalStateException(
                         readerId + " asked to release a segment that was not assigned to it " + segment);
@@ -374,7 +374,7 @@ public class ReaderGroupState implements Revisioned {
         @Override
         void update(ReaderGroupState state) {
             Map<Segment, Long> assigned = state.assignedSegments.get(readerId);
-            Preconditions.checkState(assigned != null, "{} is not part of the readerGroup", readerId);
+            Preconditions.checkState(assigned != null, "%s is not part of the readerGroup", readerId);
             Long offset = state.unassignedSegments.remove(segment);
             if (offset == null) {
                 throw new IllegalStateException("Segment: " + segment + " is not unassigned. " + state);
@@ -417,7 +417,7 @@ public class ReaderGroupState implements Revisioned {
         @Override
         void update(ReaderGroupState state) {
             Map<Segment, Long> assigned = state.assignedSegments.get(readerId);
-            Preconditions.checkState(assigned != null, "{} is not part of the readerGroup", readerId);
+            Preconditions.checkState(assigned != null, "%s is not part of the readerGroup", readerId);
             if (assigned.remove(segmentCompleted) == null) {
                 throw new IllegalStateException(
                         readerId + " asked to complete a segment that was not assigned to it " + segmentCompleted);


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Fix the error message pattern for `Preconditions`.

**Purpose of the change**
Fixes #2038 

**What the code does**
Replace {} with %s.

**How to verify it**
Test should continue to pass.