### PR TITLE
Issue 2409: Fix intermittent failures with ReadTest integration tests

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -53,17 +53,19 @@ import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import io.pravega.test.common.TestUtils;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -72,9 +74,12 @@ import static org.junit.Assert.fail;
 
 public class ReadTest {
 
+    private static final int TIMEOUT_MILLIS = 30000;
     private Level originalLevel;
     private ServiceBuilder serviceBuilder;
     private final Consumer<Segment> segmentSealedCallback = segment -> { };
+    @Rule
+    public Timeout globalTimeout = Timeout.millis(TIMEOUT_MILLIS);
 
     @Before
     public void setup() throws Exception {
@@ -92,7 +97,7 @@ public class ReadTest {
     }
 
     @Test
-    public void testReadDirectlyFromStore() throws InterruptedException, ExecutionException, IOException {
+    public void testReadDirectlyFromStore() throws Exception {
         String segmentName = "testReadFromStore";
         final int entries = 10;
         final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -107,10 +112,11 @@ public class ReadTest {
         while (result.hasNext()) {
             ReadResultEntry entry = result.next();
             ReadResultEntryType type = entry.getType();
-            assertEquals(ReadResultEntryType.Cache, type);
+            assertTrue(type == ReadResultEntryType.Cache || type == ReadResultEntryType.Future);
 
             // Each ReadResultEntryContents may be of an arbitrary length - we should make no assumptions.
-            ReadResultEntryContents contents = entry.getContent().get();
+            // Also put a timeout when fetching the response in case we get back a Future read and it never completes.
+            ReadResultEntryContents contents = entry.getContent().get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             byte next;
             while ((next = (byte) contents.getData().read()) != -1) {
                 byte expected = data[index % data.length];
@@ -134,19 +140,30 @@ public class ReadTest {
         @Cleanup
         EmbeddedChannel channel = AppendTest.createChannel(segmentStore);
 
-        SegmentRead result = (SegmentRead) AppendTest.sendRequest(channel, new ReadSegment(segmentName, 0, 10000, ""));
+        ByteBuffer actual = ByteBuffer.allocate(entries * data.length);
+        while (actual.position() < actual.capacity()) {
+            SegmentRead result = (SegmentRead) AppendTest.sendRequest(channel, new ReadSegment(segmentName, actual.position(), 10000, ""));
 
-        assertEquals(result.getSegment(), segmentName);
-        assertEquals(result.getOffset(), 0);
-        assertTrue(result.isAtTail());
-        assertFalse(result.isEndOfSegment());
+            assertEquals(segmentName, result.getSegment());
+            assertEquals(result.getOffset(), actual.position());
+            assertTrue(result.isAtTail());
+            assertFalse(result.isEndOfSegment());
+            actual.put(result.getData());
+            if (actual.position() < actual.capacity()) {
+                // Prevent entering a tight loop by giving the store a bit of time to process al the appends internally
+                // before trying again.
+                Thread.sleep(10);
+            }
+        }
 
         ByteBuffer expected = ByteBuffer.allocate(entries * data.length);
         for (int i = 0; i < entries; i++) {
             expected.put(data);
         }
+
         expected.rewind();
-        assertEquals(expected, result.getData());
+        actual.rewind();
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
**Change log description**
Fixed two read tests to expect Future reads when reading from the Store. These tests were failing intermittently and were caused due to a recent behavioral change in the Segment store where we ack earlier (after writing to Tier1 but before writing to the ReadIndex/cache) - see #1702. In that case, the Store will return a Future read, which will be fulfilled very soon - when the data is inserted into the cache.

This PR updates these two tests to expect such a behavior.

**Purpose of the change**
Fixes #2409.

**What the code does**
Fixed two unit/integration tests.

**How to verify it**
Run the unit tests a sufficiently large number of times.
