### PR TITLE
Issue 2388: Prevent blocking in background threadpool.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -10,6 +10,7 @@
 package io.pravega.client.netty.impl;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.netty.bootstrap.Bootstrap;
@@ -57,15 +58,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ConnectionFactoryImpl implements ConnectionFactory {
 
-    private static final Integer POOL_SIZE = Integer.valueOf(
-            System.getProperty("pravega.client.internal.threadpool.size",
-                    String.valueOf(Runtime.getRuntime().availableProcessors())));
     private EventLoopGroup group;
     private boolean nio = false;
     private final ClientConfig clientConfig;
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(POOL_SIZE,
-                                                                                                    "clientInternal");
+    private final ScheduledExecutorService executor;
     private final ChannelGroup allChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
     /**
@@ -73,6 +70,12 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
      * @param clientConfig Configuration object holding details about connection to the segmentstore.
      */
     public ConnectionFactoryImpl(ClientConfig clientConfig) {
+        this(clientConfig, null);
+    }
+
+    @VisibleForTesting
+    public ConnectionFactoryImpl(ClientConfig clientConfig, Integer numThreadsInPool) {
+        executor = ExecutorServiceHelpers.newScheduledThreadPool(getNumThreads(numThreadsInPool), "clientInternal");
         this.clientConfig = clientConfig;
         try {
             this.group = new EpollEventLoopGroup();
@@ -83,6 +86,17 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
         }
     }
 
+    private int getNumThreads(Integer numThreadsInPool) {
+        if (numThreadsInPool != null) {
+            return numThreadsInPool;
+        }
+        String configuredThreads = System.getProperty("pravega.client.internal.threadpool.size", null);
+        if (configuredThreads != null) {
+            return Integer.parseInt(configuredThreads);
+        }
+        return Runtime.getRuntime().availableProcessors();
+    }
+    
     @Override
     public CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri location, ReplyProcessor rp) {
         Preconditions.checkNotNull(location);

--- a/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
@@ -14,6 +14,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -21,6 +23,10 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
@@ -45,15 +51,14 @@ import org.apache.curator.test.TestingServer;
 @Slf4j
 @NotThreadSafe
 public final class SetupUtils {
-    // The controller RPC endpoint.
-    @Getter
-    private URI controllerUri = null;
-
-    // The controller REST endpoint.
-    @Getter
-    private URI controllerRestUri = null;
-
+    
     // The different services.
+    @Getter
+    private ConnectionFactory connectionFactory = null;
+    @Getter
+    private Controller controller = null;
+    @Getter
+    private ClientFactory clientFactory = null;
     private ControllerWrapper controllerWrapper = null;
     private PravegaConnectionListener server = null;
     private TestingServer zkTestServer = null;
@@ -64,18 +69,36 @@ public final class SetupUtils {
     // The test Scope name.
     @Getter
     private final String scope = "scope";
-
+    private final int controllerRPCPort = TestUtils.getAvailableListenPort();
+    private final int controllerRESTPort = TestUtils.getAvailableListenPort();
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final ClientConfig clientConfig = ClientConfig.builder().controllerURI(URI.create("tcp://localhost:" + String.valueOf(controllerRPCPort))).build();
+    
     /**
      * Start all pravega related services required for the test deployment.
      *
      * @throws Exception on any errors.
      */
     public void startAllServices() throws Exception {
+        startAllServices(null);
+    }
+    
+    /**
+     * Start all pravega related services required for the test deployment.
+     *
+     * @param numThreads the number of threads for the internal client threadpool.
+     * @throws Exception on any errors.
+     */
+    public void startAllServices(Integer numThreads) throws Exception {
         if (!this.started.compareAndSet(false, true)) {
             log.warn("Services already started, not attempting to start again");
             return;
         }
-
+        this.connectionFactory = new ConnectionFactoryImpl(clientConfig, numThreads);
+        this.controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(clientConfig).build(),
+                                             connectionFactory.getInternalExecutor());
+        this.clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
+        
         // Start zookeeper.
         this.zkTestServer = new TestingServerStarter().start();
         this.zkTestServer.start();
@@ -85,21 +108,16 @@ public final class SetupUtils {
 
         serviceBuilder.initialize();
         StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
-        int servicePort = TestUtils.getAvailableListenPort();
         this.server = new PravegaConnectionListener(false, servicePort, store);
         this.server.startListening();
         log.info("Started Pravega Service");
 
         // Start Controller.
-        int controllerRPCPort = TestUtils.getAvailableListenPort();
-        int controllerRESTPort = TestUtils.getAvailableListenPort();
         this.controllerWrapper = new ControllerWrapper(
                 this.zkTestServer.getConnectString(), false, true, controllerRPCPort, "localhost", servicePort,
                 Config.HOST_STORE_CONTAINER_COUNT, controllerRESTPort);
         this.controllerWrapper.awaitRunning();
-        this.controllerWrapper.getController().createScope(this.scope).get();
-        this.controllerUri = URI.create("tcp://localhost:" + String.valueOf(controllerRPCPort));
-        this.controllerRestUri = URI.create("http://localhost:" + String.valueOf(controllerRESTPort));
+        this.controllerWrapper.getController().createScope(scope).get();
         log.info("Initialized Pravega Controller");
     }
 
@@ -117,6 +135,9 @@ public final class SetupUtils {
         this.controllerWrapper.close();
         this.server.close();
         this.zkTestServer.close();
+        this.clientFactory.close();
+        this.controller.close();
+        this.connectionFactory.close();
     }
 
     /**
@@ -134,14 +155,14 @@ public final class SetupUtils {
         Preconditions.checkArgument(numSegments > 0);
 
         @Cleanup
-        StreamManager streamManager = StreamManager.create(ClientConfig.builder().controllerURI(this.controllerUri).build());
-        streamManager.createScope(this.scope);
-        streamManager.createStream(this.scope, streamName,
-                StreamConfiguration.builder()
-                        .scope(this.scope)
-                        .streamName(streamName)
-                        .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                        .build());
+        StreamManager streamManager = StreamManager.create(clientConfig);
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName,
+                                   StreamConfiguration.builder()
+                                                      .scope(scope)
+                                                      .streamName(streamName)
+                                                      .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                      .build());
         log.info("Created stream: " + streamName);
     }
 
@@ -156,11 +177,8 @@ public final class SetupUtils {
         Preconditions.checkState(this.started.get(), "Services not yet started");
         Preconditions.checkNotNull(streamName);
 
-        ClientFactory clientFactory = ClientFactory.withScope(this.scope, ClientConfig.builder().controllerURI(this.controllerUri).build());
-        return clientFactory.createEventWriter(
-                streamName,
-                new IntegerSerializer(),
-                EventWriterConfig.builder().build());
+        return clientFactory.createEventWriter(streamName, new IntegerSerializer(),
+                                               EventWriterConfig.builder().build());
     }
 
     /**
@@ -174,20 +192,23 @@ public final class SetupUtils {
         Preconditions.checkState(this.started.get(), "Services not yet started");
         Preconditions.checkNotNull(streamName);
 
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(this.scope,
-                ClientConfig.builder().controllerURI(controllerUri).build());
-        final String readerGroup = "testReaderGroup" + this.scope + streamName;
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        final String readerGroup = "testReaderGroup" + scope + streamName;
         readerGroupManager.createReaderGroup(
                 readerGroup,
                 ReaderGroupConfig.builder().startingTime(0).build(),
                 Collections.singleton(streamName));
 
-        ClientFactory clientFactory = ClientFactory.withScope(this.scope, ClientConfig.builder().controllerURI(this.controllerUri).build());
         final String readerGroupId = UUID.randomUUID().toString();
-        return clientFactory.createReader(
-                readerGroupId,
-                readerGroup,
-                new IntegerSerializer(),
-                ReaderConfig.builder().build());
+        return clientFactory.createReader(readerGroupId, readerGroup, new IntegerSerializer(),
+                                          ReaderConfig.builder().build());
+    }
+    
+    public URI getControllerUri() {
+        return clientConfig.getControllerURI();
+    }
+    
+    public URI getControllerRestUri() {
+        return URI.create("http://localhost:" + String.valueOf(controllerRESTPort));
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
@@ -1,10 +1,11 @@
 /**
- * Copyright (c) 20 17 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration;
 

--- a/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 20 17 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.test.integration.utils.SetupUtils;
+import lombok.Cleanup;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This runs a basic end to end test with a single thread in the thread pool to make sure we don't
+ * block anything on it.
+ */
+public class SingleThreadEndToEndTest {
+
+    @Test(timeout = 10000)
+    public void testReadWrite() throws Exception {
+        @Cleanup("stopAllServices")
+        SetupUtils setupUtils = new SetupUtils();
+        setupUtils.startAllServices(1);
+        setupUtils.createTestStream("stream", 1);
+        @Cleanup
+        EventStreamWriter<Integer> writer = setupUtils.getIntegerWriter("stream");
+        writer.writeEvent(1);
+        writer.flush();
+        @Cleanup
+        EventStreamReader<Integer> reader = setupUtils.getIntegerReader("stream");
+
+        EventRead<Integer> event = reader.readNextEvent(100);
+        Assert.assertEquals(1, (int) event.getEvent());
+    }
+
+}

--- a/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
  */
 public class SingleThreadEndToEndTest {
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testReadWrite() throws Exception {
         @Cleanup("stopAllServices")
         SetupUtils setupUtils = new SetupUtils();


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Avoid calling connection.join() in the RawClient because it is running in the background thread pool.

**Purpose of the change**
This should prevent integration tests from failing on single core systems. See #2388

**What the code does**
Uses compose instead of join.

**How to verify it**
New test added.