### PR TITLE
Issue 2290: Updating gradle tasks to push all the docker images generated using build task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -686,13 +686,13 @@ task docker(dependsOn: [buildPravegaImage, buildBookkeeperImage]) {
 task pushPravegaImage(type: DockerPushTask) {
     // No explicit dependency on building the pravega image
     mustRunAfter buildPravegaImage
-    tag = "${pravegaBaseTag}:${version}"
+    tag = "${pravegaBaseTag}"
 }
 
 task pushBookkeeperImage(type: DockerPushTask) {
     // No explicit dependency on building the bookkeeper image
     mustRunAfter buildBookkeeperImage
-    tag = "${bookkeeperBaseTag}:${version}"
+    tag = "${bookkeeperBaseTag}"
 }
 
 task dockerPush(dependsOn: [pushPravegaImage, pushBookkeeperImage]) {
@@ -743,7 +743,7 @@ class DockerPushTask extends Exec {
 
     String getRemoteTag() {
         if (project.hasProperty('dockerRegistry')) {
-            return "${project.property('dockerRegistry')}/${tag}"
+            return "${project.property('dockerRegistry')}/${tag}:${version}"
         }
         else {
             return tag

--- a/build.gradle
+++ b/build.gradle
@@ -743,7 +743,7 @@ class DockerPushTask extends Exec {
 
     String getRemoteTag() {
         if (project.hasProperty('dockerRegistry')) {
-            return "${project.property('dockerRegistry')}/${tag}:${version}"
+            return "${project.property('dockerRegistry')}/${tag}:${project.version}"
         }
         else {
             return tag


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <Vijayalakshmi.Veerubhotla@emc.com>

**Change log description**
    1. Modifies the variable tag in `pushPravegaTask` and `pushBookkeeperTask`
    2. Adds the tag `latest-version` in case a `dockerRegistryUrl` is provided. 
1 ->  is to fix the issue when pushing to docker hub 
2 ->  is to push only `current-version` image to repo, as we don't need to push latest along with the current version image. This is the usual case when we build master/a pull request/ from a particular branch. 

**Purpose of the change**
All the images generated using `DockerBuildTask` are not pushed using `DockerPushTask`. 
We need the image with tag `latest` also to be updated whenever we make a release, so as to match
`pravega/pravega:latest` with `pravega/pravega:latest-version>.

**What the code does**
The code modifies the `tag` passed to `DockerPushTask`. We don't provide a tag while pushing the image.  
Ex : we do
1.  `docker push pravega/pravega` instead of  2. `docker push pravega/pravega:<tag-name>`. 
The reason for doing this is in case of 1) we push all the tags associated with repository `pravega/pravega`. 
Fixes #2290 

**How to verify it**
Run `gradle pushPravegaImage` & `gradle pushBookkeeperImage`.  It should push both the images with tags `latest` and `latest-version` to dockerhub.