### PR TITLE
Issue 2133: System test code issues

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -546,9 +546,11 @@ abstract class AbstractFailoverTests {
                 scaled = true;
                 break;
             }
+            //Scaling operation did not happen, wait
+            Exceptions.handleInterrupted(() -> Thread.sleep(10000));
         }
 
-        assertTrue("scaling did not happen within desired time", scaled);
+        assertTrue("Scaling did not happen within desired time", scaled);
     }
 
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -104,7 +104,7 @@ abstract class AbstractFailoverTests {
                 try {
                     future.cancel(true);
                 } catch (Exception e) {
-                    log.error("exception thrown while cancelling reader and writer threads", e);
+                    log.error("exception thrown while cancelling reader thread", e);
                 }
             });
 
@@ -112,7 +112,7 @@ abstract class AbstractFailoverTests {
                 try {
                     future.cancel(true);
                 } catch (Exception e) {
-                    log.error("exception thrown while cancelling reader and writer threads", e);
+                    log.error("exception thrown while cancelling writer thread", e);
                 }
             });
         }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -13,6 +13,7 @@ import com.google.common.base.Preconditions;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -63,7 +64,7 @@ abstract class AbstractFailoverTests {
     static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;
     static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
     static final int WRITER_MAX_RETRY_ATTEMPTS = 20;
-    static final int NUM_EVENTS_PER_TRANSACTION = 50;
+    static final int NUM_EVENTS_PER_TRANSACTION = 500;
     static final int SCALE_WAIT_ITERATIONS = 12;
 
     final String readerName = "reader";
@@ -87,7 +88,6 @@ abstract class AbstractFailoverTests {
         final AtomicReference<Throwable> getWriteException = new AtomicReference<>();
         final AtomicReference<Throwable> getTxnWriteException = new AtomicReference<>();
         final AtomicReference<Throwable> getReadException =  new AtomicReference<>();
-        final AtomicInteger currentNumOfSegments = new AtomicInteger(0);
         //list of all writer's futures
         final List<CompletableFuture<Void>> writers = synchronizedList(new ArrayList<CompletableFuture<Void>>());
         //list of all reader's futures
@@ -341,7 +341,8 @@ abstract class AbstractFailoverTests {
     }
 
     void cleanUp(String scope, String stream, ReaderGroupManager readerGroupManager, String readerGroupName ) throws InterruptedException, ExecutionException {
-        CompletableFuture<Boolean> sealStreamStatus = controller.sealStream(scope, stream);
+        CompletableFuture<Boolean> sealStreamStatus = Retry.indefinitelyWithExpBackoff("Failed to seal stream. retrying ...")
+                .runAsync(() -> controller.sealStream(scope, stream), executorService);
         log.info("Sealing stream {}", stream);
         assertTrue(sealStreamStatus.get());
         CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, stream);
@@ -518,24 +519,18 @@ abstract class AbstractFailoverTests {
         assertEquals(testState.eventWriteCount.get(), new TreeSet<>(testState.eventsReadFromPravega).size()); //check unique events.
     }
 
-    void waitForScaling(String scope, String stream) {
+    void waitForScaling(String scope, String stream, StreamConfiguration initialConfig) {
+        int initialMaxSegmentNumber = initialConfig.getScalingPolicy().getMinNumSegments() - 1;
+        boolean scaled = false;
         for (int waitCounter = 0; waitCounter < SCALE_WAIT_ITERATIONS; waitCounter++) {
             StreamSegments streamSegments = controller.getCurrentSegments(scope, stream).join();
-            testState.currentNumOfSegments.set(streamSegments.getSegments().size());
-            if (testState.currentNumOfSegments.get() == 2) {
-                log.info("The current number of segments is equal to 2, ScaleOperation did not happen");
-                //Scaling operation did not happen, wait
-                Exceptions.handleInterrupted(() -> Thread.sleep(10000));
-            }
-            if (testState.currentNumOfSegments.get() > 2) {
-                //scale operation successful.
-                log.info("Current Number of segments is {}", testState.currentNumOfSegments.get());
+            if (streamSegments.getSegments().stream().mapToInt(Segment::getSegmentNumber).max().orElse(-1) > initialMaxSegmentNumber) {
+                scaled = true;
                 break;
             }
         }
-        if (testState.currentNumOfSegments.get() == 2) {
-            Assert.fail("Current number of Segments reduced to less than 2. Failure of test");
-        }
+
+        assertTrue("scaling did not happen within desired time", scaled);
     }
 
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -121,8 +121,7 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -121,8 +121,7 @@ public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -125,8 +125,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
         readerGroupManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -157,7 +157,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         //run the failover test while scaling
         performFailoverForTestsInvolvingTxns();
 
-        waitForScaling(scope, stream);
+        waitForScaling(scope, stream, config);
 
         //bring the instances back to 3 before performing failover
         controllerInstance.scaleService(3, true);

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -129,8 +129,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
         readerGroupManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -131,7 +131,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         log.debug("Create stream status {}", createStreamStatus);
     }
 
-    @Test(timeout = 6 * 60 * 1000) //timeout of 6 mins.
+    @Test(timeout = 10 * 60 * 1000) //timeout of 6 mins.
     public void scaleTestsWithReader() {
 
         URI controllerUri = getControllerURI();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -131,7 +131,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         log.debug("Create stream status {}", createStreamStatus);
     }
 
-    @Test(timeout = 10 * 60 * 1000) //timeout of 6 mins.
+    @Test(timeout = 10 * 60 * 1000) //timeout of 10 mins.
     public void scaleTestsWithReader() {
 
         URI controllerUri = getControllerURI();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -157,7 +157,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         //run the failover test while scaling
         performFailoverTest();
 
-        waitForScaling(scope, AUTO_SCALE_STREAM);
+        waitForScaling(scope, AUTO_SCALE_STREAM, config);
 
         //bring the instances back to 3 before performing failover
         controllerInstance.scaleService(3, true);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -124,8 +124,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
         readerGroupManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -127,8 +127,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
         //interrupt writers and readers threads if they are still running.
-        testState.writers.forEach(future -> future.cancel(true));
-        testState.readers.forEach(future -> future.cancel(true));
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close(); //close the clientFactory/connectionFactory.
         readerGroupManager.close();


### PR DESCRIPTION
Signed-off-by: shivesh ranjan <shivesh.ranjan@gmail.com>

**Change log description**

1. Add retry logic around seal stream because it can fail if it conflicts with another stream operation (typically auto-scale).
2.   To verify if scaling has happened, look for scale operations rather than segment count.
3.    Increase timeout in ReadWithAutoScale test.
4. Unwanted test failure because clients threw exception after stream was deleted causing test failures.

**Purpose of the change**
Fixes #2133

**What the code does**
Fixes system test issues

**How to verify it**
We should not observe these issues in system test