### PR TITLE
Issue 2392: RetryHelperTest.testLoopWithDelay sporadic failure

### DIFF
--- a/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
@@ -101,23 +101,27 @@ public class RetryHelperTest {
         }), RetryHelper.UNCONDITIONAL_PREDICATE, 2, executor), RuntimeException::new) == 4);
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void testLoopWithDelay() {
-        final int maxLoops = 3;
+        final int maxLoops = 5;
         AtomicInteger loopCounter = new AtomicInteger();
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
         AtomicLong previous = new AtomicLong(System.nanoTime());
         AtomicBoolean loopDelayHonored = new AtomicBoolean(true);
 
-        long oneSecond = Duration.ofSeconds(1).toMillis();
+        long oneSecondInNano = Duration.ofSeconds(1).toNanos();
+        long delayInMs = Duration.ofSeconds(1).toMillis();
+        // try multiple loops and verify that across multiple loops the delay is honoured
         RetryHelper.loopWithDelay(
                 () -> loopCounter.incrementAndGet() < maxLoops,
                 () -> {
-                    loopDelayHonored.compareAndSet(true, System.nanoTime() - previous.get() >= oneSecond);
+                    loopDelayHonored.compareAndSet(true, System.nanoTime() - previous.get() >= oneSecondInNano);
+                    previous.set(System.nanoTime());
+
                     return CompletableFuture.completedFuture(null);
                 },
-                oneSecond,
+                delayInMs,
                 executorService
         ).join();
         Assert.assertTrue(loopDelayHonored.get());

--- a/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
@@ -107,14 +107,14 @@ public class RetryHelperTest {
         AtomicInteger loopCounter = new AtomicInteger();
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
-        AtomicLong previous = new AtomicLong(System.currentTimeMillis());
+        AtomicLong previous = new AtomicLong(System.nanoTime());
         AtomicBoolean loopDelayHonored = new AtomicBoolean(true);
 
         long oneSecond = Duration.ofSeconds(1).toMillis();
         RetryHelper.loopWithDelay(
                 () -> loopCounter.incrementAndGet() < maxLoops,
                 () -> {
-                    loopDelayHonored.compareAndSet(true, System.currentTimeMillis() - previous.get() > oneSecond);
+                    loopDelayHonored.compareAndSet(true, System.nanoTime() - previous.get() >= oneSecond);
                     return CompletableFuture.completedFuture(null);
                 },
                 oneSecond,


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
We check for delay to be strictly greater than 1 second when we introduce a delay of one second. 
We should have a greater than or equal to check because the clock delay could be exactly equal when looking at time in millis. 

**Purpose of the change**
Fixes #2392

**What the code does**
1. changes milli second precision to nano second precision. 
2. change the check to be greater than equal to one second as we request Scheduled Executor to introduce a delay of 1 second. 

**How to verify it**
Test should pass consistently. 