### PR TITLE
Issue 2096: Ensure segmentInputStream closed inside method read(EventPointer pointer).

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -35,6 +35,7 @@ import java.util.Map.Entry;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
+import lombok.Cleanup;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 
@@ -224,7 +225,8 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     @Override
     public Type read(EventPointer pointer) throws NoSuchEventException {
         Preconditions.checkNotNull(pointer);
-        // Create SegmentInputBuffer
+        // Create SegmentInputStream
+        @Cleanup
         SegmentInputStream inputStream = inputStreamFactory.createInputStreamForSegment(pointer.asImpl().getSegment(),
                                                                                         pointer.asImpl().getEventLength());
         inputStream.setOffset(pointer.asImpl().getEventStartOffset());


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure SegmentInputStream is closed inside method `io.pravega.client.stream.impl.EventStreamReaderImpl#read(Eventpointer pointer)
`
**Purpose of the change**
Fixes #2096 

**What the code does**
Closes SegmentInputStream created inside read(EventPointer) method.

**How to verify it**
Tests should continue to pass.