### PR TITLE
Issue 2174: Controller instance does not exit upon receiving ZK session expiry

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -162,6 +162,9 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
             log.error("Controller Service Main thread exited exceptionally", e);
             throw e;
         } finally {
+            if (storeClient != null) {
+                storeClient.close();
+            }
             LoggerHelpers.traceLeave(log, this.objectId, "run", traceId);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -156,6 +156,9 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
 
             log.info("Awaiting termination of ControllerServiceStarter");
             starter.awaitTerminated();
+        } catch (Exception e) {
+            log.error("Controller Service Main thread exited exceptionally", e);
+            throw e;
         } finally {
             LoggerHelpers.traceLeave(log, this.objectId, "run", traceId);
         }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -9,15 +9,15 @@
  */
 package io.pravega.controller.server;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.AbstractExecutionThreadService;
-import com.google.common.util.concurrent.Monitor;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.controller.store.client.StoreClient;
 import io.pravega.controller.store.client.StoreClientFactory;
 import io.pravega.controller.store.client.StoreType;
 import io.pravega.controller.util.ZKUtils;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.Monitor;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
@@ -102,60 +102,62 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
     protected void run() throws Exception {
         long traceId = LoggerHelpers.traceEnter(log, this.objectId, "run");
         try {
-            // Create store client.
-            log.info("Creating store client");
-            storeClient = StoreClientFactory.createStoreClient(serviceConfig.getStoreClientConfig());
+            while (isRunning()) {
+                // Create store client.
+                log.info("Creating store client");
+                storeClient = StoreClientFactory.createStoreClient(serviceConfig.getStoreClientConfig());
 
-            boolean hasZkConnection = serviceConfig.getStoreClientConfig().getStoreType().equals(StoreType.Zookeeper) ||
-                    serviceConfig.isControllerClusterListenerEnabled();
+                boolean hasZkConnection = serviceConfig.getStoreClientConfig().getStoreType().equals(StoreType.Zookeeper) ||
+                        serviceConfig.isControllerClusterListenerEnabled();
 
-            CompletableFuture<Void> sessionExpiryFuture = new CompletableFuture<>();
-            if (hasZkConnection) {
-                CuratorFramework client = (CuratorFramework) storeClient.getClient();
+                CompletableFuture<Void> sessionExpiryFuture = new CompletableFuture<>();
+                if (hasZkConnection) {
+                    CuratorFramework client = (CuratorFramework) storeClient.getClient();
 
-                log.info("Awaiting ZK client connection to ZK server");
-                client.blockUntilConnected();
+                    log.info("Awaiting ZK client connection to ZK server");
+                    client.blockUntilConnected();
 
-                // Await ZK session expiry.
-                log.info("Awaiting ZK session expiry or termination trigger for ControllerServiceMain");
-                client.getZookeeperClient().getZooKeeper().register(new ZKWatcher(sessionExpiryFuture));
-            }
-
-            // Start controller services.
-            starter = starterFactory.apply(serviceConfig, storeClient);
-            log.info("Starting controller services");
-            notifyServiceStateChange(ServiceState.STARTING);
-            starter.startAsync();
-
-            log.info("Awaiting controller services start");
-            starter.awaitRunning();
-
-            if (hasZkConnection) {
-                // At this point, wait until either of the two things happen
-                // 1. ZK session expires, i.e., sessionExpiryFuture completes, or
-                // 2. This ControllerServiceMain instance is stopped by invoking stopAsync() method,
-                //    i.e., serviceStopFuture completes.
-                CompletableFuture.anyOf(sessionExpiryFuture, this.serviceStopFuture).join();
-
-                // Problem of curator automatically recreating ZK client on session expiry is mitigated by
-                // employing a custom ZookeeperFactory that always returns the same ZK client to curator
-
-                // Once ZK session expires or once ControllerServiceMain is externally stopped,
-                // stop ControllerServiceStarter.
-                if (sessionExpiryFuture.isDone()) {
-                    log.info("ZK session expired");
-                    storeClient.close();
+                    // Await ZK session expiry.
+                    log.info("Awaiting ZK session expiry or termination trigger for ControllerServiceMain");
+                    client.getZookeeperClient().getZooKeeper().register(new ZKWatcher(sessionExpiryFuture));
                 }
-            } else {
-                this.serviceStopFuture.join();
+
+                // Start controller services.
+                starter = starterFactory.apply(serviceConfig, storeClient);
+                log.info("Starting controller services");
+                notifyServiceStateChange(ServiceState.STARTING);
+                starter.startAsync();
+
+                log.info("Awaiting controller services start");
+                starter.awaitRunning();
+
+                if (hasZkConnection) {
+                    // At this point, wait until either of the two things happen
+                    // 1. ZK session expires, i.e., sessionExpiryFuture completes, or
+                    // 2. This ControllerServiceMain instance is stopped by invoking stopAsync() method,
+                    //    i.e., serviceStopFuture completes.
+                    CompletableFuture.anyOf(sessionExpiryFuture, this.serviceStopFuture).join();
+
+                    // Problem of curator automatically recreating ZK client on session expiry is mitigated by
+                    // employing a custom ZookeeperFactory that always returns the same ZK client to curator
+
+                    // Once ZK session expires or once ControllerServiceMain is externally stopped,
+                    // stop ControllerServiceStarter.
+                    if (sessionExpiryFuture.isDone()) {
+                        log.info("ZK session expired");
+                        storeClient.close();
+                    }
+                } else {
+                    this.serviceStopFuture.join();
+                }
+
+                log.info("Stopping ControllerServiceStarter");
+                notifyServiceStateChange(ServiceState.PAUSING);
+                starter.stopAsync();
+
+                log.info("Awaiting termination of ControllerServiceStarter");
+                starter.awaitTerminated();
             }
-
-            log.info("Stopping ControllerServiceStarter");
-            notifyServiceStateChange(ServiceState.PAUSING);
-            starter.stopAsync();
-
-            log.info("Awaiting termination of ControllerServiceStarter");
-            starter.awaitTerminated();
         } catch (Exception e) {
             log.error("Controller Service Main thread exited exceptionally", e);
             throw e;

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -307,6 +307,12 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 log.info("Awaiting termination of auto retention");
                 streamCutService.awaitTerminated();
             }
+        } catch (Exception e) {
+            log.error("Controller Service Starter threw exception during shutdown", e);
+            throw e;
+        } finally {
+            // We will stop our executors in `finally` so that even if an exception is thrown, we are not left with
+            // lingering threads that prevent our process from exiting.
 
             // Next stop all executors
             log.info("Stopping controller executor");
@@ -328,7 +334,7 @@ public class ControllerServiceStarter extends AbstractIdleService {
 
             log.info("Closing storeClient");
             storeClient.close();
-        } finally {
+
             LoggerHelpers.traceLeave(log, this.objectId, "shutDown", traceId);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -36,54 +36,62 @@ public class Main {
 
     public static void main(String[] args) {
 
-        //0. Initialize metrics provider
-        MetricsProvider.initialize(Config.getMetricsConfig());
+        try {
+            //0. Initialize metrics provider
+            MetricsProvider.initialize(Config.getMetricsConfig());
 
-        ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder()
-                .connectionString(Config.ZK_URL)
-                .namespace("pravega/" + Config.CLUSTER_NAME)
-                .initialSleepInterval(Config.ZK_RETRY_SLEEP_MS)
-                .maxRetries(Config.ZK_MAX_RETRIES)
-                .sessionTimeoutMs(Config.ZK_SESSION_TIMEOUT_MS)
-                .build();
+            ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder()
+                    .connectionString(Config.ZK_URL)
+                    .namespace("pravega/" + Config.CLUSTER_NAME)
+                    .initialSleepInterval(Config.ZK_RETRY_SLEEP_MS)
+                    .maxRetries(Config.ZK_MAX_RETRIES)
+                    .sessionTimeoutMs(Config.ZK_SESSION_TIMEOUT_MS)
+                    .build();
 
-        StoreClientConfig storeClientConfig = StoreClientConfigImpl.withZKClient(zkClientConfig);
+            StoreClientConfig storeClientConfig = StoreClientConfigImpl.withZKClient(zkClientConfig);
 
-        HostMonitorConfig hostMonitorConfig = HostMonitorConfigImpl.builder()
-                .hostMonitorEnabled(Config.HOST_MONITOR_ENABLED)
-                .hostMonitorMinRebalanceInterval(Config.CLUSTER_MIN_REBALANCE_INTERVAL)
-                .containerCount(Config.HOST_STORE_CONTAINER_COUNT)
-                .hostContainerMap(HostMonitorConfigImpl.getHostContainerMap(Config.SERVICE_HOST,
-                        Config.SERVICE_PORT, Config.HOST_STORE_CONTAINER_COUNT))
-                .build();
+            HostMonitorConfig hostMonitorConfig = HostMonitorConfigImpl.builder()
+                    .hostMonitorEnabled(Config.HOST_MONITOR_ENABLED)
+                    .hostMonitorMinRebalanceInterval(Config.CLUSTER_MIN_REBALANCE_INTERVAL)
+                    .containerCount(Config.HOST_STORE_CONTAINER_COUNT)
+                    .hostContainerMap(HostMonitorConfigImpl.getHostContainerMap(Config.SERVICE_HOST,
+                            Config.SERVICE_PORT, Config.HOST_STORE_CONTAINER_COUNT))
+                    .build();
 
-        TimeoutServiceConfig timeoutServiceConfig = TimeoutServiceConfig.builder()
-                .maxLeaseValue(Config.MAX_LEASE_VALUE)
-                .maxScaleGracePeriod(Config.MAX_SCALE_GRACE_PERIOD)
-                .build();
+            TimeoutServiceConfig timeoutServiceConfig = TimeoutServiceConfig.builder()
+                    .maxLeaseValue(Config.MAX_LEASE_VALUE)
+                    .maxScaleGracePeriod(Config.MAX_SCALE_GRACE_PERIOD)
+                    .build();
 
-        ControllerEventProcessorConfig eventProcessorConfig = ControllerEventProcessorConfigImpl.withDefault();
+            ControllerEventProcessorConfig eventProcessorConfig = ControllerEventProcessorConfigImpl.withDefault();
 
-        GRPCServerConfig grpcServerConfig = Config.getGRPCServerConfig();
+            GRPCServerConfig grpcServerConfig = Config.getGRPCServerConfig();
 
-        RESTServerConfig restServerConfig = RESTServerConfigImpl.builder()
-                .host(Config.REST_SERVER_IP)
-                .port(Config.REST_SERVER_PORT)
-                .build();
+            RESTServerConfig restServerConfig = RESTServerConfigImpl.builder()
+                    .host(Config.REST_SERVER_IP)
+                    .port(Config.REST_SERVER_PORT)
+                    .build();
 
-        ControllerServiceConfig serviceConfig = ControllerServiceConfigImpl.builder()
-                .threadPoolSize(Config.ASYNC_TASK_POOL_SIZE)
-                .storeClientConfig(storeClientConfig)
-                .hostMonitorConfig(hostMonitorConfig)
-                .controllerClusterListenerEnabled(true)
-                .timeoutServiceConfig(timeoutServiceConfig)
-                .eventProcessorConfig(Optional.of(eventProcessorConfig))
-                .grpcServerConfig(Optional.of(grpcServerConfig))
-                .restServerConfig(Optional.of(restServerConfig))
-                .build();
+            ControllerServiceConfig serviceConfig = ControllerServiceConfigImpl.builder()
+                    .threadPoolSize(Config.ASYNC_TASK_POOL_SIZE)
+                    .storeClientConfig(storeClientConfig)
+                    .hostMonitorConfig(hostMonitorConfig)
+                    .controllerClusterListenerEnabled(true)
+                    .timeoutServiceConfig(timeoutServiceConfig)
+                    .eventProcessorConfig(Optional.of(eventProcessorConfig))
+                    .grpcServerConfig(Optional.of(grpcServerConfig))
+                    .restServerConfig(Optional.of(restServerConfig))
+                    .build();
 
-        ControllerServiceMain controllerServiceMain = new ControllerServiceMain(serviceConfig);
-        controllerServiceMain.startAsync();
-        controllerServiceMain.awaitTerminated();
+            ControllerServiceMain controllerServiceMain = new ControllerServiceMain(serviceConfig);
+            controllerServiceMain.startAsync();
+            controllerServiceMain.awaitTerminated();
+
+            log.info("Controller service exited");
+            System.exit(0);
+        } catch (Throwable e) {
+            log.error("Controller service failed", e);
+            System.exit(-1);
+        }
     }
 }


### PR DESCRIPTION
**Change log description**
If during shutdown in ControllerServiceStarter, some component's shutdown fails, an exception can be thrown all the way to Main.java whereby killing the main thread. 
However, if our executors have not been shutdown, then we have threads running for the process and the process itself is not terminated. 
This can cause controller process to continue running despite ZK session expiration. 

Note: this is a possible reason for the issue observed. But since we dont have logs to corroborate this line of reasoning, we are going with this fix and will see if the observed state reproduces. 


**Purpose of the change**
Fixes issue #2174

**What the code does**
Controller process, upon encountering zk session expiry, is supposed to perform graceful shutdown of all its components and executors (ControllerServiceStart.stop) and then restart them again within the same process (ControllerServiceMain.run has a while(isRunning()) loop). 

The way this is achieved is:
- After successfully starting controller service and all its components, `ControllerServiceMain` registers a listener/watch on zookeeper to listen for session notifications. 
- If ZK session expiry is received, `ControllerServiceMain` starts shutdown of all controller components (by calling shutdown on ControllerServiceStart).

However, during shutdown, if an exception is thrown before we successfully shutdown our executors, then ControllerServiceStart reaches `FAILED` state as opposed to `TERMINATED`, and `ControllerServiceMain.controllerServiceStarter.awaitTermination` throws `IllegalStateException` which is thrown out of Main thread of the process.  
So now we can have a situation where controllerServiceStarter, while trying to shutdown components, got an exception and `FAILED` without stopping the executors. And main method exits. Then controller process may be left in a bad state where some components are still running and have not been stopped, but they cant connect to zk because of session expiry. 

So the way we have fixed it is following:
1. In controllerServiceStart.shutdown we shutdown our executors in the finally block. This ensures that we shutdown our executors even if there was a failure to terminate any component. 
2. As an added measure, if the main method in controller is exiting we explicitly terminate controller process by calling System.exit.  
This is useful if an exception was thrown after having created our executors, but an excpetion was thrown while attempting to start a component (implemented as different flavours of abstractservice).

**How to verify it**
All existing unit tests should pass. And we should not observe the issue in test environments. 