### PR TITLE
Issue 2104: Ensure all the logs are compressed after rollover.

### DIFF
--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -21,10 +21,10 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>controller_server_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>controller_server_%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>5MB</maxFileSize>
+                <maxFileSize>10MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <!-- keep 30 days' worth of history -->
             <maxHistory>30</maxHistory>

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -21,7 +21,7 @@ You may obtain a copy of the License at
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${log.dir:-.}/${log.name:-pravega}_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>${log.dir:-.}/${log.name:-pravega}_%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>10MB</maxFileSize>

--- a/segmentstore/server/host/src/config/logback.xml
+++ b/segmentstore/server/host/src/config/logback.xml
@@ -21,7 +21,7 @@ You may obtain a copy of the License at
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>segmentstore_server_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>segmentstore_server_%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>10MB</maxFileSize>


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure pravega logs are compressed after rollover.

**Purpose of the change**
Fixes #2104 

**What the code does**
Ensure logs are compressed during rollover.

**How to verify it**
Tested that the compression of logs does happen.