### PR TITLE
Issue 2246: Create temporary directories for rocksdb in end-to-end tests

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -43,7 +43,8 @@ public class ExtendedS3IntegrationTest extends StreamSegmentStoreTestBase {
     private static final int BOOKIE_COUNT = 1;
     private String endpoint;
     private BookKeeperRunner bookkeeper = null;
-    private String baseDir;
+    private File baseDir = null;
+    private File rocksDBDir = null;
     private S3FileSystemImpl filesystemS3;
 
     /**
@@ -55,13 +56,16 @@ public class ExtendedS3IntegrationTest extends StreamSegmentStoreTestBase {
         bookkeeper.initialize();
         endpoint = "http://127.0.0.1:" + TestUtils.getAvailableListenPort();
         URI uri = URI.create(endpoint);
-        baseDir = Files.createTempDirectory("extendeds3_wrapper").toString();
-        filesystemS3 = new S3FileSystemImpl(baseDir);
+        baseDir = Files.createTempDirectory("extendeds3_wrapper").toFile().getAbsoluteFile();
+        rocksDBDir = Files.createTempDirectory("rocksdb").toFile().getAbsoluteFile();
+        filesystemS3 = new S3FileSystemImpl(baseDir.toString());
         this.configBuilder.include(ExtendedS3StorageConfig.builder()
                                                           .with(ExtendedS3StorageConfig.BUCKET, "kanpravegatest")
                                                           .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
                                                           .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
-                                                          .with(ExtendedS3StorageConfig.URI, endpoint));
+                                                          .with(ExtendedS3StorageConfig.URI, endpoint))
+                          .include(RocksDBConfig.builder()
+                                                .with(RocksDBConfig.DATABASE_DIR, rocksDBDir.toString()));
     }
 
     /**
@@ -70,7 +74,15 @@ public class ExtendedS3IntegrationTest extends StreamSegmentStoreTestBase {
     @After
     public void tearDown() throws Exception {
         bookkeeper.close();
-        FileHelpers.deleteFileOrDirectory(new File(baseDir));
+        if (baseDir != null) {
+            FileHelpers.deleteFileOrDirectory(baseDir);
+        }
+        if (rocksDBDir != null) {
+            FileHelpers.deleteFileOrDirectory(rocksDBDir);
+        }
+
+        baseDir = null;
+        rocksDBDir = null;
     }
 
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -32,6 +32,7 @@ public class FileSystemIntegrationTest extends StreamSegmentStoreTestBase {
 
     private static final int BOOKIE_COUNT = 1;
     private File baseDir = null;
+    private File rocksDBDir = null;
     private BookKeeperRunner bookkeeper = null;
     /**
      * Starts BookKeeper.
@@ -42,10 +43,12 @@ public class FileSystemIntegrationTest extends StreamSegmentStoreTestBase {
         bookkeeper.initialize();
 
         this.baseDir = Files.createTempDirectory("test_fs").toFile().getAbsoluteFile();
+        this.rocksDBDir = Files.createTempDirectory("rocksdb").toFile().getAbsoluteFile();
 
-        this.configBuilder.include(FileSystemStorageConfig
-                .builder()
-                .with(FileSystemStorageConfig.ROOT, this.baseDir.getAbsolutePath()));
+        this.configBuilder.include(FileSystemStorageConfig.builder()
+                                                          .with(FileSystemStorageConfig.ROOT, this.baseDir.getAbsolutePath()))
+                          .include(RocksDBConfig.builder()
+                                                .with(RocksDBConfig.DATABASE_DIR, rocksDBDir.toString()));
     }
 
     /**
@@ -54,8 +57,16 @@ public class FileSystemIntegrationTest extends StreamSegmentStoreTestBase {
     @After
     public void tearDown() throws Exception {
         bookkeeper.close();
-        FileHelpers.deleteFileOrDirectory(this.baseDir);
+        if (baseDir != null) {
+            FileHelpers.deleteFileOrDirectory(this.baseDir);
+        }
+
+        if (baseDir != null) {
+            FileHelpers.deleteFileOrDirectory(this.rocksDBDir);
+        }
+
         this.baseDir = null;
+        this.rocksDBDir = null;
     }
 
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -35,6 +35,7 @@ public class HDFSIntegrationTest extends StreamSegmentStoreTestBase {
 
     private static final int BOOKIE_COUNT = 1;
     private File baseDir = null;
+    private File rocksDBDir = null;
     private MiniDFSCluster hdfsCluster = null;
     private BookKeeperRunner bookkeeper = null;
 
@@ -47,12 +48,15 @@ public class HDFSIntegrationTest extends StreamSegmentStoreTestBase {
        bookkeeper.initialize();
         // HDFS
         this.baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
+        this.rocksDBDir = Files.createTempDirectory("rocksdb").toFile().getAbsoluteFile();
         this.hdfsCluster = HDFSClusterHelpers.createMiniDFSCluster(this.baseDir.getAbsolutePath());
 
         this.configBuilder.include(HDFSStorageConfig
                 .builder()
                 .with(HDFSStorageConfig.REPLICATION, 1)
-                .with(HDFSStorageConfig.URL, String.format("hdfs://localhost:%d/", hdfsCluster.getNameNodePort())));
+                .with(HDFSStorageConfig.URL, String.format("hdfs://localhost:%d/", hdfsCluster.getNameNodePort())))
+                          .include(RocksDBConfig.builder()
+                                                .with(RocksDBConfig.DATABASE_DIR, rocksDBDir.toString()));
     }
 
     /**
@@ -69,6 +73,17 @@ public class HDFSIntegrationTest extends StreamSegmentStoreTestBase {
             FileHelpers.deleteFileOrDirectory(this.baseDir);
             this.baseDir = null;
         }
+
+        if (baseDir != null) {
+            FileHelpers.deleteFileOrDirectory(this.baseDir);
+        }
+
+        if (baseDir != null) {
+            FileHelpers.deleteFileOrDirectory(this.rocksDBDir);
+        }
+
+        this.baseDir = null;
+        this.rocksDBDir = null;
     }
 
     //endregion


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**

* Configures rocksdb to use a temporary directory in each of these test classes: HDFSIntegrationTest, FileSystemIntegrationTest, ExtendedS3IntegrationTest. 

**Purpose of the change**
Fixes #2246 

**What the code does**
The code changes primarily configures rocksdb to use a temporary directory created for the test case. It also makes the use of `File` uniform across the end-to-end tests, and checks that the `File` reference is not null before trying to close it.

To avoid code redundancy, I tried to configure the rocksdb dir in `StreamSegmentStoreTestBase`, bout couldn't find a very clean way to do it without further changes.

**How to verify it**
Run tests in `segmentstore/server/host`