### PR TITLE
Issue 2180: (SegmentStore) Reducing number of SegmentChunks during transaction merges

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3SegmentHandle.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3SegmentHandle.java
@@ -10,10 +10,9 @@
 package io.pravega.segmentstore.storage.impl.extendeds3;
 
 import io.pravega.segmentstore.storage.SegmentHandle;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class ExtendedS3SegmentHandle implements SegmentHandle {
     private final String segmentName;
     private final boolean isReadOnly;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3SegmentHandle.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3SegmentHandle.java
@@ -10,9 +10,10 @@
 package io.pravega.segmentstore.storage.impl.extendeds3;
 
 import io.pravega.segmentstore.storage.SegmentHandle;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExtendedS3SegmentHandle implements SegmentHandle {
     private final String segmentName;
     private final boolean isReadOnly;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/filesystem/FileSystemStorage.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.storage.impl.filesystem;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.Timer;
@@ -44,9 +45,6 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.AccessControlException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -80,18 +78,16 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 public class FileSystemStorage implements SyncStorage {
     //region members
 
-    private static final Set<PosixFilePermission> READ_ONLY_PERMISSION = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.GROUP_READ,
-                    PosixFilePermission.OTHERS_READ)));
+    private static final Set<PosixFilePermission> READ_ONLY_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
 
-    private static final Set<PosixFilePermission> READ_WRITE_PERMISSION = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    PosixFilePermission.OWNER_WRITE,
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.GROUP_READ,
-                    PosixFilePermission.OTHERS_READ)));
+    private static final Set<PosixFilePermission> READ_WRITE_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
 
     private final FileSystemStorageConfig config;
     private final AtomicBoolean closed;
@@ -108,6 +104,7 @@ public class FileSystemStorage implements SyncStorage {
     public FileSystemStorage(FileSystemStorageConfig config) {
         this.config = Preconditions.checkNotNull(config, "config");
         this.closed = new AtomicBoolean(false);
+
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/FileSystemOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/FileSystemOperation.java
@@ -328,6 +328,17 @@ abstract class FileSystemOperation<T> {
     }
 
     /**
+     * Sets the Sealed attribute to false on the file represented by the given descriptor.
+     *
+     * @param file The FileDescriptor of the file to unseal.
+     * @throws IOException If an exception occurred.
+     */
+    void makeUnsealed(FileDescriptor file) throws IOException {
+        setBooleanAttributeValue(file.getPath(), SEALED_ATTRIBUTE, false);
+        log.debug("MakeUnsealed '{}'.", file.getPath());
+    }
+
+    /**
      * Determines whether the given FileStatus indicates the file is read-only.
      *
      * @param fs The FileStatus to check.
@@ -362,7 +373,7 @@ abstract class FileSystemOperation<T> {
      * @param file The FileDescriptor of the file to set.
      * @throws IOException If an exception occurred.
      */
-    private void makeReadWrite(FileDescriptor file) throws IOException {
+    void makeReadWrite(FileDescriptor file) throws IOException {
         this.context.fileSystem.setPermission(file.getPath(), READWRITE_PERMISSION);
         log.debug("MakeReadWrite '{}'.", file.getPath());
         file.markReadWrite();

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -170,6 +170,11 @@ class HDFSStorage implements SyncStorage {
     }
 
     @Override
+    public void unseal(SegmentHandle handle) throws StreamSegmentException {
+        run(new UnsealOperation(asReadableHandle(handle), this.context));
+    }
+
+    @Override
     public void concat(SegmentHandle targetHandle, long offset, String sourceSegment) throws StreamSegmentException {
         run(new ConcatOperation(asWritableHandle(targetHandle), offset, sourceSegment, this.context));
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/UnsealOperation.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/UnsealOperation.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.impl.hdfs;
+
+import io.pravega.common.LoggerHelpers;
+import io.pravega.common.function.RunnableWithException;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.hadoop.hdfs.protocol.AclException;
+
+/**
+ * FileSystemOperation that Unseals a Segment.
+ */
+@Slf4j
+public class UnsealOperation extends FileSystemOperation<HDFSSegmentHandle> implements RunnableWithException {
+    /**
+     * Creates a new instance of the UnsealOperation class.
+     *
+     * @param handle  A WriteHandle containing information about the Segment to unseal.
+     * @param context Context for the operation.
+     */
+    UnsealOperation(HDFSSegmentHandle handle, OperationContext context) {
+        super(handle, context);
+    }
+
+    @Override
+    public void run() throws IOException, StorageNotPrimaryException {
+        HDFSSegmentHandle handle = getTarget();
+        long traceId = LoggerHelpers.traceEnter(log, "unseal", handle);
+        val lastHandleFile = handle.getLastFile();
+        try {
+            if (lastHandleFile.isReadOnly()) {
+                makeReadWrite(lastHandleFile);
+            }
+
+            // Set the Sealed attribute on the last file and update the handle.
+            if (isSealed(lastHandleFile)) {
+                makeUnsealed(lastHandleFile);
+            }
+        } catch (FileNotFoundException | AclException ex) {
+            checkForFenceOut(handle.getSegmentName(), handle.getFiles().size(), handle.getLastFile());
+            throw ex; // If we were not fenced out, then this is a legitimate exception - rethrow it.
+        }
+
+        LoggerHelpers.traceLeave(log, "unseal", traceId, handle);
+    }
+}

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/UnsealOperationTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/hdfs/UnsealOperationTests.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.impl.hdfs;
+
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.test.common.AssertExtensions;
+import java.io.ByteArrayInputStream;
+import lombok.Cleanup;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+/**
+ * Unit tests for the SealOperation class.
+ */
+public class UnsealOperationTests extends FileSystemOperationTestBase {
+    private static final String SEGMENT_NAME = "segment";
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT_SECONDS);
+
+    /**
+     * Tests the basic functionality of Unseal.
+     */
+    @Test
+    public void testUnseal() throws Exception {
+        @Cleanup
+        val fs = new MockFileSystem();
+        val context = newContext(1, fs);
+
+        // Create, write and seal a file.
+        new CreateOperation(SEGMENT_NAME, context).call();
+        val handle = new OpenWriteOperation(SEGMENT_NAME, context).call();
+        new WriteOperation(handle, 0, new ByteArrayInputStream(new byte[1]), 1, context).run();
+        new SealOperation(handle, context).run();
+
+        new UnsealOperation(handle, context).run();
+        Assert.assertFalse("Last file in handle was not marked as read-write.", handle.getLastFile().isReadOnly());
+        Assert.assertFalse("Last file in file system was not set as 'not-sealed'.", context.isSealed(handle.getLastFile()));
+
+        // Repeat (this time file is not sealed).
+        val handle2 = new OpenReadOperation(SEGMENT_NAME, context).call();
+        new UnsealOperation(handle2, context).run();
+        Assert.assertFalse("Last file in read-only handle was not marked as read-write.", handle2.getLastFile().isReadOnly());
+        Assert.assertFalse("Last file in file system was not set as 'not-sealed' (read-only).", context.isSealed(handle2.getLastFile()));
+    }
+
+    /**
+     * Tests the ability to detect fence-outs.
+     */
+    @Test
+    public void testFenceOut() throws Exception {
+        @Cleanup
+        val fs = new MockFileSystem();
+        val context1 = newContext(1, fs);
+
+        // Create, write and seal a file. Then open-write it a few times, each time with a higher epoch.
+        new CreateOperation(SEGMENT_NAME, context1).call();
+        val handle = new OpenWriteOperation(SEGMENT_NAME, context1).call();
+        new WriteOperation(handle, 0, new ByteArrayInputStream(new byte[1]), 1, context1).run();
+
+        val context2 = newContext(2, fs);
+        val handle2 = new OpenWriteOperation(SEGMENT_NAME, context2).call();
+        new WriteOperation(handle2, 1, new ByteArrayInputStream(new byte[1]), 1, context2).run();
+
+        val context3 = newContext(3, fs);
+        val handle3 = new OpenWriteOperation(SEGMENT_NAME, context3).call();
+        new WriteOperation(handle3, 2, new ByteArrayInputStream(new byte[1]), 1, context3).run();
+        new SealOperation(handle3, context3).run();
+
+        val context4 = newContext(4, fs);
+        new OpenWriteOperation(SEGMENT_NAME, context4).call();
+
+        // Verify Unseal fails due to fence-out while using a lower epoch.
+        AssertExtensions.assertThrows(
+                "Unseal did not fail when fenced out.",
+                new UnsealOperation(handle2, context2)::run,
+                ex -> ex instanceof StorageNotPrimaryException);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 
 /**
  * Defines an abstraction for Permanent Storage.
+ * Note: not all operations defined here are needed in the (async) Storage interface.
  */
 @SuppressWarnings("checkstyle:JavadocMethod")
 public interface SyncStorage extends AutoCloseable {
@@ -150,6 +151,18 @@ public interface SyncStorage extends AutoCloseable {
      *                                         fenced out).
      */
     void seal(SegmentHandle handle) throws StreamSegmentException;
+
+    /**
+     * Un-Seals a StreamSegment. After this operation completes successfully, the Segment can be written to again..
+     *
+     * @param handle A read-only or read-write SegmentHandle that points to a Segment to Seal. Since open-write will only
+     *               return a read-only handle for a Sealed Segment, this is the only modify operation that allows a
+     *               read-only handle as input.
+     * @throws StreamSegmentNotExistsException When the given Segment does not exist in Storage.
+     * @throws StorageNotPrimaryException      When this Storage instance is no longer primary for this Segment (it was
+     *                                         fenced out).
+     */
+    void unseal(SegmentHandle handle) throws StreamSegmentException;
 
     /**
      * Concatenates two StreamSegments together. The Source StreamSegment will be appended as one atomic block at the end

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -136,6 +136,12 @@ public class InMemoryStorage implements SyncStorage {
     }
 
     @Override
+    public void unseal(SegmentHandle handle) throws StreamSegmentException {
+        ensurePreconditions();
+        getStreamSegmentData(handle.getSegmentName()).markUnsealed();
+    }
+
+    @Override
     public SegmentProperties getStreamSegmentInfo(String streamSegmentName) throws StreamSegmentNotExistsException {
         ensurePreconditions();
         return getStreamSegmentData(streamSegmentName).getInfo();
@@ -320,6 +326,13 @@ public class InMemoryStorage implements SyncStorage {
             synchronized (this.lock) {
                 checkOpened();
                 this.sealed = true;
+            }
+        }
+
+        void markUnsealed() {
+            synchronized (this.lock) {
+                checkOpened();
+                this.sealed = false;
             }
         }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/SegmentChunk.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/SegmentChunk.java
@@ -106,6 +106,13 @@ class SegmentChunk {
     }
 
     /**
+     * Records the fact that this SegmentChunk has been unsealed.
+     */
+    synchronized void markUnsealed() {
+        this.sealed = false;
+    }
+
+    /**
      * Gets a value indicating whether this SegmentChunk exists or not.
      */
     synchronized boolean exists() {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
@@ -14,6 +14,13 @@ import io.pravega.segmentstore.storage.SegmentRollingPolicy;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageTestBase;
 import io.pravega.segmentstore.storage.SyncStorage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+import lombok.Cleanup;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Base class for testing any Storage implementation that has a layer of RollingStorage.
@@ -24,6 +31,96 @@ public abstract class RollingStorageTestBase extends StorageTestBase {
     @Override
     public void testFencing() throws Exception {
         // Fencing is left up to the underlying Storage implementation to handle. There's nothing to test here.
+    }
+
+    /**
+     * Tests a scenario that would concatenate various segments successively into an initially empty segment while not
+     * producing an excessive number of chunks. The initial concat will use header merge since the segment has no chunks,
+     * but successive concats should unseal that last chunk and concat to it using the native method.
+     * <p>
+     * NOTE: this could be moved down into RollingStorageTests.java, however it being here ensures that unseal() is being
+     * exercised in all classes that derive from this, which is all of the Storage implementations.
+     *
+     * @throws Exception If one occurred.
+     */
+    @Test
+    public void testSuccessiveConcats() throws Exception {
+        final String segmentName = "Segment";
+        final int writeLength = 21;
+        final int concatCount = 10;
+
+        @Cleanup
+        val s = createStorage();
+        s.initialize(1);
+
+        // Create Target Segment with infinite rolling. Do not write anything to it yet.
+        val writeHandle = s.create(segmentName, SegmentRollingPolicy.NO_ROLLING, TIMEOUT)
+                .thenCompose(v -> s.openWrite(segmentName)).join();
+
+        final Random rnd = new Random(0);
+        byte[] writeBuffer = new byte[writeLength];
+        val writeStream = new ByteArrayOutputStream();
+        for (int i = 0; i < concatCount; i++) {
+            // Create a source segment, write a little bit to it, then seal & merge it.
+            String sourceSegment = segmentName + "_Source_" + i;
+            val sourceHandle = s.create(sourceSegment, TIMEOUT).thenCompose(v -> s.openWrite(sourceSegment)).join();
+            rnd.nextBytes(writeBuffer);
+            s.write(sourceHandle, 0, new ByteArrayInputStream(writeBuffer), writeBuffer.length, TIMEOUT).join();
+            s.seal(sourceHandle, TIMEOUT).join();
+            s.concat(writeHandle, writeStream.size(), sourceSegment, TIMEOUT).join();
+            writeStream.write(writeBuffer);
+        }
+
+        // Write directly to the target segment - this ensures that writes themselves won't create a new chunk if the
+        // write can still fit into the last chunk.
+        rnd.nextBytes(writeBuffer);
+        s.write(writeHandle, writeStream.size(), new ByteArrayInputStream(writeBuffer), writeBuffer.length, TIMEOUT).join();
+        writeStream.write(writeBuffer);
+
+        // Get a read handle, which will also fetch the number of chunks for us.
+        val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
+        Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
+        val writtenData = writeStream.toByteArray();
+        byte[] readBuffer = new byte[writtenData.length];
+        int bytesRead = s.read(readHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
+        Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
+        Assert.assertArrayEquals("Unexpected data read back.", writtenData, readBuffer);
+    }
+
+    @Test
+    public void testWriteAfterHeaderMerge() throws Exception {
+        final String segmentName = "Segment";
+        final int writeLength = 21;
+
+        @Cleanup
+        val s = createStorage();
+        s.initialize(1);
+
+        // Create Target Segment with infinite rolling. Do not write anything to it yet.
+        val writeHandle = s.create(segmentName, SegmentRollingPolicy.NO_ROLLING, TIMEOUT)
+                .thenCompose(v -> s.openWrite(segmentName)).join();
+
+        final Random rnd = new Random(0);
+        byte[] writeBuffer = new byte[writeLength];
+        val writeStream = new ByteArrayOutputStream();
+
+        // Create a source segment, write a little bit to it, then seal & merge it.
+        String sourceSegment = segmentName + "_Source";
+        val sourceHandle = s.create(sourceSegment, TIMEOUT).thenCompose(v -> s.openWrite(sourceSegment)).join();
+        rnd.nextBytes(writeBuffer);
+        s.write(sourceHandle, 0, new ByteArrayInputStream(writeBuffer), writeBuffer.length, TIMEOUT).join();
+        s.seal(sourceHandle, TIMEOUT).join();
+        s.concat(writeHandle, writeStream.size(), sourceSegment, TIMEOUT).join();
+        writeStream.write(writeBuffer);
+
+        // Write directly to the target segment.
+        rnd.nextBytes(writeBuffer);
+        s.write(writeHandle, writeStream.size(), new ByteArrayInputStream(writeBuffer), writeBuffer.length, TIMEOUT).join();
+        writeStream.write(writeBuffer);
+
+        // Get a read handle, which will also fetch the number of chunks for us.
+        val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
+        Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
     }
 
     @Override


### PR DESCRIPTION
**Change log description**
Fixed a corner case that would cause the Segment Store to create an excessive number of Segment Chunks when the Segment is made up entirely of transactions. Full repro case is detailed in the accompanying issue; here's a sample scenario:
- Segment S is initially empty (has no chunks)
- We have transactions T0..TN that need to be merged into S
- T0 is merged using header merge since S has no chunks. After this, S is made up of a number of chunks, the last of which is sealed (since transactions are sealed prior to merging).
- Subsequent mergers will still use header merge method since the last chunk of S is sealed, even if they could otherwise fit entirely into S's last chunk.

This change unseals the last chunk of a Segment after a successful header merge. This allows future writes or mergers/concats to write directly to that last chunk vs creating a new one.

Changes:
- `SyncStorage`: Added ability to unseal a Segment. This functionality is needed internally and is not exposed to upstream layers via the `Storage` interface.
    - Implemented this in all known implementations.
- `RollingStorage`: unsealing the last chunk of the Segment after a header merge to allow future writes/merges to make use of available space in that chunk instead of creating a new one.
    - This handles the case when the underlying `SyncStorage` does not support unsealing by catching an `UnsupportedOperationException` and not doing anything (in which case it would revert back to the behavior described above).

**Purpose of the change**
Fixes #2180.

**What the code does**
See **Change log description**.

**How to verify it**
New unit tests added to verify this specific scenario.
