### PR TITLE
Issue 2423: Flag to enable mkdocs plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ buildscript {
     }
 }
 
-apply from: "$rootDir/gradle/mkdocs.gradle"
+if (project.hasProperty("enableMkdocs")) {
+    apply from: "$rootDir/gradle/mkdocs.gradle"
+}
 
 allprojects {
     apply plugin: 'idea'

--- a/gradle/mkdocs.gradle
+++ b/gradle/mkdocs.gradle
@@ -18,6 +18,9 @@ mkdocs {
     sourcesDir = "$rootDir/documentation/src"
     buildDir = "$rootDir/documentation/generated"
     updateSiteUrl = false
+    publish {
+        repoUri = "https://github.com/pravega/pravega.git"
+    }
 }
 
 remotes {

--- a/gradle/mkdocs.gradle
+++ b/gradle/mkdocs.gradle
@@ -18,9 +18,6 @@ mkdocs {
     sourcesDir = "$rootDir/documentation/src"
     buildDir = "$rootDir/documentation/generated"
     updateSiteUrl = false
-    publish {
-        repoUri = "https://github.com/pravega/pravega.git"
-    }
 }
 
 remotes {


### PR DESCRIPTION
**Changelog description**
* Adds a flag to enable mkdocs plugin to generate site documentation.

**Purpose of the change**
Fixes #2423

**What the code does**
To support `flink-connector` build (https://github.com/pravega/flink-connectors/issues/112) where `pravega` is referenced as a git sub-module and the usage of `mkdocs` plugin is broken since the plugin is not able to find git configuration file (sub-modules don't keep the same configuration file as regular project) which is used to derive the `repoUri`.

This change adds a flag to enable the mkdocs plugin. If disabled, then the described problem won't manifest.

**How to verify it**
Build pravega and flink-connector project and make sure there is no error or side-effects due to this configuration