### PR TITLE
Issue 2276: Sporadic build failure, NPE in ZkStoreRetentionTest > testOwnershipOfExistingBucket 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/retention/StreamCutBucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/retention/StreamCutBucketService.java
@@ -152,6 +152,8 @@ public class StreamCutBucketService extends AbstractService implements BucketCha
                     notifyStopped();
                 }
             });
+        } else {
+            notifyStopped();
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@emc.com>

**Change log description**
Fixes issue 2276 where NPE can be caused if dostop is called immediately after awaitStarted and it wins the race in accessing notificationLoop field before  it is set. 

**Purpose of the change**
Fixes #2276

**What the code does**
Adds a new latch that waits on notification loop to be set. 

**How to verify it**
All existing tests should pass