### PR TITLE
Issue 2220: Change version to 0.2.1-SNAPSHOT in r0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ slf4jApiVersion=1.7.25
 typesafeConfigVersion=1.3.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.2.0
+pravegaVersion=0.2.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Changes the Pravega version in gradle.properties to 0.2.1-SNAPSHOT

**Purpose of the change**
Fixes #2220 

**What the code does**
There is no code change, only gradle configuration.

**How to verify it**
Build and verify that the version is as expected.