### PR TITLE
Issue 2148: Cancel outstanding read requests in SegmentInputStream#close().

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -200,6 +200,10 @@ class SegmentInputStreamImpl implements SegmentInputStream {
     @Synchronized
     public void close() {
         log.trace("Closing {}", this);
+        if (outstandingRequest != null) {
+            log.trace("Cancel outstanding read request for segment {}", asyncInput.getSegmentId());
+            outstandingRequest.cancel(true);
+        }
         asyncInput.close();
     }
 


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
 Ensure outstanding read requests are cancelled when sgmentInputStream#close() is invoked.

**Purpose of the change**
Fixes #2148 

**What the code does**
Cancels outstanding requests.

**How to verify it**
Tests should continue to pass.