### PR TITLE
Issue 2114 :  Ensure out of order acks are not sent by the append processor.

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -255,14 +255,6 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             long previousEventNumber;
             synchronized (lock) {
                 previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
-                if (exception == null) {
-                    latestEventNumbers.put(Pair.of(append.getSegment(), append.getWriterId()), append.getEventNumber());                 
-                } else {
-                    if (!conditionalFailed) {
-                        waitingAppends.removeAll(append.getWriterId());
-                        latestEventNumbers.remove(Pair.of(append.getSegment(), append.getWriterId()));
-                    } 
-                }
             }
       
             if (exception != null) {
@@ -276,17 +268,30 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 if (statsRecorder != null) {
                     statsRecorder.record(append.getSegment(), append.getDataLength(), append.getEventCount());
                 }
-                connection.send(new DataAppended(append.getWriterId(), append.getEventNumber(), previousEventNumber));
+                final DataAppended dataAppendedAck = new DataAppended(append.getWriterId(), append.getEventNumber(),
+                        previousEventNumber);
+                log.trace("Sending DataAppended : {}", dataAppendedAck);
+                connection.send(dataAppendedAck);
                 DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
                 DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
             }
 
-            /* Reply (DataAppended in case of success, else an error Reply based on exception) has been sent, clear
-             outstandingAppend to handle the next Append message. */
+            /* Reply (DataAppended in case of success, else an error Reply based on exception) has been sent. Next,
+             *   - clear outstandingAppend to handle the next Append message.
+             *   - ensure latestEventNumbers and waitingAppends are updated.
+             */
             synchronized (lock) {
                 Preconditions.checkState(outstandingAppend == append,
                         "Synchronization error in: %s.", AppendProcessor.this.getClass().getName());
                 outstandingAppend = null;
+                if (exception == null) {
+                    latestEventNumbers.put(Pair.of(append.getSegment(), append.getWriterId()), append.getEventNumber());
+                } else {
+                    if (!conditionalFailed) {
+                        waitingAppends.removeAll(append.getWriterId());
+                        latestEventNumbers.remove(Pair.of(append.getSegment(), append.getWriterId()));
+                    }
+                }
             }
       
             pauseOrResumeReading();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -255,6 +255,9 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             long previousEventNumber;
             synchronized (lock) {
                 previousEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
+                Preconditions.checkState(outstandingAppend == append,
+                        "Synchronization error in: %s while processing append: %s.",
+                        AppendProcessor.this.getClass().getName(), append);
             }
       
             if (exception != null) {
@@ -282,7 +285,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
              */
             synchronized (lock) {
                 Preconditions.checkState(outstandingAppend == append,
-                        "Synchronization error in: %s.", AppendProcessor.this.getClass().getName());
+                        "Synchronization error in: %s while processing append: %s.",
+                        AppendProcessor.this.getClass().getName(), append);
                 outstandingAppend = null;
                 if (exception == null) {
                     latestEventNumbers.put(Pair.of(append.getSegment(), append.getWriterId()), append.getEventNumber());

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -415,6 +415,8 @@ public class AppendProcessorTest {
                 AppendProcessor.TIMEOUT);
         //Verify two DataAppended acks are sent out.
         verify(connection, times(2)).send(any(DataAppended.class));
+        verify(connection).send(new DataAppended(clientId, 100, Long.MIN_VALUE));
+        verify(connection).send(new DataAppended(clientId, 200, 100));
     }
 
     @Test

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -348,7 +348,10 @@ public class AppendProcessorTest {
 
     /**
      * Test to ensure newer appends are processed only after successfully sending the DataAppended acknowledgement
-     * back to client.
+     * back to client. This test tests the following:
+     * - If sending first DataAppended is blocked, ensure future appends are not written to store.
+     * - Once the first DataAppended is sent ensure the remaining appends are written to store and DataAppended ack'ed
+     * back.
      */
     @Test(timeout = 15 * 1000)
     public void testDelayedDataAppended() throws Exception {


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure ack (WireCommands.DataAppended) is sent on wire before the next Append is written to the store.

**Purpose of the change**
Fixes #2114 

**What the code does**
Ensures outstandingAppend is cleared only after the ack is sent over wire, there by ensuring Acks are not send out of order.

**How to verify it**
Tests should pass.