### PR TITLE
Issue 2234: (Segment Store) Cleaning up empty ledgers upon recovery

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -659,7 +659,7 @@ class BookKeeperLog implements DurableDataLog {
      * @param newLedger         The newly added Ledger.
      * @param clearEmptyLedgers If true, the new metadata will not not contain any pointers to empty Ledgers. Setting this
      *                          to true will not remove a pointer to the last few ledgers in the Log (controlled by
-     *                          Ledgers.MIN_FENCE_LEDGER_COUNT, even if they are indeed empty (this is so we don't interfere
+     *                          Ledgers.MIN_FENCE_LEDGER_COUNT), even if they are indeed empty (this is so we don't interfere
      *                          with any ongoing fencing activities as another instance of this Log may not have yet been
      *                          fenced out).
      * @return A new instance of the LogMetadata, which includes the new ledger.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.storage.DataLogNotAvailableException;
@@ -100,6 +101,11 @@ public class BookKeeperLogFactory implements DurableDataLogFactory {
     public DurableDataLog createDurableDataLog(int containerId) {
         Preconditions.checkState(this.bookKeeper.get() != null, "BookKeeperLogFactory is not initialized.");
         return new BookKeeperLog(containerId, this.zkClient, this.bookKeeper.get(), this.config, this.executor);
+    }
+
+    @VisibleForTesting
+    BookKeeper getBookKeeperClient() {
+        return this.bookKeeper.get();
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,11 +19,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 class LedgerMetadata {
-    /**
-     * Defines a special value for LastAddConfirmed that indicates this has not yet been set.
-     */
-    static final long NO_LAST_ADD_CONFIRMED = -1;
-
     /**
      * The BookKeeper-assigned Ledger Id.
      */
@@ -34,22 +30,43 @@ class LedgerMetadata {
     private final int sequence;
 
     /**
-     * The Entry Id of the Last Confirmed Add inside this Ledger. Only applies to closed ledgers.
+     * Gets the current status of this Ledger.
      */
-    private final long lastAddConfirmed;
+    private final Status status;
 
     /**
-     * Creates a new instance of the LedgerMetadata class with no defined LastAddConfirmed.
+     * Creates a new instance of the LedgerMetadata class with an unknown Empty Status.
      *
      * @param ledgerId The BookKeeper-assigned Ledger Id.
      * @param sequence The metadata-assigned sequence number.
      */
     LedgerMetadata(long ledgerId, int sequence) {
-        this(ledgerId, sequence, NO_LAST_ADD_CONFIRMED);
+        this(ledgerId, sequence, Status.Unknown);
     }
 
     @Override
     public String toString() {
-        return String.format("Id = %d, Sequence = %d, LAC = %d", this.ledgerId, this.sequence, this.lastAddConfirmed);
+        return String.format("Id = %d, Sequence = %d, Status = %s", this.ledgerId, this.sequence, this.status);
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    enum Status {
+        Unknown((byte) 0),
+        Empty((byte) 1),
+        NotEmpty((byte) 2);
+        @Getter
+        private final byte value;
+
+        static Status valueOf(byte b) {
+            if (b == Unknown.value) {
+                return Unknown;
+            } else if (b == Empty.value) {
+                return Empty;
+            } else if (b == NotEmpty.value) {
+                return NotEmpty;
+            }
+
+            throw new IllegalArgumentException("Unsupported Status " + b);
+        }
     }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
@@ -9,13 +9,20 @@
  */
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Represents metadata about a particular ledger.
  */
-@Data
+@RequiredArgsConstructor
+@Getter
 class LedgerMetadata {
+    /**
+     * Defines a special value for LastAddConfirmed that indicates this has not yet been set.
+     */
+    static final long NO_LAST_ADD_CONFIRMED = -1;
+
     /**
      * The BookKeeper-assigned Ledger Id.
      */
@@ -26,8 +33,23 @@ class LedgerMetadata {
      */
     private final int sequence;
 
+    /**
+     * The Entry Id of the Last Confirmed Add inside this Ledger. Only applies to closed ledgers.
+     */
+    private final long lastAddConfirmed;
+
+    /**
+     * Creates a new instance of the LedgerMetadata class with no defined LastAddConfirmed.
+     *
+     * @param ledgerId The BookKeeper-assigned Ledger Id.
+     * @param sequence The metadata-assigned sequence number.
+     */
+    LedgerMetadata(long ledgerId, int sequence) {
+        this(ledgerId, sequence, NO_LAST_ADD_CONFIRMED);
+    }
+
     @Override
     public String toString() {
-        return String.format("Id = %d, Sequence = %d", this.ledgerId, this.sequence);
+        return String.format("Id = %d, Sequence = %d, LAC = %d", this.ledgerId, this.sequence, this.lastAddConfirmed);
     }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
@@ -63,7 +63,7 @@ class LogMetadata {
     private final long epoch;
 
     /**
-     * An ordered list of LedgerMetadatas that represent the ledgers in the log.
+     * An ordered list of LedgerMetadata instances that represent the ledgers in the log.
      */
     @Getter
     private final List<LedgerMetadata> ledgers;
@@ -142,7 +142,7 @@ class LogMetadata {
     }
 
     /**
-     * Removes LedgerMetadatas for those Ledgers that are known to be empty.
+     * Removes LedgerMetadata instances for those Ledgers that are known to be empty.
      *
      * @param skipCountFromEnd The number of Ledgers to spare, counting from the end of the LedgerMetadata list.
      * @return A new instance of LogMetadata with the updated ledger list.
@@ -168,11 +168,11 @@ class LogMetadata {
     }
 
     /**
-     * Updates the LastAddConfirmed on individual LedgerMetadatas based on the provided argument.
+     * Updates the LastAddConfirmed on individual LedgerMetadata instances based on the provided argument.
      *
      * @param lastAddConfirmed A Map of LedgerId to LastAddConfirmed based on which we can update the status.
      * @return This (unmodified) instance if lastAddConfirmed.isEmpty() or a new instance of the LogMetadata class with
-     * the updated LedgerMetadatas.
+     * the updated LedgerMetadata instances.
      */
     LogMetadata updateLedgerStatus(Map<Long, Long> lastAddConfirmed) {
         if (lastAddConfirmed.isEmpty()) {


### PR DESCRIPTION
**Change log description**
* Keeps track of Ledger Status
* Removes empty ledgers from BookKeperLog metadata
* Deletes empty ledger removed in step 2 above.

**Purpose of the change**
Fixes #2234.

**What the code does**
During each initialization, the `BookKeeperLog` creates a new BK Ledger and adds it to the BookKeeperLog metadata (stored in ZK). However, if, after this, the Container Recovery fails or otherwise succeeds but it doesn't write data to it until the next failover, we can end up with a lot of empty ledgers in the Log, which will significantly slow down future recoveries. The first scenario (recovery failure) is more likely to lead to such a situation, since whatever problem caused it to fail in the first place will occur every subsequent time.

To alleviate this, the `BookKeeperLog` will keep track of Ledger Status (Empty|NotEmpty|Unknown). A ledger's status is initially Unknown, and upon initialization (the open-fence phase), it will read the LAC from BK and determine whether it is empty or not. Ledgers that are determined to be empty will be removed from the `BookKeeperLog` metadata and subsequently deleted from BK.

One exception to the deletion is the last 2 Ledgers in the Log. Those will be kept regardless of status, since they actively participate in the fencing process - we need to ensure that the previous writers to them know they have been fenced out and that this wasn't some other kind of error.

**How to verify it**
New unit tests added to verify desired behavior.