### PR TITLE
Issue 2120: Handle StreamConfiguration with null retention policy

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
@@ -65,8 +65,14 @@ public class UpdateStreamTask implements StreamTask<UpdateStreamEvent> {
     private CompletableFuture<Void> processUpdate(String scope, String stream, StreamProperty<StreamConfiguration> configProperty,
                                                   OperationContext context) {
         return Futures.toVoid(streamMetadataStore.setState(scope, stream, State.UPDATING, context, executor)
-                .thenCompose(x -> streamMetadataStore.addUpdateStreamForAutoStreamCut(scope, stream,
-                        configProperty.getProperty().getRetentionPolicy(), context, executor))
+                .thenCompose(x -> {
+                    if (configProperty.getProperty().getRetentionPolicy() != null) {
+                        return streamMetadataStore.addUpdateStreamForAutoStreamCut(scope, stream,
+                                configProperty.getProperty().getRetentionPolicy(), context, executor);
+                    } else {
+                        return streamMetadataStore.removeStreamFromAutoStreamCut(scope, stream, context, executor);
+                    }
+                })
                 .thenCompose(x -> notifyPolicyUpdate(context, scope, stream, configProperty.getProperty()))
                 .thenCompose(x -> streamMetadataStore.completeUpdateConfiguration(scope, stream, context, executor))
                 .thenCompose(x -> streamMetadataStore.setState(scope, stream, State.ACTIVE, context, executor)));

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -189,7 +189,9 @@ class InMemoryStreamMetadataStore extends AbstractStreamMetadataStore {
 
     @Synchronized
     @Override
-    public CompletableFuture<Void> addUpdateStreamForAutoStreamCut(String scope, String stream, RetentionPolicy retentionPolicy, OperationContext context, Executor executor) {
+    public CompletableFuture<Void> addUpdateStreamForAutoStreamCut(String scope, String stream, RetentionPolicy retentionPolicy,
+                                                                   OperationContext context, Executor executor) {
+        Preconditions.checkNotNull(retentionPolicy);
         int bucket = getBucket(scope, stream);
         List<String> list;
         if (bucketedStreams.containsKey(bucket)) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -219,6 +219,7 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
     @Override
     public CompletableFuture<Void> addUpdateStreamForAutoStreamCut(final String scope, final String stream, final RetentionPolicy retentionPolicy,
                                                                    final OperationContext context, final Executor executor) {
+        Preconditions.checkNotNull(retentionPolicy);
         int bucket = getBucket(scope, stream);
         String retentionPath = String.format(ZKStoreHelper.RETENTION_PATH, bucket, encodedScopedStreamName(scope, stream));
         byte[] serialize = SerializationUtils.serialize(retentionPolicy);

--- a/controller/src/test/java/io/pravega/controller/server/retention/StreamCutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/retention/StreamCutServiceTest.java
@@ -95,6 +95,11 @@ public abstract class StreamCutServiceTest {
         String scope = "scope";
         String streamName = "stream";
         Stream stream = new StreamImpl(scope, streamName);
+
+        AssertExtensions.assertThrows("Null retention policy check",
+                () -> streamMetadataStore.addUpdateStreamForAutoStreamCut(scope, streamName, null, null, executor).join(),
+                e -> e instanceof NullPointerException);
+
         streamMetadataStore.addUpdateStreamForAutoStreamCut(scope, streamName, RetentionPolicy.builder().build(), null, executor).join();
 
         // verify that at least one of the buckets got the notification


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**
* Does not add stream to the retention bucket if it has null retention policy.

* Checks during stream configuration updates whether retention policy is added or removed from previous configuration and add or remove stream from the bucket accordingly.

**Purpose of the change**
Fixes #2120

**What the code does**
If a stream configuration has a null retention policy, then stream should not be considered for auto-retention. 

AutoRetention is performed on all streams that are part of some bucket. 
So we should not add stream to the bucket if it has null retention policy. 
Similarly, during configuration update, we should check if retention policy is added or removed from previous configuration and add or remove stream from the bucket respectively.

**How to verify it**
Unit test added. 