### PR TITLE
Issue 1960: Simple retention system test

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
@@ -21,7 +21,6 @@ import io.pravega.test.system.framework.services.marathon.PravegaSegmentStoreSer
 import io.pravega.test.system.framework.services.marathon.ZookeeperService;
 
 import java.net.URI;
-import java.util.Map;
 
 /**
  * Utility methods used inside the TestFramework.
@@ -59,12 +58,6 @@ public class Utils {
         return DOCKER_BASED
                 ? new PravegaControllerDockerService("controller", zkUri)
                 : new PravegaControllerService("controller", zkUri);
-    }
-
-    public static Service createPravegaControllerService(final URI zkUri, final Map<String, String> systemProperties) {
-        return DOCKER_BASED
-                ? new PravegaControllerDockerService("controller", zkUri, systemProperties)
-                : new PravegaControllerService("controller", zkUri, systemProperties);
     }
 
     public static Service createPravegaSegmentStoreService(final URI zkUri, final URI contUri) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
@@ -21,6 +21,7 @@ import io.pravega.test.system.framework.services.marathon.PravegaSegmentStoreSer
 import io.pravega.test.system.framework.services.marathon.ZookeeperService;
 
 import java.net.URI;
+import java.util.Map;
 
 /**
  * Utility methods used inside the TestFramework.
@@ -58,6 +59,12 @@ public class Utils {
         return DOCKER_BASED
                 ? new PravegaControllerDockerService("controller", zkUri)
                 : new PravegaControllerService("controller", zkUri);
+    }
+
+    public static Service createPravegaControllerService(final URI zkUri, final Map<String, String> systemProperties) {
+        return DOCKER_BASED
+                ? new PravegaControllerDockerService("controller", zkUri, systemProperties)
+                : new PravegaControllerService("controller", zkUri, systemProperties);
     }
 
     public static Service createPravegaSegmentStoreService(final URI zkUri, final URI contUri) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import static io.pravega.test.system.framework.Utils.DOCKER_CONTROLLER_PORT;
 import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
@@ -38,17 +37,10 @@ public class PravegaControllerDockerService extends DockerBasedService {
     private final double cpu = 0.5;
     private final double mem = 700.0;
     private final URI zkUri;
-    private Map<String, String> systemProperties;
 
     public PravegaControllerDockerService(final String serviceName, final URI zkUri) {
         super(serviceName);
         this.zkUri = zkUri;
-    }
-
-    public PravegaControllerDockerService(final String serviceName, final URI zkUri, final Map<String, String> systemProperties) {
-        super(serviceName);
-        this.zkUri = zkUri;
-        this.systemProperties = systemProperties;
     }
 
     public void stop() {
@@ -78,12 +70,7 @@ public class PravegaControllerDockerService extends DockerBasedService {
         stringBuilderMap.put("ZK_SESSION_TIMEOUT_MS", String.valueOf(30 * 1000));
         stringBuilderMap.put("MAX_LEASE_VALUE", String.valueOf(60 * 1000));
         stringBuilderMap.put("MAX_SCALE_GRACE_PERIOD", String.valueOf(60 * 1000));
-
-        Iterator it = systemProperties.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry pair = (Map.Entry) it.next();
-            stringBuilderMap.put((String) pair.getKey(), (String) pair.getValue());
-        }
+        stringBuilderMap.put("RETENTION_FREQUENCY_MINUTES", String.valueOf(2));
         StringBuilder systemPropertyBuilder = new StringBuilder();
         for (Map.Entry<String, String> entry : stringBuilderMap.entrySet()) {
             systemPropertyBuilder.append("-D").append(entry.getKey()).append("=").append(entry.getValue()).append(" ");

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import static io.pravega.test.system.framework.Utils.DOCKER_CONTROLLER_PORT;
 import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
@@ -37,10 +38,17 @@ public class PravegaControllerDockerService extends DockerBasedService {
     private final double cpu = 0.5;
     private final double mem = 700.0;
     private final URI zkUri;
+    private Map<String, String> systemProperties;
 
     public PravegaControllerDockerService(final String serviceName, final URI zkUri) {
         super(serviceName);
         this.zkUri = zkUri;
+    }
+
+    public PravegaControllerDockerService(final String serviceName, final URI zkUri, final Map<String, String> systemProperties) {
+        super(serviceName);
+        this.zkUri = zkUri;
+        this.systemProperties = systemProperties;
     }
 
     public void stop() {
@@ -70,6 +78,12 @@ public class PravegaControllerDockerService extends DockerBasedService {
         stringBuilderMap.put("ZK_SESSION_TIMEOUT_MS", String.valueOf(30 * 1000));
         stringBuilderMap.put("MAX_LEASE_VALUE", String.valueOf(60 * 1000));
         stringBuilderMap.put("MAX_SCALE_GRACE_PERIOD", String.valueOf(60 * 1000));
+
+        Iterator it = systemProperties.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry pair = (Map.Entry) it.next();
+            stringBuilderMap.put((String) pair.getKey(), (String) pair.getValue());
+        }
         StringBuilder systemPropertyBuilder = new StringBuilder();
         for (Map.Entry<String, String> entry : stringBuilderMap.entrySet()) {
             systemPropertyBuilder.append("-D").append(entry.getKey()).append("=").append(entry.getValue()).append(" ");

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaControllerService.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -26,7 +27,6 @@ import mesosphere.marathon.client.model.v2.Container;
 import mesosphere.marathon.client.model.v2.Docker;
 import mesosphere.marathon.client.model.v2.HealthCheck;
 import mesosphere.marathon.client.MarathonException;
-
 import static io.pravega.test.system.framework.TestFrameworkException.Type.InternalError;
 
 /**
@@ -41,11 +41,19 @@ public class PravegaControllerService extends MarathonBasedService {
     private int instances = 1;
     private double cpu = 0.5;
     private double mem = 700;
+    private Map<String, String> systemProperties = new HashMap<>();
 
     public PravegaControllerService(final String id, final URI zkUri) {
         // if SkipserviceInstallation flag is enabled used the default id.
         super(Utils.isSkipServiceInstallationEnabled() ? "/pravega/controller" : id);
         this.zkUri = zkUri;
+    }
+
+    public PravegaControllerService(final String id, final URI zkUri, final Map<String, String> systemProperties) {
+        // if SkipserviceInstallation flag is enabled used the default id.
+        super(Utils.isSkipServiceInstallationEnabled() ? "/pravega/controller" : id);
+        this.zkUri = zkUri;
+        this.systemProperties = systemProperties;
     }
 
     public PravegaControllerService(final String id, final URI zkUri, int instances, double cpu, double mem) {
@@ -119,18 +127,33 @@ public class PravegaControllerService extends MarathonBasedService {
         List<HealthCheck> healthCheckList = new ArrayList<HealthCheck>();
         healthCheckList.add(setHealthCheck(300, "TCP", false, 60, 20, 0, CONTROLLER_PORT));
         app.setHealthChecks(healthCheckList);
+
         //set env
-        String controllerSystemProperties = "-Xmx512m" +
-                setSystemProperty("ZK_URL", zk) +
-                setSystemProperty("CONTROLLER_RPC_PUBLISHED_HOST", this.id + ".marathon.mesos") +
-                setSystemProperty("CONTROLLER_RPC_PUBLISHED_PORT", String.valueOf(CONTROLLER_PORT)) +
-                setSystemProperty("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT)) +
-                setSystemProperty("REST_SERVER_PORT", String.valueOf(REST_PORT)) +
-                setSystemProperty("log.level", "DEBUG") +
-                setSystemProperty("log.dir", "$MESOS_SANDBOX/pravegaLogs") +
-                setSystemProperty("curator-default-session-timeout", String.valueOf(10 * 1000)) +
-                setSystemProperty("MAX_LEASE_VALUE", String.valueOf(60 * 1000)) +
-                setSystemProperty("MAX_SCALE_GRACE_PERIOD", String.valueOf(60 * 1000));
+        Map<String, String> stringBuilderMap = new HashMap<>();
+        stringBuilderMap.put("ZK_URL", zk);
+        stringBuilderMap.put("CONTROLLER_RPC_PUBLISHED_HOST", this.id + ".marathon.mesos");
+        stringBuilderMap.put("CONTROLLER_RPC_PUBLISHED_PORT", String.valueOf(CONTROLLER_PORT));
+        stringBuilderMap.put("CONTROLLER_SERVER_PORT", String.valueOf(CONTROLLER_PORT));
+        stringBuilderMap.put("REST_SERVER_PORT", String.valueOf(REST_PORT));
+        stringBuilderMap.put("log.level", "DEBUG");
+        stringBuilderMap.put("log.dir", "$MESOS_SANDBOX/pravegaLogs");
+        stringBuilderMap.put("curator-default-session-timeout", String.valueOf(10 * 1000));
+        stringBuilderMap.put("MAX_LEASE_VALUE", String.valueOf(60 * 1000));
+        stringBuilderMap.put("MAX_SCALE_GRACE_PERIOD", String.valueOf(60 * 1000));
+
+        StringBuilder systemPropertyBuilder = new StringBuilder();
+        for (Map.Entry<String, String> entry : stringBuilderMap.entrySet()) {
+            systemPropertyBuilder.append("-D").append(entry.getKey()).append("=").append(entry.getValue()).append(" ");
+        }
+
+        Iterator it = systemProperties.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry pair = (Map.Entry) it.next();
+            stringBuilderMap.put((String) pair.getKey(), (String) pair.getValue());
+        }
+
+        String controllerSystemProperties = "-Xmx512m" + systemPropertyBuilder.toString();
+
         Map<String, Object> map = new HashMap<>();
         map.put("PRAVEGA_CONTROLLER_OPTS", controllerSystemProperties);
         app.setEnv(map);

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -1,0 +1,163 @@
+package io.pravega.test.system;
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.RetentionPolicy;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.Exceptions;
+import io.pravega.test.system.framework.Environment;
+import io.pravega.test.system.framework.SystemTestRunner;
+import io.pravega.test.system.framework.Utils;
+import io.pravega.test.system.framework.services.Service;
+import lombok.extern.slf4j.Slf4j;
+import mesosphere.marathon.client.MarathonException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import java.io.Serializable;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+@RunWith(SystemTestRunner.class)
+public class RetentionTest {
+
+    private final static String STREAM = "testRetentionStream1";
+    private final static String SCOPE = "testRetentionScope" + new Random().nextInt(Integer.MAX_VALUE);
+    private final static String READER_GROUP = "testRetentionReaderGroup1";
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(2);
+    private final RetentionPolicy retentionPolicy= RetentionPolicy.byTime(Duration.ofMinutes(1));
+    private final StreamConfiguration config = StreamConfiguration.builder().scope(SCOPE)
+            .streamName(STREAM).scalingPolicy(scalingPolicy).retentionPolicy(retentionPolicy).build();
+    private URI controllerURI;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
+
+
+    /**
+     * This is used to setup the various services required by the system test framework.
+     *
+     * @throws MarathonException    when error in setup
+     */
+    @Environment
+    public static void initialize() throws MarathonException {
+
+        //1. check if zk is running, if not start it
+        Service zkService = Utils.createZookeeperService();
+        if (!zkService.isRunning()) {
+            zkService.start(true);
+        }
+
+        List<URI> zkUris = zkService.getServiceDetails();
+        log.debug("Zookeeper service details: {}", zkUris);
+        //get the zk ip details and pass it to bk, host, controller
+        URI zkUri = zkUris.get(0);
+        //2, check if bk is running, otherwise start, get the zk ip
+        Service bkService = Utils.createBookkeeperService(zkUri);
+        if (!bkService.isRunning()) {
+            bkService.start(true);
+        }
+
+        List<URI> bkUris = bkService.getServiceDetails();
+        log.debug("Bookkeeper service details: {}", bkUris);
+
+        //3. start controller
+        Service conService = Utils.createPravegaControllerService(zkUri);
+        if (!conService.isRunning()) {
+            conService.start(true);
+        }
+
+        List<URI> conUris = conService.getServiceDetails();
+        log.debug("Pravega controller service details: {}", conUris);
+
+        //4.start segmentstore
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
+        if (!segService.isRunning()) {
+            segService.start(true);
+        }
+
+        List<URI> segUris = segService.getServiceDetails();
+        log.debug("Pravega segmentstore service details: {}", segUris);
+    }
+
+    @Before
+    public void setup() {
+        Service conService = Utils.createPravegaControllerService(null);
+        List<URI> ctlURIs = conService.getServiceDetails();
+        controllerURI = ctlURIs.get(0);
+        StreamManager streamManager = StreamManager.create(controllerURI);
+        assertTrue("Creating Scope", streamManager.createScope(SCOPE));
+        assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, config));
+    }
+
+    @Test
+    public void retentionTest() {
+
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(false);
+        ControllerImpl controller = new ControllerImpl(controllerURI,
+                ControllerImplConfig.builder().build(), connectionFactory.getInternalExecutor());
+
+        ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, controller);
+        log.info("Invoking Writer test with Controller URI: {}", controllerURI);
+
+
+        //create a writer
+        EventStreamWriter<Serializable> writer = clientFactory.createEventWriter(STREAM,
+                new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+
+        //write an event
+        String writeEvent = "event";
+        writer.writeEvent("", writeEvent);
+        writer.flush();
+        log.debug("Writing event: {} ", writeEvent);
+
+        //sleep for 4 mins
+        Exceptions.handleInterrupted(() -> Thread.sleep(4*60*1000));
+
+        //create a reader
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().startingTime(0).build(),
+                Collections.singleton(STREAM));
+        EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),
+                READER_GROUP,
+                new JavaSerializer<>(),
+                ReaderConfig.builder().build());
+
+        //read the same event
+        try {
+           String readEvent = reader.readNextEvent(6000).getEvent();
+           log.debug("Reading event: {} ", readEvent);
+           assertEquals(readEvent, null);
+        }  catch (ReinitializationRequiredException e) {
+           log.error("Unexpected request to reinitialize {}", e);
+           System.exit(0);
+       }
+
+       log.debug("the stream is already truncated");
+       log.debug("Simple retention test passed");
+    }
+}

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -145,12 +145,12 @@ public class RetentionTest {
 
         //write an event
         String writeEvent = "event";
-        writer.writeEvent("", writeEvent);
+        writer.writeEvent(writeEvent);
         writer.flush();
         log.debug("Writing event: {} ", writeEvent);
 
         //sleep for 4 mins
-        Exceptions.handleInterrupted(() -> Thread.sleep(4 * 60 * 1000));
+        Exceptions.handleInterrupted(() -> Thread.sleep(5 * 60 * 1000));
 
         //create a reader
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
@@ -172,7 +172,6 @@ public class RetentionTest {
             Assert.fail("Unexpected request to reinitialize.Test failed.");
         }
 
-       log.debug("The stream is already truncated");
-       log.debug("Simple retention test passed");
+       log.debug("The stream is already truncated.Simple retention test passed.");
     }
 }


### PR DESCRIPTION
**Change log description**
1. New system test is added, with focus on `retention`.
2. Controller is configured with `retention frequency` of `2 * 60 s`.
**Purpose of the change**
We need system tests where controller workflows like truncate, update is exercised.
**What the code does**
Fixes #1960 
Adds a very simple retention test, where the controller is configured with `retention frequency` of  2mins, a stream is created with a retention policy of 1 min, an event is written to a stream and read after 4 mins of sleep. It is verified that data is lost. The reader only reads `null` event.
**How to verify it**
Run system tests. 