### PR TITLE
Issue 2164: Trying to recreate a stream can let stream specific metrics get reset to original values

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -138,8 +138,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                                                    final Executor executor) {
         return withCompletion(getStream(scope, name, context).create(configuration, createTimestamp), executor)
                 .thenApply(result -> {
-                    if (result.getStatus().equals(CreateStreamResponse.CreateStatus.NEW) ||
-                            result.getStatus().equals(CreateStreamResponse.CreateStatus.EXISTS_CREATING)) {
+                    if (result.getStatus().equals(CreateStreamResponse.CreateStatus.NEW)) {
                         CREATE_STREAM.reportSuccessValue(1);
                         DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), 0);
                         DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(SEGMENTS_COUNT, scope, name),
@@ -150,7 +149,6 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                     
                     return result;
                 });
-
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -138,15 +138,19 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                                                    final Executor executor) {
         return withCompletion(getStream(scope, name, context).create(configuration, createTimestamp), executor)
                 .thenApply(result -> {
-                    CREATE_STREAM.reportSuccessValue(1);
-                    DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), 0);
-                    DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(SEGMENTS_COUNT, scope, name),
-                            configuration.getScalingPolicy().getMinNumSegments());
-                    DYNAMIC_LOGGER.incCounterValue(nameFromStream(SEGMENTS_SPLITS, scope, name), 0);
-                    DYNAMIC_LOGGER.incCounterValue(nameFromStream(SEGMENTS_MERGES, scope, name), 0);
-
+                    if (result.getStatus().equals(CreateStreamResponse.CreateStatus.NEW) ||
+                            result.getStatus().equals(CreateStreamResponse.CreateStatus.EXISTS_CREATING)) {
+                        CREATE_STREAM.reportSuccessValue(1);
+                        DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), 0);
+                        DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(SEGMENTS_COUNT, scope, name),
+                                configuration.getScalingPolicy().getMinNumSegments());
+                        DYNAMIC_LOGGER.incCounterValue(nameFromStream(SEGMENTS_SPLITS, scope, name), 0);
+                        DYNAMIC_LOGGER.incCounterValue(nameFromStream(SEGMENTS_MERGES, scope, name), 0);
+                    }
+                    
                     return result;
                 });
+
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
If we recreate a stream, we can get a response from the store saying "Stream_exists" but we dont tackle this and set metrics values based on the configuration. This results in metrics being set to incorrect value. 

**Purpose of the change**
Fixes issue 2164

**What the code does**
Adds a check that only for new stream creation do we add the metric. If its a recreation, then dont update the metric. 

**How to verify it**
All existing tests should pass. 