### PR TITLE
Issue 2215: [BatchClient] drop endingOffset parameter of readSegment, improved javadoc

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/BatchClient.java
+++ b/client/src/main/java/io/pravega/client/batch/BatchClient.java
@@ -55,10 +55,10 @@ public interface BatchClient {
      * segment ending at the current end of the segment.
      * 
      * Offsets can be obtained by calling {@link SegmentIterator#getOffset()} or
-     * {@link SegmentInfo#getLength()}. There is no validation that the provided offset actually
+     * {@link SegmentInfo#getWriteOffset()}. There is no validation that the provided offset actually
      * aligns to an event. If it does not, the deserializer will be passed corrupt data. This means
-     * that it is invalid to for example attempt to divide a segment by simply passing a starting
-     * offset that is half of the segment lenght.
+     * that it is invalid to, for example, attempt to divide a segment by simply passing a starting
+     * offset that is half of the segment length.
      * 
      * @param <T> The type of events written to the segment.
      * @param segment The segment to read from

--- a/client/src/main/java/io/pravega/client/batch/BatchClient.java
+++ b/client/src/main/java/io/pravega/client/batch/BatchClient.java
@@ -55,7 +55,10 @@ public interface BatchClient {
      * segment ending at the current end of the segment.
      * 
      * Offsets can be obtained by calling {@link SegmentIterator#getOffset()} or
-     * {@link SegmentInfo#getLength()}
+     * {@link SegmentInfo#getLength()}. There is no validation that the provided offset actually
+     * aligns to an event. If it does not, the deserializer will be passed corrupt data. This means
+     * that it is invalid to for example attempt to divide a segment by simply passing a starting
+     * offset that is half of the segment lenght.
      * 
      * @param <T> The type of events written to the segment.
      * @param segment The segment to read from

--- a/client/src/main/java/io/pravega/client/batch/BatchClient.java
+++ b/client/src/main/java/io/pravega/client/batch/BatchClient.java
@@ -51,18 +51,18 @@ public interface BatchClient {
     <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer);
 
     /**
-     * Provides a SegmentIterator to read the events after the startingOffset but before the
-     * endingOffset in the requested segment.
+     * Provides a SegmentIterator to read the events after the startingOffset in the requested
+     * segment ending at the current end of the segment.
      * 
-     * Offsets can be obtained by calling {@link SegmentIterator#getOffset()} or {@link SegmentInfo#getLength()}
+     * Offsets can be obtained by calling {@link SegmentIterator#getOffset()} or
+     * {@link SegmentInfo#getLength()}
      * 
      * @param <T> The type of events written to the segment.
      * @param segment The segment to read from
      * @param deserializer A deserializer to be used to parse events
      * @param startingOffset The offset to start iterating from.
-     * @param endingOffset The offset to stop iterating at.
      * @return A SegmentIterator over the requested segment at startingOffset
      */
-    <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer, long startingOffset, long endingOffset);
+    <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer, long startingOffset);
     
 }

--- a/client/src/main/java/io/pravega/client/batch/SegmentInfo.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentInfo.java
@@ -13,14 +13,40 @@ import com.google.common.annotations.Beta;
 import io.pravega.client.segment.impl.Segment;
 import lombok.Data;
 
+/**
+ * Information about a segment of a stream.
+ */
 @Beta
 @Data
 public class SegmentInfo {
 
+    /**
+     * Which segment these properties relate to.
+     */
     private final Segment segment;
+    
+    /**
+     * The offset at which data is available. In the event the stream has never been truncated this
+     * is 0. However if all data below a certain offset has been truncated, that offset will be
+     * provide here. (Offsets are left absolute even if data is truncated so that positions in the
+     * segment can be refered to consistantly)
+     */
     private final long startingOffset;
+    
+    /**
+     * The offset at which new data would be written if it were to be added. This is equal to the
+     * total length of all data written to the segment.
+     */
     private final long writeOffset;
+    
+    /**
+     * If the segment is sealed and can no longer be written to.
+     */
     private final boolean isSealed;
+    
+    /**
+     * The last time the segment was written to.
+     */
     private final long lastModifiedTime;
 
 }

--- a/client/src/main/java/io/pravega/client/batch/SegmentInfo.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentInfo.java
@@ -27,9 +27,9 @@ public class SegmentInfo {
     
     /**
      * The offset at which data is available. In the event the stream has never been truncated this
-     * is 0. However if all data below a certain offset has been truncated, that offset will be
+     * is 0. However, if all data below a certain offset has been truncated, that offset will be
      * provide here. (Offsets are left absolute even if data is truncated so that positions in the
-     * segment can be refered to consistantly)
+     * segment can be referred to consistently)
      */
     private final long startingOffset;
     

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientImpl.java
@@ -87,14 +87,16 @@ public class BatchClientImpl implements BatchClient {
     public <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer) {
         @Cleanup
         SegmentMetadataClient metadataClient = segmentMetadataClientFactory.createSegmentMetadataClient(segment);
-        long segmentLength = metadataClient.fetchCurrentSegmentLength();
-        return readSegment(segment, deserializer, 0, segmentLength);
+        SegmentInfo segmentInfo = metadataClient.getSegmentInfo();
+        return new SegmentIteratorImpl<>(inputStreamFactory, segment, deserializer, segmentInfo.getStartingOffset(), segmentInfo.getWriteOffset());
     }
 
     @Override
-    public <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer, long startingOffset,
-                                              long endingOffset) {
-        return new SegmentIteratorImpl<>(inputStreamFactory, segment, deserializer, startingOffset, endingOffset);
+    public <T> SegmentIterator<T> readSegment(Segment segment, Serializer<T> deserializer, long startingOffset) {
+        @Cleanup
+        SegmentMetadataClient metadataClient = segmentMetadataClientFactory.createSegmentMetadataClient(segment);
+        SegmentInfo segmentInfo = metadataClient.getSegmentInfo();
+        return new SegmentIteratorImpl<>(inputStreamFactory, segment, deserializer, startingOffset, segmentInfo.getWriteOffset());
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
* Add Javadocs for SegmentInfo
* Remove confusing parameter "endingOffset"
* Fix bug where two argument readSegment would start from offset 0.

**Purpose of the change**
Fixes #2215

**What the code does**
Attempts to remove some confusion sounding when iterators will stop when reading from the batch client.

**How to verify it**
Unfortunately there are no integration tests using the BatchApi at the moment.