### PR TITLE
Issue 2254: Disable auto-checkpointing for readers used in controller's event processor 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -97,7 +97,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
         readerGroup = createIfNotExists(
                 actorSystem.readerGroupManager,
                 eventProcessorConfig.getConfig().getReaderGroupName(),
-                ReaderGroupConfig.builder().startingPosition(Sequence.MIN_VALUE).build(),
+                ReaderGroupConfig.builder().disableAutomaticCheckpoints().startingPosition(Sequence.MIN_VALUE).build(),
                 Collections.singleton(eventProcessorConfig.getConfig().getStreamName()));
 
         createEventProcessors(eventProcessorConfig.getConfig().getEventProcessorCount() - eventProcessorMap.values().size());


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
Disable automatic checkpoints for readergroups used in controller's event processors. 

**Purpose of the change**
Fixes #2254.

**What the code does**
Uses disableAutomaticCheckpoints on readergroup config for creating controller readergroups.

**How to verify it**
All exiting tests should pass. 