### PR TITLE
Issue 2233: (SegmentStore) Limiting maximum number of Segment Attributes

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/TooManyAttributesException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/TooManyAttributesException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.contracts;
+
+/**
+ * Indicates that the given Segment has reached the maximum number of allowed attributes and no new attributes can be
+ * added anymore.
+ */
+public class TooManyAttributesException extends StreamSegmentException {
+    /**
+     * Creates a new instance of the TooManyAttributesException class.
+     * @param streamSegmentName The name of the Stream Segment
+     * @param maxAttributeCount The maximum number of allowed attributes per Stream segment.
+     */
+    public TooManyAttributesException(String streamSegmentName, int maxAttributeCount) {
+        super(streamSegmentName, String.format("The maximum number of attributes (%d) has been reached.", maxAttributeCount));
+    }
+}

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -26,6 +26,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.TooManyAttributesException;
 import io.pravega.segmentstore.contracts.WrongHostException;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
@@ -334,6 +335,10 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             connection.send(new WrongHost(requestId, segment, ""));
         } else if (u instanceof BadAttributeUpdateException) {
             log.warn("Bad attribute update by {} on segment {} ", writerId, segment);
+            connection.send(new InvalidEventNumber(writerId, requestId));
+            connection.close();
+        } else if (u instanceof TooManyAttributesException) {
+            log.warn("Attribute limit would be exceeded by {} on segment {}", writerId, segment, u);
             connection.send(new InvalidEventNumber(writerId, requestId));
             connection.close();
         } else if (u instanceof UnsupportedOperationException) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeSerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeSerializer.java
@@ -9,9 +9,9 @@
  */
 package io.pravega.segmentstore.server;
 
+import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -34,6 +34,8 @@ public final class AttributeSerializer {
      * @throws IOException If an exception occurred.
      */
     public static void serialize(Map<UUID, Long> attributes, DataOutputStream stream) throws IOException {
+        Preconditions.checkArgument(attributes.size() <= Short.MAX_VALUE,
+                "Too many attributes. Must be at most %s.", Short.MAX_VALUE);
         stream.writeShort(attributes.size());
         for (Map.Entry<UUID, Long> attribute : attributes.entrySet()) {
             stream.writeLong(attribute.getKey().getMostSignificantBits());
@@ -71,7 +73,9 @@ public final class AttributeSerializer {
      * @throws IOException If an exception occurred.
      */
     public static void serializeUpdates(Collection<AttributeUpdate> attributeUpdates, DataOutputStream stream) throws IOException {
-        stream.writeShort(attributeUpdates == null ? 0 : attributeUpdates.size());
+        int count = attributeUpdates == null ? 0 : attributeUpdates.size();
+        Preconditions.checkArgument(count <= Short.MAX_VALUE, "Too many attribute updates. Must be at most %s.", Short.MAX_VALUE);
+        stream.writeShort(count);
         if (attributeUpdates != null) {
             for (AttributeUpdate au : attributeUpdates) {
                 UUID attributeId = au.getAttributeId();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -18,9 +18,15 @@ import java.util.HashMap;
  */
 public interface SegmentMetadata extends SegmentProperties {
     /**
+     * The maximum number of attributes that a single Segment can have at any given time. Due to serialization constraints
+     * there needs to be a hard limit as to how many attributes each segment can have.
+     */
+    int MAXIMUM_ATTRIBUTE_COUNT = 1024;
+
+    /**
      * Defines an attribute value that denotes a missing value.
      */
-    Long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as WireCommands.NULL_ATTRIBUTE_VALUE
+    long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as WireCommands.NULL_ATTRIBUTE_VALUE
 
     /**
      * Gets a value indicating the id of this StreamSegment.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -466,7 +466,10 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
             }
         }
 
-        if (newAttributeCount > SegmentMetadata.MAXIMUM_ATTRIBUTE_COUNT) {
+        if (newAttributeCount > SegmentMetadata.MAXIMUM_ATTRIBUTE_COUNT && newAttributeCount > this.attributeValues.size()) {
+            // We only want to prevent exceeding the max attribute count if the number of attributes increased. Should
+            // we ever want to decrease this limit in the future, we need to make sure that we can still remove/replace
+            // attributes of existing segments, but not increase their count.
             throw new TooManyAttributesException(this.name, SegmentMetadata.MAXIMUM_ATTRIBUTE_COUNT);
         }
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -20,6 +20,7 @@ import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.StreamSegmentMergedException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import io.pravega.segmentstore.contracts.TooManyAttributesException;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.MergeTransactionOperation;
@@ -215,9 +216,11 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
      * @throws IllegalArgumentException     If the operation is for a different Segment.
      * @throws BadAttributeUpdateException  If at least one of the AttributeUpdates is invalid given the current attribute
      *                                      values of the segment.
+     * @throws TooManyAttributesException  If, as a result of applying the given updates, the Segment would exceed the
+     *                                     maximum allowed number of Attributes.
      */
     void preProcessOperation(StreamSegmentAppendOperation operation) throws StreamSegmentSealedException, StreamSegmentMergedException,
-            BadOffsetException, BadAttributeUpdateException {
+            BadOffsetException, BadAttributeUpdateException, TooManyAttributesException {
         ensureSegmentId(operation);
         if (this.merged) {
             // We do not allow any operation after merging (since after merging the Segment disappears).
@@ -257,9 +260,11 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
      * @throws IllegalArgumentException     If the operation is for a different Segment.
      * @throws BadAttributeUpdateException  If at least one of the AttributeUpdates is invalid given the current attribute
      *                                      values of the segment.
+     * @throws TooManyAttributesException  If, as a result of applying the given updates, the Segment would exceed the
+     *                                     maximum allowed number of Attributes.
      */
     void preProcessOperation(UpdateAttributesOperation operation) throws StreamSegmentSealedException, StreamSegmentMergedException,
-            BadAttributeUpdateException {
+            BadAttributeUpdateException, TooManyAttributesException {
         ensureSegmentId(operation);
         if (this.merged) {
             // We do not allow any operation after merging (since after merging the Segment disappears).
@@ -399,12 +404,15 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
      * @param attributeUpdates The Updates to process (if any).
      * @throws BadAttributeUpdateException If any of the given AttributeUpdates is invalid given the current state of
      *                                     the segment.
+     * @throws TooManyAttributesException  If, as a result of applying the given updates, the Segment would exceed the
+     *                                     maximum allowed number of Attributes.
      */
-    private void preProcessAttributes(Collection<AttributeUpdate> attributeUpdates) throws BadAttributeUpdateException {
+    private void preProcessAttributes(Collection<AttributeUpdate> attributeUpdates) throws BadAttributeUpdateException, TooManyAttributesException {
         if (attributeUpdates == null) {
             return;
         }
 
+        int newAttributeCount = this.attributeValues.size();
         for (AttributeUpdate u : attributeUpdates) {
             AttributeUpdateType updateType = u.getUpdateType();
             long previousValue = this.attributeValues.getOrDefault(u.getAttributeId(), SegmentMetadata.NULL_ATTRIBUTE_VALUE);
@@ -448,6 +456,18 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
                 default:
                     throw new BadAttributeUpdateException(this.name, u, "Unexpected update type: " + updateType);
             }
+
+            if (previousValue == SegmentMetadata.NULL_ATTRIBUTE_VALUE && u.getValue() != SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
+                // This attribute did not exist and is about to be added.
+                newAttributeCount++;
+            } else if (previousValue != SegmentMetadata.NULL_ATTRIBUTE_VALUE && u.getValue() == SegmentMetadata.NULL_ATTRIBUTE_VALUE) {
+                // This attribute existed and is about to be removed.
+                newAttributeCount--;
+            }
+        }
+
+        if (newAttributeCount > SegmentMetadata.MAXIMUM_ATTRIBUTE_COUNT) {
+            throw new TooManyAttributesException(this.name, SegmentMetadata.MAXIMUM_ATTRIBUTE_COUNT);
         }
     }
 


### PR DESCRIPTION
**Change log description**
1. Defined a hard limit on how many attributes a Segment can have at any given time.
2. Enforcing this limit upon Segment updates via any operation that can alter attributes (at this time: `append` and `updateAttributes`). If an operation would have the effect of exceeding this limit, it will be rejected with `TooManyAttributesException`.

NOTE: The Client and/or `PravegaConnectionListener`/`PravegaRequestProcessor`/`AppendProcessor` will need some updating to be able to handle this exception. Please refer to issue #2239. 

**Purpose of the change**
Fixes #2233.

**What the code does**
Defined a hardcoded limit of Segment attributes and enforcing it in Operation pre-processing.

**How to verify it**
New unit test added.
  