### PR TITLE
Issue 2152 : BugFix, ensure the test does not stop reading if event read is a checkpoint.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -262,7 +262,8 @@ public class ReaderCheckpointTest {
                     log.error("Exception while reading event using readerId: {}", readerId, e);
                     fail("Reinitialization Exception is not expected");
                 }
-            } while (event.getEvent() != null);
+            } while (event.isCheckpoint() || event.getEvent() != null);
+            //stop reading if event read(non-checkpoint) is null.
             log.info("No more events from {}/{} for readerId: {}", SCOPE, STREAM, readerId);
         } //reader.close() will automatically invoke ReaderGroup#readerOffline(String, Position)
         return events;

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -258,6 +258,9 @@ public class ReaderCheckpointTest {
                         log.info("Read event {}", event.getEvent());
                         events.add(event);
                     }
+                    if (event.isCheckpoint()) {
+                        log.info("Read a check point event, checkpointName: {}", event.getCheckpointName());
+                    }
                 } catch (ReinitializationRequiredException e) {
                     log.error("Exception while reading event using readerId: {}", readerId, e);
                     fail("Reinitialization Exception is not expected");


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure the test method `io.pravega.test.system.ReaderCheckpointTest#readEvents` continues reading if event read is a checkpoint event. 

**Purpose of the change**
Related to #2152.

**What the code does**
Ensure we continue reading if event read is a checkpoint event.

**How to verify it**
Tests should continue to pass.