### PR TITLE
[issue-2258] Support cancellation on Futures.loop/doWhileLoop

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -586,7 +586,7 @@ public final class Futures {
         AtomicBoolean canContinue = new AtomicBoolean();
         Consumer<T> iterationResultHandler = ir -> canContinue.set(condition.test(ir));
         loopBody.get()
-                .thenAccept(iterationResultHandler)
+                .thenAccept(ir -> { if (!result.isCancelled()) iterationResultHandler.accept(ir); })
                 .thenRunAsync(() -> {
                     Loop<T> loop = new Loop<>(canContinue::get, loopBody, iterationResultHandler, result, executor);
                     executor.execute(loop);
@@ -635,7 +635,7 @@ public final class Futures {
 
         @Override
         public Void call() throws Exception {
-            if (this.condition.get()) {
+            if (!this.result.isCancelled() && this.condition.get()) {
                 // Execute another iteration of the loop.
                 this.loopBody.get()
                              .thenAccept(this::acceptIterationResult)


### PR DESCRIPTION
**Change log description**
-  Support cancellation of CompletableFuture produced by Futures.loop/doWhileLoop

**Purpose of the change**
- Closes #2258 
- Improve determinism and prevent a loop from silently continuing after cancellation
- Support cancellation of reader group checkpointing w/ flink-connector

**What the code does**
- Checks the cancellation status of the promise before continuing with condition evaluation/body execution.   Also covers the special case of the first iteration on a do..while loop.

**How to verify it**
- `FuturesTest`
