### PR TITLE
Issue 2080: Scope delete fails with directory not empty

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -108,6 +108,13 @@ class InMemoryStreamMetadataStore extends AbstractStreamMetadataStore {
 
     @Override
     @Synchronized
+    public CompletableFuture<Boolean> checkStreamExists(final String scopeName,
+                                                        final String streamName) {
+        return CompletableFuture.completedFuture(streams.containsKey(scopedStreamName(scopeName, streamName)));
+    }
+
+    @Override
+    @Synchronized
     public CompletableFuture<Void> deleteStream(final String scopeName, final String streamName,
                                                 final OperationContext context,
                                                 final Executor executor) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -66,6 +66,16 @@ public interface StreamMetadataStore {
                                             final Executor executor);
 
     /**
+     * Api to check if a stream exists in the store or not.
+     * @param scopeName scope name
+     * @param streamName stream name
+     * @return true if stream exists, false otherwise
+     */
+    CompletableFuture<Boolean> checkStreamExists(final String scopeName,
+                                                 final String streamName);
+
+
+    /**
      * Api to Delete the stream related metadata.
      *
      * @param scopeName       scope name

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -20,6 +20,8 @@ import io.pravega.controller.store.stream.tables.Data;
 import io.pravega.controller.store.stream.tables.State;
 import io.pravega.controller.store.stream.tables.StreamTruncationRecord;
 import io.pravega.controller.store.stream.tables.TableHelper;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.curator.utils.ZKPaths;
 
@@ -65,6 +67,7 @@ class ZKStream extends PersistentStreamBase<Integer> {
     private final String completedTxPath;
     private final String markerPath;
     private final String scopePath;
+    @Getter(AccessLevel.PACKAGE)
     private final String streamPath;
 
     private final Cache<Integer> cache;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -93,6 +93,13 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
     }
 
     @Override
+    public CompletableFuture<Boolean> checkStreamExists(final String scopeName,
+                                                        final String streamName) {
+        ZKStream stream = newStream(scopeName, streamName);
+        return storeHelper.checkExists(stream.getStreamPath());
+    }
+
+    @Override
     @SneakyThrows
     public void registerBucketOwnershipListener(BucketOwnershipListener listener) {
         Preconditions.checkNotNull(listener);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -406,8 +406,8 @@ public class StreamMetadataTasks extends TaskBase {
     }
 
     private CompletableFuture<Boolean> isDeleted(String scope, String stream) {
-        return streamMetadataStore.getState(scope, stream, true, null, executor)
-                .handle((state, ex) -> (ex != null && ex instanceof StoreException.DataNotFoundException) || state == null);
+        return streamMetadataStore.checkStreamExists(scope, stream)
+                .thenApply(x -> !x);
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -626,8 +626,11 @@ public class StreamMetadataTasks extends TaskBase {
                                 .thenCompose(y -> {
                                     final OperationContext context = streamMetadataStore.createContext(scope, stream);
 
-                                    return withRetries(() -> streamMetadataStore.setState(scope,
-                                            stream, State.ACTIVE, context, executor), executor)
+                                    return withRetries(() ->
+                                            streamMetadataStore.addUpdateStreamForAutoStreamCut(scope, stream,
+                                                    config.getRetentionPolicy(), context, executor)
+                                            .thenCompose(v ->  streamMetadataStore.setState(scope, stream, State.ACTIVE,
+                                                    context, executor)), executor)
                                             .thenApply(z -> status);
                                 });
                     } else {

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -476,6 +476,26 @@ public abstract class StreamMetadataStoreTest {
     }
 
     @Test
+    public void deleteTest() throws Exception {
+        final String scope = "ScopeDelete";
+        final String stream = "StreamDelete";
+        final ScalingPolicy policy = ScalingPolicy.fixed(2);
+        final StreamConfiguration configuration = StreamConfiguration.builder().scope(scope).streamName(stream).scalingPolicy(policy).build();
+
+        long start = System.currentTimeMillis();
+        store.createScope(scope).get();
+
+        store.createStream(scope, stream, configuration, start, null, executor).get();
+        store.setState(scope, stream, State.ACTIVE, null, executor).get();
+        assertTrue(store.checkStreamExists(scope, stream).join());
+
+        store.deleteStream(scope, stream, null, executor).get();
+        assertFalse(store.checkStreamExists(scope, stream).join());
+        DeleteScopeStatus status = store.deleteScope(scope).join();
+        assertEquals(status.getStatus(), DeleteScopeStatus.Status.SUCCESS);
+    }
+
+    @Test
     public void scaleWithTxTest() throws Exception {
         final String scope = "ScopeScaleWithTx";
         final String stream = "StreamScaleWithTx";

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -511,6 +511,8 @@ public class StreamMetadataTasksTest {
         assertTrue(Futures.await(processEvent(requestEventWriter)));
 
         assertEquals(Controller.DeleteStreamStatus.Status.SUCCESS, future.get());
+
+        assertFalse(streamStorePartialMock.checkStreamExists(SCOPE, stream1).join());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
There are two issues:
1. Delete Scope fails. which is the root cause for test failure
Stream Deletion is done asynchronously. 
We used to check if delete is done by looking to access some property within the stream (like state) and on not being able to find such a property we would conclude that the stream was deleted. 

The stream may be in the process of being deleted, but not all of its data may have been deleted while a request for deletion of scope is received. 

Deletion of scopes fails with "container not empty" from zookeeper. 

2. delete stream under bucket gives NoNode
This is because we are not adding the node while creating the stream. 

**Purpose of the change**
Fixes #2080

**What the code does**
Introduces a new api on metadataStore interface to check if stream exists or not. 

**How to verify it**
Unit tests added