### PR TITLE
Issue 2168: (SegmentStore) StorageWriter can't handle recovery with partially written appends

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -386,6 +386,13 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
      */
     private void aggregateAppendOperation(StorageOperation operation, AggregatedAppendOperation aggregatedAppend, int maxLength) {
         long remainingLength = operation.getLength();
+        if (operation.getStreamSegmentOffset() < aggregatedAppend.getLastStreamSegmentOffset()) {
+            // The given operation begins before the AggregatedAppendOperation. This is likely due to it having been
+            // partially written to Storage prior to some recovery event. We must make sure we only include the part that
+            // has not yet been written.
+            remainingLength -= aggregatedAppend.getLastStreamSegmentOffset() - operation.getStreamSegmentOffset();
+        }
+
         while (remainingLength > 0) {
             // All append lengths are integers, so it's safe to cast here.
             int lengthToAdd = (int) Math.min(maxLength - aggregatedAppend.getLength(), remainingLength);
@@ -428,8 +435,10 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
         }
 
         if (aggregatedAppend == null) {
-            // No operations or last operation not an AggregatedAppend - create a new one.
-            aggregatedAppend = new AggregatedAppendOperation(this.metadata.getId(), operationOffset, operationSequenceNumber);
+            // No operations or last operation not an AggregatedAppend - create a new one, while making sure the first
+            // offset is not below the current StorageLength (otherwise we risk re-writing data that's already in Storage).
+            long offset = Math.max(operationOffset, this.metadata.getStorageLength());
+            aggregatedAppend = new AggregatedAppendOperation(this.metadata.getId(), offset, operationSequenceNumber);
             this.operations.add(aggregatedAppend);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -390,7 +390,9 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
             // The given operation begins before the AggregatedAppendOperation. This is likely due to it having been
             // partially written to Storage prior to some recovery event. We must make sure we only include the part that
             // has not yet been written.
-            remainingLength -= aggregatedAppend.getLastStreamSegmentOffset() - operation.getStreamSegmentOffset();
+            long delta = aggregatedAppend.getLastStreamSegmentOffset() - operation.getStreamSegmentOffset();
+            remainingLength -= delta;
+            log.debug("Skipping {} bytes from the beginning of '{}' since it has already been partially written to Storage.", this.traceObjectId, delta, operation);
         }
 
         while (remainingLength > 0) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
@@ -15,6 +15,7 @@ import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.function.Callbacks;
 import io.pravega.common.util.SequencedItemList;
+import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
@@ -273,6 +274,16 @@ class TestWriterDataSource implements WriterDataSource, AutoCloseable {
         }
 
         synchronized (this.lock) {
+            // Perform the same validation checks as the ReadIndex would do.
+            SegmentMetadata sm = this.metadata.getStreamSegmentMetadata(streamSegmentId);
+            Preconditions.checkArgument(length >= 0, "length must be a non-negative number");
+            Preconditions.checkArgument(startOffset >= sm.getStorageLength(),
+                    "startOffset must be larger than refer to an offset beyond the Segment's StorageLength offset.");
+            Preconditions.checkArgument(startOffset + length <= sm.getLength(),
+                    "startOffset+length must be less than the length of the Segment.");
+            Preconditions.checkArgument(startOffset >= Math.min(sm.getStartOffset(), sm.getStorageLength()),
+                    "startOffset is before the Segment's StartOffset.");
+
             ad = this.appendData.getOrDefault(streamSegmentId, null);
         }
 


### PR DESCRIPTION
**Change log description**
Fixed a bug in `SegmentAggregator` where it would fail post-recovery if an append was already partially written to Storage.

Details:
- Writes to Tier2 Storage are capped (to a configurable value, default 1MB). A single write can aggregate multiple appends to a Segment, and as such, an append can be split across multiple Storage Writes.
- As such, it is quite likely that an append may be split across multiple such Tier2 writes, and some complete but at least one does not (since the process may have crashed or we failed over to some other host).
- Upon recovery, the `StorageWriter` must handle this situation and ensure that only those bytes which haven't been written are added.
- Prior to this change, the `StorageWriter` would do no such thing, and it would incorrectly attempt to rewrite the whole append. Had it not been for the safety check in the `ReadIndex` to prevent it from fetching the data, it would have corrupted the data in Tier2.

**Purpose of the change**
Fixes #2168 .

**What the code does**
See description.

**How to verify it**
New unit test added to exercise this particular case.
