### PR TITLE
Issue 2205: Change Pravega version in master to 0.3.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ slf4jApiVersion=1.7.25
 typesafeConfigVersion=1.3.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.2.0-SNAPSHOT
+pravegaVersion=0.3.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Change Pravega version in gradle.properties to 0.3.0-SNAPSHOT.

**Purpose of the change**
Fixes #2205 

**What the code does**
There is no functional change, only a property in `gradle.properties`.

**How to verify it**
Visual inspection.
