### PR TITLE
Issue 2429: Get initial number of segments via SegmentNotifier.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
@@ -54,9 +54,9 @@ public class SegmentNotifier extends AbstractPollingNotifier<SegmentNotification
         int newNumberOfSegments = state.getNumberOfSegments();
         checkState(newNumberOfSegments > 0, "Number of segments cannot be zero");
 
-        if (this.numberOfSegments == 0) { //initialize the number of segments.
-            this.numberOfSegments = newNumberOfSegments;
-        } else if (this.numberOfSegments != newNumberOfSegments) { // SegmentNotification has happened.
+        //Trigger a notification with the initial number of segments, subsequent notifications are triggered only if there
+        //is a change in the number of segments.
+        if (this.numberOfSegments != newNumberOfSegments) {
             this.numberOfSegments = newNumberOfSegments;
             SegmentNotification notification = SegmentNotification.builder().numOfSegments(state.getNumberOfSegments())
                                                            .numOfReaders(state.getOnlineReaders().size())

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
@@ -54,8 +54,8 @@ public class SegmentNotifier extends AbstractPollingNotifier<SegmentNotification
         int newNumberOfSegments = state.getNumberOfSegments();
         checkState(newNumberOfSegments > 0, "Number of segments cannot be zero");
 
-        //Trigger a notification with the initial number of segments, subsequent notifications are triggered only if there
-        //is a change in the number of segments.
+        //Trigger a notification with the initial number of segments.
+        //Subsequent notifications are triggered only if there is a change in the number of segments.
         if (this.numberOfSegments != newNumberOfSegments) {
             this.numberOfSegments = newNumberOfSegments;
             SegmentNotification notification = SegmentNotification.builder().numOfSegments(state.getNumberOfSegments())

--- a/client/src/test/java/io/pravega/client/stream/notifications/SegmentNotifierTest.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/SegmentNotifierTest.java
@@ -10,6 +10,7 @@
 package io.pravega.client.stream.notifications;
 
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,10 +19,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,7 +36,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.notifications.notifier.SegmentNotifier;
-import io.pravega.common.util.ReusableLatch;
 import io.pravega.test.common.InlineExecutor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -58,16 +60,19 @@ public class SegmentNotifierTest {
     @Test
     public void segmentNotifierTest() throws Exception {
         AtomicBoolean listenerInvoked = new AtomicBoolean();
-        ReusableLatch latch = new ReusableLatch();
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger segmentCount = new AtomicInteger(0);
 
         when(state.getOnlineReaders()).thenReturn(new HashSet<>(singletonList("reader1")));
-        when(state.getNumberOfSegments()).thenReturn(1).thenReturn(2);
+        when(state.getNumberOfSegments()).thenReturn(1, 1, 2 ).thenReturn(2);
         when(sync.getState()).thenReturn(state);
 
         Listener<SegmentNotification> listener1 = e -> {
             log.info("listener 1 invoked");
             listenerInvoked.set(true);
-            latch.release();
+            segmentCount.set(e.getNumOfSegments());
+            latch.countDown();
+
         };
         Listener<SegmentNotification> listener2 = e -> {
         };
@@ -77,6 +82,7 @@ public class SegmentNotifierTest {
         verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
         latch.await();
         assertTrue(listenerInvoked.get());
+        assertEquals(2, segmentCount.get());
 
         notifier.registerListener(listener2);
         verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -69,7 +69,7 @@ public class ReaderGroupNotificationTest {
     private final int controllerPort = TestUtils.getAvailableListenPort();
     private final String serviceHost = "localhost";
     private final int servicePort = TestUtils.getAvailableListenPort();
-    private final int   containerCount = 4;
+    private final int containerCount = 4;
     private TestingServer zkTestServer;
     private PravegaConnectionListener server;
     private ControllerWrapper controllerWrapper;

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -41,13 +41,14 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
@@ -68,15 +69,13 @@ public class ReaderGroupNotificationTest {
     private final int controllerPort = TestUtils.getAvailableListenPort();
     private final String serviceHost = "localhost";
     private final int servicePort = TestUtils.getAvailableListenPort();
-    private final int containerCount = 4;
+    private final int   containerCount = 4;
     private TestingServer zkTestServer;
     private PravegaConnectionListener server;
     private ControllerWrapper controllerWrapper;
     private ServiceBuilder serviceBuilder;
     private ScheduledExecutorService executor;
     private AtomicBoolean listenerInvoked = new AtomicBoolean();
-    private AtomicInteger numberOfReaders = new AtomicInteger(0);
-    private AtomicInteger numberOfSegments = new AtomicInteger(0);
     private ReusableLatch listenerLatch = new ReusableLatch();
 
     @BeforeClass
@@ -159,12 +158,14 @@ public class ReaderGroupNotificationTest {
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
                 ReaderConfig.builder().build());
 
+        final CountDownLatch latch = new CountDownLatch(2);
+        final ArrayDeque<SegmentNotification> notificationResults = new ArrayDeque<>();
+
         //Add segment event listener
         Listener<SegmentNotification> l1 = notification -> {
-            listenerInvoked.set(true);
-            numberOfReaders.set(notification.getNumOfReaders());
-            numberOfSegments.set(notification.getNumOfSegments());
-            listenerLatch.release();
+            log.info("Number of Segments{}, Number of Readers: {}", notification.getNumOfSegments(), notification.getNumOfReaders());
+            notificationResults.offer(notification);
+            latch.countDown();
         };
         readerGroup.getSegmentNotifier(executor).registerListener(l1);
 
@@ -175,10 +176,16 @@ public class ReaderGroupNotificationTest {
         assertNotNull(event2);
         assertEquals("data2", event2.getEvent());
 
-        listenerLatch.await();
-        assertTrue("Listener invoked", listenerInvoked.get());
-        assertEquals(2, numberOfSegments.get());
-        assertEquals(1, numberOfReaders.get());
+        latch.await(); // await two invocations.
+
+        SegmentNotification initialSegmentNotification = notificationResults.poll();
+        assertNotNull(initialSegmentNotification);
+        assertEquals(1, initialSegmentNotification.getNumOfReaders());
+        assertEquals(1, initialSegmentNotification.getNumOfSegments());
+
+        SegmentNotification segmentNotificationPostScale = notificationResults.poll();
+        assertEquals(1, segmentNotificationPostScale.getNumOfReaders());
+        assertEquals(2, segmentNotificationPostScale.getNumOfSegments());
     }
 
     @Test(timeout = 40000)


### PR DESCRIPTION
**Change log description**
Trigger a notification with the initial number of segments as soon as the user registers a Segment listener.

**Purpose of the change**
Fixes #2429 

**What the code does**
Triggers a Segment Notification with the initial number of Segments as soon as the user registers a Segment Listener. Subsequent segment notifications are generated only if there is a change in the number of segments.

**How to verify it**
All tests should continue to pass.