### PR TITLE
Issue 2235: Made BookKeeper read timeout configurable

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -241,6 +241,10 @@ bookkeeper.zkAddress=master.mesos:2181
 # Note: BookKeeper only allows multiples of 1 second (1000 millis). This value will be rounded up to the nearest second.
 #bookkeeper.bkWriteTimeoutMillis=5000
 
+# Read Timeout, in milliseconds.
+# Note: BookKeeper only allows multiples of 1 second (1000 millis). This value will be rounded up to the nearest second.
+#bookkeeper.bkReadTimeoutMillis=5000
+
 # Maximum Ledger size (bytes) in BookKeeper. Once a Ledger reaches this size, it will be closed and another one open.
 # Note that ledgers will not be cut off at this size, rather them reaching this size will trigger a rollover; in-flight
 # writes will continue to get written to the previous ledger.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -35,6 +35,7 @@ public class BookKeeperConfig {
     public static final Property<Integer> BK_ACK_QUORUM_SIZE = Property.named("bkAckQuorumSize", 3);
     public static final Property<Integer> BK_WRITE_QUORUM_SIZE = Property.named("bkWriteQuorumSize", 3);
     public static final Property<Integer> BK_WRITE_TIMEOUT = Property.named("bkWriteTimeoutMillis", 5000);
+    public static final Property<Integer> BK_READ_TIMEOUT = Property.named("readTimeoutMillis", 5000);
     public static final Property<Integer> BK_LEDGER_MAX_SIZE = Property.named("bkLedgerMaxSize", 1024 * 1024 * 1024);
     public static final Property<String> BK_PASSWORD = Property.named("bkPass", "");
     public static final Property<String> BK_LEDGER_PATH = Property.named("bkLedgerPath", "");
@@ -116,6 +117,12 @@ public class BookKeeperConfig {
     private final int bkWriteTimeoutMillis;
 
     /**
+     * The Read Timeout (BookKeeper client), in milliseconds.
+     */
+    @Getter
+    private final int bkReadTimeoutMillis;
+
+    /**
      * The Maximum size of a ledger, in bytes. On or around this value the current ledger is closed and a new one
      * is created. By design, this property cannot be larger than Int.MAX_VALUE, since we want Ledger Entry Ids to be
      * representable with an Int.
@@ -155,6 +162,7 @@ public class BookKeeperConfig {
         }
 
         this.bkWriteTimeoutMillis = properties.getInt(BK_WRITE_TIMEOUT);
+        this.bkReadTimeoutMillis = properties.getInt(BK_READ_TIMEOUT);
         this.bkLedgerMaxSize = properties.getInt(BK_LEDGER_MAX_SIZE);
         this.bkPassword = properties.get(BK_PASSWORD).getBytes(Charset.forName("UTF-8"));
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
@@ -107,12 +107,15 @@ public class BookKeeperLogFactory implements DurableDataLogFactory {
     //region Initialization
 
     private BookKeeper startBookKeeperClient() throws Exception {
-        // AddEntryTimeout is in Seconds, not Millis.
-        int entryTimeout = (int) Math.ceil(this.config.getBkWriteTimeoutMillis() / 1000.0);
+        // These two are in Seconds, not Millis.
+        int writeTimeout = (int) Math.ceil(this.config.getBkWriteTimeoutMillis() / 1000.0);
+        int readTimeout = (int) Math.ceil(this.config.getBkReadTimeoutMillis() / 1000.0);
         ClientConfiguration config = new ClientConfiguration()
                 .setZkServers(this.config.getZkAddress())
                 .setClientTcpNoDelay(true)
-                .setAddEntryTimeout(entryTimeout)
+                .setAddEntryTimeout(writeTimeout)
+                .setReadEntryTimeout(readTimeout)
+                .setGetBookieInfoTimeout(readTimeout)
                 .setClientConnectTimeoutMillis((int) this.config.getZkConnectionTimeout().toMillis())
                 .setZkTimeout((int) this.config.getZkConnectionTimeout().toMillis());
         if (this.config.getBkLedgerPath().isEmpty()) {


### PR DESCRIPTION
**Change log description**
Added the ability to configure the timeout for BookKeeper reads. Previously, this would be left as a BK default (5s) and the user would not be able to change it.

**Purpose of the change**
Fixes #2235 

**What the code does**
Explicitly sets the BK Read timeout based on a config value.

**How to verify it**
Code review. This is just passing through a config value to the BK client.
