### PR TITLE
Issue 2312: Create node with Ephemeral mode in ZkStoreHelper.createEphemeralZNode mode

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
@@ -65,6 +65,7 @@ public class TruncateStreamTask implements StreamTask<TruncateStreamEvent> {
 
     private CompletableFuture<Void> processTruncate(String scope, String stream, StreamTruncationRecord truncationRecord,
                                                     OperationContext context) {
+        log.info("Truncating stream {}/{} at stream cut: {}", scope, stream, truncationRecord.getStreamCut());
         return Futures.toVoid(streamMetadataStore.setState(scope, stream, State.TRUNCATING, context, executor)
                  .thenCompose(x -> notifyTruncateSegments(scope, stream, truncationRecord.getStreamCut()))
                  .thenCompose(x -> notifyDeleteSegments(scope, stream, truncationRecord.getToDelete()))

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -26,6 +26,7 @@ import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 
 @Slf4j
@@ -275,7 +276,8 @@ public class ZKStoreHelper {
                             result.completeExceptionally(e);
                         }
                     }, path);
-                createBuilder.creatingParentsIfNeeded().inBackground(callback, executor).forPath(path, data);
+                createBuilder.creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL)
+                        .inBackground(callback, executor).forPath(path, data);
         } catch (Exception e) {
             result.completeExceptionally(StoreException.create(StoreException.Type.UNKNOWN, e, path));
         }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -216,7 +216,10 @@ public class StreamMetadataTasks extends TaskBase {
         if (latestCut == null || recordingTime - latestCut.getRecordingTime() > RETENTION_FREQUENCY_IN_MINUTES) {
             return generateStreamCut(scope, stream, context)
                     .thenCompose(newRecord -> streamMetadataStore.addStreamCutToRetentionSet(scope, stream, newRecord, context, executor)
-                        .thenApply(x -> newRecord));
+                        .thenApply(x -> {
+                            log.debug("New streamCut generated for stream {}/{}", scope, stream);
+                            return newRecord;
+                        }));
         } else {
             return  CompletableFuture.completedFuture(null);
         }
@@ -331,7 +334,10 @@ public class StreamMetadataTasks extends TaskBase {
                                 // 3. start truncation by updating the metadata
                                 .thenCompose(x -> streamMetadataStore.startTruncation(scope, stream, streamCut,
                                         context, executor))
-                                .thenApply(x -> true);
+                                .thenApply(x -> {
+                                    log.debug("Started truncation request for stream {}/{}", scope, stream);
+                                    return true;
+                                });
                     } else {
                         log.warn("Another truncation in progress for {}/{}", scope, stream);
                         return CompletableFuture.completedFuture(false);

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
@@ -10,7 +10,6 @@
 package io.pravega.controller.store.stream;
 
 import io.pravega.common.concurrent.Futures;
-import io.pravega.controller.store.stream.tables.Data;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import org.apache.curator.framework.CuratorFramework;
@@ -25,9 +24,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**

1. ZkStoreHelper.createEphemeral node to actually create ephemeral node
2. Use map.computeIfAbsent instead of putIfAbsent in StreamCutBucketService while adding new stream. 
3. Add more info and debug logging for retention workflow

**Purpose of the change**
Fixes #2312.

**What the code does**
There is a bug in ZkStoreHelper's helper method for creating ephemeral node where CreateMode.Ephemeral flag is not passed. 
Because of this issue retention buckets were not failed over in case of owning controller instance failures. So we faced system test failure. 

Apart from that, from the logs we noticed that two background processing for same stream was getting invoked because we were actually doing map.putIfAbsent instead of computeIfAbsent and the value was being computed twice even though it was not getting added to the map. The value here being future of background processing for retention. 

Added more logs to help with debugging issues in future. 

**How to verify it**
Added new unit test for ephemeral node. 