### PR TITLE
Issue 2170: Bugfix: Ensure automatic checkpointing is disabled for MultiSegmentstoreTest.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -186,8 +186,9 @@ public class MultiSegmentStoreTest {
         log.info("Invoking reader with controller URI: {}", controllerUri);
         final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerUri);
-        groupManager.createReaderGroup(readerGroup, ReaderGroupConfig.builder().startingTime(0).build(),
-                                       Collections.singleton(stream));
+        groupManager.createReaderGroup(readerGroup,
+                ReaderGroupConfig.builder().disableAutomaticCheckpoints().startingTime(0).build(),
+                Collections.singleton(stream));
 
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure checkpoint events do not cause of failure of MultiSegmentstore test.

**Purpose of the change**
Fixes #2170 

**What the code does**
Disables automatic checkpointing.

**How to verify it**
Tests should continue to pass.