### PR TITLE
Issue 2157: Rename read to fetchEvent

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
@@ -37,7 +37,7 @@ public interface SegmentInputStreamFactory {
      * This operation additionally takes a buffer size parameter. This size is
      * used to allocate buffer space for the bytes this stream reads from the
      * segment. It is important to control the buffer size, e.g., when randomly
-     * reading events with {@link EventStreamReader#read(EventPointer)}
+     * reading events with {@link EventStreamReader#fetchEvent(EventPointer)}
      *
      * @param segment  The segment to create an input for.
      * @param bufferSize Size of the input stream read buffer.

--- a/client/src/main/java/io/pravega/client/stream/EventPointer.java
+++ b/client/src/main/java/io/pravega/client/stream/EventPointer.java
@@ -14,7 +14,7 @@ import io.pravega.client.stream.impl.EventPointerInternal;
 import java.io.Serializable;
 
 /**
- * A pointer to an event. This can be used to retrieve a previously read event by calling {@link EventStreamReader#read(EventPointer)}
+ * A pointer to an event. This can be used to retrieve a previously read event by calling {@link EventStreamReader#fetchEvent(EventPointer)}
  */
 public interface EventPointer extends Serializable {
 

--- a/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
@@ -54,7 +54,7 @@ public interface EventStreamReader<T> extends AutoCloseable {
      *         been deleted.
      * @throws NoSuchEventException Reader was not able to fetch the event.
      */
-    T read(EventPointer pointer) throws NoSuchEventException;
+    T fetchEvent(EventPointer pointer) throws NoSuchEventException;
 
     /**
      * Close the reader. No further actions may be performed. If this reader is part of a

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -222,7 +222,7 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     }
 
     @Override
-    public Type read(EventPointer pointer) throws NoSuchEventException {
+    public Type fetchEvent(EventPointer pointer) throws NoSuchEventException {
         Preconditions.checkNotNull(pointer);
         // Create SegmentInputBuffer
         SegmentInputStream inputStream = inputStreamFactory.createInputStreamForSegment(pointer.asImpl().getSegment(),

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -203,9 +203,9 @@ public class EventStreamReaderTest {
         assertEquals(buffer2, ByteBuffer.wrap(event2.getEvent()));
         assertEquals(buffer3, ByteBuffer.wrap(event3.getEvent()));
         assertNull(reader.readNextEvent(0).getEvent());
-        assertEquals(buffer1, ByteBuffer.wrap(reader.read(event1.getEventPointer())));
-        assertEquals(buffer3, ByteBuffer.wrap(reader.read(event3.getEventPointer())));
-        assertEquals(buffer2, ByteBuffer.wrap(reader.read(event2.getEventPointer())));
+        assertEquals(buffer1, ByteBuffer.wrap(reader.fetchEvent(event1.getEventPointer())));
+        assertEquals(buffer3, ByteBuffer.wrap(reader.fetchEvent(event3.getEventPointer())));
+        assertEquals(buffer2, ByteBuffer.wrap(reader.fetchEvent(event2.getEventPointer())));
         reader.close();
     }
 

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
@@ -44,7 +44,7 @@ public class EventStreamReaderMock<T> implements EventStreamReader<T> {
     }
 
     @Override
-    public T read(EventPointer pointer) throws NoSuchEventException {
+    public T fetchEvent(EventPointer pointer) throws NoSuchEventException {
         return null;
     }
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
@@ -181,7 +181,7 @@ class ClientReader implements StoreReader, AutoCloseable {
 
         ReadItem readExact(EventPointer a) {
             try {
-                byte[] data = getReader().read(a);
+                byte[] data = getReader().fetchEvent(a);
                 return toReadItem(data, a);
             } catch (NoSuchEventException e) {
                 throw new CompletionException(e);

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -254,7 +254,7 @@ public class ReadTest {
 
             for (int i = 0; i < 100; i++) {
                 pointer = reader.readNextEvent(5000).getEventPointer();
-                read = reader.read(pointer);
+                read = reader.fetchEvent(pointer);
                 assertEquals(testString + i, read);
             }
         } catch (NoSuchEventException e) {


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
* Rename read(EventPointer) to fetchEvent()

**Purpose of the change**
Fixes https://github.com/pravega/pravega/issues/2157

**What the code does**
Renames the method.

**How to verify it**
Should have no functional impact.