### PR TITLE
Issue 2345: VersionedSerialization improvements 

### DIFF
--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 /**
@@ -99,6 +100,33 @@ public interface RevisionDataInput extends DataInput {
      * @throws IOException If an IO Exception occurred.
      */
     <T, C extends Collection<T>> C readCollection(ElementDeserializer<T> elementDeserializer, Supplier<C> newCollection) throws IOException;
+
+    /**
+     * Decodes a specific array that has been serialized using RevisionDataOutput.writeArray(T[], ElementSerializer).
+     *
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * RevisionDataOutput.writeArray(T[], ElementSerializer).
+     *
+     * @param elementDeserializer A Function that will decode a single element of the Collection from the given RevisionDataInput.
+     * @param newArray            A Function that will create a new instance of the array type desired, with the specified length.
+     * @param <T>                 Type of the elements in the array.
+     * @return A new array. If the original array passed to RevisionDataOutput.writeArray() was null, this
+     * will return an empty array.
+     * @throws IOException If an IO Exception occurred.
+     */
+    <T> T[] readArray(ElementDeserializer<T> elementDeserializer, IntFunction<T[]> newArray) throws IOException;
+
+    /**
+     * Decodes a byte array that has been serialized using RevisionDataOutput.writeArray(byte[]).
+     *
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * RevisionDataOutput.writeArray(byte[]).
+     *
+     * @return A new byte array. If the original array passed to RevisionDataOutput.writeArray(byte[]) was null, this
+     * will return an empty array.
+     * @throws IOException If an IO Exception occurred.
+     */
+    byte[] readArray() throws IOException;
 
     /**
      * Decodes a generic Map that has been serialized using RevisionDataOutput.writeMap(). The underlying type of the map

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -140,6 +141,24 @@ class RevisionDataInputStream extends DataInputStream implements RevisionDataInp
         for (int i = 0; i < count; i++) {
             result.add(elementDeserializer.apply(this));
         }
+        return result;
+    }
+
+    @Override
+    public <T> T[] readArray(ElementDeserializer<T> elementDeserializer, IntFunction<T[]> arrayCreator) throws IOException {
+        int count = readCompactInt();
+        T[] result = arrayCreator.apply(count);
+        for (int i = 0; i < count; i++) {
+            result[i] = elementDeserializer.apply(this);
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] readArray() throws IOException {
+        int count = readCompactInt();
+        byte[] result = new byte[count];
+        readFully(result);
         return result;
     }
 

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -143,7 +143,8 @@ public interface RevisionDataOutput extends DataOutput {
     void writeUUID(UUID uuid) throws IOException;
 
     /**
-     * Calculates the number of bytes required to serialize a Collection.
+     * Calculates the number of bytes required to serialize a Collection or array. This method can be used to estimate the
+     * serialization length of both writeCollection() and writeArray().
      *
      * @param elementCount  The size of the collection.
      * @param elementLength The size (in bytes) of each element's serialization.
@@ -152,14 +153,26 @@ public interface RevisionDataOutput extends DataOutput {
     int getCollectionLength(int elementCount, int elementLength);
 
     /**
-     * Calculates the number of bytes required to serialize a Collection.
+     * Calculates the number of bytes required to serialize a Collection. This method can be used to estimate the
+     * serialization length of writeCollection().
      *
      * @param collection            The Collection to measure.
      * @param elementLengthProvider A Function that, given an Element of type T, will return its serialization length.
-     * @param <T>                   Type of the Map's Keys.
+     * @param <T>                   Type of the Collection's Elements.
      * @return The number of bytes.
      */
     <T> int getCollectionLength(Collection<T> collection, ToIntFunction<T> elementLengthProvider);
+
+    /**
+     * Calculates the number of bytes required to serialize an array. This method can be used to estimate the
+     * serialization length of writeArray().
+     *
+     * @param array                 The array to measure.
+     * @param elementLengthProvider A Function that, given an Element of type T, will return its serialization length.
+     * @param <T>                   Type of the Array's Elements
+     * @return The number of bytes.
+     */
+    <T> int getCollectionLength(T[] array, ToIntFunction<T> elementLengthProvider);
 
     /**
      * Serializes the given Collection using the given ElementSerializer. It first writes a Compact Integer representing
@@ -173,6 +186,29 @@ public interface RevisionDataOutput extends DataOutput {
      * @throws IOException If an IO Exception occurred.
      */
     <T> void writeCollection(Collection<T> collection, ElementSerializer<T> elementSerializer) throws IOException;
+
+    /**
+     * Serializes the given array using the given ElementSerializer. It first writes a Compact Integer representing
+     * the number of elements in the array, followed by each element's serialization, in the order in which they appear in
+     * the array.
+     *
+     * @param array             The array to serialize. Can be null (in which case an Empty array will be deserialized
+     *                          by RevisionDataInput.readArray()).
+     * @param elementSerializer A Function that serializes a single element of the array to a RevisionDataOutput.
+     * @param <T>               Type of the elements in the array.
+     * @throws IOException If an IO Exception occurred.
+     */
+    <T> void writeArray(T[] array, ElementSerializer<T> elementSerializer) throws IOException;
+
+    /**
+     * Serializes the given byte array. It first writes a Compact Integer representing the length of the the array, followed
+     * by the actual array being written.
+     *
+     * @param array The array to serialize. Can be null (in which case an Empty array will be deserialized
+     *              by RevisionDataInput.readArray()).
+     * @throws IOException If an IO Exception occurred.
+     */
+    void writeArray(byte[] array) throws IOException;
 
     /**
      * Calculates the number of bytes required to serialize a Map.

--- a/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
@@ -45,7 +45,7 @@ import lombok.val;
  * * To introduce a new Version B = A + 1, its format needs to be established and published with the code. While doing so,
  * the code must still write version A (since during an upgrade not all existing code will immediately know how to handle
  * Version B). Only after all existing deployed code knows about Version B, can we have the code serialize in Version B.
- * ** This can be achieved by declaring the serialization version using the writeVersion() method.
+ * ** This can be achieved by declaring the serialization version using the getWriteVersion() method.
  *
  * Revisions
  * * Are incremental on top of the previous ones, can be added on the fly, and can be used to make format changes
@@ -276,14 +276,14 @@ public abstract class VersionedSerializer<T> {
         SingleType() {
             this.versions = (FormatVersion<TargetType, ReaderType>[]) new FormatVersion[Byte.MAX_VALUE];
             declareVersions();
-            Preconditions.checkArgument(this.versions[writeVersion()] != null, "Write version %s is not defined.", writeVersion());
+            Preconditions.checkArgument(this.versions[getWriteVersion()] != null, "Write version %s is not defined.", getWriteVersion());
         }
 
         /**
          * Gets a value indicating the Version to use for serializing. This will be invoked once during the Constructor (for
          * validation purposes) and once per invocation of serialize().
          */
-        protected abstract byte writeVersion();
+        protected abstract byte getWriteVersion();
 
         /**
          * When implemented in a derived class, this method will declare the FormatVersions that are supported for reading and
@@ -311,7 +311,7 @@ public abstract class VersionedSerializer<T> {
         void serializeContents(OutputStream stream, TargetType o) throws IOException {
             DataOutputStream dataOutput = stream instanceof DataOutputStream ? (DataOutputStream) stream : new DataOutputStream(stream);
 
-            val writeVersion = this.versions[writeVersion()];
+            val writeVersion = this.versions[getWriteVersion()];
             dataOutput.writeByte(writeVersion.getVersion());
             dataOutput.writeByte(writeVersion.getRevisions().size());
 
@@ -412,7 +412,7 @@ public abstract class VersionedSerializer<T> {
      *    // we cannot write into Version 1 until we know that all deployed code knows how to read it. In order to guarantee
      *    // a successful upgrade when changing Versions, all existing code needs to know how to read the new version.
      *    @Override
-     *    protected byte writeVersion() { return 0; }
+     *    protected byte getWriteVersion() { return 0; }
      *
      *    @Override
      *    protected void declareVersions() {
@@ -473,7 +473,7 @@ public abstract class VersionedSerializer<T> {
      *
      * class AttributeSerializer extends VersionedSerializer.WithBuilder<Attribute, Attribute.AttributeBuilder> {
      *    @Override
-     *    protected byte writeVersion() { return 0; } // Version we're serializing at.
+     *    protected byte getWriteVersion() { return 0; } // Version we're serializing at.
      *
      *    @Override
      *    protected Attribute.AttributeBuilder newBuilder() { return Attribute.builder(); }

--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
@@ -217,6 +217,9 @@ public class RevisionDataStreamCommonTests {
         }
     }
 
+    /**
+     * Tests the ability to encode and decode a generic array.
+     */
     @Test
     public void testGenericArrays() throws Exception {
         val numbers = getAllOneBitNumbers(Long.SIZE);
@@ -230,10 +233,13 @@ public class RevisionDataStreamCommonTests {
                     is -> is.readArray(DataInput::readLong, Long[]::new),
                     (s, v) -> s.getCollectionLength(v, e -> Long.BYTES),
                     value,
-                    this::arraysEqual);
+                    (s, t) -> Arrays.equals(s == null ? new Long[0] : s, t));
         }
     }
 
+    /**
+     * Tests the ability to encode and decode a byte array.
+     */
     @Test
     public void testByteArrays() throws Exception {
         byte[] numbers = new byte[Byte.MAX_VALUE];
@@ -251,7 +257,7 @@ public class RevisionDataStreamCommonTests {
                     RevisionDataInput::readArray,
                     (s, v) -> s.getCollectionLength(v == null ? 0 : v.length, 1),
                     value,
-                    this::byteArraysEqual);
+                    (s, t) -> Arrays.equals(s == null ? new byte[0] : s, t));
         }
     }
 
@@ -349,42 +355,6 @@ public class RevisionDataStreamCommonTests {
             sb.append((char) i);
         }
         return sb.toString();
-    }
-
-    private <T> boolean arraysEqual(T[] a1, T[] a2) {
-        int s1 = a1 == null ? 0 : a1.length;
-        int s2 = a2 == null ? 0 : a2.length;
-        if (s1 != s2) {
-            return false;
-        } else if (s1 == 0) {
-            // Both empty arrays; they could be null so don't proceed.
-            return true;
-        }
-        for (int i = 0; i < a1.length; i++) {
-            if (!a1[i].equals(a2[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private boolean byteArraysEqual(byte[] a1, byte[] a2) {
-        int s1 = a1 == null ? 0 : a1.length;
-        int s2 = a2 == null ? 0 : a2.length;
-        if (s1 != s2) {
-            return false;
-        } else if (s1 == 0) {
-            // Both empty arrays; they could be null so don't proceed.
-            return true;
-        }
-        for (int i = 0; i < a1.length; i++) {
-            if (a1[i] != a2[i]) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private <T> boolean collectionsEqual(Collection<T> c1, Collection<T> c2) {

--- a/common/src/test/java/io/pravega/common/io/serialization/VersionedSerializerTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/VersionedSerializerTests.java
@@ -329,7 +329,7 @@ public class VersionedSerializerTests {
         static final byte VERSION = 0;
 
         @Override
-        protected byte writeVersion() {
+        protected byte getWriteVersion() {
             return VERSION;
         }
 
@@ -435,7 +435,7 @@ public class VersionedSerializerTests {
         }
 
         @Override
-        protected byte writeVersion() {
+        protected byte getWriteVersion() {
             return VERSION;
         }
 
@@ -558,7 +558,7 @@ public class VersionedSerializerTests {
         }
 
         @Override
-        protected byte writeVersion() {
+        protected byte getWriteVersion() {
             return VERSION;
         }
 
@@ -590,7 +590,7 @@ public class VersionedSerializerTests {
         }
 
         @Override
-        protected byte writeVersion() {
+        protected byte getWriteVersion() {
             return VERSION;
         }
 
@@ -624,7 +624,7 @@ public class VersionedSerializerTests {
         }
 
         @Override
-        protected byte writeVersion() {
+        protected byte getWriteVersion() {
             return VERSION;
         }
 


### PR DESCRIPTION
**Change log description**
Made a few improvements to VersionedSerialization
- Renamed `writeVersion()` to `getWriteVersion()` in `SingleType`
- Added support for encoding and decoding arrays.

**Purpose of the change**
Fixes #2345.

**What the code does**
New code for encoding/decoding arrays.
Renamed `writeVersion` to `getWriteVersion`

**How to verify it**
Unit tests.
