### PR TITLE
Issue 2191: (SegmentStore) Do not attempt to delete already deleted transactions

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -238,10 +238,11 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
             result.add(segmentMetadata);
             segmentMetadata.markDeleted();
 
-            // Find any transactions that point to this StreamSegment (as a parent).
+            // Find any transactions that point to this StreamSegment (as a parent) which haven't already been deleted
+            // or fully merged in Storage.
             this.metadataById
                     .values().stream()
-                    .filter(m -> m.getParentId() == segmentMetadata.getId())
+                    .filter(m -> m.getParentId() == segmentMetadata.getId() && !m.isDeleted())
                     .forEach(m -> {
                         m.markDeleted();
                         result.add(m);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1277,7 +1277,6 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
     private void updateMetadataForTransactionPostMerger(UpdateableSegmentMetadata transactionMetadata) {
         // The other StreamSegment no longer exists and/or is no longer usable. Make sure it is marked as deleted.
         transactionMetadata.markDeleted();
-        this.dataSource.deleteStreamSegment(transactionMetadata.getName()); // This may be redundant...
 
         // Complete the merger (in the ReadIndex and whatever other listeners we might have).
         this.dataSource.completeMerge(transactionMetadata.getParentId(), transactionMetadata.getId());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
@@ -108,12 +108,6 @@ public class StorageWriterFactory implements WriterFactory {
         }
 
         @Override
-        public void deleteStreamSegment(String streamSegmentName) {
-            log.info("{}: DeleteSegment (SegmentName={}).", this.traceObjectId, streamSegmentName);
-            this.containerMetadata.deleteStreamSegment(streamSegmentName);
-        }
-
-        @Override
         public UpdateableSegmentMetadata getStreamSegmentMetadata(long streamSegmentId) {
             return this.containerMetadata.getStreamSegmentMetadata(streamSegmentId);
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterDataSource.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterDataSource.java
@@ -80,13 +80,6 @@ interface WriterDataSource {
     long getClosestValidTruncationPoint(long operationSequenceNumber);
 
     /**
-     * Marks the StreamSegment as deleted in the Container Metadata.
-     *
-     * @param streamSegmentName The name of the StreamSegment to delete.
-     */
-    void deleteStreamSegment(String streamSegmentName);
-
-    /**
      * Gets the StreamSegmentMetadata mapped to the given StreamSegment Id.
      *
      * @param streamSegmentId The Id of the StreamSegment to query for.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
@@ -294,11 +294,6 @@ class TestWriterDataSource implements WriterDataSource, AutoCloseable {
     }
 
     @Override
-    public void deleteStreamSegment(String streamSegmentName) {
-        this.metadata.deleteStreamSegment(streamSegmentName);
-    }
-
-    @Override
     public UpdateableSegmentMetadata getStreamSegmentMetadata(long streamSegmentId) {
         Consumer<Long> callback;
         synchronized (this.lock) {


### PR DESCRIPTION
**Change log description**
Fixed a bug where the SegmentStore would incorrectly issue delete requests for transactions that have already been fully merged in Tier2 Storage or aborted (deleted). Such requests, while not harmful, would potentially create unnecessary load on the Storage adapter by issuing bogus delete requests, which may affect performance.

Details:
- `StreamSegmentContainerMetadata`: Fixed `deleteStreamSegment` to not include Transactions for a parent Segment that do not exist in Storage anymore (this includes deleted transactions and transactions that have been merged in Storage).
- `SegmentAggregator`: removed redundant call that would achieve the same effect as the code executing right before that.

**Purpose of the change**
Fixes #2191.

**What the code does**
See description.

**How to verify it**
Unit test updated.