### PR TITLE
Issue 2229: Fix ports in StartLocalService

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -70,7 +70,7 @@ public final class PravegaConnectionListener implements AutoCloseable {
      */
     @VisibleForTesting
     public PravegaConnectionListener(boolean ssl, int port, StreamSegmentStore streamSegmentStore) {
-        this(ssl, "localhost", port, streamSegmentStore, null);
+        this(ssl, "0.0.0.0", port, streamSegmentStore, null);
     }
 
     /**

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
@@ -18,7 +18,8 @@ import lombok.Cleanup;
 
 public class StartLocalService {
     
-    static final int PORT = 9090;
+    static final int SERVICE_PORT = 6000;
+    static final int CONTROLLER_PORT = 9090;
     static final String SCOPE = "Scope";
     static final String STREAM_NAME = "Foo";
 
@@ -28,11 +29,11 @@ public class StartLocalService {
         serviceBuilder.initialize();
         StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
         @Cleanup
-        PravegaConnectionListener server = new PravegaConnectionListener(false, PORT, store);
+        PravegaConnectionListener server = new PravegaConnectionListener(false, StartLocalService.SERVICE_PORT, store);
         server.startListening();
         
         @Cleanup
-        MockStreamManager streamManager = new MockStreamManager(SCOPE, "localhost", StartLocalService.PORT);
+        MockStreamManager streamManager = new MockStreamManager(SCOPE, "localhost", StartLocalService.CONTROLLER_PORT);
         streamManager.createScope(SCOPE);
         streamManager.createStream(SCOPE, STREAM_NAME, null);
         

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
@@ -19,7 +19,6 @@ import lombok.Cleanup;
 public class StartLocalService {
     
     static final int SERVICE_PORT = 6000;
-    static final int CONTROLLER_PORT = 9090;
     static final String SCOPE = "Scope";
     static final String STREAM_NAME = "Foo";
 
@@ -33,7 +32,7 @@ public class StartLocalService {
         server.startListening();
         
         @Cleanup
-        MockStreamManager streamManager = new MockStreamManager(SCOPE, "localhost", StartLocalService.CONTROLLER_PORT);
+        MockStreamManager streamManager = new MockStreamManager(SCOPE, "localhost", StartLocalService.SERVICE_PORT);
         streamManager.createScope(SCOPE);
         streamManager.createStream(SCOPE, STREAM_NAME, null);
         

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
@@ -28,7 +28,7 @@ public class StartReader {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
                                                                 "localhost",
-                                                                StartLocalService.CONTROLLER_PORT);
+                                                                StartLocalService.SERVICE_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);
         streamManager.createReaderGroup(READER_GROUP,

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
@@ -15,6 +15,7 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.mock.MockStreamManager;
 
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -27,7 +28,7 @@ public class StartReader {
     public static void main(String[] args) throws Exception {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
-                                                                "localhost",
+                                                                InetAddress.getLocalHost().getHostAddress(),
                                                                 StartLocalService.SERVICE_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
@@ -28,7 +28,7 @@ public class StartReader {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
                                                                 "localhost",
-                                                                StartLocalService.PORT);
+                                                                StartLocalService.CONTROLLER_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);
         streamManager.createReaderGroup(READER_GROUP,

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
@@ -24,7 +24,7 @@ public class StartWriter {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
                                                                 "localhost",
-                                                                StartLocalService.PORT);
+                                                                StartLocalService.CONTROLLER_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);
         MockClientFactory clientFactory = streamManager.getClientFactory();

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
@@ -24,7 +24,7 @@ public class StartWriter {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
                                                                 "localhost",
-                                                                StartLocalService.CONTROLLER_PORT);
+                                                                StartLocalService.SERVICE_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);
         MockClientFactory clientFactory = streamManager.getClientFactory();

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
@@ -18,12 +18,14 @@ import io.pravega.client.stream.mock.MockStreamManager;
 
 import lombok.Cleanup;
 
+import java.net.InetAddress;
+
 public class StartWriter {
 
     public static void main(String[] args) throws Exception {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(StartLocalService.SCOPE,
-                                                                "localhost",
+                                                                InetAddress.getLocalHost().getHostAddress(),
                                                                 StartLocalService.SERVICE_PORT);
         streamManager.createScope(StartLocalService.SCOPE);
         streamManager.createStream(StartLocalService.SCOPE, StartLocalService.STREAM_NAME, null);


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Changes port in StartLocalService to 6000

* Replaces `localhost` in `StartReader` and `StartWriter`

* Changes the name in the constructor of `PravegaConnectionListener` to listen on all addresses.

**Purpose of the change**
Fixes #2229 

**What the code does**
Changes the service port in`StartLocalService` and updates other classes that rely on the port constant.

To make it work with both `StartLocalService` and `standalone`, I have changed some of the host names. Specifically, `standalone` is picking my external IP, while `StarLocalService` ends up using `localhost` because of how `PravegaConnectionListener` initializes. Consequently, I have made the following changes:

* Give the local IP rather than `localhost` in `StartReader` and `StartWriter`
* Use `0.0.0.0` in the constructor of `PravegaConnectionListener` that is visible for testing

**How to verify it**
Run `StartReader` and `StartWriter` against both `StartLocalService` and standalone. Specifically:

1- Run `./gradlew startLocalService` in a terminal window
2- Run `./gradlew startWriter` in a different terminal window
3- Stop local service
4- Run `./gradlew :standalone:startStandlone` in a terminal window
5- Run `./gradlew startWriter` in a different terminal window
  
  
  