### PR TITLE
Issue 2178: Ensure REST APIs works on container based pravega-standalone.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -469,6 +469,7 @@ project('standalone') {
         compile project(':segmentstore:storage')
         compile project(':segmentstore:storage:impl')
 
+        compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: javaxwsrsApiVersion
         runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
         // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -308,7 +308,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                 .build();
 
         RESTServerConfig restServerConfig = RESTServerConfigImpl.builder()
-                .host("localhost")
+                .host("0.0.0.0")
                 .port(this.restServerPort)
                 .build();
 


### PR DESCRIPTION
Signed-off-by: shrids <sandeep.shridhar@emc.com>

**Change log description**
Ensure REST APIs works on pravega container when started in standalone mode.

**Purpose of the change**
Fixes #2178 

**What the code does**
Ensure, we have handle different JAX-RS (jersey) versions part of segmentstore and controller.

**How to verify it**
Verified that REST APIs work with container based standalone.
Steps to test it
```
* ./gradlew clean buildPravegaImage
* docker run --rm -it -e HOST_IP=10.0.2.15 -p 9090:9090 -p 12345:12345 -p 9091:9091 -p 10000:10000 pravega/pravega:latest standalone
*  curl http://localhost:9091/v1/scopes
Output :{"scopes":[{"scopeName":"_system"}]}
```
