### PR TITLE
Issue 2231: Remove redundant AckFuture reference from documentation.

### DIFF
--- a/docs/basic-reader-and-writer.md
+++ b/docs/basic-reader-and-writer.md
@@ -48,7 +48,7 @@ public void run(String routingKey, String message) {
              
          System.out.format("Writing message: '%s' with routing-key: '%s' to stream '%s / %s'%n",
                 message, routingKey, scope, streamName);
-         final AckFuture writeFuture = writer.writeEvent(routingKey, message);
+         final CompletableFuture writeFuture = writer.writeEvent(routingKey, message);
     }
 }
 ```

--- a/docs/basic-reader-and-writer.md
+++ b/docs/basic-reader-and-writer.md
@@ -48,7 +48,7 @@ public void run(String routingKey, String message) {
              
          System.out.format("Writing message: '%s' with routing-key: '%s' to stream '%s / %s'%n",
                 message, routingKey, scope, streamName);
-         final CompletableFuture writeFuture = writer.writeEvent(routingKey, message);
+         final CompletableFuture<Void> writeFuture = writer.writeEvent(routingKey, message);
     }
 }
 ```


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Remove AckFuture references from documentation.

**Purpose of the change**
Fixes #2231 

**What the code does**
Removes AckFuture reference from basic-reader-and-writer.md.

**How to verify it**
Tests should continue to pass.