### PR TITLE
Issue 2298: Fix reader rebalance bug, and add test coverage

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -310,7 +310,7 @@ public class ReaderGroupState implements Revisioned {
             if (oldPos != null) {
                 throw new IllegalStateException("Attempted to add a reader that is already online: " + readerId);
             }
-            state.distanceToTail.putIfAbsent(readerId, 10 * ASSUMED_LAG_MILLIS);
+            state.distanceToTail.putIfAbsent(readerId, Long.MAX_VALUE);
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -111,6 +111,7 @@ public class ReaderGroupState implements Revisioned {
     /**
      * @return The 0 indexed ranking of the requested reader in the reader group in terms of amount
      *         of keyspace assigned to it, or -1 if the reader is not part of the group.
+     *         The reader with the most keyspace will be 0 and the reader with the least keyspace will be numReaders-1.
      */
     @Synchronized
     int getRanking(String reader) {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -114,9 +114,9 @@ public class ReaderGroupState implements Revisioned {
      */
     @Synchronized
     int getRanking(String reader) {
-        List<String> sorted = distanceToTail.entrySet()
+        List<String> sorted = getRelativeSizes().entrySet()
                                    .stream()
-                                   .sorted((o1, o2) -> -Long.compare(o1.getValue(), o2.getValue()))
+                                   .sorted((o1, o2) -> -Double.compare(o1.getValue(), o2.getValue()))
                                    .map(Entry::getKey)
                                    .collect(Collectors.toList());
         return sorted.indexOf(reader);
@@ -310,7 +310,7 @@ public class ReaderGroupState implements Revisioned {
             if (oldPos != null) {
                 throw new IllegalStateException("Attempted to add a reader that is already online: " + readerId);
             }
-            state.distanceToTail.putIfAbsent(readerId, Long.MAX_VALUE);
+            state.distanceToTail.putIfAbsent(readerId, 10 * ASSUMED_LAG_MILLIS);
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -240,6 +240,7 @@ public class ReaderGroupStateManager {
         });
         ReaderGroupState state = sync.getState();
         releaseTimer.reset(calculateReleaseTime(readerId, state));
+        acquireTimer.reset(calculateAcquireTime(readerId, state));
         if (!state.isReaderOnline(readerId)) {
             throw new ReinitializationRequiredException();
         }
@@ -343,7 +344,7 @@ public class ReaderGroupStateManager {
 
     @VisibleForTesting
     static Duration calculateAcquireTime(String readerId, ReaderGroupState state) {
-        return TIME_UNIT.multipliedBy(state.getNumberOfReaders() - state.getRanking(readerId));
+        return TIME_UNIT.multipliedBy(2 * (state.getNumberOfReaders() - state.getRanking(readerId)));
     }
     
     String getCheckpoint() throws ReinitializationRequiredException {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -186,6 +186,7 @@ public class ReaderGroupStateManager {
                 segment = findSegmentToRelease();
                 if (segment != null) {
                     releaseTimer.reset(UPDATE_WINDOW);
+                    acquireTimer.reset(UPDATE_WINDOW);
                 }
             }
         }
@@ -288,6 +289,7 @@ public class ReaderGroupStateManager {
                 return false;
             }
             acquireTimer.reset(UPDATE_WINDOW);
+            releaseTimer.reset(UPDATE_WINDOW);
             return true;
         }
     }
@@ -325,6 +327,7 @@ public class ReaderGroupStateManager {
         if (reinitRequired.get()) {
             throw new ReinitializationRequiredException();
         }
+        releaseTimer.reset(calculateReleaseTime(readerId, sync.getState()));
         acquireTimer.reset(calculateAcquireTime(readerId, sync.getState()));
         return result.get();
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -385,7 +385,7 @@ public class ReaderGroupStateManagerTest {
         assertEquals(segments2, segments1);
     }
 
-    @Test(timeout = 20000)
+    @Test//(timeout = 20000)
     public void testReleaseWhenReadersAdded() throws ReinitializationRequiredException {
         String scope = "scope";
         String stream = "stream";
@@ -451,7 +451,8 @@ public class ReaderGroupStateManagerTest {
 
         Map<Segment, Long> segments2 = reader2.acquireNewSegmentsIfNeeded(0);
         assertEquals(3, segments2.size());
-
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        
         ReaderGroupStateManager reader3 = new ReaderGroupStateManager("reader3", stateSynchronizer, controller,
                 clock::get);
         reader3.initializeReader(0);

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -284,7 +284,6 @@ public class ReaderGroupStateManagerTest {
         ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2", state, controller, clock::get);
         reader2.initializeReader(0);
         
-        
         clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
         Map<Segment, Long> newSegments = reader1.acquireNewSegmentsIfNeeded(123);
         assertEquals(2, newSegments.size());

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -254,7 +254,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 5000)
-    public void testReleaseAndAquireTimes() throws ReinitializationRequiredException {
+    public void testReleaseAndAcquireTimes() throws ReinitializationRequiredException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.test.common.AssertExtensions;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -231,7 +232,8 @@ public class ReaderGroupStateManagerTest {
                 controller,
                 clock::get);
         readerState2.initializeReader(0);
-
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        assertNotNull(readerState1.findSegmentToReleaseIfRequired());
         boolean released = readerState1.releaseSegment(new Segment(scope, stream, 0), 789L, 0L);
         assertTrue(released);
         newSegments = readerState2.acquireNewSegmentsIfNeeded(0);
@@ -249,6 +251,63 @@ public class ReaderGroupStateManagerTest {
 
         AssertExtensions.assertThrows(ReinitializationRequiredException.class,
                 () -> readerState2.acquireNewSegmentsIfNeeded(0L));
+    }
+    
+    @Test(timeout = 5000)
+    public void testReleaseAndAquireTimes() throws ReinitializationRequiredException {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
+
+        SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> state = clientFactory.createStateSynchronizer(stream,
+                                                                                          new JavaSerializer<>(),
+                                                                                          new JavaSerializer<>(),
+                                                                                          config);
+        AtomicLong clock = new AtomicLong();
+        Map<Segment, Long> segments = new HashMap<>();
+        segments.put(new Segment(scope, stream, 0), 0L);
+        segments.put(new Segment(scope, stream, 1), 1L);
+        segments.put(new Segment(scope, stream, 2), 2L);
+        segments.put(new Segment(scope, stream, 3), 3L);
+        ReaderGroupStateManager.initializeReaderGroup(state, ReaderGroupConfig.builder().build(), segments);
+
+        ReaderGroupStateManager reader1 = new ReaderGroupStateManager("reader1", state, controller, clock::get);
+        reader1.initializeReader(0);
+
+        ReaderGroupStateManager reader2 = new ReaderGroupStateManager("reader2", state, controller, clock::get);
+        reader2.initializeReader(0);
+        
+        
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        Map<Segment, Long> newSegments = reader1.acquireNewSegmentsIfNeeded(123);
+        assertEquals(2, newSegments.size());
+        
+        Duration r1aqt = ReaderGroupStateManager.calculateAcquireTime("reader1", state.getState());
+        Duration r2aqt = ReaderGroupStateManager.calculateAcquireTime("reader2", state.getState());
+        assertTrue(r1aqt.toMillis() > r2aqt.toMillis());
+        
+        Duration r1rlt = ReaderGroupStateManager.calculateReleaseTime("reader1", state.getState());
+        Duration r2rlt = ReaderGroupStateManager.calculateReleaseTime("reader2", state.getState());
+        assertTrue(r1rlt.toMillis() < r2rlt.toMillis());
+        
+        reader1.releaseSegment(newSegments.keySet().iterator().next(), 0, 123);
+        newSegments = reader2.acquireNewSegmentsIfNeeded(123);
+        assertEquals(2, newSegments.size());
+        
+        r1aqt = ReaderGroupStateManager.calculateAcquireTime("reader1", state.getState());
+        r2aqt = ReaderGroupStateManager.calculateAcquireTime("reader2", state.getState());
+        assertTrue(r1aqt.toMillis() < r2aqt.toMillis());
+        
+        r1rlt = ReaderGroupStateManager.calculateReleaseTime("reader1", state.getState());
+        r2rlt = ReaderGroupStateManager.calculateReleaseTime("reader2", state.getState());
+        assertTrue(r1rlt.toMillis() > r2rlt.toMillis());
     }
 
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
@@ -59,6 +59,7 @@ public class ReaderGroupStateTest {
         addR2.applyTo(readerState, revision);
         assertEquals(2, readerState.getOnlineReaders().size());
         new ReaderGroupState.AcquireSegment("r1", getSegment("S1")).applyTo(readerState, revision);
+        new ReaderGroupState.UpdateDistanceToTail("r1", 1);
         assertEquals(Collections.singleton(getSegment("S1")), readerState.getSegments("r1"));
         assertEquals(0, readerState.getRanking("r1"));
         assertEquals(1, readerState.getRanking("r2"));
@@ -70,6 +71,7 @@ public class ReaderGroupStateTest {
         new ReaderGroupState.ReleaseSegment("r1", getSegment("S2"), 1).applyTo(readerState, revision);
         new ReaderGroupState.AcquireSegment("r2", getSegment("S1")).applyTo(readerState, revision);
         new ReaderGroupState.AcquireSegment("r2", getSegment("S2")).applyTo(readerState, revision);
+        new ReaderGroupState.UpdateDistanceToTail("r1", 1);
         assertEquals(0, readerState.getSegments("r1").size());
         assertEquals(1, readerState.getRanking("r1"));
         assertEquals(0, readerState.getRanking("r2"));

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
@@ -9,7 +9,14 @@
  */
 package io.pravega.client.stream.impl;
 
+import com.google.common.collect.ImmutableSet;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.state.Revision;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.ReaderGroupState.AddReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,11 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import com.google.common.collect.ImmutableSet;
-import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.state.Revision;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -45,6 +47,34 @@ public class ReaderGroupStateTest {
         readerState = new ReaderGroupState("stream", revision, readerConf,
                 getOffsetMap(1L, Arrays.asList("S1", "S2")));
     }
+    
+
+    @Test
+    public void getRanking() throws Exception {
+        assertTrue(readerState.getOnlineReaders().isEmpty());
+        AddReader addR1 = new ReaderGroupState.AddReader("r1");
+        addR1.applyTo(readerState, revision);
+        assertEquals(1, readerState.getOnlineReaders().size());
+        AddReader addR2 = new ReaderGroupState.AddReader("r2");
+        addR2.applyTo(readerState, revision);
+        assertEquals(2, readerState.getOnlineReaders().size());
+        new ReaderGroupState.AcquireSegment("r1", getSegment("S1")).applyTo(readerState, revision);
+        assertEquals(Collections.singleton(getSegment("S1")), readerState.getSegments("r1"));
+        assertEquals(0, readerState.getRanking("r1"));
+        assertEquals(1, readerState.getRanking("r2"));
+        new ReaderGroupState.AcquireSegment("r1", getSegment("S2")).applyTo(readerState, revision);
+        assertEquals(2, readerState.getSegments("r1").size());
+        assertEquals(0, readerState.getRanking("r1"));
+        assertEquals(1, readerState.getRanking("r2"));
+        new ReaderGroupState.ReleaseSegment("r1", getSegment("S1"), 1).applyTo(readerState, revision);
+        new ReaderGroupState.ReleaseSegment("r1", getSegment("S2"), 1).applyTo(readerState, revision);
+        new ReaderGroupState.AcquireSegment("r2", getSegment("S1")).applyTo(readerState, revision);
+        new ReaderGroupState.AcquireSegment("r2", getSegment("S2")).applyTo(readerState, revision);
+        assertEquals(0, readerState.getSegments("r1").size());
+        assertEquals(1, readerState.getRanking("r1"));
+        assertEquals(0, readerState.getRanking("r2"));
+    }
+    
 
     @Test
     public void getPositionsForLastCompletedCheckpointSuccess() throws Exception {

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
@@ -59,7 +59,7 @@ public class ReaderGroupStateTest {
         addR2.applyTo(readerState, revision);
         assertEquals(2, readerState.getOnlineReaders().size());
         new ReaderGroupState.AcquireSegment("r1", getSegment("S1")).applyTo(readerState, revision);
-        new ReaderGroupState.UpdateDistanceToTail("r1", 1);
+        new ReaderGroupState.UpdateDistanceToTail("r1", 1).applyTo(readerState, revision);
         assertEquals(Collections.singleton(getSegment("S1")), readerState.getSegments("r1"));
         assertEquals(0, readerState.getRanking("r1"));
         assertEquals(1, readerState.getRanking("r2"));
@@ -71,7 +71,7 @@ public class ReaderGroupStateTest {
         new ReaderGroupState.ReleaseSegment("r1", getSegment("S2"), 1).applyTo(readerState, revision);
         new ReaderGroupState.AcquireSegment("r2", getSegment("S1")).applyTo(readerState, revision);
         new ReaderGroupState.AcquireSegment("r2", getSegment("S2")).applyTo(readerState, revision);
-        new ReaderGroupState.UpdateDistanceToTail("r1", 1);
+        new ReaderGroupState.UpdateDistanceToTail("r2", 1).applyTo(readerState, revision);
         assertEquals(0, readerState.getSegments("r1").size());
         assertEquals(1, readerState.getRanking("r1"));
         assertEquals(0, readerState.getRanking("r2"));


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Fix bug that prevented reader groups from properly rebalancing.

**Purpose of the change**
Fixes #2298

**What the code does**
There was a bug where the function to rank the readers in terms of ownership was using the wrong map, and was not taking into account the number of segments assigned. This fixes that bug and adds test coverage.

**How to verify it**
New tests should pass.