### PR TITLE
Issue 2320: Remove deprecated gradle api usage in build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -553,7 +553,7 @@ project('test:system') {
         ext.repoUrl = project.hasProperty("repoUrl") ? project.repoUrl : ""
 
         description 'Used to invoke system tests, example usage: gradle startSystemTests -DmasterIP=xx.xx.xx.xx'
-        testClassesDir = sourceSets.test.output.classesDir
+        testClassesDirs = sourceSets.test.output.classesDirs
         classpath = sourceSets.test.runtimeClasspath
 
         systemProperty "test_collection_jar_path", "$jar.archivePath.path"
@@ -598,7 +598,7 @@ project('test:system') {
         ext.dockerRegistryUrl = project.hasProperty("dockerRegistryUrl") ? project.dockerRegistryUrl : ""
 
         description 'Used to invoke docker based system tests, example usage: gradle startSystemTests -DmasterIP=xx.xx.xx.xx'
-        testClassesDir = sourceSets.test.output.classesDir
+        testClassesDirs = sourceSets.test.output.classesDirs
         classpath = sourceSets.test.runtimeClasspath
 
         systemProperty "execType", System.getProperty("execType")


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Remove deprecated Gradle features from `build.gradle`.

**Purpose of the change**
Fixes #2320

**What the code does**
Update  `build.gradle `to remove the following warning observed during builds
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.5/userguide/command_line_interface.html#sec:command_line_warnings
```
**How to verify it**
Verified that all the tests pass successfully.
