### PR TITLE
Issue 2094: Improve retention and scaling policy classes

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
@@ -36,7 +36,7 @@ public class RetentionPolicy implements Serializable {
     }
 
     private final RetentionType retentionType;
-    private final long retentionDurationOrSize;
+    private final long retentionParam;
 
     /**
      * Create a retention policy to configure a stream to periodically truncated

--- a/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class RetentionPolicy implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public enum Type {
+    public enum RetentionType {
         /**
          * Set retention based on how long data has been in the stream in milliseconds.
          */
@@ -35,14 +35,28 @@ public class RetentionPolicy implements Serializable {
         SIZE
     }
 
-    private final Type type;
-    private final long value;
+    private final RetentionType retentionType;
+    private final long retentionDurationOrSize;
 
+    /**
+     * Create a retention policy to configure a stream to periodically truncated
+     * according to the specified duration.
+     *
+     * @param duration Period to retain data in a stream.
+     * @return Retention policy object.
+     */
     public static RetentionPolicy byTime(Duration duration) {
-        return new RetentionPolicy(Type.TIME, duration.toMillis());
+        return new RetentionPolicy(RetentionType.TIME, duration.toMillis());
     }
 
+    /**
+     * Create a retention policy to configure a stream to truncate a stream
+     * according to the amount of data currently stored.
+     *
+     * @param size Amount of data to retain in a stream.
+     * @return Retention policy object.
+     */
     public static RetentionPolicy bySizeBytes(long size) {
-        return new RetentionPolicy(Type.SIZE, size);
+        return new RetentionPolicy(RetentionType.SIZE, size);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class ScalingPolicy implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public enum Type {
+    public enum RetentionType {
         /**
          * No scaling, there will only ever be {@link ScalingPolicy#minNumSegments} at any given time.
          */
@@ -39,20 +39,76 @@ public class ScalingPolicy implements Serializable {
         BY_RATE_IN_EVENTS_PER_SEC,
     }
 
-    private final Type type;
+    private final RetentionType type;
     private final int targetRate;
     private final int scaleFactor;
     private final int minNumSegments;
-    
+
+    /**
+     * Create a scaling policy to configure a stream to have a fixed number of segments.
+     *
+     * @param numSegments
+     * @return
+     */
     public static ScalingPolicy fixed(int numSegments) {
-        return new ScalingPolicy(Type.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
+        return new ScalingPolicy(RetentionType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
     }
-    
+
+    /**
+     * Create a scaling policy to configure a stream to scale up and down according
+     * to event rate. Pravega scales a stream segment up in the case that:
+     *   - The two-minute rate is greater than 5x the target rate
+     *   - The five-minute rate is greater than 2x the target rate
+     *   - The ten-minute rate is greater than the target rate
+     *
+     * It scales a segment down (merges with a neighbor segment) in the case that:
+     *   - The two-, five-, ten-minute rate is smaller than the target rate
+     *   - The twenty-minute rate is smaller than half of the target rate
+     *
+     * The scale factor bounds the number of new segments that can be created upon
+     * a scaling event. In the case the controller computes the number of splits
+     * to be greater than the scale factor for a given scale-up event, the number
+     * of splits for the event is going to be equal to the scale factor.
+     *
+     * The policy is configured with a minimum number of segments for the stream,
+     * independent of the number of scale down events.
+     *
+     * @param targetRate Target rate in events per second to enable scaling events.
+     * @param scaleFactor Maximum number of splits of a segment for a scale-up event.
+     * @param minNumSegments Minimum number of segments that a stream can have
+     *                       independent of the number of scale down events.
+     * @return Scaling policy object.
+     */
     public static ScalingPolicy byEventRate(int targetRate, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(Type.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
+        return new ScalingPolicy(RetentionType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
     }
-    
+
+    /**
+     * Create a scaling policy to configure a stream to scale up and down according
+     * to byte rate. Pravega scales a stream segment up in the case that:
+     *   - The two-minute rate is greater than 5x the target rate
+     *   - The five-minute rate is greater than 2x the target rate
+     *   - The ten-minute rate is greater than the target rate
+     *
+     * It scales a segment down (merges with a neighbor segment) in the case that:
+     *   - The two-, five-, ten-minute rate is smaller than the target rate
+     *   - The twenty-minute rate is smaller than half of the target rate
+     *
+     * The scale factor bounds the number of new segments that can be created upon
+     * a scaling event. In the case the controller computes the number of splits
+     * to be greater than the scale factor for a given scale-up event, the number
+     * of splits for the event is going to be equal to the scale factor.
+     *
+     * The policy is configured with a minimum number of segments for a stream,
+     * independent of the number of scale down events.
+     *
+     * @param targetKBps Target rate in kilo bytes per second to enable scaling events.
+     * @param scaleFactor Maximum number of splits of a segment for a scale-up event.
+     * @param minNumSegments Minimum number of segments that a stream can have
+     *                       independent of the number of scale down events.
+     * @return Scaling policy object.
+     */
     public static ScalingPolicy byDataRate(int targetKBps, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(Type.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
+        return new ScalingPolicy(RetentionType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class ScalingPolicy implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public enum RetentionType {
+    public enum ScalingType {
         /**
          * No scaling, there will only ever be {@link ScalingPolicy#minNumSegments} at any given time.
          */
@@ -39,7 +39,7 @@ public class ScalingPolicy implements Serializable {
         BY_RATE_IN_EVENTS_PER_SEC,
     }
 
-    private final RetentionType type;
+    private final ScalingType scalingType;
     private final int targetRate;
     private final int scaleFactor;
     private final int minNumSegments;
@@ -47,11 +47,11 @@ public class ScalingPolicy implements Serializable {
     /**
      * Create a scaling policy to configure a stream to have a fixed number of segments.
      *
-     * @param numSegments
-     * @return
+     * @param numSegments Fixed number of segments for the stream.
+     * @return Scaling policy object.
      */
     public static ScalingPolicy fixed(int numSegments) {
-        return new ScalingPolicy(RetentionType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
+        return new ScalingPolicy(ScalingType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
     }
 
     /**
@@ -80,7 +80,7 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byEventRate(int targetRate, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(RetentionType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
+        return new ScalingPolicy(ScalingType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
     }
 
     /**
@@ -109,6 +109,6 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byDataRate(int targetKBps, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(RetentionType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
+        return new ScalingPolicy(ScalingType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class ScalingPolicy implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public enum ScalingType {
+    public enum ScaleType {
         /**
          * No scaling, there will only ever be {@link ScalingPolicy#minNumSegments} at any given time.
          */
@@ -39,7 +39,7 @@ public class ScalingPolicy implements Serializable {
         BY_RATE_IN_EVENTS_PER_SEC,
     }
 
-    private final ScalingType scalingType;
+    private final ScaleType scaleType;
     private final int targetRate;
     private final int scaleFactor;
     private final int minNumSegments;
@@ -51,7 +51,7 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy fixed(int numSegments) {
-        return new ScalingPolicy(ScalingType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
+        return new ScalingPolicy(ScaleType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
     }
 
     /**
@@ -80,7 +80,7 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byEventRate(int targetRate, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(ScalingType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
+        return new ScalingPolicy(ScaleType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
     }
 
     /**
@@ -109,6 +109,6 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byDataRate(int targetKBps, int scaleFactor, int minNumSegments) {
-        return new ScalingPolicy(ScalingType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
+        return new ScalingPolicy(ScaleType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -68,7 +68,7 @@ public final class ModelHelper {
     public static final ScalingPolicy encode(final Controller.ScalingPolicy policy) {
         Preconditions.checkNotNull(policy, "policy");
         return ScalingPolicy.builder()
-                            .type(ScalingPolicy.Type.valueOf(policy.getType().name()))
+                            .scalingType(ScalingPolicy.ScalingType.valueOf(policy.getType().name()))
                             .targetRate(policy.getTargetRate())
                             .scaleFactor(policy.getScaleFactor())
                             .minNumSegments(policy.getMinNumSegments())
@@ -86,8 +86,8 @@ public final class ModelHelper {
         // This is required since proto3 does not have any other way to detect if a field has been set or not.
         if (policy != null && policy.getType() != Controller.RetentionPolicy.RetentionPolicyType.UNKNOWN) {
             return RetentionPolicy.builder()
-                    .type(RetentionPolicy.Type.valueOf(policy.getType().name()))
-                    .value(policy.getValue())
+                    .retentionType(RetentionPolicy.RetentionType.valueOf(policy.getType().name()))
+                    .retentionParam(policy.getValue())
                     .build();
         } else {
             return null;
@@ -228,7 +228,7 @@ public final class ModelHelper {
     public static final Controller.ScalingPolicy decode(final ScalingPolicy policyModel) {
         Preconditions.checkNotNull(policyModel, "policyModel");
         return Controller.ScalingPolicy.newBuilder()
-                .setType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getType().name()))
+                .setType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getScalingType().name()))
                 .setTargetRate(policyModel.getTargetRate())
                 .setScaleFactor(policyModel.getScaleFactor())
                 .setMinNumSegments(policyModel.getMinNumSegments())
@@ -244,8 +244,8 @@ public final class ModelHelper {
     public static final Controller.RetentionPolicy decode(final RetentionPolicy policyModel) {
         if (policyModel != null) {
             return Controller.RetentionPolicy.newBuilder()
-                    .setType(Controller.RetentionPolicy.RetentionPolicyType.valueOf(policyModel.getType().name()))
-                    .setValue(policyModel.getValue())
+                    .setType(Controller.RetentionPolicy.RetentionPolicyType.valueOf(policyModel.getRetentionType().name()))
+                    .setValue(policyModel.getRetentionParam())
                     .build();
         } else {
             return null;

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -68,7 +68,7 @@ public final class ModelHelper {
     public static final ScalingPolicy encode(final Controller.ScalingPolicy policy) {
         Preconditions.checkNotNull(policy, "policy");
         return ScalingPolicy.builder()
-                            .scaleType(ScalingPolicy.ScaleType.valueOf(policy.getType().name()))
+                            .scaleType(ScalingPolicy.ScaleType.valueOf(policy.getScaleType().name()))
                             .targetRate(policy.getTargetRate())
                             .scaleFactor(policy.getScaleFactor())
                             .minNumSegments(policy.getMinNumSegments())
@@ -84,10 +84,10 @@ public final class ModelHelper {
     public static final RetentionPolicy encode(final Controller.RetentionPolicy policy) {
         // Using default enum type of UNKNOWN(0) to detect if retention policy has been set or not.
         // This is required since proto3 does not have any other way to detect if a field has been set or not.
-        if (policy != null && policy.getType() != Controller.RetentionPolicy.RetentionPolicyType.UNKNOWN) {
+        if (policy != null && policy.getRetentionType() != Controller.RetentionPolicy.RetentionPolicyType.UNKNOWN) {
             return RetentionPolicy.builder()
-                    .retentionType(RetentionPolicy.RetentionType.valueOf(policy.getType().name()))
-                    .retentionParam(policy.getValue())
+                    .retentionType(RetentionPolicy.RetentionType.valueOf(policy.getRetentionType().name()))
+                    .retentionParam(policy.getRetentionParam())
                     .build();
         } else {
             return null;
@@ -228,7 +228,7 @@ public final class ModelHelper {
     public static final Controller.ScalingPolicy decode(final ScalingPolicy policyModel) {
         Preconditions.checkNotNull(policyModel, "policyModel");
         return Controller.ScalingPolicy.newBuilder()
-                .setType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getScaleType().name()))
+                .setScaleType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getScaleType().name()))
                 .setTargetRate(policyModel.getTargetRate())
                 .setScaleFactor(policyModel.getScaleFactor())
                 .setMinNumSegments(policyModel.getMinNumSegments())
@@ -244,8 +244,8 @@ public final class ModelHelper {
     public static final Controller.RetentionPolicy decode(final RetentionPolicy policyModel) {
         if (policyModel != null) {
             return Controller.RetentionPolicy.newBuilder()
-                    .setType(Controller.RetentionPolicy.RetentionPolicyType.valueOf(policyModel.getRetentionType().name()))
-                    .setValue(policyModel.getRetentionParam())
+                    .setRetentionType(Controller.RetentionPolicy.RetentionPolicyType.valueOf(policyModel.getRetentionType().name()))
+                    .setRetentionParam(policyModel.getRetentionParam())
                     .build();
         } else {
             return null;

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -68,7 +68,7 @@ public final class ModelHelper {
     public static final ScalingPolicy encode(final Controller.ScalingPolicy policy) {
         Preconditions.checkNotNull(policy, "policy");
         return ScalingPolicy.builder()
-                            .scalingType(ScalingPolicy.ScalingType.valueOf(policy.getType().name()))
+                            .scaleType(ScalingPolicy.ScaleType.valueOf(policy.getType().name()))
                             .targetRate(policy.getTargetRate())
                             .scaleFactor(policy.getScaleFactor())
                             .minNumSegments(policy.getMinNumSegments())
@@ -228,7 +228,7 @@ public final class ModelHelper {
     public static final Controller.ScalingPolicy decode(final ScalingPolicy policyModel) {
         Preconditions.checkNotNull(policyModel, "policyModel");
         return Controller.ScalingPolicy.newBuilder()
-                .setType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getScalingType().name()))
+                .setType(Controller.ScalingPolicy.ScalingPolicyType.valueOf(policyModel.getScaleType().name()))
                 .setTargetRate(policyModel.getTargetRate())
                 .setScaleFactor(policyModel.getScaleFactor())
                 .setMinNumSegments(policyModel.getMinNumSegments())

--- a/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
@@ -100,7 +100,7 @@ public class ModelHelperTest {
     @Test
     public void encodeScalingPolicy() {
         ScalingPolicy policy = ModelHelper.encode(ModelHelper.decode(ScalingPolicy.byEventRate(100, 2, 3)));
-        assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScalingType());
+        assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScaleType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());
@@ -173,7 +173,7 @@ public class ModelHelperTest {
           .build()));
         assertEquals("test", config.getStreamName());
         ScalingPolicy policy = config.getScalingPolicy();
-        assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScalingType());
+        assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScaleType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());

--- a/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
@@ -100,7 +100,7 @@ public class ModelHelperTest {
     @Test
     public void encodeScalingPolicy() {
         ScalingPolicy policy = ModelHelper.encode(ModelHelper.decode(ScalingPolicy.byEventRate(100, 2, 3)));
-        assertEquals(ScalingPolicy.Type.BY_RATE_IN_EVENTS_PER_SEC, policy.getType());
+        assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScalingType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());
@@ -109,12 +109,12 @@ public class ModelHelperTest {
     @Test
     public void encodeRetentionPolicy() {
         RetentionPolicy policy1 = ModelHelper.encode(ModelHelper.decode(RetentionPolicy.bySizeBytes(1000L)));
-        assertEquals(RetentionPolicy.Type.SIZE, policy1.getType());
-        assertEquals(1000L, (long) policy1.getValue());
+        assertEquals(RetentionPolicy.RetentionType.SIZE, policy1.getRetentionType());
+        assertEquals(1000L, (long) policy1.getRetentionParam());
 
         RetentionPolicy policy2 = ModelHelper.encode(ModelHelper.decode(RetentionPolicy.byTime(Duration.ofDays(100L))));
-        assertEquals(RetentionPolicy.Type.TIME, policy2.getType());
-        assertEquals(Duration.ofDays(100L).toMillis(), (long) policy2.getValue());
+        assertEquals(RetentionPolicy.RetentionType.TIME, policy2.getRetentionType());
+        assertEquals(Duration.ofDays(100L).toMillis(), (long) policy2.getRetentionParam());
 
         RetentionPolicy policy3 = ModelHelper.encode(ModelHelper.decode((RetentionPolicy) null));
         assertNull(policy3);
@@ -173,13 +173,13 @@ public class ModelHelperTest {
           .build()));
         assertEquals("test", config.getStreamName());
         ScalingPolicy policy = config.getScalingPolicy();
-        assertEquals(ScalingPolicy.Type.BY_RATE_IN_EVENTS_PER_SEC, policy.getType());
+        assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScalingType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());
         RetentionPolicy retentionPolicy = config.getRetentionPolicy();
-        assertEquals(RetentionPolicy.Type.SIZE, retentionPolicy.getType());
-        assertEquals(1000L, (long) retentionPolicy.getValue());
+        assertEquals(RetentionPolicy.RetentionType.SIZE, retentionPolicy.getRetentionType());
+        assertEquals(1000L, (long) retentionPolicy.getRetentionParam());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
@@ -86,7 +86,7 @@ public class ModelHelperTest {
     @Test
     public void decodeScalingPolicy() {
         Controller.ScalingPolicy policy = ModelHelper.decode(ScalingPolicy.byEventRate(100, 2, 3));
-        assertEquals(Controller.ScalingPolicy.ScalingPolicyType.BY_RATE_IN_EVENTS_PER_SEC, policy.getType());
+        assertEquals(Controller.ScalingPolicy.ScalingPolicyType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScaleType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());
@@ -123,12 +123,12 @@ public class ModelHelperTest {
     @Test
     public void decodeRetentionPolicy() {
         Controller.RetentionPolicy policy1 = ModelHelper.decode(RetentionPolicy.bySizeBytes(1000L));
-        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.SIZE, policy1.getType());
-        assertEquals(1000L, policy1.getValue());
+        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.SIZE, policy1.getRetentionType());
+        assertEquals(1000L, policy1.getRetentionParam());
 
         Controller.RetentionPolicy policy2 = ModelHelper.decode(RetentionPolicy.byTime(Duration.ofDays(100L)));
-        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.TIME, policy2.getType());
-        assertEquals(Duration.ofDays(100L).toMillis(), policy2.getValue());
+        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.TIME, policy2.getRetentionType());
+        assertEquals(Duration.ofDays(100L).toMillis(), policy2.getRetentionParam());
 
         Controller.RetentionPolicy policy3 = ModelHelper.decode((RetentionPolicy) null);
         assertNull(policy3);
@@ -149,13 +149,13 @@ public class ModelHelperTest {
                 .build());
         assertEquals("test", config.getStreamInfo().getStream());
         Controller.ScalingPolicy policy = config.getScalingPolicy();
-        assertEquals(Controller.ScalingPolicy.ScalingPolicyType.BY_RATE_IN_EVENTS_PER_SEC, policy.getType());
+        assertEquals(Controller.ScalingPolicy.ScalingPolicyType.BY_RATE_IN_EVENTS_PER_SEC, policy.getScaleType());
         assertEquals(100L, policy.getTargetRate());
         assertEquals(2, policy.getScaleFactor());
         assertEquals(3, policy.getMinNumSegments());
         Controller.RetentionPolicy retentionPolicy = config.getRetentionPolicy();
-        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.TIME, retentionPolicy.getType());
-        assertEquals(Duration.ofDays(100L).toMillis(), retentionPolicy.getValue());
+        assertEquals(Controller.RetentionPolicy.RetentionPolicyType.TIME, retentionPolicy.getRetentionType());
+        assertEquals(Duration.ofDays(100L).toMillis(), retentionPolicy.getRetentionParam());
     }
 
     @Test(expected = NullPointerException.class)

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -123,7 +123,7 @@ public class MockController implements Controller {
         StreamConfiguration config = createdStreams.get(stream);
         Preconditions.checkArgument(config != null, "Stream must be created first");
         ScalingPolicy scalingPolicy = config.getScalingPolicy();
-        if (scalingPolicy.getType() != ScalingPolicy.Type.FIXED_NUM_SEGMENTS) {
+        if (scalingPolicy.getScalingType() != ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
             throw new IllegalArgumentException("Dynamic scaling not supported with a mock controller");
         }
         List<Segment> result = new ArrayList<>(scalingPolicy.getMinNumSegments());
@@ -409,7 +409,7 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<Set<Segment>> getSuccessors(StreamCut from) {
         StreamConfiguration configuration = createdStreams.get(from.getStream());
-        if (configuration.getScalingPolicy().getType() != ScalingPolicy.Type.FIXED_NUM_SEGMENTS) {
+        if (configuration.getScalingPolicy().getScalingType() != ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
             throw new IllegalArgumentException("getSuccessors not supported with dynamic scaling on mock controller");
         }
         return CompletableFuture.completedFuture(Collections.emptySet());

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -123,7 +123,7 @@ public class MockController implements Controller {
         StreamConfiguration config = createdStreams.get(stream);
         Preconditions.checkArgument(config != null, "Stream must be created first");
         ScalingPolicy scalingPolicy = config.getScalingPolicy();
-        if (scalingPolicy.getScalingType() != ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
+        if (scalingPolicy.getScaleType() != ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS) {
             throw new IllegalArgumentException("Dynamic scaling not supported with a mock controller");
         }
         List<Segment> result = new ArrayList<>(scalingPolicy.getMinNumSegments());
@@ -409,7 +409,7 @@ public class MockController implements Controller {
     @Override
     public CompletableFuture<Set<Segment>> getSuccessors(StreamCut from) {
         StreamConfiguration configuration = createdStreams.get(from.getStream());
-        if (configuration.getScalingPolicy().getScalingType() != ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
+        if (configuration.getScalingPolicy().getScaleType() != ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS) {
             throw new IllegalArgumentException("getSuccessors not supported with dynamic scaling on mock controller");
         }
         return CompletableFuture.completedFuture(Collections.emptySet());

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -490,12 +490,12 @@ public class SegmentHelper {
     private Pair<Byte, Integer> extractFromPolicy(ScalingPolicy policy) {
         final int desiredRate;
         final byte rateType;
-        if (policy.getType().equals(ScalingPolicy.Type.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
             desiredRate = 0;
             rateType = WireCommands.CreateSegment.NO_SCALE;
         } else {
             desiredRate = Math.toIntExact(policy.getTargetRate());
-            if (policy.getType().equals(ScalingPolicy.Type.BY_RATE_IN_KBYTES_PER_SEC)) {
+            if (policy.getScalingType().equals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC)) {
                 rateType = WireCommands.CreateSegment.IN_KBYTES_PER_SEC;
             } else {
                 rateType = WireCommands.CreateSegment.IN_EVENTS_PER_SEC;

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -490,12 +490,12 @@ public class SegmentHelper {
     private Pair<Byte, Integer> extractFromPolicy(ScalingPolicy policy) {
         final int desiredRate;
         final byte rateType;
-        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScaleType().equals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS)) {
             desiredRate = 0;
             rateType = WireCommands.CreateSegment.NO_SCALE;
         } else {
             desiredRate = Math.toIntExact(policy.getTargetRate());
-            if (policy.getScalingType().equals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC)) {
+            if (policy.getScaleType().equals(ScalingPolicy.ScaleType.BY_RATE_IN_KBYTES_PER_SEC)) {
                 rateType = WireCommands.CreateSegment.IN_KBYTES_PER_SEC;
             } else {
                 rateType = WireCommands.CreateSegment.IN_EVENTS_PER_SEC;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
@@ -87,7 +87,7 @@ public class AutoScaleTask {
 
     private CompletableFuture<Void> processScaleUp(final AutoScaleEvent request, final ScalingPolicy policy, final OperationContext context) {
         log.info("scale up request received for stream {} segment {}", request.getStream(), request.getSegmentNumber());
-        if (policy.getType().equals(ScalingPolicy.Type.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
             return CompletableFuture.completedFuture(null);
         }
         return streamMetadataStore.getSegment(request.getScope(), request.getStream(), request.getSegmentNumber(), context, executor)
@@ -107,7 +107,7 @@ public class AutoScaleTask {
 
     private CompletableFuture<Void> processScaleDown(final AutoScaleEvent request, final ScalingPolicy policy, final OperationContext context) {
         log.info("scale down request received for stream {} segment {}", request.getStream(), request.getSegmentNumber());
-        if (policy.getType().equals(ScalingPolicy.Type.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
@@ -87,7 +87,7 @@ public class AutoScaleTask {
 
     private CompletableFuture<Void> processScaleUp(final AutoScaleEvent request, final ScalingPolicy policy, final OperationContext context) {
         log.info("scale up request received for stream {} segment {}", request.getStream(), request.getSegmentNumber());
-        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScaleType().equals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS)) {
             return CompletableFuture.completedFuture(null);
         }
         return streamMetadataStore.getSegment(request.getScope(), request.getStream(), request.getSegmentNumber(), context, executor)
@@ -107,7 +107,7 @@ public class AutoScaleTask {
 
     private CompletableFuture<Void> processScaleDown(final AutoScaleEvent request, final ScalingPolicy policy, final OperationContext context) {
         log.info("scale down request received for stream {} segment {}", request.getStream(), request.getSegmentNumber());
-        if (policy.getScalingType().equals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS)) {
+        if (policy.getScaleType().equals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS)) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
@@ -128,13 +128,13 @@ public class ModelHelper {
      */
     public static final StreamProperty encodeStreamResponse(final StreamConfiguration streamConfiguration) {
         ScalingConfig scalingPolicy = new ScalingConfig();
-        if (streamConfiguration.getScalingPolicy().getType() == ScalingPolicy.Type.FIXED_NUM_SEGMENTS) {
+        if (streamConfiguration.getScalingPolicy().getScalingType() == ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
             scalingPolicy.setType(ScalingConfig.TypeEnum.valueOf(streamConfiguration.getScalingPolicy().
-                    getType().name()));
+                    getScalingType().name()));
             scalingPolicy.setMinSegments(streamConfiguration.getScalingPolicy().getMinNumSegments());
         } else {
             scalingPolicy.setType(ScalingConfig.TypeEnum.valueOf(streamConfiguration.getScalingPolicy().
-                    getType().name()));
+                    getScalingType().name()));
             scalingPolicy.setTargetRate(streamConfiguration.getScalingPolicy().getTargetRate());
             scalingPolicy.setScaleFactor(streamConfiguration.getScalingPolicy().getScaleFactor());
             scalingPolicy.setMinSegments(streamConfiguration.getScalingPolicy().getMinNumSegments());
@@ -143,15 +143,15 @@ public class ModelHelper {
         RetentionConfig retentionConfig = null;
         if (streamConfiguration.getRetentionPolicy() != null) {
             retentionConfig = new RetentionConfig();
-            switch (streamConfiguration.getRetentionPolicy().getType()) {
+            switch (streamConfiguration.getRetentionPolicy().getRetentionType()) {
                 case SIZE:
                     retentionConfig.setType(RetentionConfig.TypeEnum.LIMITED_SIZE_MB);
-                    retentionConfig.setValue(streamConfiguration.getRetentionPolicy().getValue() / (1024 * 1024));
+                    retentionConfig.setValue(streamConfiguration.getRetentionPolicy().getRetentionParam() / (1024 * 1024));
                     break;
                 case TIME:
                     retentionConfig.setType(RetentionConfig.TypeEnum.LIMITED_DAYS);
                     retentionConfig.setValue(
-                            Duration.ofMillis(streamConfiguration.getRetentionPolicy().getValue()).toDays());
+                            Duration.ofMillis(streamConfiguration.getRetentionPolicy().getRetentionParam()).toDays());
                     break;
             }
         }

--- a/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
@@ -128,13 +128,13 @@ public class ModelHelper {
      */
     public static final StreamProperty encodeStreamResponse(final StreamConfiguration streamConfiguration) {
         ScalingConfig scalingPolicy = new ScalingConfig();
-        if (streamConfiguration.getScalingPolicy().getScalingType() == ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS) {
+        if (streamConfiguration.getScalingPolicy().getScaleType() == ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS) {
             scalingPolicy.setType(ScalingConfig.TypeEnum.valueOf(streamConfiguration.getScalingPolicy().
-                    getScalingType().name()));
+                    getScaleType().name()));
             scalingPolicy.setMinSegments(streamConfiguration.getScalingPolicy().getMinNumSegments());
         } else {
             scalingPolicy.setType(ScalingConfig.TypeEnum.valueOf(streamConfiguration.getScalingPolicy().
-                    getScalingType().name()));
+                    getScaleType().name()));
             scalingPolicy.setTargetRate(streamConfiguration.getScalingPolicy().getTargetRate());
             scalingPolicy.setScaleFactor(streamConfiguration.getScalingPolicy().getScaleFactor());
             scalingPolicy.setMinSegments(streamConfiguration.getScalingPolicy().getMinNumSegments());

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -210,7 +210,7 @@ public class StreamMetadataTasks extends TaskBase {
 
     private CompletableFuture<Void> checkGenerateStreamCut(String scope, String stream, OperationContext context,
                                                            RetentionPolicy policy, StreamCutRecord latestCut, long recordingTime) {
-        switch (policy.getType()) {
+        switch (policy.getRetentionType()) {
             case TIME:
                 if (latestCut == null || recordingTime - latestCut.getRecordingTime() > Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES).toMillis()) {
                     return generateStreamCut(scope, stream, context)
@@ -240,9 +240,9 @@ public class StreamMetadataTasks extends TaskBase {
     }
 
     private Optional<StreamCutRecord> findTruncationRecord(RetentionPolicy policy, List<StreamCutRecord> retentionSet, long recordingTime) {
-        switch (policy.getType()) {
+        switch (policy.getRetentionType()) {
             case TIME:
-                return retentionSet.stream().filter(x -> x.getRecordingTime() < recordingTime - policy.getValue())
+                return retentionSet.stream().filter(x -> x.getRecordingTime() < recordingTime - policy.getRetentionParam())
                         .max(Comparator.comparingLong(StreamCutRecord::getRecordingTime));
             case SIZE:
             default:

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -48,7 +48,7 @@ public class ModelHelperTest {
         createStreamRequest.setScalingPolicy(scalingConfig);
 
         StreamConfiguration streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.Type.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getMinNumSegments());
         Assert.assertNull(streamConfig.getRetentionPolicy());
 
@@ -63,13 +63,13 @@ public class ModelHelperTest {
         createStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.Type.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals("scope", streamConfig.getScope());
         Assert.assertEquals("stream", streamConfig.getStreamName());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(123, streamConfig.getScalingPolicy().getTargetRate());
-        Assert.assertEquals(RetentionPolicy.Type.TIME, streamConfig.getRetentionPolicy().getType());
-        Assert.assertEquals(Duration.ofDays(1234L).toMillis(), streamConfig.getRetentionPolicy().getValue());
+        Assert.assertEquals(RetentionPolicy.RetentionType.TIME, streamConfig.getRetentionPolicy().getRetentionType());
+        Assert.assertEquals(Duration.ofDays(1234L).toMillis(), streamConfig.getRetentionPolicy().getRetentionParam());
 
         scalingConfig.setType(ScalingConfig.TypeEnum.BY_RATE_IN_KBYTES_PER_SEC);
         scalingConfig.setTargetRate(1234);
@@ -81,11 +81,11 @@ public class ModelHelperTest {
         createStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.Type.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals(23, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(1234, streamConfig.getScalingPolicy().getTargetRate());
-        Assert.assertEquals(RetentionPolicy.Type.SIZE, streamConfig.getRetentionPolicy().getType());
-        Assert.assertEquals(12345L * 1024 * 1024, streamConfig.getRetentionPolicy().getValue());
+        Assert.assertEquals(RetentionPolicy.RetentionType.SIZE, streamConfig.getRetentionPolicy().getRetentionType());
+        Assert.assertEquals(12345L * 1024 * 1024, streamConfig.getRetentionPolicy().getRetentionParam());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class ModelHelperTest {
         updateStreamRequest.setScalingPolicy(scalingConfig);
 
         StreamConfiguration streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
-        Assert.assertEquals(ScalingPolicy.Type.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getMinNumSegments());
         Assert.assertNull(streamConfig.getRetentionPolicy());
 
@@ -113,11 +113,11 @@ public class ModelHelperTest {
         streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
         Assert.assertEquals("scope", streamConfig.getScope());
         Assert.assertEquals("stream", streamConfig.getStreamName());
-        Assert.assertEquals(ScalingPolicy.Type.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(123, streamConfig.getScalingPolicy().getTargetRate());
-        Assert.assertEquals(RetentionPolicy.Type.TIME, streamConfig.getRetentionPolicy().getType());
-        Assert.assertEquals(Duration.ofDays(1234L).toMillis(), streamConfig.getRetentionPolicy().getValue());
+        Assert.assertEquals(RetentionPolicy.RetentionType.TIME, streamConfig.getRetentionPolicy().getRetentionType());
+        Assert.assertEquals(Duration.ofDays(1234L).toMillis(), streamConfig.getRetentionPolicy().getRetentionParam());
 
         scalingConfig.setType(ScalingConfig.TypeEnum.BY_RATE_IN_KBYTES_PER_SEC);
         scalingConfig.setTargetRate(1234);
@@ -128,11 +128,11 @@ public class ModelHelperTest {
         updateStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
-        Assert.assertEquals(ScalingPolicy.Type.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getType());
+        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
         Assert.assertEquals(23, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(1234, streamConfig.getScalingPolicy().getTargetRate());
-        Assert.assertEquals(RetentionPolicy.Type.SIZE, streamConfig.getRetentionPolicy().getType());
-        Assert.assertEquals(12345L * 1024 * 1024, streamConfig.getRetentionPolicy().getValue());
+        Assert.assertEquals(RetentionPolicy.RetentionType.SIZE, streamConfig.getRetentionPolicy().getRetentionType());
+        Assert.assertEquals(12345L * 1024 * 1024, streamConfig.getRetentionPolicy().getRetentionParam());
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -48,7 +48,7 @@ public class ModelHelperTest {
         createStreamRequest.setScalingPolicy(scalingConfig);
 
         StreamConfiguration streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getMinNumSegments());
         Assert.assertNull(streamConfig.getRetentionPolicy());
 
@@ -63,7 +63,7 @@ public class ModelHelperTest {
         createStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals("scope", streamConfig.getScope());
         Assert.assertEquals("stream", streamConfig.getStreamName());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getScaleFactor());
@@ -81,7 +81,7 @@ public class ModelHelperTest {
         createStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getCreateStreamConfig(createStreamRequest, "scope");
-        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(23, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(1234, streamConfig.getScalingPolicy().getTargetRate());
         Assert.assertEquals(RetentionPolicy.RetentionType.SIZE, streamConfig.getRetentionPolicy().getRetentionType());
@@ -97,7 +97,7 @@ public class ModelHelperTest {
         updateStreamRequest.setScalingPolicy(scalingConfig);
 
         StreamConfiguration streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
-        Assert.assertEquals(ScalingPolicy.ScalingType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getMinNumSegments());
         Assert.assertNull(streamConfig.getRetentionPolicy());
 
@@ -113,7 +113,7 @@ public class ModelHelperTest {
         streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
         Assert.assertEquals("scope", streamConfig.getScope());
         Assert.assertEquals("stream", streamConfig.getStreamName());
-        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_EVENTS_PER_SEC, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(123, streamConfig.getScalingPolicy().getTargetRate());
         Assert.assertEquals(RetentionPolicy.RetentionType.TIME, streamConfig.getRetentionPolicy().getRetentionType());
@@ -128,7 +128,7 @@ public class ModelHelperTest {
         updateStreamRequest.setRetentionPolicy(retentionConfig);
 
         streamConfig = getUpdateStreamConfig(updateStreamRequest, "scope", "stream");
-        Assert.assertEquals(ScalingPolicy.ScalingType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScalingType());
+        Assert.assertEquals(ScalingPolicy.ScaleType.BY_RATE_IN_KBYTES_PER_SEC, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(23, streamConfig.getScalingPolicy().getScaleFactor());
         Assert.assertEquals(1234, streamConfig.getScalingPolicy().getTargetRate());
         Assert.assertEquals(RetentionPolicy.RetentionType.SIZE, streamConfig.getRetentionPolicy().getRetentionType());

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -649,7 +649,10 @@ public abstract class StreamMetadataStoreTest {
         final String scope = "ScopeRetain";
         final String stream = "StreamRetain";
         final ScalingPolicy policy = ScalingPolicy.fixed(2);
-        final RetentionPolicy retentionPolicy = RetentionPolicy.builder().type(RetentionPolicy.Type.TIME).value(Duration.ofDays(2).toMillis()).build();
+        final RetentionPolicy retentionPolicy = RetentionPolicy.builder()
+                .retentionType(RetentionPolicy.RetentionType.TIME)
+                .retentionParam(Duration.ofDays(2).toMillis())
+                .build();
         final StreamConfiguration configuration = StreamConfiguration.builder().scope(scope).streamName(stream)
                 .scalingPolicy(policy).retentionPolicy(retentionPolicy).build();
 

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -369,7 +369,10 @@ public class StreamMetadataTasksTest {
     @Test(timeout = 30000)
     public void retentionStreamTest() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(2);
-        final RetentionPolicy retentionPolicy = RetentionPolicy.builder().type(RetentionPolicy.Type.TIME).value(Duration.ofMinutes(60).toMillis()).build();
+        final RetentionPolicy retentionPolicy = RetentionPolicy.builder()
+                .retentionType(RetentionPolicy.RetentionType.TIME)
+                .retentionParam(Duration.ofMinutes(60).toMillis())
+                .build();
 
         final StreamConfiguration configuration = StreamConfiguration.builder().scope(SCOPE).streamName("test").scalingPolicy(policy)
                 .retentionPolicy(retentionPolicy).build();
@@ -436,7 +439,7 @@ public class StreamMetadataTasksTest {
         Map<Integer, Long> map4 = new HashMap<>();
         map4.put(0, 20L);
         map4.put(1, 20L);
-        long recordingTime4 = recordingTime1 + retentionPolicy.getValue() + 2;
+        long recordingTime4 = recordingTime1 + retentionPolicy.getRetentionParam() + 2;
         StreamCutRecord streamCut4 = new StreamCutRecord(recordingTime4, Long.MIN_VALUE, map4);
         doReturn(CompletableFuture.completedFuture(streamCut4)).when(streamMetadataTasks).generateStreamCut(
                 anyString(), anyString(), any());

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -144,7 +144,7 @@ message ScalingPolicy {
         BY_RATE_IN_KBYTES_PER_SEC = 1;
         BY_RATE_IN_EVENTS_PER_SEC = 2;
     }
-    ScalingPolicyType type = 1;
+    ScalingPolicyType scaleType = 1;
     int32 targetRate = 2;
     int32 scaleFactor = 3;
     int32 minNumSegments = 4;
@@ -156,8 +156,8 @@ message RetentionPolicy {
         TIME = 1;
         SIZE = 2;
     }
-    RetentionPolicyType type = 1;
-    int64 value = 2;
+    RetentionPolicyType retentionType = 1;
+    int64 retentionParam = 2;
 }
 
 message StreamConfig {


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**
* Adds javadocs to the public static classes in ScalingPolicy and RetentionPolicy

* Renames the type classes in ScalingPolicy and RetentionPolicy to be more specific
 
**Purpose of the change**
Fixes #2094

**What the code does**
There is no functional change, it only adds javadocs to explain how to set the parameter values that creates a policy instance.

**How to verify it**
Tests should pass, but it is mostly visual inspection.