### PR TITLE
Issue 2211: Ensure state.connection is cleared incase of exceptions during SegmentOutputStreamImpl#reconnect()

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -530,6 +530,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          try {
                              connection.send(cmd);
                          } catch (ConnectionFailedException e1) {
+                             state.failConnection(e1);
                              throw Lombok.sneakyThrow(e1);
                          }
                          return connectionSetupFuture.exceptionally(t -> {

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -53,12 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 
 public class SegmentOutputStreamTest {
@@ -111,6 +106,26 @@ public class SegmentOutputStreamTest {
 
         cf.getProcessor(uri).connectionDropped(); // simulate a connection dropped
         //Ensure setup Append is invoked on the executor.
+        verify(connection).send(new SetupAppend(2, cid, SEGMENT));
+    }
+
+    @Test(timeout = 10000)
+    public void testConnectAndFailedSetupAppend() throws Exception {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        cf.setExecutor(executor);
+
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        ClientConnection connection = mock(ClientConnection.class);
+        doThrow(ConnectionFailedException.class).doNothing().when(connection).send(any(SetupAppend.class));
+        cf.provideConnection(uri, connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE);
+        output.reconnect();
+        verify(connection).send(new SetupAppend(1, cid, SEGMENT));
         verify(connection).send(new SetupAppend(2, cid, SEGMENT));
     }
 


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Ensure state.connection is cleared upon exceptions during `SegmentOutputStreamImpl#reconnect()`

**Purpose of the change**
Fixes #2211 

**What the code does**
Ensure state.connection is cleared incase of ConnectionFailedException while sending WireCommand.SetupAppend.

**How to verify it**
Tests should continue to pass.