### PR TITLE
Issue 2188: (SegmentStore) Split the common Thread Pool into Core and Storage

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -38,12 +38,17 @@ pravegaservice.clusterName=pravega-cluster
 # Required.
 pravegaservice.containerCount=4
 
-# Maximum number of threads in the common SegmentStore thread pool. This pool is used for all SegmentStore-related
-# activities, except Netty-related tasks. Examples include: handling inbound requests, processing reads, reading and writing
-# to Tier 2 Storage, background maintenance operations and background operation processing.
+# Maximum number of threads in the Core SegmentStore Thread Pool. This pool is used for all SegmentStore-related
+# activities, except Netty-related tasks and Tier2 Storage activities. Examples include: handling inbound requests,
+# processing reads, background maintenance operations and background operation processing.
 # Valid values: Positive integer.
-# Recommended setting: 3 * Number of containers per node, minimum 20.
-#pravegaservice.threadPoolSize=50
+# Recommended setting: 2 * Number of containers per node, minimum 20.
+#pravegaservice.threadPoolSize=30
+
+# Maximum number of threads in the Thread Pool used for Tier2 tasks (reading, writing, create, delete, etc.).
+# Valid values: Positive integer.
+# Recommended setting: 2 * Number of containers per node, minimum 20.
+#pravegaservice.storageThreadPoolSize=20
 
 # TCP port where the SegmentStore will be listening for incoming requests.
 # Valid values: Positive integer in the valid TCP port ranges.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -142,9 +142,9 @@ public final class ServiceStarter {
         builder.withDataLogFactory(setup -> {
             switch (this.serviceConfig.getDataLogTypeImplementation()) {
                 case BOOKKEEPER:
-                    return new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), this.zkClient, setup.getExecutor());
+                    return new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), this.zkClient, setup.getCoreExecutor());
                 case INMEMORY:
-                    return new InMemoryDurableDataLogFactory(setup.getExecutor());
+                    return new InMemoryDurableDataLogFactory(setup.getCoreExecutor());
                 default:
                     throw new IllegalStateException("Unsupported storage implementation: " + this.serviceConfig.getDataLogTypeImplementation());
             }
@@ -160,15 +160,15 @@ public final class ServiceStarter {
             switch (this.serviceConfig.getStorageImplementation()) {
                 case HDFS:
                     HDFSStorageConfig hdfsConfig = setup.getConfig(HDFSStorageConfig::builder);
-                    return new HDFSStorageFactory(hdfsConfig, setup.getExecutor());
+                    return new HDFSStorageFactory(hdfsConfig, setup.getStorageExecutor());
                 case FILESYSTEM:
                     FileSystemStorageConfig fsConfig = setup.getConfig(FileSystemStorageConfig::builder);
-                    return new FileSystemStorageFactory(fsConfig, setup.getExecutor());
+                    return new FileSystemStorageFactory(fsConfig, setup.getStorageExecutor());
                 case EXTENDEDS3:
                     ExtendedS3StorageConfig extendedS3Config = setup.getConfig(ExtendedS3StorageConfig::builder);
-                    return new ExtendedS3StorageFactory(extendedS3Config, setup.getExecutor());
+                    return new ExtendedS3StorageFactory(extendedS3Config, setup.getStorageExecutor());
                 case INMEMORY:
-                    return new InMemoryStorageFactory(setup.getExecutor());
+                    return new InMemoryStorageFactory(setup.getStorageExecutor());
                 default:
                     throw new IllegalStateException("Unsupported storage implementation: " + this.serviceConfig.getStorageImplementation());
             }
@@ -181,7 +181,7 @@ public final class ServiceStarter {
                         this.zkClient,
                         new Host(this.serviceConfig.getPublishedIPAddress(),
                                 this.serviceConfig.getPublishedPort(), null),
-                        setup.getExecutor()));
+                        setup.getCoreExecutor()));
     }
 
     private CuratorFramework createZKClient() {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -84,7 +84,7 @@ public class ExtendedS3IntegrationTest extends StreamSegmentStoreTestBase {
                 .withCacheFactory(setup -> new RocksDBCacheFactory(builderConfig.getConfig(RocksDBConfig::builder)))
                 .withStorageFactory(setup -> new LocalExtendedS3StorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder)))
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
-                        bookkeeper.getZkClient(), setup.getExecutor()));
+                        bookkeeper.getZkClient(), setup.getCoreExecutor()));
     }
 
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -67,9 +67,9 @@ public class FileSystemIntegrationTest extends StreamSegmentStoreTestBase {
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
                 .withCacheFactory(setup -> new RocksDBCacheFactory(builderConfig.getConfig(RocksDBConfig::builder)))
-                .withStorageFactory(setup -> new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getExecutor()))
+                .withStorageFactory(setup -> new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor()))
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
-                                                            bookkeeper.getZkClient(), setup.getExecutor()));
+                                                            bookkeeper.getZkClient(), setup.getCoreExecutor()));
     }
 
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -80,8 +80,8 @@ public class HDFSIntegrationTest extends StreamSegmentStoreTestBase {
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
                 .withCacheFactory(setup -> new RocksDBCacheFactory(builderConfig.getConfig(RocksDBConfig::builder)))
-                .withStorageFactory(setup -> new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getExecutor()))
-                .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), bookkeeper.getZkClient(), setup.getExecutor()));
+                .withStorageFactory(setup -> new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor()))
+                .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), bookkeeper.getZkClient(), setup.getCoreExecutor()));
     }
 
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -477,7 +477,7 @@ public class PravegaRequestProcessorTest {
     }
 
     private static ServiceBuilder newInlineExecutionInMemoryBuilder(ServiceBuilderConfig config) {
-        return ServiceBuilder.newInMemoryBuilder(config, new InlineExecutor())
+        return ServiceBuilder.newInMemoryBuilder(config, (size, name) -> new InlineExecutor())
                              .withStreamSegmentStore(setup -> new SynchronousStreamSegmentStore(new StreamSegmentService(
                                      setup.getContainerRegistry(), setup.getSegmentToContainerMapper())));
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMapper.java
@@ -203,13 +203,13 @@ public class StreamSegmentMapper extends SegmentStateMapper {
                         this.storage.create(segmentName, rollingPolicy, timer.getRemaining()),
                         ex -> handleStorageCreateException(segmentName, Exceptions.unwrap(ex), timer))
                 .thenComposeAsync(segmentProps -> saveState(segmentProps, attributes, timer.getRemaining())
-                                .thenRun(() -> {
+                                .thenRunAsync(() -> {
                                     // Need to create the state file before we throw any further exceptions in order to recover from
                                     // previous partial executions (where we created a segment but no or empty state file).
                                     if (segmentProps.getLength() > 0) {
                                         throw new CompletionException(new StreamSegmentExistsException(segmentName));
                                     }
-                                }),
+                                }, this.executor),
                         this.executor);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
@@ -107,8 +107,8 @@ public class ServiceBuilder implements AutoCloseable {
         this.streamSegmentStoreCreator = notConfiguredCreator(StreamSegmentStore.class);
 
         // Setup Thread Pools.
-        this.coreExecutor = executorBuilder.apply(serviceConfig.getCoreThreadPoolSize(), "segment-store");
-        this.storageExecutor = executorBuilder.apply(serviceConfig.getStorageThreadPoolSize(), "storage");
+        this.coreExecutor = executorBuilder.apply(serviceConfig.getCoreThreadPoolSize(), "core");
+        this.storageExecutor = executorBuilder.apply(serviceConfig.getStorageThreadPoolSize(), "storage-io");
         this.threadPoolMetrics = new SegmentStoreMetrics.ThreadPool(this.coreExecutor);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.store;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.util.ConfigBuilder;
@@ -42,6 +43,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -54,7 +57,9 @@ public class ServiceBuilder implements AutoCloseable {
     private final SegmentStoreMetrics.ThreadPool threadPoolMetrics;
     private final SegmentToContainerMapper segmentToContainerMapper;
     private final ServiceBuilderConfig serviceBuilderConfig;
-    private final ScheduledExecutorService executorService;
+    @Getter(AccessLevel.PROTECTED)
+    private final ScheduledExecutorService coreExecutor;
+    private final ScheduledExecutorService storageExecutor;
     private final AtomicReference<OperationLogFactory> operationLogFactory;
     private final AtomicReference<ReadIndexFactory> readIndexFactory;
     private final AtomicReference<DurableDataLogFactory> dataLogFactory;
@@ -79,11 +84,9 @@ public class ServiceBuilder implements AutoCloseable {
      * Creates a new instance of the ServiceBuilder class.
      *
      * @param serviceBuilderConfig The ServiceBuilderConfig to use.
-     * @param executorService      The executor to use for background tasks.
      */
-    private ServiceBuilder(ServiceBuilderConfig serviceBuilderConfig, ServiceConfig serviceConfig, ScheduledExecutorService executorService) {
+    private ServiceBuilder(ServiceBuilderConfig serviceBuilderConfig, ServiceConfig serviceConfig, ExecutorBuilder executorBuilder) {
         this.serviceBuilderConfig = Preconditions.checkNotNull(serviceBuilderConfig, "serviceBuilderConfig");
-        this.executorService = Preconditions.checkNotNull(executorService, "executorService");
         this.segmentToContainerMapper = createSegmentToContainerMapper(serviceConfig);
         this.operationLogFactory = new AtomicReference<>();
         this.readIndexFactory = new AtomicReference<>();
@@ -102,7 +105,11 @@ public class ServiceBuilder implements AutoCloseable {
         this.segmentContainerManagerCreator = notConfiguredCreator(SegmentContainerManager.class);
         this.cacheFactoryCreator = notConfiguredCreator(CacheFactory.class);
         this.streamSegmentStoreCreator = notConfiguredCreator(StreamSegmentStore.class);
-        this.threadPoolMetrics = new SegmentStoreMetrics.ThreadPool(this.executorService);
+
+        // Setup Thread Pools.
+        this.coreExecutor = executorBuilder.apply(serviceConfig.getCoreThreadPoolSize(), "segment-store");
+        this.storageExecutor = executorBuilder.apply(serviceConfig.getStorageThreadPoolSize(), "storage");
+        this.threadPoolMetrics = new SegmentStoreMetrics.ThreadPool(this.coreExecutor);
     }
 
     //endregion
@@ -117,7 +124,8 @@ public class ServiceBuilder implements AutoCloseable {
         closeComponent(this.readIndexFactory);
         closeComponent(this.cacheFactory);
         this.threadPoolMetrics.close();
-        this.executorService.shutdown();
+        this.storageExecutor.shutdown();
+        this.coreExecutor.shutdown();
     }
 
     //endregion
@@ -217,10 +225,6 @@ public class ServiceBuilder implements AutoCloseable {
         return getSingleton(this.containerRegistry, this::createSegmentContainerRegistry);
     }
 
-    protected ScheduledExecutorService getExecutorService() {
-        return this.executorService;
-    }
-
     //endregion
 
     //region Component Builders
@@ -231,13 +235,13 @@ public class ServiceBuilder implements AutoCloseable {
 
     protected WriterFactory createWriterFactory() {
         WriterConfig writerConfig = this.serviceBuilderConfig.getConfig(WriterConfig::builder);
-        return new StorageWriterFactory(writerConfig, this.executorService);
+        return new StorageWriterFactory(writerConfig, this.coreExecutor);
     }
 
     protected ReadIndexFactory createReadIndexFactory() {
         CacheFactory cacheFactory = getSingleton(this.cacheFactory, this.cacheFactoryCreator);
         ReadIndexConfig readIndexConfig = this.serviceBuilderConfig.getConfig(ReadIndexConfig::builder);
-        return new ContainerReadIndexFactory(readIndexConfig, cacheFactory, this.executorService);
+        return new ContainerReadIndexFactory(readIndexConfig, cacheFactory, this.coreExecutor);
     }
 
     protected StorageFactory createStorageFactory() {
@@ -250,18 +254,18 @@ public class ServiceBuilder implements AutoCloseable {
         OperationLogFactory operationLogFactory = getSingleton(this.operationLogFactory, this::createOperationLogFactory);
         WriterFactory writerFactory = getSingleton(this.writerFactory, this::createWriterFactory);
         ContainerConfig containerConfig = this.serviceBuilderConfig.getConfig(ContainerConfig::builder);
-        return new StreamSegmentContainerFactory(containerConfig, operationLogFactory, readIndexFactory, writerFactory, storageFactory, this.executorService);
+        return new StreamSegmentContainerFactory(containerConfig, operationLogFactory, readIndexFactory, writerFactory, storageFactory, this.coreExecutor);
     }
 
     private SegmentContainerRegistry createSegmentContainerRegistry() {
         SegmentContainerFactory containerFactory = getSingleton(this.containerFactory, this::createSegmentContainerFactory);
-        return new StreamSegmentContainerRegistry(containerFactory, this.executorService);
+        return new StreamSegmentContainerRegistry(containerFactory, this.coreExecutor);
     }
 
     protected OperationLogFactory createOperationLogFactory() {
         DurableDataLogFactory dataLogFactory = getSingleton(this.dataLogFactory, this.dataLogFactoryCreator);
         DurableLogConfig durableLogConfig = this.serviceBuilderConfig.getConfig(DurableLogConfig::builder);
-        return new DurableLogFactory(durableLogConfig, dataLogFactory, this.executorService);
+        return new DurableLogFactory(durableLogConfig, dataLogFactory, this.coreExecutor);
     }
 
     private <T> T getSingleton(AtomicReference<T> instance, Function<ComponentSetup, T> creator) {
@@ -314,38 +318,45 @@ public class ServiceBuilder implements AutoCloseable {
      * @param builderConfig The ServiceBuilderConfig to use.
      */
     public static ServiceBuilder newInMemoryBuilder(ServiceBuilderConfig builderConfig) {
-        int threadPoolSize = builderConfig.getConfig(ServiceConfig::builder).getThreadPoolSize();
-        return newInMemoryBuilder(builderConfig, ExecutorServiceHelpers.newScheduledThreadPool(threadPoolSize, "segment-store"));
+        return newInMemoryBuilder(builderConfig, ExecutorServiceHelpers::newScheduledThreadPool);
     }
 
     /**
      * Creates a new instance of the ServiceBuilder class which is contained in memory. Any data added to this service will
      * be lost when the object is garbage collected or the process terminates.
      *
-     * @param builderConfig          The ServiceBuilderConfig to use.
-     * @param executorService An ExecutorService to use for async operations.
+     * @param builderConfig   The ServiceBuilderConfig to use.
+     * @param executorBuilder A Function that, given a thread count and a pool name, creates a ScheduledExecutorService
+     *                        with the given number of threads that have the given name as prefix.
      */
-    public static ServiceBuilder newInMemoryBuilder(ServiceBuilderConfig builderConfig, ScheduledExecutorService executorService) {
+    @VisibleForTesting
+    public static ServiceBuilder newInMemoryBuilder(ServiceBuilderConfig builderConfig, ExecutorBuilder executorBuilder) {
         ServiceConfig serviceConfig = builderConfig.getConfig(ServiceConfig::builder);
         ServiceBuilder builder;
         if (serviceConfig.isReadOnlySegmentStore()) {
             // Only components required for ReadOnly SegmentStore.
-            builder = new ReadOnlyServiceBuilder(builderConfig, serviceConfig, executorService);
+            builder = new ReadOnlyServiceBuilder(builderConfig, serviceConfig, executorBuilder);
         } else {
             // Components that are required for general SegmentStore.
-            builder = new ServiceBuilder(builderConfig, serviceConfig, executorService)
+            builder = new ServiceBuilder(builderConfig, serviceConfig, executorBuilder)
                     .withCacheFactory(setup -> new InMemoryCacheFactory());
         }
 
         // Components that are required for all types of SegmentStore.
         return builder
-                .withDataLogFactory(setup -> new InMemoryDurableDataLogFactory(setup.getExecutor()))
+                .withDataLogFactory(setup -> new InMemoryDurableDataLogFactory(setup.getCoreExecutor()))
                 .withContainerManager(setup -> new LocalSegmentContainerManager(
                         setup.getContainerRegistry(), setup.getSegmentToContainerMapper()))
-                .withStorageFactory(setup -> new InMemoryStorageFactory(setup.getExecutor()))
+                .withStorageFactory(setup -> new InMemoryStorageFactory(setup.getStorageExecutor()))
                 .withStreamSegmentStore(setup -> new StreamSegmentService(setup.getContainerRegistry(),
                         setup.getSegmentToContainerMapper()));
 
+    }
+
+    @FunctionalInterface
+    @VisibleForTesting
+    public interface ExecutorBuilder {
+        ScheduledExecutorService apply(int threadPoolSize, String name);
     }
 
     //endregion
@@ -355,8 +366,8 @@ public class ServiceBuilder implements AutoCloseable {
     private static class ReadOnlyServiceBuilder extends ServiceBuilder {
         private static final int READONLY_CONTAINER_COUNT = 1; // Everything maps to a single container.
 
-        private ReadOnlyServiceBuilder(ServiceBuilderConfig serviceBuilderConfig, ServiceConfig serviceConfig, ScheduledExecutorService executorService) {
-            super(serviceBuilderConfig, serviceConfig, executorService);
+        private ReadOnlyServiceBuilder(ServiceBuilderConfig serviceBuilderConfig, ServiceConfig serviceConfig, ExecutorBuilder executorBuilder) {
+            super(serviceBuilderConfig, serviceConfig, executorBuilder);
 
             // We attach a LocalSegmentContainerManager, since we only have one Container Running.
             // Note that withContainerManager() is disabled in ReadOnlyServiceBuilder, hence we must invoke the one on
@@ -372,7 +383,7 @@ public class ServiceBuilder implements AutoCloseable {
         @Override
         protected SegmentContainerFactory createSegmentContainerFactory() {
             StorageFactory storageFactory = createStorageFactory();
-            return new ReadOnlySegmentContainerFactory(storageFactory, getExecutorService());
+            return new ReadOnlySegmentContainerFactory(storageFactory, getCoreExecutor());
         }
 
         @Override
@@ -437,10 +448,17 @@ public class ServiceBuilder implements AutoCloseable {
         }
 
         /**
-         * Gets a pointer to the Executor Service for this ServiceBuilder.
+         * Gets a pointer to the Core Executor Service for this ServiceBuilder.
          */
-        public ScheduledExecutorService getExecutor() {
-            return this.builder.executorService;
+        public ScheduledExecutorService getCoreExecutor() {
+            return this.builder.coreExecutor;
+        }
+
+        /**
+         * Gets a pointer to the Executor Service for this ServiceBuilder that is used for Storage access.
+         */
+        public ScheduledExecutorService getStorageExecutor() {
+            return this.builder.storageExecutor;
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -26,7 +26,8 @@ public class ServiceConfig {
     //region Config Names
 
     public static final Property<Integer> CONTAINER_COUNT = Property.named("containerCount");
-    public static final Property<Integer> THREAD_POOL_SIZE = Property.named("threadPoolSize", 50);
+    public static final Property<Integer> THREAD_POOL_SIZE = Property.named("threadPoolSize", 30);
+    public static final Property<Integer> STORAGE_THREAD_POOL_SIZE = Property.named("storageThreadPoolSize", 20);
     public static final Property<Integer> LISTENING_PORT = Property.named("listeningPort", 12345);
     public static final Property<Integer> PUBLISHED_PORT = Property.named("publishedPort");
     public static final Property<String> LISTENING_IP_ADDRESS = Property.named("listeningIPAddress", "");
@@ -91,10 +92,16 @@ public class ServiceConfig {
     private final int containerCount;
 
     /**
-     * The number of threads in the common thread pool.
+     * The number of threads in the core Segment Store Thread Pool.
      */
     @Getter
-    private final int threadPoolSize;
+    private final int coreThreadPoolSize;
+
+    /**
+     * The number of threads in the Thread Pool used for accessing Storage.
+     */
+    @Getter
+    private final int storageThreadPoolSize;
 
     /**
      * The TCP Port number to listen to.
@@ -188,7 +195,8 @@ public class ServiceConfig {
      */
     private ServiceConfig(TypedProperties properties) throws ConfigurationException {
         this.containerCount = properties.getInt(CONTAINER_COUNT);
-        this.threadPoolSize = properties.getInt(THREAD_POOL_SIZE);
+        this.coreThreadPoolSize = properties.getInt(THREAD_POOL_SIZE);
+        this.storageThreadPoolSize = properties.getInt(STORAGE_THREAD_POOL_SIZE);
         this.listeningPort = properties.getInt(LISTENING_PORT);
 
         int publishedPort;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1693,7 +1693,7 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
                 TIMEOUT).join();
 
         // Initialize the SegmentAggregator. This should pick up the half-written operation.
-        context.segmentAggregator.initialize(TIMEOUT, executorService()).join();
+        context.segmentAggregator.initialize(TIMEOUT).join();
         Assert.assertEquals("", partialWriteLength, context.segmentAggregator.getMetadata().getStorageLength());
 
         // Add all operations we had so far.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
@@ -91,11 +91,11 @@ class SegmentStoreAdapter extends StoreAdapter {
                 .withCacheFactory(setup -> new RocksDBCacheFactory(setup.getConfig(RocksDBConfig::builder)))
                 .withStorageFactory(setup -> {
                     // We use the Segment Store Executor for the real storage.
-                    SingletonStorageFactory factory = new SingletonStorageFactory(setup.getExecutor());
+                    SingletonStorageFactory factory = new SingletonStorageFactory(setup.getStorageExecutor());
                     this.storage.set(factory.createStorageAdapter());
 
                     // A bit hack-ish, but we need to get a hold of the Store Executor, so we can request snapshots for it.
-                    this.storeExecutor.set(setup.getExecutor());
+                    this.storeExecutor.set(setup.getCoreExecutor());
                     return factory;
                 }));
         this.stopBookKeeperProcess = new Thread(this::stopBookKeeper);
@@ -116,11 +116,11 @@ class SegmentStoreAdapter extends StoreAdapter {
             this.zkClient.start();
             return builder.withDataLogFactory(setup -> {
                 BookKeeperConfig bkConfig = setup.getConfig(BookKeeperConfig::builder);
-                return new BookKeeperLogFactory(bkConfig, this.zkClient, setup.getExecutor());
+                return new BookKeeperLogFactory(bkConfig, this.zkClient, setup.getCoreExecutor());
             });
         } else {
             // No Bookies -> InMemory Tier1.
-            return builder.withDataLogFactory(setup -> new InMemoryDurableDataLogFactory(setup.getExecutor()));
+            return builder.withDataLogFactory(setup -> new InMemoryDurableDataLogFactory(setup.getCoreExecutor()));
         }
     }
 


### PR DESCRIPTION
**Change log description**
Split the Common SegmentStore Thread Pool in two:
- Storage Pool: every operation executed in `Storage` (essentially what `SyncStorage` is run on). This is exclusively for the IO intensive operations that the Storage adapters run (all Storage adapters are non-async, and the `AsyncStorageWrapper` uses a thread pool to run those tasks on). 
- Core Pool: everything else (except BookKepeer and Netty - those haven't changed).
    - This includes `StorageWriter`, which is a SegmentStore component that picks data from `DurableLog` and issues Storage requests (while the StorageWriter executes on the Core pool, the Storage requests are run on the Storage Pool (see bullet above)).

Updated some callbacks to better ensure that they are executed on the proper thread pool (in `StreamSegmentMapper` and `SegmentAggregator`).

**Purpose of the change**
Fixes #2188.

**What the code does**
See Description. There are no functional changes to the SegmentStore. The bulk of the logic is in `ServiceBuilder`.

**How to verify it**
All unit tests must pass. Examine the run of a System test and verify that all Tier2 operations are executed on their special thread pool and that there aren't too many non-Tier2 Storage messages on that pool (exceptional messages will end up there since exception handlers are executed in the same thread).