### PR TITLE
Issue 2306: Refactor ReaderGroup#getStreamCuts() api

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -13,7 +13,6 @@ import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.impl.StreamCut;
 import io.pravega.client.stream.notifications.ReaderGroupNotificationListener;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -131,7 +130,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener {
      * A stream cut corresponds to a position in the stream, and it can be used by
      * the application as reference to such a position.
      *
-     * @return Map of streams that this group is reading from to the corresponding cuts.
+     * @return {@link StreamCut StreamCuts} of streams that this reader group is reading from.
      */
-    Map<Stream, StreamCut> getStreamCuts();
+    Set<StreamCut> getStreamCuts();
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -242,19 +242,12 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
     }
 
     @Override
-    public Map<Stream, StreamCut> getStreamCuts() {
+    public Set<StreamCut> getStreamCuts() {
         @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = createSynchronizer();
         synchronizer.fetchUpdates();
         ReaderGroupState state = synchronizer.getState();
-        Map<Stream, Map<Segment, Long>> positions = state.getPositions();
-        HashMap<Stream, StreamCut> cuts = new HashMap<>();
-
-        for (Entry<Stream, Map<Segment, Long>> streamPosition : positions.entrySet()) {
-            StreamCut position = new StreamCut(streamPosition.getKey(), streamPosition.getValue());
-            cuts.put(streamPosition.getKey(), position);
-        }
-
-        return cuts;
+        return state.getPositions().entrySet().stream().map(entry -> new StreamCut(entry.getKey(), entry
+                .getValue())).collect(Collectors.toSet());
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -137,7 +137,7 @@ public class StreamCutsTest {
         assertNotNull(secondEvent);
         assertEquals("fpj was here again", secondEvent.getEvent());
 
-        Map<Stream, StreamCut> cuts = readerGroup.getStreamCuts();
+        Set<StreamCut> cuts = readerGroup.getStreamCuts();
         validateCuts(readerGroup, cuts, Collections.singleton("test/test/0"));
 
         // Scale the stream to verify that we get more segments in the cut.
@@ -197,10 +197,10 @@ public class StreamCutsTest {
         validateCuts(readerGroup, cuts, Collections.unmodifiableSet(segmentNames));
     }
 
-    private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, Set<String> segmentNames) {
+    private void validateCuts(ReaderGroup group, Set<StreamCut> cuts, Set<String> segmentNames) {
         Set<String> streamNames = group.getStreamNames();
-        cuts.forEach((s, c) -> {
-                assertTrue(streamNames.contains(s.getStreamName()));
+        cuts.forEach((c) -> {
+                assertTrue(streamNames.contains(c.getStream().getStreamName()));
                 assertTrue(c.validate(segmentNames));
         });
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -199,7 +199,7 @@ public class StreamCutsTest {
 
     private void validateCuts(ReaderGroup group, Set<StreamCut> cuts, Set<String> segmentNames) {
         Set<String> streamNames = group.getStreamNames();
-        cuts.forEach((c) -> {
+        cuts.forEach(c -> {
                 assertTrue(streamNames.contains(c.getStream().getStreamName()));
                 assertTrue(c.validate(segmentNames));
         });


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
`ReaderGroup#getStreamCuts()` api now returns a ` Set<StreamCut>`.

**Purpose of the change**
Fixes #2306 

**What the code does**
The StreamCut object already represents the Stream that it is associated with. Hence, the API is changed from `Map<Stream, StreamCut> getStreamCuts();` to  `Set<StreamCut> getStreamCuts();`

**How to verify it**
The existing tests should continue to pass.