### PR TITLE
Issue 2207: Fixed jersey dependency for the controller service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -469,6 +469,7 @@ project('standalone') {
         compile project(':segmentstore:storage')
         compile project(':segmentstore:storage:impl')
 
+        compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
         compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: javaxwsrsApiVersion
         runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion


### PR DESCRIPTION
**Change log description**
Added jersey dependency to the standalone project for the `InProcPravegaCluster` to work properly 

**Purpose of the change**
To resolve the build dependency for the `flink-connector` project which is using `InProcPravegaCluster` for running the test modules

**How to verify it**
Verified building `flink-connector` with the changes and it is working fine.