### PR TITLE
Issue 2108:  Ensure pravega logs are stored on Mesos Sandbox directory.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -75,8 +75,6 @@ public class RemoteSequential implements TestExecutor {
                                 methodName);
 
                     }
-                    //Wait for a minute between tests runs.
-                    Exceptions.handleInterrupted(() -> TimeUnit.MINUTES.sleep(1));
                 });
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/MarathonBasedService.java
@@ -131,7 +131,7 @@ public abstract class MarathonBasedService implements Service {
 
     CompletableFuture<Void> waitUntilServiceRunning() {
         return Futures.loop(() -> !isRunning(), //condition
-                () -> Futures.delayedFuture(Duration.ofSeconds(20), executorService),
+                () -> Futures.delayedFuture(Duration.ofSeconds(10), executorService),
                 executorService);
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaControllerService.java
@@ -127,6 +127,7 @@ public class PravegaControllerService extends MarathonBasedService {
                 setSystemProperty("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT)) +
                 setSystemProperty("REST_SERVER_PORT", String.valueOf(REST_PORT)) +
                 setSystemProperty("log.level", "DEBUG") +
+                setSystemProperty("log.dir", "$MESOS_SANDBOX/pravegaLogs") +
                 setSystemProperty("curator-default-session-timeout", String.valueOf(10 * 1000)) +
                 setSystemProperty("MAX_LEASE_VALUE", String.valueOf(60 * 1000)) +
                 setSystemProperty("MAX_SCALE_GRACE_PERIOD", String.valueOf(60 * 1000));

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/PravegaSegmentStoreService.java
@@ -129,6 +129,7 @@ public class PravegaSegmentStoreService extends MarathonBasedService {
                 setSystemProperty("autoScale.cacheExpiryInSeconds", "120") +
                 setSystemProperty("autoScale.cacheCleanUpInSeconds", "120") +
                 setSystemProperty("log.level", "DEBUG") +
+                setSystemProperty("log.dir", "$MESOS_SANDBOX/pravegaLogs") +
                 setSystemProperty("curator-default-session-timeout", String.valueOf(30 * 1000)) +
                 setSystemProperty("hdfs.replaceDataNodesOnFailure", "false");
 


### PR DESCRIPTION
**Change log description**
- Ensure pravegalogs are stored in mesos sandbox directory.
- Remove sleep post test execution as we have a sleep before execution of tests.
- Check if service is running every 10seconds instead of 20seconds.

**Purpose of the change**
Fixes #2108

**What the code does**
Ensure logs are stored in mesos sandbox directory and remove redundant waits in the system test framework.

**How to verify it**
Tests should continue to pass.