### PR TITLE
Issue 2273: Prevent stalling reader following a connection failure. 

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -18,7 +18,6 @@ import io.pravega.shared.protocol.netty.WireCommandType;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Synchronized;

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -149,6 +149,7 @@ public class SegmentInputStreamTest {
         ByteBuffer read = stream.read(10);
         assertNull(read);
         fakeNetwork.completeExceptionally(1, new ConnectionFailedException());
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> stream.read());
         stream.read(10);
         assertNull(read);
         read = stream.read(10);

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -136,7 +136,7 @@ public class SegmentInputStreamTest {
         assertEquals(ByteBuffer.wrap(data), read);
     }
 
-    @Test(timeout=10000)
+    @Test(timeout = 10000)
     public void testTimeout() throws EndOfSegmentException, SegmentTruncatedException {
         byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         ByteBuffer wireData = createEventFromData(data);

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import static io.pravega.test.common.Async.testBlocking;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class SegmentInputStreamTest {
@@ -135,18 +136,40 @@ public class SegmentInputStreamTest {
         assertEquals(ByteBuffer.wrap(data), read);
     }
 
+    @Test(timeout=10000)
+    public void testTimeout() throws EndOfSegmentException, SegmentTruncatedException {
+        byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        ByteBuffer wireData = createEventFromData(data);
+        TestAsyncSegmentInputStream fakeNetwork = new TestAsyncSegmentInputStream(segment, 7);
+        @Cleanup
+        SegmentInputStreamImpl stream = new SegmentInputStreamImpl(fakeNetwork, 0);
+
+        testBlocking(() -> stream.read(),
+                     () -> fakeNetwork.complete(0, new WireCommands.SegmentRead(segment.getScopedName(), 0, false, false, wireData.slice())));
+        ByteBuffer read = stream.read(10);
+        assertNull(read);
+        fakeNetwork.completeExceptionally(1, new ConnectionFailedException());
+        stream.read(10);
+        assertNull(read);
+        read = stream.read(10);
+        assertNull(read);
+    }
+    
+    
     @Test
     public void testExceptionRecovery() throws EndOfSegmentException, SegmentTruncatedException {
         byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         ByteBuffer wireData = createEventFromData(data);
-        TestAsyncSegmentInputStream fakeNetwork = new TestAsyncSegmentInputStream(segment, 6);
+        TestAsyncSegmentInputStream fakeNetwork = new TestAsyncSegmentInputStream(segment, 7);
         @Cleanup
         SegmentInputStreamImpl stream = new SegmentInputStreamImpl(fakeNetwork, 0);
         fakeNetwork.complete(0, new WireCommands.SegmentRead(segment.getScopedName(), 0, false, false, ByteBufferUtils.slice(wireData, 0, 2)));
         fakeNetwork.completeExceptionally(1, new ConnectionFailedException());
-        fakeNetwork.complete(2, new WireCommands.SegmentRead(segment.getScopedName(), 2, false, false, ByteBufferUtils.slice(wireData, 2, 7)));
-        fakeNetwork.complete(3, new WireCommands.SegmentRead(segment.getScopedName(), 9, false, false, ByteBufferUtils.slice(wireData, 9, 2)));
-        fakeNetwork.complete(4, new WireCommands.SegmentRead(segment.getScopedName(), 11, false, false, ByteBufferUtils.slice(wireData, 11, wireData.capacity() - 11)));
+        fakeNetwork.complete(2, new WireCommands.SegmentRead(segment.getScopedName(), 0, false, false, ByteBufferUtils.slice(wireData, 0, 2)));
+        fakeNetwork.complete(3, new WireCommands.SegmentRead(segment.getScopedName(), 2, false, false, ByteBufferUtils.slice(wireData, 2, 7)));
+        fakeNetwork.complete(4, new WireCommands.SegmentRead(segment.getScopedName(), 9, false, false, ByteBufferUtils.slice(wireData, 9, 2)));
+        fakeNetwork.complete(5, new WireCommands.SegmentRead(segment.getScopedName(), 11, false, false, ByteBufferUtils.slice(wireData, 11, wireData.capacity() - 11)));
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> stream.read());
         ByteBuffer read = stream.read();
         assertEquals(ByteBuffer.wrap(data), read);
     }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Previously if `AsyncSegmentInputStream` threw a `RetriesExhaustedException`, the `issueRequestIfNeeded()` method would get invoked creating a new request, then when `handleRequest()` was invoked by the `read()` call, the timeout would be ignored and the call would block. 
This changes the logic to not issue a new request inside of `handleRequest()` so it will instead throw rather than issuing a new request and blocking on it. This will prevent the reader from stalling on one segment following an extended connection failure.

**Purpose of the change**
Fixes #2273 

**What the code does**
Throws the exception rather than re-issuing the request. This way the request is already completed in `handleRequest()`.

**How to verify it**
New unit test added to assert correct behavior. 