### PR TITLE
Issue 2258: Support cancellation on Futures.loop/doWhileLoop

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -670,4 +670,58 @@ public final class Futures {
     }
 
     //endregion
+
+    // region Cancellation
+
+    /**
+     * Returns a CompletableFuture that listens to the given future and, when cancelled, automatically cancels
+     * the given upstream futures.  The upstream futures are cancelled before the returned future is cancelled.
+     *
+     * @param <T>    The type of the future result.
+     * @param future the future to listen to.
+     * @param toCancel the upstream futures to cancel.
+     * @return A CompletableFuture that will complete when the given future completes.
+     */
+    public static <T> CompletableFuture<T> cancellable(CompletableFuture<T> future, CompletableFuture... toCancel) {
+        final AtomicBoolean cancelling = new AtomicBoolean();
+
+        CompletableFuture<T> promise = new CompletableFuture<T>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                if (cancelling.compareAndSet(false, true)) {
+                    // cancel the upstream future(s), which will likely propagate an exception to 'future'
+                    for (CompletableFuture u : toCancel) {
+                        try {
+                            u.cancel(mayInterruptIfRunning);
+                        } catch (Exception e) {
+                        }
+                    }
+                    return super.cancel(mayInterruptIfRunning);
+                }
+                return false;
+            }
+        };
+
+        try {
+            // Async termination.
+            future.whenComplete((v, ex) -> {
+                // suppress results that arrive post-cancellation, to ensure that the promise ends with isCancelled
+                if (!cancelling.get()) {
+                    if (ex != null) {
+                        promise.completeExceptionally(ex);
+                    } else {
+                        promise.complete(v);
+                    }
+                }
+            });
+        } catch (Throwable ex) {
+            // Synchronous termination.
+            promise.completeExceptionally(ex);
+            throw ex;
+        }
+
+        return promise;
+    }
+
+    // endregion
 }

--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -586,7 +586,7 @@ public final class Futures {
         AtomicBoolean canContinue = new AtomicBoolean();
         Consumer<T> iterationResultHandler = ir -> canContinue.set(condition.test(ir));
         loopBody.get()
-                .thenAccept(iterationResultHandler)
+                .thenAccept(ir -> { if (!result.isCancelled()) iterationResultHandler.accept(ir); })
                 .thenRunAsync(() -> {
                     Loop<T> loop = new Loop<>(canContinue::get, loopBody, iterationResultHandler, result, executor);
                     executor.execute(loop);
@@ -635,7 +635,7 @@ public final class Futures {
 
         @Override
         public Void call() throws Exception {
-            if (this.condition.get()) {
+            if (!this.result.isCancelled() && this.condition.get()) {
                 // Execute another iteration of the loop.
                 this.loopBody.get()
                              .thenAccept(this::acceptIterationResult)

--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -586,7 +586,11 @@ public final class Futures {
         AtomicBoolean canContinue = new AtomicBoolean();
         Consumer<T> iterationResultHandler = ir -> canContinue.set(condition.test(ir));
         loopBody.get()
-                .thenAccept(ir -> { if (!result.isCancelled()) iterationResultHandler.accept(ir); })
+                .thenAccept(ir -> {
+                    if (!result.isCancelled()) {
+                        iterationResultHandler.accept(ir);
+                    }
+                })
                 .thenRunAsync(() -> {
                     Loop<T> loop = new Loop<>(canContinue::get, loopBody, iterationResultHandler, result, executor);
                     executor.execute(loop);

--- a/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -487,6 +488,42 @@ public class FuturesTests {
                 ex -> ex instanceof CancellationException);
         barrier.complete(null);
         Assert.assertEquals("Loop condition was unexpectedly evaluated after cancellation", 0, loopCounter.get());
+    }
+
+    @Test
+    public void testCancellable() {
+        // 1. Cancellation w/ correct ordering
+        AtomicBoolean upstreamCompletedBeforeCancellable = new AtomicBoolean();
+        CompletableFuture<Void> upstream = new CompletableFuture<>();
+        final CompletableFuture<Void> cancellable1 = Futures.cancellable(upstream, upstream);
+        upstream.whenComplete((v, th) -> upstreamCompletedBeforeCancellable.set(!cancellable1.isDone()));
+        cancellable1.cancel(false);
+        Assert.assertTrue(upstreamCompletedBeforeCancellable.get());
+        Assert.assertTrue(upstream.isCancelled());
+        Assert.assertTrue(cancellable1.isCancelled());
+
+        // 2. Exceptional completion
+        upstream = new CompletableFuture<>();
+        CompletableFuture<Void> cancellable2 = Futures.cancellable(upstream, upstream);
+        upstream.completeExceptionally(new RuntimeException());
+        Assert.assertTrue(cancellable2.isCompletedExceptionally());
+
+        // 3. Successful completion
+        upstream = new CompletableFuture<>();
+        CompletableFuture<Void> cancellable3 = Futures.cancellable(upstream, upstream);
+        upstream.complete(null);
+        Assert.assertTrue(cancellable3.isDone() && !cancellable3.isCompletedExceptionally());
+
+        // 3. Successful completion (synchronous)
+        upstream = CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> cancellable4 = Futures.cancellable(upstream, upstream);
+        Assert.assertTrue(cancellable4.isDone() && !cancellable4.isCompletedExceptionally());
+
+        // 2. Exceptional completion (synchronous)
+        upstream = new CompletableFuture<>();
+        upstream.completeExceptionally(new RuntimeException());
+        CompletableFuture<Void> cancellable5 = Futures.cancellable(upstream, upstream);
+        Assert.assertTrue(cancellable5.isCompletedExceptionally());
     }
 
     private List<CompletableFuture<Integer>> createNumericFutures(int count) {


### PR DESCRIPTION
**Change log description**
-  Support cancellation of CompletableFuture produced by Futures.loop/doWhileLoop
-  Provide a helper method for cancellation of composed futures

**Purpose of the change**
- Closes #2258 
- Improve determinism and prevent a loop from silently continuing after cancellation
- Makes progress towards cancellation of reader group checkpointing w/ flink-connector

**What the code does**
- Checks the cancellation status of the promise before continuing with condition evaluation/body execution.   Also covers the special case of the first iteration on a do..while loop.
- Introduces a new `cancellable` helper method that makes it easy to propagate upstream

**How to verify it**
- `FuturesTest`
