### PR TITLE
Issue 2159: NPE in SegmentInputStreamImpl

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -144,6 +144,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
         ByteBuffer result = ByteBuffer.allocate(length);
         offset += buffer.read(result);
         while (result.hasRemaining()) {
+            issueRequestIfNeeded();
             handleRequest();
             offset += buffer.read(result);
         }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -181,7 +181,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
      * Issues a request if there is enough room for another request, and we aren't already waiting on one
      */
     private void issueRequestIfNeeded() {
-        if (!receivedEndOfSegment && buffer.capacityAvailable() > readLength) {
+        if (!receivedEndOfSegment && buffer.capacityAvailable() >= readLength) {
             if (outstandingRequest == null) {
                 outstandingRequest = asyncInput.read(offset + buffer.dataAvailable(), readLength);
             } else if (outstandingRequest.isCompletedExceptionally()) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +71,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Slf4j
 public class ReadTest {
 
     private Level originalLevel;
@@ -181,6 +183,10 @@ public class ReadTest {
         SegmentInputStream in = segmentConsumerClient.createInputStreamForSegment(segment);
         ByteBuffer result = in.read();
         assertEquals(ByteBuffer.wrap(testString.getBytes()), result);
+
+        // Test large write followed by read
+        out.write(new PendingEvent(null, ByteBuffer.wrap(new byte[150000]), new CompletableFuture<>()));
+        in.read();
     }
 
     @Test

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -183,8 +183,12 @@ public class ReadTest {
         assertEquals(ByteBuffer.wrap(testString.getBytes()), result);
 
         // Test large write followed by read
+        out.write(new PendingEvent(null, ByteBuffer.wrap(new byte[15]), new CompletableFuture<>()));
+        out.write(new PendingEvent(null, ByteBuffer.wrap(new byte[15]), new CompletableFuture<>()));
         out.write(new PendingEvent(null, ByteBuffer.wrap(new byte[150000]), new CompletableFuture<>()));
-        in.read();
+        assertEquals(in.read().capacity(), 15);
+        assertEquals(in.read().capacity(), 15);
+        assertEquals(in.read().capacity(), 150000);
     }
 
     @Test

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -61,7 +61,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +70,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Slf4j
 public class ReadTest {
 
     private Level originalLevel;


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**
* Fixes a bug in SegmentInputStreamImpl that causes an NPE to be thrown when events are larger than the read length.

* Adds a call to issueRequestIfNecessary to the loop that handles the case in which the event is greater than the read length.

* Changes the sign in issueRequestIfNeeded from greater to greater or equal.

**Purpose of the change**
Fixes #2159 

**What the code does**
In `SegmentInputStreamImpl.issueRequestIfNeeded`, in the case we are reading an event that is greater than read length, we end up with `buffer.capacityAvailable() <= readLength`, which causes the value of `outstandingRequest` to remain null and induces the NPE when handleRequest is invoked next. The solution to this scenario is to simply make the predicate of the `if` greater or equal rather than just greater:

```
buffer.capacityAvailable() >= readLength
```

Additionally, we need to add a call to `SegmentInputStreamImpl.issueRequestIfNeeded` to the loop that handles events that are greater than the read length before invoking `handleRequest`.

It also adds a couple of scenarios to `ReadTest` integration test to verify that this fixes the issue with larger events. If we remove the changes, we can see the test case failing with NPE.

**How to verify it**
Tests should pass. Removing the equal sign added in this PR causes the `ReadTest` integration test to fail.