### PR TITLE
Issue 2384: Standardize use of `Authorization` header

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -14,7 +14,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.stream.impl.Credentials;
 import java.io.Serializable;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -81,6 +80,7 @@ public class ClientConfig implements Serializable {
         private static final String AUTH_PROPS_PREFIX = "pravega.client.auth.";
         private static final String AUTH_METHOD = "method";
         private static final String AUTH_METHOD_LOAD_DYNAMIC = "loadDynamic";
+        private static final String AUTH_TOKEN = "token";
 
         private static final String AUTH_PROPS_PREFIX_ENV = "pravega_client_auth_";
 
@@ -174,8 +174,8 @@ public class ClientConfig implements Serializable {
                 }
 
                 @Override
-                public Map<String, String> getAuthParameters() {
-                    return Collections.unmodifiableMap(credsMap);
+                public String getAuthenticationToken() {
+                    return credsMap.get(AUTH_TOKEN);
                 }
             };
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
@@ -10,7 +10,6 @@
 package io.pravega.client.stream.impl;
 
 import java.io.Serializable;
-import java.util.Map;
 
 /**
  * This interface represents the credentials passed to Pravega for authentication and authorizing the access.
@@ -27,8 +26,8 @@ public interface Credentials extends Serializable {
     String getAuthenticationType();
 
     /**
-     * Returns authorization parameters used by this specific authentication type.
-     * @return The map of authentication headers and values.
+     * Returns the authorization token to be sent to Pravega.
+     * @return A token in token68-compatible format (as defined by RFC 7235).
      */
-    Map<String, String> getAuthParameters();
+    String getAuthenticationToken();
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
@@ -9,30 +9,34 @@
  */
 package io.pravega.client.stream.impl;
 
-import com.google.common.collect.ImmutableMap;
+import io.pravega.common.auth.AuthConstants;
 import lombok.EqualsAndHashCode;
 
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
+/**
+ * Username/password credentials for basic authentication.
+ */
 @EqualsAndHashCode
 public class DefaultCredentials implements Credentials {
     
     private static final long serialVersionUID = 1L;
 
-    private final ImmutableMap<String, String> credsMap;
+    private final String token;
 
     public DefaultCredentials(String password, String userName) {
-        credsMap = ImmutableMap.of("userName", userName,
-                "password", password);
+        String decoded = userName + ":" + password;
+        this.token = Base64.getEncoder().encodeToString(decoded.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public String getAuthenticationType() {
-        return "Pravega-Default";
+        return AuthConstants.BASIC;
     }
 
     @Override
-    public Map<String, String> getAuthParameters() {
-        return credsMap;
+    public String getAuthenticationToken() {
+        return token;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
@@ -9,12 +9,13 @@
  */
 package io.pravega.client.stream.impl;
 
+import io.pravega.common.auth.AuthConstants;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PravegaCredsWrapper extends com.google.auth.Credentials {
     private final Credentials creds;
@@ -30,15 +31,9 @@ public class PravegaCredsWrapper extends com.google.auth.Credentials {
 
     @Override
     public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
-        Map<String, String> metadata = creds.getAuthParameters();
-
-        Map<String, List<String>> retVal = metadata.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                e -> {
-                    List<String> list = Collections.singletonList(e.getValue());
-                    return list;
-                }));
-        retVal.put("method", Collections.singletonList(creds.getAuthenticationType()));
-        return retVal;
+        String token = creds.getAuthenticationToken();
+        String credential = creds.getAuthenticationType() + " " + token;
+        return Collections.singletonMap(AuthConstants.AUTHORIZATION, Collections.singletonList(credential));
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -9,11 +9,8 @@
  */
 package io.pravega.client;
 
-import com.google.common.collect.ImmutableMap;
 import io.pravega.client.stream.impl.Credentials;
-import io.pravega.test.common.AssertExtensions;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,19 +28,15 @@ public class CredentialsExtractorTest {
         //Test custom creds
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.method", "temp");
-        properties.setProperty("pravega.client.auth.prop1", "prop1");
-        properties.setProperty("pravega.client.auth.prop2", "prop2");
+        properties.setProperty("pravega.client.auth.token", "mytoken");
 
         config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
 
         assertEquals("Method is not picked up from properties",
-                config.getCredentials().getAuthenticationType(), "temp");
+                "temp", config.getCredentials().getAuthenticationType());
 
-        AssertExtensions.assertMapEquals("Paramters are not same",
-                config.getCredentials().getAuthParameters(),
-                ImmutableMap.of("prop1", "prop1",
-                        "prop2", "prop2",
-                        "method", "temp"));
+        assertEquals("Token is not same",
+                "mytoken", config.getCredentials().getAuthenticationToken());
 
         //If a credential is explicitly mentioned, do not override from properties
         config = ClientConfig.builder().credentials(new Credentials() {
@@ -53,7 +46,7 @@ public class CredentialsExtractorTest {
             }
 
             @Override
-            public Map<String, String> getAuthParameters() {
+            public String getAuthenticationToken() {
                 return null;
             }
         }).build();
@@ -92,8 +85,8 @@ public class CredentialsExtractorTest {
         }
 
         @Override
-        public Map<String, String> getAuthParameters() {
-            return null;
+        public String getAuthenticationToken() {
+            return "DynamicallyLoadedCreds";
         }
     }
 
@@ -105,8 +98,8 @@ public class CredentialsExtractorTest {
         }
 
         @Override
-        public Map<String, String> getAuthParameters() {
-            return null;
+        public String getAuthenticationToken() {
+            return "DynamicallyLoadedCredsSecond";
         }
     }
 }

--- a/common/src/main/java/io/pravega/common/auth/AuthConstants.java
+++ b/common/src/main/java/io/pravega/common/auth/AuthConstants.java
@@ -22,7 +22,7 @@ public class AuthConstants {
     public static final String BEARER = "Bearer";
 
     /**
-     * HTTP "Authentication" header.
+     * HTTP "Authorization" header.
      */
     public static final String AUTHORIZATION = "Authorization";
 

--- a/common/src/main/java/io/pravega/common/auth/AuthConstants.java
+++ b/common/src/main/java/io/pravega/common/auth/AuthConstants.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.auth;
+
+public class AuthConstants {
+
+    /**
+     * HTTP "Basic" authentication scheme.
+     */
+    public static final String BASIC = "Basic";
+
+    /**
+     * HTTP "Bearer" authentication scheme.
+     */
+    public static final String BEARER = "Bearer";
+
+    /**
+     * HTTP "Authentication" header.
+     */
+    public static final String AUTHORIZATION = "Authorization";
+
+}

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -45,12 +45,9 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteStreamStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
 import io.pravega.shared.NameUtils;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
@@ -135,18 +132,16 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
 
     private void authenticate(String resourceName, AuthHandler.Permissions level) throws AuthException {
         if (pravegaAuthManager != null ) {
-            Map<String, String> map = null;
             List<String> authParams = headers.getRequestHeader(HttpHeaders.AUTHORIZATION);
 
             if (authParams == null || authParams.isEmpty()) {
                 throw new AuthenticationException("Auth failed for " + resourceName);
             }
 
-            String authHeader = authParams.get(0);
-            map = Arrays.stream(authHeader.split(",")).map(str -> str.split(":"))
-                                            .collect(Collectors.toMap(e -> e[0], e -> e[1]));
+            String credentials = authParams.get(0);
+            assert credentials != null;
 
-            if (!pravegaAuthManager.authenticate(resourceName, map, level)) {
+            if (!pravegaAuthManager.authenticate(resourceName, credentials, level)) {
                 throw new AuthorizationException("Auth failed for " + resourceName, 403);
             }
         }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -23,6 +23,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.pravega.auth.AuthHandler;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.pravega.common.auth.AuthConstants;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +35,7 @@ public class PravegaInterceptor implements ServerInterceptor {
     private static final boolean AUTH_ENABLED = true;
     private static final String AUTH_CONTEXT = "PravegaContext";
     private static final String INTERCEPTOR_CONTEXT = "InterceptorContext";
-    private static final Context.Key<Map<String, String>> AUTH_CONTEXT_PARAMS = Context.key(AUTH_CONTEXT);
+    private static final Context.Key<String> AUTH_CONTEXT_TOKEN = Context.key(AUTH_CONTEXT);
     public static final Context.Key<PravegaInterceptor> INTERCEPTOR_OBJECT = Context.key(INTERCEPTOR_CONTEXT);
 
     private final AuthHandler handler;
@@ -48,38 +50,33 @@ public class PravegaInterceptor implements ServerInterceptor {
     @Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
 
-        Map<String, String> paramMap = new HashMap<>();
-        headers.keys().stream()
-               .filter(key -> !key.endsWith(Metadata.BINARY_HEADER_SUFFIX))
-               .forEach(key -> {
-                   try {
-                       paramMap.put(key,
-                               headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
-                   } catch (IllegalArgumentException e) {
-                       log.warn("Error while marshalling some of the headers {}", e.toString());
-                   }
-               });
-        String method = paramMap.get("method");
         Context context = Context.current();
-        if (!Strings.isNullOrEmpty(method)) {
-            if (method.equals(handler.getHandlerName())) {
 
-                if (!handler.authenticate(paramMap)) {
-                    call.close(Status.fromCode(Status.Code.UNAUTHENTICATED), headers);
-                    return null;
+        String credentials = headers.get(Metadata.Key.of(AuthConstants.AUTHORIZATION, Metadata.ASCII_STRING_MARSHALLER));
+        if (!Strings.isNullOrEmpty(credentials)) {
+            String[] parts = credentials.split("\\s+", 2);
+            if (parts.length == 2) {
+                String method = parts[0];
+                String token = parts[1];
+                if (!Strings.isNullOrEmpty(method)) {
+                    if (method.equals(handler.getHandlerName())) {
+                        if (!handler.authenticate(token)) {
+                            call.close(Status.fromCode(Status.Code.UNAUTHENTICATED), headers);
+                            return null;
+                        }
+                        context = context.withValue(AUTH_CONTEXT_TOKEN, token);
+                        context = context.withValue(INTERCEPTOR_OBJECT, this);
+                    }
                 }
-                context = context.withValue(AUTH_CONTEXT_PARAMS, paramMap);
-                context = context.withValue(INTERCEPTOR_OBJECT, this);
             }
-        } else {
-            call.close(Status.fromCode(Status.Code.UNAUTHENTICATED), headers);
-            return null;
         }
+
+        // reaching this point means that the handler wasn't applicable to this request.
         return Contexts.interceptCall(context, call, headers, next);
     }
 
     public AuthHandler.Permissions authorize(String resource) {
-        return this.handler.authorize(resource, AUTH_CONTEXT_PARAMS.get());
+        return this.handler.authorize(resource, AUTH_CONTEXT_TOKEN.get());
     }
 
     public static String retrieveDelegationToken(String tokenSigningKey) {

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
@@ -11,9 +11,11 @@ package io.pravega.controller.server.rpc.auth;
 
 import io.pravega.auth.AuthHandler;
 import io.pravega.auth.ServerConfig;
-import java.util.Map;
 
 public class TestAuthHandler implements AuthHandler {
+
+    public static final String DUMMY_USER = "dummy";
+    public static final String ADMIN_USER = "admin";
 
     @Override
     public String getHandlerName() {
@@ -21,13 +23,13 @@ public class TestAuthHandler implements AuthHandler {
     }
 
     @Override
-    public boolean authenticate(Map<String, String> headers) {
+    public boolean authenticate(String token) {
         return true;
     }
 
     @Override
-    public Permissions authorize(String resource, Map<String, String> headers) {
-        if (headers.get("username").equals("dummy")) {
+    public Permissions authorize(String resource, String token) {
+        if (token.contains(DUMMY_USER)) {
             return Permissions.NONE;
         } else {
             return Permissions.READ_UPDATE;
@@ -37,5 +39,9 @@ public class TestAuthHandler implements AuthHandler {
     @Override
     public void initialize(ServerConfig serverConfig) {
 
+    }
+
+    public static String testAuthToken(String userName) {
+        return String.format("testHandler %s", userName);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
@@ -13,6 +13,8 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+
+import io.pravega.controller.server.rpc.auth.TestAuthHandler;
 import org.junit.Before;
 
 public class Failing403StreamMetaDataTests extends  FailingSecureStreamMetaDataTests {
@@ -26,7 +28,7 @@ public class Failing403StreamMetaDataTests extends  FailingSecureStreamMetaDataT
     @Override
     protected Invocation.Builder addAuthHeaders(Invocation.Builder request) {
         MultivaluedMap<String, Object> map = new MultivaluedHashMap<>();
-        map.addAll(HttpHeaders.AUTHORIZATION, "method:testHandler", "username:dummy", "password:1111_aaaa");
+        map.addAll(HttpHeaders.AUTHORIZATION, TestAuthHandler.testAuthToken(TestAuthHandler.DUMMY_USER));
         return request.headers(map);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/SecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/SecureStreamMetaDataTests.java
@@ -38,7 +38,7 @@ public class SecureStreamMetaDataTests extends  StreamMetaDataTests {
     @Override
     protected Invocation.Builder addAuthHeaders(Invocation.Builder request) {
         MultivaluedMap<String, Object> map = new MultivaluedHashMap<>();
-        map.addAll(HttpHeaders.AUTHORIZATION, "method:testHandler", "username:arvind", "password:1111_aaaa");
+        map.addAll(HttpHeaders.AUTHORIZATION, TestUtils.basicAuthToken("admin", "1111_aaaa"));
         return request.headers(map);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/PravegaAuthManagerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/PravegaAuthManagerTest.java
@@ -14,6 +14,9 @@ import io.pravega.auth.AuthHandler;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
+import io.pravega.client.stream.impl.Credentials;
+import io.pravega.client.stream.impl.DefaultCredentials;
+import io.pravega.common.auth.AuthConstants;
 import io.pravega.common.auth.AuthenticationException;
 import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.controller.server.rpc.grpc.GRPCServerConfig;
@@ -25,8 +28,6 @@ import io.pravega.test.common.TestUtils;
 import java.io.File;
 import java.io.FileWriter;
 import java.net.URI;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import lombok.Cleanup;
 import org.junit.After;
 import org.junit.Before;
@@ -98,62 +99,66 @@ public class PravegaAuthManagerTest {
                 .retryAttempts(1).build(),
                 executor);
 
-        MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
-
-        //Without specifying a valid handler.
+        //Malformed authorization header.
         assertThrows(AuthenticationException.class, () ->
-                manager.authenticate("hi", map, AuthHandler.Permissions.READ));
+                manager.authenticate("hi", "", AuthHandler.Permissions.READ));
 
         //Non existent interceptor method.
-        map.add("method", "invalid");
         assertThrows(AuthenticationException.class, () ->
-        manager.authenticate("hi", map, AuthHandler.Permissions.READ));
+        manager.authenticate("hi", credentials("invalid", ""), AuthHandler.Permissions.READ));
 
-        //Specify a valid method but no parameters for default interceptor.
-        map.putSingle("method", "Pravega-Default");
+        //Specify a valid method but malformed parameters for password interceptor.
         assertThrows(AuthenticationException.class, () ->
-        manager.authenticate("hi", map, AuthHandler.Permissions.READ));
+        manager.authenticate("hi", credentials(AuthConstants.BASIC, ""), AuthHandler.Permissions.READ));
 
-        //Specify a valid method but no password for default interceptor.
-        map.putSingle("username", "dummy3");
+        //Specify a valid method but incorrect password for password interceptor.
         assertThrows(AuthenticationException.class, () ->
-                manager.authenticate("hi", map, AuthHandler.Permissions.READ));
+                manager.authenticate("hi", basic("dummy3", "wrong"), AuthHandler.Permissions.READ));
 
         //Specify a valid method and parameters but invalid resource for default interceptor.
-        map.putSingle("password", "password");
         assertFalse("Not existent resource should return false",
-                manager.authenticate("invalid", map, AuthHandler.Permissions.READ));
+                manager.authenticate("invalid", basic("dummy3", "password"), AuthHandler.Permissions.READ));
 
         //Valid parameters for default interceptor
-        map.putSingle("username", "dummy3");
-        map.putSingle("password", "password");
         assertTrue("Read access for read resource should return true",
-                manager.authenticate("readresource", map, AuthHandler.Permissions.READ));
+                manager.authenticate("readresource", basic("dummy3", "password"), AuthHandler.Permissions.READ));
 
         //Stream/scope access should be extended to segment.
         assertTrue("Read access for read resource should return true",
-                manager.authenticate("readresource/segment", map, AuthHandler.Permissions.READ));
+                manager.authenticate("readresource/segment", basic("dummy3", "password"), AuthHandler.Permissions.READ));
 
         //Levels of access
         assertFalse("Write access for read resource should return false",
-                manager.authenticate("readresource", map, AuthHandler.Permissions.READ_UPDATE));
+                manager.authenticate("readresource", basic("dummy3", "password"), AuthHandler.Permissions.READ_UPDATE));
 
         assertTrue("Read access for write resource should return true",
-                manager.authenticate("totalaccess", map, AuthHandler.Permissions.READ));
+                manager.authenticate("totalaccess", basic("dummy3", "password"), AuthHandler.Permissions.READ));
 
         assertTrue("Write access for write resource should return true",
-                manager.authenticate("totalaccess", map, AuthHandler.Permissions.READ_UPDATE));
+                manager.authenticate("totalaccess", basic("dummy3", "password"), AuthHandler.Permissions.READ_UPDATE));
 
         //Check the wildcard access
-        map.putSingle("username", "dummy4");
         assertTrue("Write access for write resource should return true",
-                manager.authenticate("totalaccess", map, AuthHandler.Permissions.READ_UPDATE));
+                manager.authenticate("totalaccess", basic("dummy4", "password"), AuthHandler.Permissions.READ_UPDATE));
 
-        map.putSingle("method", "testHandler");
-        assertTrue("Test handler should be called", manager.authenticate("any", map, AuthHandler.Permissions.READ));
+        assertTrue("Test handler should be called", manager.authenticate("any", testHandler(), AuthHandler.Permissions.READ));
 
         assertThrows(RetriesExhaustedException.class, () -> controllerClient.createScope("hi").join());
     }
 
+    private static String credentials(String scheme, String token) {
+        return scheme + " " + token;
+    }
 
+    private static String credentials(Credentials credentials) {
+        return credentials(credentials.getAuthenticationType(), credentials.getAuthenticationToken());
+    }
+
+    private static String basic(String userName, String password) {
+        return credentials(new DefaultCredentials(password, userName));
+    }
+
+    private static String testHandler() {
+        return credentials("testHandler", "token");
+    }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -23,7 +23,6 @@ import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.LocalBookKeeper;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
-import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 
 /**
@@ -82,29 +81,15 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
     }
 
     public void stop() {
-        try {
-            NIOServerCnxnFactory sf = this.serverFactory.getAndSet(null);
-            if (sf != null) {
-                sf.closeAll();
-                sf.shutdown();
-            }
-        } catch (Throwable e) {
-            log.warn("Unable to cleanly shutdown ZooKeeper connection factory", e);
+        ZooKeeperServer zs = this.server.getAndSet(null);
+        if (zs != null) {
+            zs.shutdown();
         }
 
-        try {
-            ZooKeeperServer zs = this.server.getAndSet(null);
-            if (zs != null) {
-                zs.shutdown();
-                ZKDatabase zkDb = zs.getZKDatabase();
-                if (zkDb != null) {
-                    // make ZK server close its log files
-                    zkDb.close();
-                }
-            }
-
-        } catch (Throwable e) {
-            log.warn("Unable to cleanly shutdown ZooKeeper server", e);
+        NIOServerCnxnFactory sf = this.serverFactory.getAndSet(null);
+        if (sf != null) {
+            sf.closeAll();
+            sf.shutdown();
         }
     }
 

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
@@ -9,16 +9,22 @@
  */
 package io.pravega.auth;
 
-import java.util.Map;
-
 /**
  * Custom authorization/authentication handlers implement this interface.
  * The implementations are loaded from the classpath using `ServiceLoader` (https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html)
  * Pravega controller also implements this interface through {@link #PasswordAuthHandler}.
  *
- * Each custom auth handler is registered with a unique name.
- * A client selects its auth handler by setting a grpc header with a name "method". T
- * his is done by implementing `PravegaCredentials` interface and passing it to client calls.
+ * Each custom auth handler is registered with a unique name identifying a supported authentication scheme.
+ *
+ * The client supplies authentication credentials formatted as per HTTP 1.1 (RFC 7235):
+ * <pre>
+ *     Authentication: &lt;scheme&gt; &lt;token&gt;
+ * </pre>
+ * This is done by implementing `PravegaCredentials` interface and passing it to client calls.
+ *
+ * The credentials are passed via the {@code Authorization} header.  For gRPC, the header is passed via call metadata.
+ * For REST, the credentials are passed as the value of the HTTP {@code Authorization} header.
+ * For gRPC, the credentials are passed as the value of the {@code Authorization} header in call metadata.
  *
  */
 public interface AuthHandler {
@@ -39,10 +45,10 @@ public interface AuthHandler {
      * Authenticates a given request. Pravega controller passes the HTTP headers associated with the call.
      * The custom implementation returns whether the user represented by these headers is authenticated.
      *
-     * @param headers the key-value pairs passed through grpc.
+     * @param token the credentials token passed via the {@code Authorization} header.
      * @return Returns true when the user is authenticated.
      */
-    boolean authenticate(Map<String, String> headers);
+    boolean authenticate(String token);
 
     /**
      * Authorizes the access to a given resource. Pravega controller passes the HTTP headers associated with the call.
@@ -50,10 +56,10 @@ public interface AuthHandler {
      * by the headers.
      *
      * @param resource the resource that needs to be accessed.
-     * @param headers the context for authorization.
+     * @param token the credentials token passed via the {@code Authorization} header.
      * @return The level of authorization.
      */
-    Permissions authorize(String resource, Map<String, String> headers);
+    Permissions authorize(String resource, String token);
 
     /**
      * Sets the configuration. If the auth handler needs to access the server configuration, it can be accessed though this var.

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -11,10 +11,13 @@ package io.pravega.test.common;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,5 +73,17 @@ public class TestUtils {
         if (!condition.get() && remainingMillis <= 0) {
             throw new TimeoutException("Timeout expired prior to the condition becoming true.");
         }
+    }
+
+    /**
+     * Generates an auth token using the Basic authentication scheme.
+     * @param username the username to use.
+     * @param password the password to use.
+     * @return an en encoded token.
+     */
+    public static String basicAuthToken(String username, String password) {
+        String decoded = String.format("%s:%s", username, password);
+        String encoded = Base64.getEncoder().encodeToString(decoded.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
     }
 }


### PR DESCRIPTION
**Change log description**
- Updated `AuthHandler` to use a single token rather than a map of values
- Updated `PasswordAuthHandler` to use RFC 7617 (Basic Auth) encoding
- Updated gRPC interceptor to use a single `Authorization` metadata header


**Purpose of the change**
Closes #2384 

This PR enhances the Pravega auth plugin system to support standard authentication schemes such as `Basic` (which is understood by ordinary HTTP clients), without loss of functionality. 
 Shown here is an ordinary HTTP client making an authenticated request to the controller:
```
$ curl -v -u admin:1111_aaaa http://localhost:9091/v1/scopes/_system
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 9091 (#0)
* Server auth using Basic with user 'admin'
> GET /v1/scopes/_system HTTP/1.1
> Authorization: Basic YWRtaW46MTExMV9hYWFh
> User-Agent: curl/7.35.0
> Host: localhost:9091
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 23
<
{"scopeName":"_system"}
```

**How to verify it**
- `PravegaAuthManagerTest`
