### PR TITLE
Issue 2412: (SegmentStore) Fix operation_queue_size metric

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -299,7 +299,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 // context switching, better DataFrame occupancy optimization) rather than by going back to run().
                 if (operations.isEmpty()) {
                     // We have processed all operations in the queue: this is a good time to report metrics.
-                    this.metrics.currentState(this.operationQueue.size(), this.state.getPendingCount());
+                    this.metrics.currentState(this.operationQueue.size() + count, this.state.getPendingCount());
                     this.metrics.processOperations(count, processTimer.getElapsedMillis());
                     processTimer = new Timer(); // Reset this timer since we may be pulling in new operations.
                     count = 0;


### PR DESCRIPTION
**Change log description**
Reporting the whole size of the Operation Queue, including the items that were just fetched.

Previously we were only reporting the size of the queue after we fetched the items, thus consistently under-reporting its size.

**Purpose of the change**
Fixes #2412.

**What the code does**
Better metric reporting.

**How to verify it**
Verify metrics in perf tests.