### PR TITLE
Issue 208: (SegmentStore) Taking SegmentContainers Offline

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/Services.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Services.java
@@ -87,6 +87,19 @@ public final class Services {
         }
     }
 
+    /**
+     * Determines whether the given Service.State indicates the Service is either in the process of Stopping or already
+     * Terminated or Failed.
+     *
+     * @param state The Service.State to test.
+     * @return Whether this is a terminating state.
+     */
+    public static boolean isTerminating(Service.State state) {
+        return state == Service.State.STOPPING
+                || state == Service.State.TERMINATED
+                || state == Service.State.FAILED;
+    }
+
 
     //region ShutdownListener
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Container.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Container.java
@@ -21,6 +21,15 @@ public interface Container extends Service, AutoCloseable {
      */
     int getId();
 
+    /**
+     * Gets a value indicating whether the Container is in an Offline state. When in such a state, even if state() == Service.State.RUNNING,
+     * all operations invoked on it will fail with ContainerOfflineException.
+     *
+     * @return True if the Container is Offline, false if Online.
+     */
+    boolean isOffline();
+
+
     @Override
     void close();
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerOfflineException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerOfflineException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server;
+
+/**
+ * Exception thrown whenever a Container is offline.
+ */
+public class ContainerOfflineException extends IllegalContainerStateException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates an new instance of the ContainerOfflineException class.
+     *
+     * @param containerId The Id of the SegmentContainer that is offline.
+     */
+    public ContainerOfflineException(int containerId) {
+        super(String.format("Container %d is offline and cannot execute any operation.", containerId));
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
@@ -57,5 +57,14 @@ public interface OperationLog extends Container {
      * point will have completed (normally or exceptionally).
      */
     CompletableFuture<Void> operationProcessingBarrier(Duration timeout);
+
+    /**
+     * Waits until the OperationLog enters an Online State.
+     *
+     * @return A CompletableFuture that, when completed, will indicate that the OperationLog is Online. If the OperationLog
+     * is already Online, this Future will be already completed when returned. If the OperationLog encounters an exception
+     * while attempting to start (including it shutting down), this Future will be completed with the appropriate exception.
+     */
+    CompletableFuture<Void> awaitOnline();
 }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
@@ -116,6 +116,12 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     }
 
     @Override
+    public boolean isOffline() {
+        // ReadOnlySegmentContainer is always online.
+        return false;
+    }
+
+    @Override
     public CompletableFuture<ReadResult> read(String streamSegmentName, long offset, int maxLength, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         TimeoutTimer timer = new TimeoutTimer(timeout);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -23,12 +23,12 @@ import io.pravega.common.util.SequencedItemList;
 import io.pravega.segmentstore.contracts.ContainerException;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamingException;
+import io.pravega.segmentstore.server.ContainerOfflineException;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.LogItemFactory;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.ReadIndex;
-import io.pravega.segmentstore.server.ContainerOfflineException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -259,6 +259,11 @@ public class DurableLog extends AbstractService implements OperationLog {
     @Override
     public int getId() {
         return this.metadata.getContainerId();
+    }
+
+    @Override
+    public boolean isOffline() {
+        return this.delayedStart.get() != null;
     }
 
     //endregion
@@ -534,10 +539,6 @@ public class DurableLog extends AbstractService implements OperationLog {
         } else if (isOffline()) {
             throw new ContainerOfflineException(getId());
         }
-    }
-
-    private boolean isOffline() {
-        return this.delayedStart.get() != null;
     }
 
     private void exitOfflineMode(Throwable failureCause) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogConfig.java
@@ -14,6 +14,7 @@ import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.InvalidPropertyValueException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
+import java.time.Duration;
 import lombok.Getter;
 
 /**
@@ -24,6 +25,7 @@ public class DurableLogConfig {
     public static final Property<Integer> CHECKPOINT_MIN_COMMIT_COUNT = Property.named("checkpointMinCommitCount", 300);
     public static final Property<Integer> CHECKPOINT_COMMIT_COUNT = Property.named("checkpointCommitCountThreshold", 300);
     public static final Property<Long> CHECKPOINT_TOTAL_COMMIT_LENGTH = Property.named("checkpointTotalCommitLengthThreshold", 256 * 1024 * 1024L);
+    public static final Property<Integer> START_RETRY_DELAY_MILLIS = Property.named("startRetryDelayMillis", 60 * 1000);
     private static final String COMPONENT_CODE = "durablelog";
 
     //endregion
@@ -48,6 +50,12 @@ public class DurableLogConfig {
     @Getter
     private final long checkpointTotalCommitLengthThreshold;
 
+    /**
+     * The amount of time to wait between consecutive start attempts in case of retryable startup failure (i.e., offline).
+     */
+    @Getter
+    private Duration startRetryDelay;
+
     //endregion
 
     //region Constructor
@@ -67,6 +75,11 @@ public class DurableLogConfig {
         }
 
         this.checkpointTotalCommitLengthThreshold = properties.getLong(CHECKPOINT_TOTAL_COMMIT_LENGTH);
+        int startRetryDelayMillis = properties.getInt(START_RETRY_DELAY_MILLIS);
+        if (startRetryDelayMillis <= 0) {
+            throw new ConfigurationException(String.format("Property '%s' must be a positive integer.", START_RETRY_DELAY_MILLIS));
+        }
+        this.startRetryDelay = Duration.ofMillis(startRetryDelayMillis);
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
@@ -92,7 +92,7 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     public SegmentContainer getContainer(int containerId) throws ContainerNotFoundException {
         Exceptions.checkNotClosed(this.closed.get(), this);
         ContainerWithHandle result = this.containers.getOrDefault(containerId, null);
-        if (result == null || isShutdown(result.container.state())) {
+        if (result == null || Services.isTerminating(result.container.state())) {
             throw new ContainerNotFoundException(containerId);
         }
 
@@ -106,7 +106,7 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
         // Check if container exists
         ContainerWithHandle existingContainer = this.containers.get(containerId);
         if (existingContainer != null) {
-            if (!isShutdown(existingContainer.container.state())) {
+            if (!Services.isTerminating(existingContainer.container.state())) {
                 // Container is already registered and not in the process of shutting down.
                 throw new IllegalArgumentException(String.format("Container %d is already registered.", containerId));
             }
@@ -188,11 +188,6 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
         containerWithHandle.shutdownNotifier.complete(null);
     }
 
-    private static boolean isShutdown(Service.State state) {
-        return state == Service.State.FAILED
-                || state == Service.State.STOPPING
-                || state == Service.State.TERMINATED;
-    }
 
     //endregion
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
@@ -70,6 +70,16 @@ public class TestDurableDataLog implements DurableDataLog {
     }
 
     @Override
+    public void enable() throws DurableDataLogException {
+        this.wrappedLog.enable();
+    }
+
+    @Override
+    public void disable() throws DurableDataLogException {
+        this.wrappedLog.disable();
+    }
+
+    @Override
     public CompletableFuture<LogAddress> append(ArrayView data, Duration timeout) {
         ErrorInjector.throwSyncExceptionIfNeeded(this.appendSyncErrorInjector);
         return ErrorInjector.throwAsyncExceptionIfNeeded(this.appendAsyncErrorInjector,

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -33,6 +33,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.TooManyActiveSegmentsException;
 import io.pravega.segmentstore.server.ConfigHelpers;
+import io.pravega.segmentstore.server.ContainerOfflineException;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.OperationLogFactory;
 import io.pravega.segmentstore.server.ReadIndex;
@@ -42,6 +43,7 @@ import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.SegmentMetadataComparer;
 import io.pravega.segmentstore.server.ServiceListeners;
+import io.pravega.segmentstore.server.TestDurableDataLogFactory;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.Writer;
 import io.pravega.segmentstore.server.WriterFactory;
@@ -56,6 +58,7 @@ import io.pravega.segmentstore.server.writer.WriterConfig;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
 import io.pravega.segmentstore.storage.CacheFactory;
 import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
+import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogFactory;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.Storage;
@@ -135,6 +138,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
             .with(DurableLogConfig.CHECKPOINT_MIN_COMMIT_COUNT, 10)
             .with(DurableLogConfig.CHECKPOINT_COMMIT_COUNT, 100)
             .with(DurableLogConfig.CHECKPOINT_TOTAL_COMMIT_LENGTH, 10 * 1024 * 1024L)
+            .with(DurableLogConfig.START_RETRY_DELAY_MILLIS, 20)
             .build();
 
     private static final ReadIndexConfig DEFAULT_READ_INDEX_CONFIG = ConfigHelpers
@@ -1127,7 +1131,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
 
         // Wait for the container to be shut down and verify it is failed.
         ServiceListeners.awaitShutdown(container, shutdownTimeout, false);
-        Assert.assertEquals("Container is not in a failed state failed startup.", Service.State.FAILED, container.state());
+        Assert.assertEquals("Container is not in a failed state after a failed startup.", Service.State.FAILED, container.state());
 
         Throwable actualException = Exceptions.unwrap(container.failureCause());
         boolean exceptionMatch = actualException instanceof IntentionalException;
@@ -1138,6 +1142,108 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
 
         // Verify the OperationLog is also shut down, and make sure it is not in a Failed state.
         ServiceListeners.awaitShutdown(log.get(), shutdownTimeout, true);
+    }
+
+    /**
+     * Tests the ability of the StreamSegmentContainer to start in Offline mode (due to an offline DurableLog) and eventually
+     * become online when the DurableLog becomes too.
+     */
+    @Test
+    public void testStartOffline() throws Exception {
+        @Cleanup
+        val context = new TestContext();
+
+        AtomicReference<DurableDataLog> dataLog = new AtomicReference<>();
+        @Cleanup
+        val dataLogFactory = new TestDurableDataLogFactory(context.dataLogFactory, dataLog::set);
+        AtomicReference<OperationLog> durableLog = new AtomicReference<>();
+        val durableLogFactory = new WatchableOperationLogFactory(new DurableLogFactory(DEFAULT_DURABLE_LOG_CONFIG, dataLogFactory, executorService()), durableLog::set);
+        val containerFactory = new StreamSegmentContainerFactory(DEFAULT_CONFIG, durableLogFactory,
+                context.readIndexFactory, context.writerFactory, context.storageFactory, executorService());
+
+        // Write some data
+        ArrayList<String> segmentNames = new ArrayList<>();
+        HashMap<String, Long> lengths = new HashMap<>();
+        HashMap<String, ByteArrayOutputStream> segmentContents = new HashMap<>();
+        try (val container = containerFactory.createStreamSegmentContainer(CONTAINER_ID)) {
+            container.startAsync().awaitRunning();
+            ArrayList<CompletableFuture<Void>> opFutures = new ArrayList<>();
+            for (int i = 0; i < SEGMENT_COUNT; i++) {
+                String segmentName = getSegmentName(i);
+                segmentNames.add(segmentName);
+                opFutures.add(container.createStreamSegment(segmentName, null, TIMEOUT));
+            }
+
+            for (int i = 0; i < APPENDS_PER_SEGMENT / 2; i++) {
+                for (String segmentName : segmentNames) {
+                    byte[] appendData = getAppendData(segmentName, i);
+                    opFutures.add(container.append(segmentName, appendData, null, TIMEOUT));
+                    lengths.put(segmentName, lengths.getOrDefault(segmentName, 0L) + appendData.length);
+                    recordAppend(segmentName, appendData, segmentContents);
+                }
+            }
+
+            Futures.allOf(opFutures).join();
+
+            // Disable the DurableDataLog.
+            dataLog.get().disable();
+        }
+
+        // Start in "Offline" mode, verify operations cannot execute and then shut down - make sure we can shut down an offline container.
+        try (val container = containerFactory.createStreamSegmentContainer(CONTAINER_ID)) {
+            container.startAsync().awaitRunning();
+            Assert.assertTrue("Expecting Segment Container to be offline.", container.isOffline());
+
+            AssertExtensions.assertThrows(
+                    "append() worked in offline mode.",
+                    () -> container.append("foo", new byte[1], null, TIMEOUT),
+                    ex -> ex instanceof ContainerOfflineException);
+            AssertExtensions.assertThrows(
+                    "getStreamSegmentInfo() worked in offline mode.",
+                    () -> container.getStreamSegmentInfo("foo", false, TIMEOUT),
+                    ex -> ex instanceof ContainerOfflineException);
+            AssertExtensions.assertThrows(
+                    "read() worked in offline mode.",
+                    () -> container.read("foo", 0, 1, TIMEOUT),
+                    ex -> ex instanceof ContainerOfflineException);
+
+            container.stopAsync().awaitTerminated();
+        }
+
+        // Start in "Offline" mode and verify we can resume a normal startup.
+        try (val container = containerFactory.createStreamSegmentContainer(CONTAINER_ID)) {
+            container.startAsync().awaitRunning();
+            Assert.assertTrue("Expecting Segment Container to be offline.", container.isOffline());
+            dataLog.get().enable();
+
+            // Wait for the DurableLog to become online.
+            durableLog.get().awaitOnline().get(DEFAULT_DURABLE_LOG_CONFIG.getStartRetryDelay().toMillis() * 100, TimeUnit.MILLISECONDS);
+
+            // Verify we can execute regular operations now.
+            ArrayList<CompletableFuture<Void>> opFutures = new ArrayList<>();
+            for (int i = 0; i < APPENDS_PER_SEGMENT / 2; i++) {
+                for (String segmentName : segmentNames) {
+                    byte[] appendData = getAppendData(segmentName, i);
+                    opFutures.add(container.append(segmentName, appendData, null, TIMEOUT));
+                    lengths.put(segmentName, lengths.getOrDefault(segmentName, 0L) + appendData.length);
+                    recordAppend(segmentName, appendData, segmentContents);
+                }
+            }
+
+            Futures.allOf(opFutures).join();
+
+            // Verify all operations arrived in Storage.
+            ArrayList<CompletableFuture<Void>> segmentsCompletion = new ArrayList<>();
+            for (String segmentName : segmentNames) {
+                SegmentProperties sp = container.getStreamSegmentInfo(segmentName, false, TIMEOUT).join();
+                segmentsCompletion.add(waitForSegmentInStorage(sp, context));
+            }
+
+            Futures.allOf(segmentsCompletion).join();
+
+            container.stopAsync().awaitTerminated();
+        }
+
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -920,6 +920,11 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
         }
 
         @Override
+        public CompletableFuture<Void> awaitOnline() {
+            return null;
+        }
+
+        @Override
         public Service startAsync() {
             return null;
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMapperTests.java
@@ -900,6 +900,11 @@ public class StreamSegmentMapperTests extends ThreadPooledTestSuite {
         }
 
         @Override
+        public boolean isOffline() {
+            return false;
+        }
+
+        @Override
         public void close() {
 
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -675,6 +675,16 @@ public class OperationProcessorTests extends OperationLogTestBase {
         }
 
         @Override
+        public void enable() {
+
+        }
+
+        @Override
+        public void disable() throws DurableDataLogException {
+
+        }
+
+        @Override
         public CompletableFuture<Void> truncate(LogAddress upToAddress, Duration timeout) {
             return CompletableFuture.completedFuture(null);
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -284,6 +284,11 @@ public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
         }
 
         @Override
+        public boolean isOffline() {
+            return false;
+        }
+
+        @Override
         public void close() {
             if (!this.closed.getAndSet(true)) {
                 Futures.await(Services.stopAsync(this, executorService()));

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
@@ -31,9 +31,15 @@ class LogMetadata {
 
     /**
      * Version 0: Base.
-     * Version 1: Added LedgerMetadata.Status.
+     * Version 1: Added LedgerMetadata.Status and Flags.
      */
     private static final byte SERIALIZATION_VERSION = 1;
+
+    /**
+     * Bit mask to store the Enabled flag into an Integer value.
+     */
+    private static final int ENABLED_MASK = 1;
+
     /**
      * The initial epoch to use for the Log.
      */
@@ -63,6 +69,12 @@ class LogMetadata {
     private final long epoch;
 
     /**
+     * Whether the Log described by this LogMetadata is enabled or not.
+     */
+    @Getter
+    private final boolean enabled;
+
+    /**
      * An ordered list of LedgerMetadata instances that represent the ledgers in the log.
      */
     @Getter
@@ -85,23 +97,27 @@ class LogMetadata {
      * @param initialLedgerId The Id of the Ledger to start the log with.
      */
     LogMetadata(long initialLedgerId) {
-        this(INITIAL_EPOCH, Collections.singletonList(new LedgerMetadata(initialLedgerId, INITIAL_LEDGER_SEQUENCE)), INITIAL_TRUNCATION_ADDRESS);
+        this(INITIAL_EPOCH, true, Collections.singletonList(new LedgerMetadata(initialLedgerId, INITIAL_LEDGER_SEQUENCE)),
+                INITIAL_TRUNCATION_ADDRESS, INITIAL_VERSION);
     }
 
     /**
      * Creates a new instance of the LogMetadata class.
      *
      * @param epoch             The current Log epoch.
+     * @param enabled           Whether this Log is enabled or not.
      * @param ledgers           The ordered list of Ledger Ids making up this log.
      * @param truncationAddress The truncation address for this log. This is the address of the last entry that has been
      *                          truncated out of the log.
+     * @param updateVersion     The Update version to set on this instance.
      */
-    private LogMetadata(long epoch, List<LedgerMetadata> ledgers, LedgerAddress truncationAddress) {
+    private LogMetadata(long epoch, boolean enabled, List<LedgerMetadata> ledgers, LedgerAddress truncationAddress, int updateVersion) {
         Preconditions.checkArgument(epoch > 0, "epoch must be a positive number");
         this.epoch = epoch;
+        this.enabled = enabled;
         this.ledgers = Preconditions.checkNotNull(ledgers, "ledgers");
         this.truncationAddress = Preconditions.checkNotNull(truncationAddress, "truncationAddress");
-        this.updateVersion = new AtomicInteger(INITIAL_VERSION);
+        this.updateVersion = new AtomicInteger(updateVersion);
     }
 
     //endregion
@@ -115,6 +131,8 @@ class LogMetadata {
      * @return A new instance of the LogMetadata class.
      */
     LogMetadata addLedger(long ledgerId) {
+        Preconditions.checkState(this.enabled, "Log is not enabled. Cannot perform any modifications on it.");
+
         // Copy existing ledgers.
         List<LedgerMetadata> newLedgers = new ArrayList<>(this.ledgers.size() + 1);
         newLedgers.addAll(this.ledgers);
@@ -122,8 +140,7 @@ class LogMetadata {
         // Create and add metadata for the new ledger.
         int sequence = this.ledgers.size() == 0 ? INITIAL_LEDGER_SEQUENCE : this.ledgers.get(this.ledgers.size() - 1).getSequence() + 1;
         newLedgers.add(new LedgerMetadata(ledgerId, sequence));
-        return new LogMetadata(this.epoch + 1, Collections.unmodifiableList(newLedgers), this.truncationAddress)
-                .withUpdateVersion(this.updateVersion.get());
+        return new LogMetadata(this.epoch + 1, this.enabled, Collections.unmodifiableList(newLedgers), this.truncationAddress, this.updateVersion.get());
     }
 
     /**
@@ -133,12 +150,13 @@ class LogMetadata {
      * @return A new instance of the LogMetadata class.
      */
     LogMetadata truncate(LedgerAddress upToAddress) {
+        Preconditions.checkState(this.enabled, "Log is not enabled. Cannot perform any modifications on it.");
+
         // Exclude all those Ledgers that have a LedgerId less than the one we are given. An optimization to this would
         // involve trimming out the ledger which has a matching ledger id and the entry is is the last one, but that would
         // involve opening the Ledger in BookKeeper and inspecting it, which would take too long.
         val newLedgers = this.ledgers.stream().filter(lm -> lm.getLedgerId() >= upToAddress.getLedgerId()).collect(Collectors.toList());
-        return new LogMetadata(this.epoch, Collections.unmodifiableList(newLedgers), upToAddress)
-                .withUpdateVersion(this.updateVersion.get());
+        return new LogMetadata(this.epoch, this.enabled, Collections.unmodifiableList(newLedgers), upToAddress, this.updateVersion.get());
     }
 
     /**
@@ -163,8 +181,7 @@ class LogMetadata {
             newLedgers.add(this.ledgers.get(i));
         }
 
-        return new LogMetadata(this.epoch, Collections.unmodifiableList(newLedgers), this.truncationAddress)
-                .withUpdateVersion(this.updateVersion.get());
+        return new LogMetadata(this.epoch, this.enabled, Collections.unmodifiableList(newLedgers), this.truncationAddress, this.updateVersion.get());
     }
 
     /**
@@ -193,9 +210,7 @@ class LogMetadata {
                     return lm;
                 })
                 .collect(Collectors.toList());
-        return new LogMetadata(this.epoch, Collections.unmodifiableList(newLedgers), this.truncationAddress)
-                .withUpdateVersion(this.updateVersion.get());
-
+        return new LogMetadata(this.epoch, this.enabled, Collections.unmodifiableList(newLedgers), this.truncationAddress, this.updateVersion.get());
     }
 
     /**
@@ -218,6 +233,21 @@ class LogMetadata {
         Preconditions.checkArgument(value >= this.updateVersion.get(), "versions must increase");
         this.updateVersion.set(value);
         return this;
+    }
+
+    /**
+     * Returns a LogMetadata class with the exact contents of this instance, but the enabled flag set to true. No changes
+     * are performed on this instance.
+     *
+     * @return This instance, if isEnabled() == true, of a new instance of the LogMetadata class which will have
+     * isEnabled() == true, otherwise.
+     */
+    LogMetadata asEnabled() {
+        return this.enabled ? this : new LogMetadata(this.epoch, true, this.ledgers, this.truncationAddress, this.updateVersion.get());
+    }
+
+    LogMetadata asDisabled() {
+        return this.enabled ? new LogMetadata(this.epoch, false, this.ledgers, this.truncationAddress, this.updateVersion.get()) : this;
     }
 
     /**
@@ -303,10 +333,12 @@ class LogMetadata {
      * @return A new byte array with the serialized contents of this object.
      */
     byte[] serialize() {
-        // Serialization version (Byte), Epoch (Long), TruncationAddress (3*Long), Ledger Length (Int), Ledgers.
-        val length = Byte.BYTES + Long.BYTES + Long.BYTES * 3 + Integer.BYTES + (Long.BYTES + Integer.BYTES + Byte.BYTES) * this.ledgers.size();
+        // Serialization version (Byte), Flags(Int), Epoch (Long), TruncationAddress (3*Long), Ledger Length (Int), Ledgers.
+        val length = Byte.BYTES + Integer.BYTES + Long.BYTES + Long.BYTES * 3 + Integer.BYTES +
+                (Long.BYTES + Integer.BYTES + Byte.BYTES) * this.ledgers.size();
         ByteBuffer bb = ByteBuffer.allocate(length);
         bb.put(SERIALIZATION_VERSION);
+        bb.putInt(getFlags());
         bb.putLong(this.epoch);
 
         // Truncation Address.
@@ -332,6 +364,12 @@ class LogMetadata {
     static LogMetadata deserialize(byte[] serialization) {
         ByteBuffer bb = ByteBuffer.wrap(serialization);
         byte version = bb.get(); // We skip version for now because we only have one.
+        boolean enabled = true;
+        if (version >= 1) {
+            int flags = bb.getInt();
+            enabled = (flags & ENABLED_MASK) == ENABLED_MASK;
+        }
+
         long epoch = bb.getLong();
 
         // Truncation Address.
@@ -353,7 +391,13 @@ class LogMetadata {
             ledgers.add(new LedgerMetadata(ledgerId, seq, empty));
         }
 
-        return new LogMetadata(epoch, Collections.unmodifiableList(ledgers), new LedgerAddress(truncationSeqNo, truncationLedgerId));
+        return new LogMetadata(epoch, enabled, Collections.unmodifiableList(ledgers), new LedgerAddress(truncationSeqNo, truncationLedgerId), INITIAL_VERSION);
+    }
+
+    private int getFlags() {
+        int result = 0;
+        result |= this.enabled ? ENABLED_MASK : 0;
+        return result;
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
@@ -246,6 +246,13 @@ class LogMetadata {
         return this.enabled ? this : new LogMetadata(this.epoch, true, this.ledgers, this.truncationAddress, this.updateVersion.get());
     }
 
+    /**
+     * Returns a LogMetadata class with the exact contents of this instance, but the enabled flag set to false. No changes
+     * are performed on this instance.
+     *
+     * @return This instance, if isEnabled() == false, of a new instance of the LogMetadata class which will have
+     * isEnabled() == false, otherwise.
+     */
     LogMetadata asDisabled() {
         return this.enabled ? new LogMetadata(this.epoch, false, this.ledgers, this.truncationAddress, this.updateVersion.get()) : this;
     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogDisabledException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogDisabledException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+/**
+ * Exception that is thrown whenever the DurableDataLog cannot be initialized because it is disabled.
+ */
+public class DataLogDisabledException extends DataLogInitializationException {
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance of the DataLogDisabledException class.
+     *
+     * @param message Message for the exception.
+     */
+    public DataLogDisabledException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
**Change log description**
* Added the ability to take Segment Containers offline and back online

**Purpose of the change**
Fixes #208.

**What the code does**
Added the ability to take Segment Containers offline and back online
- **Offline Mode**: Segment Container will appear as `Started` (so that the Controller doesn't try to bounce it again), but it will reject any external operations. In addition, no internal sub-services will function.
- Added the ability to enable or disable a Tier1 Data Log. 
    - In `BookKeeperLog`, this will set a flag on the LogMetadata and immediately persist it to ZK.
    - A disabled log will only load the metadata from ZK, but will not attempt to update it or otherwise perform fencing.
    - Disabling it requires ownership (fence out), while enabling does not (precisely because we cannot perform fencing in this mode).
- `DurableLog` (one layer up from Tier1)
    - Will automatically disable its underlying Tier1 Log if it encounters a `DataCorruptionException` during recovery. Such exceptions cannot be "fixed" by re-attempting a new recovery elsewhere, so we need this in order to prevent a Container from endlessly starting, eating away valuable log space. 
    - If attempted to start using a disabled Tier1 Log, it will start in Offline Mode (see above for description), and become online once it detects that Tier1 becomes online. This is done by periodically checking the Tier1 metadata to see if its "enabled" flag changed to true.
- `StreamSegmentContainer`
    - During startup, if it detects that the underlying `DurableLog` is offline, it will start in Offline Mode as well. 
    - As soon as its `DurableLog` becomes online, it will resume its startup procedure and proceed as usual.

How this would work in practice:
1. `StreamSegmentContainer` (instance 1) initiates its startup procedure
    a. `DurableLog` detects a `DataCorruptionException` during recovery.
    b. `DurableLog` disables its Tier1 Log and re-throws the exception.
    c. `StreamSegmentContainer` fails startup and its manager will attempt to start it again (this is in `ZKSegmentContainerManager` or whoever manages its lifecycle)
2. `StreamSegmentContainer` (instance 2) initiates its startup procedure
    a. `DurableLog` detects a disabled Tier1 and starts in Offline Mode
    b. `StreamSegmentContainer` detects an Offline `DurableLog` and starts in Offline Mode. 
    c. Container Manager receives the "Started" notification and minds its own business
    d. All operations on this container will be rejected with `ContainerOfflineException`.
3. Fixing:
    a. Using the admin tools (#2228), the Tier1 log is "fixed" and its metadata will be updated with the enabled flag set.
    b. `DurableLog` (instance 2) detects the enabled flag and initiates recovery. 
    c. Upon a successful recovery, it notifies its owning `StreamSegmentContainer` (instance 2) of the fact. Should recovery fail, it will also notify it. Should it fail with `DataCorruptionException`, it goes back to step 1a. above.
   d. If 3c. resulted in success, `StreamSegmentContainer` starts its secondary services and starts accepting external requests. Business as usual. If 3c resulted in failure, `StreamSegmentContainer` will auto-shutdown and its manager will attempt to restart it (and we'll go to either step 1 or 2 above, or possibly another step, should the failure be due to a non-corruption cause).

**How to verify it**
Several new unit tests added to verify functionality at every level.
