### PR TITLE
Issue 2425: BugFix: Ensure SegmentRange.getScope() returns the scope of the stream

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/SegmentRange.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentRange.java
@@ -28,7 +28,7 @@ public interface SegmentRange {
      * Returns the stream name the segment is associated with.
      * @return The stream name.
      */
-    String getStream();
+    String getStreamName();
 
     /**
      * Returns the scope name of the stream the segment is associated with.

--- a/client/src/main/java/io/pravega/client/batch/SegmentRange.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentRange.java
@@ -28,13 +28,13 @@ public interface SegmentRange {
      * Returns the stream name the segment is associated with.
      * @return The stream name.
      */
-    String getStreamName();
+    String getStream();
 
     /**
      * Returns the scope name.
      * @return The scope name.
      */
-    String getScopeName();
+    String getScope();
 
     /**
      * Returns the start offset of the segment.

--- a/client/src/main/java/io/pravega/client/batch/SegmentRange.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentRange.java
@@ -31,7 +31,7 @@ public interface SegmentRange {
     String getStream();
 
     /**
-     * Returns the scope name.
+     * Returns the scope name of the stream the segment is associated with.
      * @return The scope name.
      */
     String getScope();

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -52,12 +52,12 @@ public class SegmentRangeImpl implements SegmentRange {
     }
 
     @Override
-    public String getStreamName() {
+    public String getStream() {
         return segment.getStreamName();
     }
 
     @Override
-    public String getScopeName() {
+    public String getScope() {
         return segment.getScope();
     }
 

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -58,7 +58,7 @@ public class SegmentRangeImpl implements SegmentRange {
 
     @Override
     public String getScopeName() {
-        return segment.getScopedName();
+        return segment.getScope();
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -15,6 +15,7 @@ import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.segment.impl.Segment;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
@@ -25,6 +26,7 @@ import lombok.ToString;
 @Beta
 @Builder
 @ToString
+@EqualsAndHashCode
 public class SegmentRangeImpl implements SegmentRange {
 
     /**
@@ -52,7 +54,7 @@ public class SegmentRangeImpl implements SegmentRange {
     }
 
     @Override
-    public String getStream() {
+    public String getStreamName() {
         return segment.getStreamName();
     }
 

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
@@ -35,5 +35,7 @@ public class SegmentRangeImplTest {
         assertEquals(0L, segmentRange.getStartOffset());
         assertEquals(20L, segmentRange.getEndOffset());
         assertEquals(new Segment("scope", "stream", 0), segmentRange.getSegment());
+        assertEquals("scope", segmentRange.getScope());
+        assertEquals("stream", segmentRange.getStream());
     }
 }

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.batch.impl;
 
+import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.segment.impl.Segment;
 import org.junit.Test;
 
@@ -30,12 +31,12 @@ public class SegmentRangeImplTest {
 
     @Test
     public void testValid() {
-        SegmentRangeImpl segmentRange = SegmentRangeImpl.builder().endOffset(20L).segment(new Segment("scope", "stream",
+        SegmentRange segmentRange = SegmentRangeImpl.builder().endOffset(20L).segment(new Segment("scope", "stream",
                 0)).build();
         assertEquals(0L, segmentRange.getStartOffset());
         assertEquals(20L, segmentRange.getEndOffset());
-        assertEquals(new Segment("scope", "stream", 0), segmentRange.getSegment());
+        assertEquals(new Segment("scope", "stream", 0), ((SegmentRangeImpl) segmentRange).getSegment());
         assertEquals("scope", segmentRange.getScope());
-        assertEquals("stream", segmentRange.getStream());
+        assertEquals("stream", segmentRange.getStreamName());
     }
 }


### PR DESCRIPTION
**Change log description**
* Changes the API call from getScopeName to getScope to be consistent with the Stream interface.
* Ensures SegmentRange.getScope() returns the scope of the stream.

**Purpose of the change**
Fixes #2425 

**What the code does**
Updated SegmentRange apis to 
`io.pravega.client.batch.SegmentRange#getStream` and `io.pravega.client.batch.SegmentRange#getScope`.

**How to verify it**
All existing tests should continue to pass.