### PR TITLE
Issue 2354: added rate limit option to self-test tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,7 @@ project('test:integration') {
         compile project(':test:testcommon')
         compile group: 'junit', name:'junit', version: junitVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
+        compile group: 'com.github.vladimir-bukhtoyarov', name: 'bucket4j-core', version: bucket4jVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'org.apache.commons', name: 'commons-csv', version: apacheCommonsCsvVersion
         testCompile project(path:':common', configuration:'testRuntime')

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -42,5 +42,6 @@
     <allow pkg="org.jclouds" />
     <allow pkg="org.glassfish.grizzly" />
     <allow pkg="com.spotify" />
+    <allow pkg="io.github.bucket4j" />
 
 </import-control>

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ rocksdbjniVersion=5.8.6
 swaggerJersey2JaxrsVersion=1.5.16
 slf4jApiVersion=1.7.25
 typesafeConfigVersion=1.3.1
+bucket4jVersion=3.0.2
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.3.0-SNAPSHOT

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
@@ -11,7 +11,6 @@ package io.pravega.test.integration.selftest;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractService;
-import io.github.bucket4j.Bucket;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.Services;

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
@@ -11,6 +11,7 @@ package io.pravega.test.integration.selftest;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractService;
+import io.github.bucket4j.Bucket;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.Services;

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
@@ -118,9 +118,9 @@ class Reporter extends AbstractScheduledService {
                 "%s; request(current/total) = %d/%d; acks(current/total) = %d/%d; pending-acks = %d; " +
                         "Ops = %d/%d; Data%s MB; TPut: %.1f/%.1f MB/s; TPools (Q/T/S): %s, %s, %s.",
                 ops,
-                currentGeneratedOperationCount <0 ? 0: currentGeneratedOperationCount,
+                currentGeneratedOperationCount < 0 ? 0 : currentGeneratedOperationCount,
                 totalGeneratedOperationCount,
-                currentSuccessfulOperationCount <0 ? 0: currentSuccessfulOperationCount,
+                currentSuccessfulOperationCount < 0 ? 0 : currentSuccessfulOperationCount,
                 opCount,
                 totalGeneratedOperationCount - opCount,
                 (int) instantOps,

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTest.java
@@ -76,7 +76,7 @@ class SelfTest extends AbstractService implements AutoCloseable {
             int opsPerSec = testConfig.getOperationsPerSecond();
             int burstSec = testConfig.getBurstSeconds();
             long duration = (long) (1000 * burstSec);
-            Bandwidth limit = Bandwidth.simple((long) (opsPerSec), Duration.ofMillis(duration));
+            Bandwidth limit = Bandwidth.simple((long) opsPerSec, Duration.ofMillis(duration));
             this.tokenBucket = Bucket4j.builder().addLimit(limit).build();
         }
     }

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTestRunner.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTestRunner.java
@@ -102,11 +102,11 @@ public class SelfTestRunner {
 
         // 5. Cross-apply common configuration that must be the same on all fronts.
         val testConfig = b.build().getConfig(TestConfig::builder);
-        int bkWriteQuorum = Math.min(3, testConfig.getBookieCount());
+        int bkWriteQuorum = testConfig.getBookieCount() == 0 ? 3 : Math.min(3, testConfig.getBookieCount());
         b.include(ServiceConfig.builder()
                                .with(ServiceConfig.CONTAINER_COUNT, testConfig.getContainerCount()));
         b.include(BookKeeperConfig.builder()
-                                  .with(BookKeeperConfig.ZK_ADDRESS, TestConfig.LOCALHOST + ":" + testConfig.getZkPort())
+                                  .with(BookKeeperConfig.ZK_ADDRESS, testConfig.getZkHost() + ":" + testConfig.getZkPort())
                                   .with(BookKeeperConfig.BK_ACK_QUORUM_SIZE, bkWriteQuorum)
                                   .with(BookKeeperConfig.BK_WRITE_QUORUM_SIZE, bkWriteQuorum)
                                   .with(BookKeeperConfig.BK_ENSEMBLE_SIZE, bkWriteQuorum));
@@ -209,6 +209,10 @@ public class SelfTestRunner {
                     new Shortcut("controllerport", TestConfig.CONTROLLER_BASE_PORT),
                     new Shortcut("metrics", TestConfig.METRICS_ENABLED),
                     new Shortcut("reads", TestConfig.READS_ENABLED),
+                    new Shortcut("warmup", TestConfig.WARMUP_ENABLED),
+                    new Shortcut("throttle", TestConfig.THROTTLE_ENABLED),
+                    new Shortcut("ops", TestConfig.OPS_COUNT),
+                    new Shortcut("burstSeconds", TestConfig.BURST_SECONDS),
                     new Shortcut("pause", TestConfig.PAUSE_BEFORE_EXIT)));
 
             SHORTCUTS = Collections.unmodifiableMap(s);

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestConfig.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestConfig.java
@@ -45,12 +45,17 @@ public class TestConfig {
     static final Property<String> TEST_TYPE = Property.named("testType", TestType.SegmentStore.toString());
     static final Property<Integer> WARMUP_PERCENTAGE = Property.named("warmupPercentage", 10);
     static final Property<Boolean> READS_ENABLED = Property.named("reads", true);
+    static final Property<Boolean> WARMUP_ENABLED = Property.named("warmup", true);
+    static final Property<Boolean> THROTTLE_ENABLED = Property.named("throttle", false);
+    static final Property<Integer> OPS_COUNT = Property.named("operationsPerSecond", 100);
+    static final Property<Integer> BURST_SECONDS = Property.named("burstSeconds", 1);
     static final Property<Boolean> METRICS_ENABLED = Property.named("metrics", false);
     static final Property<Integer> BOOKIE_COUNT = Property.named("bookieCount", 1);
     static final Property<Integer> CONTROLLER_COUNT = Property.named("controllerCount", 1);
     static final Property<Integer> SEGMENT_STORE_COUNT = Property.named("segmentStoreCount", 1);
     static final Property<String> CONTROLLER_HOST = Property.named("controllerHost", LOCALHOST);
     static final Property<Integer> CONTROLLER_BASE_PORT = Property.named("controllerPort", 9200);
+    static final Property<String> ZK_HOST = Property.named("zkHost", LOCALHOST);
     static final Property<Boolean> PAUSE_BEFORE_EXIT = Property.named("pauseBeforeExit", false);
     private static final Property<Integer> ZK_PORT = Property.named("zkPort", 9000);
     private static final Property<Integer> BK_BASE_PORT = Property.named("bkBasePort", 9100);
@@ -99,6 +104,8 @@ public class TestConfig {
     private final int segmentStoreCount;
     private final int bkBasePort;
     @Getter
+    private final String zkHost;
+    @Getter
     private final int zkPort;
     @Getter
     private final String controllerHost;
@@ -114,6 +121,14 @@ public class TestConfig {
     private final boolean pauseBeforeExit;
     @Getter
     private final String testId = Long.toHexString(System.currentTimeMillis());
+    @Getter
+    private final boolean warmup;
+    @Getter
+    private final boolean throttle;
+    @Getter
+    private final int operationsPerSecond;
+    @Getter
+    private final int burstSeconds;
 
     //endregion
 
@@ -150,6 +165,7 @@ public class TestConfig {
         this.controllerCount = properties.getInt(CONTROLLER_COUNT);
         this.segmentStoreCount = properties.getInt(SEGMENT_STORE_COUNT);
         this.bkBasePort = properties.getInt(BK_BASE_PORT);
+        this.zkHost = properties.get(ZK_HOST);
         this.zkPort = properties.getInt(ZK_PORT);
         this.controllerHost = properties.get(CONTROLLER_HOST);
         this.controllerBasePort = properties.getInt(CONTROLLER_BASE_PORT);
@@ -157,6 +173,11 @@ public class TestConfig {
         this.testType = TestType.valueOf(properties.get(TEST_TYPE));
         this.readsEnabled = properties.getBoolean(READS_ENABLED);
         this.metricsEnabled = properties.getBoolean(METRICS_ENABLED);
+        this.warmup = properties.getBoolean(WARMUP_ENABLED);
+        this.throttle = properties.getBoolean(THROTTLE_ENABLED);
+        this.operationsPerSecond = properties.getInt(OPS_COUNT);
+        this.burstSeconds = properties.getInt(BURST_SECONDS);
+
         this.pauseBeforeExit = properties.getBoolean(PAUSE_BEFORE_EXIT);
         checkOverlappingPorts();
     }

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
@@ -109,6 +109,14 @@ public class TestState {
     }
 
     /**
+     * Gets a value indicating total no of operations that were succesfully generated
+     * @return
+     */
+    int getGeneratedOperationCount() {
+        return this.generatedOperationCount.get();
+    }
+
+    /**
      * Gets a value indicating the total number of bytes produced (that were accepted by the Store).
      */
     long getProducedLength() {


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
Added ingestion rate throttling control to the `self-test` tool

**Purpose of the change**
Fixes #2354 To control the ingestion speed for performance testing type of scenarios

**What the code does**
Writer thread will be throttled to send messages based on the configurable values passed (throttling interval, total no of messages)
 
**How to verify it**
While running the self-test tool, pass these additional configurations `-Dthrottle=true -Dops=1000 -DburstSeconds=1` which will limit the ingestion speed to 1000 messages per second.