### PR TITLE
Issue 2140: Fix race resulting in an NPE if connection is immediately failed after it is setup.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -127,12 +127,14 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
 
         private void connectionSetupComplete() {
             CompletableFuture<Void> toComplete;
+            ClientConnection c;
             synchronized (lock) {
                 toComplete = connectionSetupCompleted;
+                c = connection;
             }
             if (toComplete != null) {
                 toComplete.complete(null);
-                setupConnection.release(connection);
+                setupConnection.release(c);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Fixes a race condition that could (among other things) result in a null pointer exception. 

**Purpose of the change**
Fixes #2140 . 

**What the code does**
When an AppendSeutp arrives pass the connection to the `connectionSetupComplete` method, that way there is no chance it could be failed before it is returned to the waiting caller. 

**How to verify it**
System tests should no longer see the NPE in #2140.