### PR TITLE
Issue 2114: Work around netty bug causing out of order acks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,7 @@ metrics3StatsdVersion=4.2.0
 metricsVersion=3.2.5
 metricsGangliaVersion=1.0.10
 mockitoVersion=2.10.0
+#Check issue in https://github.com/pravega/pravega/pull/2146 before when upgrading netty
 nettyVersion=4.1.15.Final
 protobufGradlePlugin=0.8.3
 protobufProtocVersion=3.3.0

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -134,6 +134,7 @@ public class AppendTest {
         channel.writeInbound(request);
         Object encodedReply = channel.readOutbound();
         for (int i = 0; encodedReply == null && i < 50; i++) {
+            channel.runPendingTasks();
             Thread.sleep(10);
             encodedReply = channel.readOutbound();
         }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Add workaround for https://github.com/netty/netty/issues/3246

**Purpose of the change**
Fixes https://github.com/pravega/pravega/issues/2114

**What the code does**
In the netty code in `AbstractChannelHandlerContext.write()` there is a [very severe bug](https://github.com/netty/netty/issues/3246). This results in data being sent in a different order than it was written even when there is explicit external synchronization. (Even when, in our case, the second write is actually triggered by the completion of the first write). As this bug has not been fixed in 3 years, we cannot assume any fix will be forthcoming or that the netty team would accept a patch if we made one.

The work around code effectively removes the `executor.inEventLoop()` check performed in netty's `AbstractChannelHandlerContext.write()` on the outermost handler. This ensures that the write always ends up being performed on the the event loop. This is vastly preferable to the workaround suggested in netty/netty#3246 of waiting on the future, because that would eliminate any pipelining and effectively hold up writes until the previous ack had been pushed to the wire. (Killing our throughput) However this workaround does have the disadvantage of being EXTREMELY specific to netty's current implementation/bug, and is not guaranteed to be correct given only the statements offered in the Javadocs. As such we will have to re-inspect netty's code every time we upgrade it to make sure this is not broken.

**How to verify it**
Unfortunately we are going to be limited to manual code inspection and running the integration test, as I cannot modify Netty's codebase to allow it to be tested.