### PR TITLE
Issue 2222: Compact reader group state.

### DIFF
--- a/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
+++ b/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
@@ -89,6 +89,14 @@ public interface StateSynchronizer<StateT extends Revisioned> extends AutoClosea
     void initialize(InitialUpdate<StateT> initial);
 
     /**
+     * Calculates the number of bytes that have been written since the state has last been compacted by calling {@link #compact(Function)}
+     * This may be useful when calculating when a compaction should occur.
+     * 
+     * @return The number of bytes written since the last call to {@link #compact(Function)}
+     */
+    long bytesWrittenSinceCompaction();
+    
+    /**
      * Provide a function that generates compacted version of localState so that we can drop some of the
      * history updates.
      * <p>

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -158,6 +158,15 @@ public class StateSynchronizerImpl<StateT extends Revisioned>
             updateCurrentState(initial.create(segment.getScopedStreamName(), result));
         }
     }
+    
+    @Override
+    public long bytesWrittenSinceCompaction() {
+        Revision mark = client.getMark();
+        StateT state = getState();
+        long compaction = (mark == null) ? 0 : mark.asImpl().getOffsetInSegment();
+        long current = (state == null) ? 0 : state.getRevision().asImpl().getOffsetInSegment();
+        return Math.max(0, current - compaction);
+    }
 
     @Override
     public void compact(Function<StateT, InitialUpdate<StateT>> compactor) {
@@ -228,5 +237,6 @@ public class StateSynchronizerImpl<StateT extends Revisioned>
         log.info("Closing stateSynchronizer ", this);
         client.close();
     }
+
 
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -146,7 +146,7 @@ public class CheckpointState implements Serializable {
         uncheckpointedHosts.forEach((cp, hosts) -> ucph.put(cp, new ArrayList<>(hosts)));
         Map<String, Map<Segment, Long>> cpps = new HashMap<>();
         checkpointPositions.forEach((cp, pos) -> cpps.put(cp, new HashMap<>(pos)));
-        Map<Segment, Long> lcp = new HashMap<>(lastCheckpointPosition);
+        Map<Segment, Long> lcp = lastCheckpointPosition == null ? null : new HashMap<>(lastCheckpointPosition);
         return new CheckpointState(cps, ucph, cpps, lcp);
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import com.google.common.base.Preconditions;
 import io.pravega.client.segment.impl.Segment;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -20,27 +21,41 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.concurrent.GuardedBy;
-import lombok.Synchronized;
+import javax.annotation.concurrent.NotThreadSafe;
 
-public class CheckpointState {
-    @GuardedBy("$lock")
-    private final List<String> checkpoints = new ArrayList<>();
+@NotThreadSafe
+public class CheckpointState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    
+    private final List<String> checkpoints;
     /**
      * Maps CheckpointId to remaining hosts.
      */
-    @GuardedBy("$lock")
-    private final Map<String, List<String>> uncheckpointedHosts = new HashMap<>();
+    private final Map<String, List<String>> uncheckpointedHosts;
     /**
      *  Maps CheckpointId to positions in segments.
      */
-    @GuardedBy("$lock")
-    private final Map<String, Map<Segment, Long>> checkpointPositions = new HashMap<>();
+    private final Map<String, Map<Segment, Long>> checkpointPositions;
 
-    @GuardedBy("$lock")
     private Map<Segment, Long> lastCheckpointPosition;
+
+
+    public CheckpointState() {
+        this(new ArrayList<>(), new HashMap<>(), new HashMap<>(), null);
+    }
     
-    @Synchronized
+    private CheckpointState(List<String> checkpoints, Map<String, List<String>> uncheckpointedHosts,
+            Map<String, Map<Segment, Long>> checkpointPositions, Map<Segment, Long> lastCheckpointPosition) {
+        Preconditions.checkNotNull(checkpoints);
+        Preconditions.checkNotNull(uncheckpointedHosts);
+        Preconditions.checkNotNull(checkpointPositions);
+        this.checkpoints = checkpoints;
+        this.uncheckpointedHosts = uncheckpointedHosts;
+        this.checkpointPositions = checkpointPositions;
+        this.lastCheckpointPosition = lastCheckpointPosition;
+    }
+    
     void beginNewCheckpoint(String checkpointId, Set<String> currentReaders, Map<Segment, Long> knownPositions) {
         if (!checkpointPositions.containsKey(checkpointId)) {
             if (!currentReaders.isEmpty()) {
@@ -51,7 +66,6 @@ public class CheckpointState {
         }
     }
     
-    @Synchronized
     String getCheckpointForReader(String readerName) {
         OptionalInt min = getCheckpointsForReader(readerName).stream().mapToInt(checkpoints::indexOf).min();
         if (min.isPresent()) {
@@ -69,15 +83,12 @@ public class CheckpointState {
             .collect(Collectors.toList());
     }
 
-    @Synchronized
     void removeReader(String readerName, Map<Segment, Long> position) {
         for (String checkpointId : getCheckpointsForReader(readerName)) {            
             readerCheckpointed(checkpointId, readerName, position);
         }
     }
     
-
-    @Synchronized
     void readerCheckpointed(String checkpointId, String readerName, Map<Segment, Long> position) {
         List<String> readers = uncheckpointedHosts.get(checkpointId);
         if (readers != null) {
@@ -93,12 +104,10 @@ public class CheckpointState {
         }
     }
     
-    @Synchronized
     boolean isCheckpointComplete(String checkpointId) {
         return !uncheckpointedHosts.containsKey(checkpointId);
     }
     
-    @Synchronized
     Map<Segment, Long> getPositionsForCompletedCheckpoint(String checkpointId) {
         if (uncheckpointedHosts.containsKey(checkpointId)) {
             return null;
@@ -106,17 +115,14 @@ public class CheckpointState {
         return checkpointPositions.get(checkpointId);
     }
 
-    @Synchronized
     Optional<Map<Segment, Long>> getPositionsForLatestCompletedCheckpoint() {
         return Optional.ofNullable(lastCheckpointPosition);
     }
     
-    @Synchronized
     boolean hasOngoingCheckpoint() {
         return !uncheckpointedHosts.isEmpty();
     }
     
-    @Synchronized
     void clearCheckpointsThrough(String checkpointId) {
         if (checkpointPositions.containsKey(checkpointId)) {
             for (Iterator<String> iterator = checkpoints.iterator(); iterator.hasNext();) {
@@ -131,8 +137,20 @@ public class CheckpointState {
         }
     }
 
+    /**
+     * @return A copy of this object
+     */
+    CheckpointState copy() {
+        List<String> cps = new ArrayList<>(checkpoints);
+        Map<String, List<String>> ucph = new HashMap<>(uncheckpointedHosts.size());
+        uncheckpointedHosts.forEach((cp, hosts) -> ucph.put(cp, new ArrayList<>(hosts)));
+        Map<String, Map<Segment, Long>> cpps = new HashMap<>();
+        checkpointPositions.forEach((cp, pos) -> cpps.put(cp, new HashMap<>(pos)));
+        Map<Segment, Long> lcp = new HashMap<>(lastCheckpointPosition);
+        return new CheckpointState(cps, ucph, cpps, lcp);
+    }
+    
     @Override
-    @Synchronized
     public String toString() {
         StringBuffer sb = new StringBuffer();
         sb.append("CheckpointState { ongoingCheckpoints: ");
@@ -141,6 +159,5 @@ public class CheckpointState {
         sb.append(uncheckpointedHosts.toString());
         sb.append(" }");
         return sb.toString();
-    }
-    
+    }    
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -32,15 +32,17 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Synchronized;
 import lombok.val;
 
 /**
- * This class encapsulates the state machine of a reader group. The class represents the full state, and each
- * of the nested classes are state transitions that can occur.
+ * This class encapsulates the state machine of a reader group. The class represents the full state,
+ * and each of the nested classes are state transitions that can occur.
  */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReaderGroupState implements Revisioned {
 
     private static final long ASSUMED_LAG_MILLIS = 30000;
@@ -52,13 +54,13 @@ public class ReaderGroupState implements Revisioned {
     @GuardedBy("$lock")
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)
-    private final CheckpointState checkpointState = new CheckpointState();
+    private final CheckpointState checkpointState;
     @GuardedBy("$lock")
-    private final Map<String, Long> distanceToTail = new HashMap<>();
+    private final Map<String, Long> distanceToTail;
     @GuardedBy("$lock")
-    private final Map<Segment, Set<Integer>> futureSegments = new HashMap<>();
+    private final Map<Segment, Set<Integer>> futureSegments;
     @GuardedBy("$lock")
-    private final Map<String, Map<Segment, Long>> assignedSegments = new HashMap<>();
+    private final Map<String, Map<Segment, Long>> assignedSegments;
     @GuardedBy("$lock")
     private final Map<Segment, Long> unassignedSegments;
 
@@ -68,8 +70,12 @@ public class ReaderGroupState implements Revisioned {
         Preconditions.checkNotNull(config);
         Exceptions.checkNotNullOrEmpty(segmentsToOffsets.entrySet(), "segmentsToOffsets");
         this.scopedSynchronizerStream = scopedSynchronizerStream;
-        this.revision = revision;
         this.config = config;
+        this.revision = revision;
+        this.checkpointState = new CheckpointState();
+        this.distanceToTail = new HashMap<>();
+        this.futureSegments = new HashMap<>();
+        this.assignedSegments = new HashMap<>();
         this.unassignedSegments = new LinkedHashMap<>(segmentsToOffsets);
     }
     
@@ -266,6 +272,40 @@ public class ReaderGroupState implements Revisioned {
         @Override
         public ReaderGroupState create(String scopedStreamName, Revision revision) {
             return new ReaderGroupState(scopedStreamName, revision, config, segments);
+        }
+    }
+    
+    static class CompactReaderGroupState implements InitialUpdate<ReaderGroupState>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final ReaderGroupConfig config;
+        private final CheckpointState checkpointState;
+        private final Map<String, Long> distanceToTail;
+        private final Map<Segment, Set<Integer>> futureSegments;
+        private final Map<String, Map<Segment, Long>> assignedSegments;
+        private final Map<Segment, Long> unassignedSegments;
+        
+        private CompactReaderGroupState(ReaderGroupState state) {
+            synchronized (state.$lock) {
+                config = state.config;
+                checkpointState = state.checkpointState.copy();
+                distanceToTail = new HashMap<>(state.distanceToTail);
+                futureSegments = new HashMap<>();
+                for (Entry<Segment, Set<Integer>> entry : state.futureSegments.entrySet()) {
+                    futureSegments.put(entry.getKey(), new HashSet<>(entry.getValue()));
+                }
+                assignedSegments = new HashMap<>();
+                for (Entry<String, Map<Segment, Long>> entry : assignedSegments.entrySet()) {
+                    assignedSegments.put(entry.getKey(), new HashMap<>(entry.getValue()));
+                }
+                unassignedSegments = new LinkedHashMap<>(state.unassignedSegments);
+            }
+        }
+        
+        @Override
+        public ReaderGroupState create(String scopedStreamName, Revision revision) {
+            return new ReaderGroupState(scopedStreamName, config, revision, checkpointState, distanceToTail,
+                                        futureSegments, assignedSegments, unassignedSegments);
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -66,6 +66,8 @@ import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
  */
 public class ReaderGroupStateManager {
     
+    private static final double COMPACTION_PROBABILITY = 0.05;
+    private static final int MIN_UPDATES_BEFORE_COMPACTION = 500;
     static final Duration TIME_UNIT = Duration.ofMillis(1000);
     static final Duration UPDATE_WINDOW = Duration.ofMillis(30000);
     private final Object decisionLock = new Object();
@@ -274,7 +276,7 @@ public class ReaderGroupStateManager {
     private void compactIfNeeded() {
         ReaderGroupState state = sync.getState();
         //Make sure it has been a while, and compaction are staggered.
-        if (state.getUpdatesSinceCompaction() > 500 && Math.random() < 0.05) {
+        if (state.getUpdatesSinceCompaction() > MIN_UPDATES_BEFORE_COMPACTION && Math.random() < COMPACTION_PROBABILITY) {
             sync.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -69,7 +69,7 @@ public class ReaderGroupStateManager {
     static final Duration TIME_UNIT = Duration.ofMillis(1000);
     static final Duration UPDATE_WINDOW = Duration.ofMillis(30000);
     private static final double COMPACTION_PROBABILITY = 0.05;
-    private static final int MIN_UPDATES_BEFORE_COMPACTION = 500;
+    private static final int MIN_BYTES_BETWEEN_COMPACTIONS = 512 * 1024;
     private final Object decisionLock = new Object();
     private final HashHelper hashHelper;
     @Getter
@@ -274,9 +274,8 @@ public class ReaderGroupStateManager {
     }
     
     private void compactIfNeeded() {
-        ReaderGroupState state = sync.getState();
         //Make sure it has been a while, and compaction are staggered.
-        if (state.getUpdatesSinceCompaction() > MIN_UPDATES_BEFORE_COMPACTION && Math.random() < COMPACTION_PROBABILITY) {
+        if (sync.bytesWrittenSinceCompaction() > MIN_BYTES_BETWEEN_COMPACTIONS && Math.random() < COMPACTION_PROBABILITY) {
             sync.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -267,6 +267,15 @@ public class ReaderGroupStateManager {
             sync.fetchUpdates();
             long groupRefreshTimeMillis = sync.getState().getConfig().getGroupRefreshTimeMillis();
             fetchStateTimer.reset(Duration.ofMillis(groupRefreshTimeMillis));
+            compactIfNeeded();
+        }
+    }
+    
+    private void compactIfNeeded() {
+        ReaderGroupState state = sync.getState();
+        //Make sure it has been a while, and compaction are staggered.
+        if (state.getUpdatesSinceCompaction() > 500 && Math.random() < 0.05) {
+            sync.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -66,10 +66,10 @@ import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
  */
 public class ReaderGroupStateManager {
     
-    private static final double COMPACTION_PROBABILITY = 0.05;
-    private static final int MIN_UPDATES_BEFORE_COMPACTION = 500;
     static final Duration TIME_UNIT = Duration.ofMillis(1000);
     static final Duration UPDATE_WINDOW = Duration.ofMillis(30000);
+    private static final double COMPACTION_PROBABILITY = 0.05;
+    private static final int MIN_UPDATES_BEFORE_COMPACTION = 500;
     private final Object decisionLock = new Object();
     private final HashHelper hashHelper;
     @Getter

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -214,6 +214,7 @@ public class SynchronizerTest {
                                                                                        new JavaSerializer<>(),
                                                                                        new JavaSerializer<>(),
                                                                                        SynchronizerConfig.builder().build());
+        assertEquals(0, sync.bytesWrittenSinceCompaction());
         AtomicInteger callCount = new AtomicInteger(0);
         sync.initialize(new RegularUpdate());
         sync.updateState(state -> {
@@ -221,26 +222,32 @@ public class SynchronizerTest {
             return Collections.singletonList(new RegularUpdate());
         });
         assertEquals(1, callCount.get());
+        long size = sync.bytesWrittenSinceCompaction();
+        assertTrue(size > 0);
         sync.updateState(state -> {
             callCount.incrementAndGet();
             return Collections.singletonList(new RegularUpdate());
         });
         assertEquals(2, callCount.get());
+        assertTrue(sync.bytesWrittenSinceCompaction() > size);
         sync.compact(state -> {
             callCount.incrementAndGet();
             return new RegularUpdate();
         });
         assertEquals(3, callCount.get());
+        assertEquals(0, sync.bytesWrittenSinceCompaction());
         sync.updateState(s -> {
             callCount.incrementAndGet();
             return Collections.singletonList(new RegularUpdate());
         });
         assertEquals(5, callCount.get());
+        assertEquals(size, sync.bytesWrittenSinceCompaction());
         sync.compact(state -> {
             callCount.incrementAndGet();
             return new RegularUpdate();
         });
         assertEquals(6, callCount.get());
+        assertEquals(0, sync.bytesWrittenSinceCompaction());
     }
     
     @Test(timeout = 20000)

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -77,40 +77,51 @@ public class ReaderGroupStateManagerTest {
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> state = clientFactory.createStateSynchronizer(stream,
-                                                                                          new JavaSerializer<>(),
-                                                                                          new JavaSerializer<>(),
-                                                                                          config);
+        StateSynchronizer<ReaderGroupState> state1 = createState(stream, clientFactory, config);
         Segment s1 = new Segment(scope, stream, 1);
         Segment s2 = new Segment(scope, stream, 2);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(s1, 1L);
         segments.put(s2, 2L);
         AtomicLong clock = new AtomicLong();
-        ReaderGroupStateManager.initializeReaderGroup(state, ReaderGroupConfig.builder().build(), segments);
-        ReaderGroupStateManager r1 = new ReaderGroupStateManager("r1", state, controller, clock::get);
+        ReaderGroupStateManager.initializeReaderGroup(state1, ReaderGroupConfig.builder().build(), segments);
+        ReaderGroupStateManager r1 = new ReaderGroupStateManager("r1", state1, controller, clock::get);
         r1.initializeReader(0);
         r1.acquireNewSegmentsIfNeeded(0);
-        assertTrue(state.getState().getUnassignedSegments().isEmpty());
-        state.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
+        assertTrue(state1.getState().getUnassignedSegments().isEmpty());
+        state1.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
         r1.acquireNewSegmentsIfNeeded(0);
-        state.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
+        state1.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
-        ReaderGroupStateManager r2 = new ReaderGroupStateManager("r2", state, controller, clock::get);
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> state2 = createState(stream, clientFactory, config);
+        ReaderGroupStateManager r2 = new ReaderGroupStateManager("r2", state2, controller, clock::get);
         r2.initializeReader(0);
+        assertEquals(state1.getState().getPositions(), state2.getState().getPositions());
+        state1.fetchUpdates();
         assertTrue(r1.releaseSegment(s1, 1, 1));
-        state.fetchUpdates();
-        assertFalse(state.getState().getUnassignedSegments().isEmpty());
+        state2.fetchUpdates();
+        assertFalse(state2.getState().getUnassignedSegments().isEmpty());
         assertFalse(r2.acquireNewSegmentsIfNeeded(0).isEmpty());
-        state.fetchUpdates();
-        assertTrue(state.getState().getUnassignedSegments().isEmpty());
-        assertEquals(Collections.singleton(s2), state.getState().getSegments("r1"));
-        assertEquals(Collections.singleton(s1), state.getState().getSegments("r2"));
-        state.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
+        state2.fetchUpdates();
+        assertTrue(state2.getState().getUnassignedSegments().isEmpty());
+        assertEquals(Collections.singleton(s2), state2.getState().getSegments("r1"));
+        assertEquals(Collections.singleton(s1), state2.getState().getSegments("r2"));
+        state2.compact(s -> new ReaderGroupState.CompactReaderGroupState(s));
         r1.findSegmentToReleaseIfRequired();
         r1.acquireNewSegmentsIfNeeded(0);
         r2.getCheckpoint();
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> state3 = createState(stream, clientFactory, config);
+        state3.fetchUpdates();
+        assertEquals(state3.getState().getPositions(), state1.getState().getPositions());
+        assertEquals(state3.getState().getPositions(), state2.getState().getPositions());
+    }
+
+    private StateSynchronizer<ReaderGroupState> createState(String stream, ClientFactory clientFactory,
+                                                            SynchronizerConfig config) {
+        return clientFactory.createStateSynchronizer(stream, new JavaSerializer<>(), new JavaSerializer<>(), config);
     }
     
     @Test(timeout = 20000)
@@ -133,10 +144,7 @@ public class ReaderGroupStateManagerTest {
                 streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                new JavaSerializer<>(),
-                new JavaSerializer<>(),
-                config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(initialSegment, 1L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer,
@@ -175,10 +183,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(initialSegmentA, 1L);
         segments.put(initialSegmentB, 2L);
@@ -218,10 +223,7 @@ public class ReaderGroupStateManagerTest {
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(new Segment(scope, stream, 0), 1L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer,
@@ -254,10 +256,7 @@ public class ReaderGroupStateManagerTest {
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         AtomicLong clock = new AtomicLong();
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(new Segment(scope, stream, 0), 123L);
@@ -314,10 +313,7 @@ public class ReaderGroupStateManagerTest {
 
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         AtomicLong clock = new AtomicLong();
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(new Segment(scope, stream, 0), 0L);
@@ -389,10 +385,7 @@ public class ReaderGroupStateManagerTest {
         ClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         AtomicLong clock = new AtomicLong();
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(new Segment(scope, stream, 0), 0L);
@@ -488,10 +481,7 @@ public class ReaderGroupStateManagerTest {
                                                             streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(initialSegment, 1L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
@@ -531,10 +521,7 @@ public class ReaderGroupStateManagerTest {
                                                             streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = ImmutableMap.of(segment0, 0L, segment1, 1L, segment2, 2L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);
         val readerState1 = new ReaderGroupStateManager("reader1", stateSynchronizer, controller, null);
@@ -572,10 +559,7 @@ public class ReaderGroupStateManagerTest {
                                                             streamFactory, streamFactory);
         SynchronizerConfig config = SynchronizerConfig.builder().build();
         @Cleanup
-        StateSynchronizer<ReaderGroupState> stateSynchronizer = clientFactory.createStateSynchronizer(stream,
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      new JavaSerializer<>(),
-                                                                                                      config);
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         AtomicLong clock = new AtomicLong();
         Map<Segment, Long> segments = ImmutableMap.of(segment0, 0L, segment1, 1L, segment2, 2L);
         ReaderGroupStateManager.initializeReaderGroup(stateSynchronizer, ReaderGroupConfig.builder().build(), segments);

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.TreeMap;
 import org.junit.Test;
 
@@ -41,6 +42,17 @@ public class StreamSegmentsTest {
         Arrays.fill(counts, 0);
         for (int i = 0; i < 20; i++) {
             Segment segment = streamSegments.getSegmentForKey("" + i);
+            assertNotNull(segment);
+            counts[segment.getSegmentNumber()]++;
+        }
+        for (int count : counts) {
+            assertTrue(count > 1);
+        }
+        
+        Random r = new Random(0);
+        Arrays.fill(counts, 0);
+        for (int i = 0; i < 20; i++) {
+            Segment segment = streamSegments.getSegmentForKey(r.nextDouble());
             assertNotNull(segment);
             counts[segment.getSegmentNumber()]++;
         }


### PR DESCRIPTION
**Change log description**
Add support for compaction in ReaderGroupState

**Purpose of the change**
Fixes #2222 . Should prevent the reader group state from growing over time. 

**What the code does**
Adds a compact call to ReaderGroupState that serializes the object using Java serialization. 
This change also converts CheckpointState from a threadSafe class to one that is not-thread safe, as Java serialization does not play well with locks. This is OK to do because it was/is always only accessed from within ReaderGroupState under it's lock. 

**How to verify it**
Added a new test to cover compaction. All existing code paths should be unaffected.