### PR TITLE
Issue 2438: (SegmentStore) Cannot truncate sealed segments

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -645,6 +645,14 @@ public class ContainerMetadataUpdateTransactionTests {
 
         // Now verify that a valid offset does work (not throwing means the test passes).
         txn.preProcessOperation(createTruncate(op1.getStreamSegmentOffset()));
+
+        // Verify it works on a Sealed Segment.
+        val sealOp = createSeal();
+        txn.preProcessOperation(sealOp);
+        txn.acceptOperation(sealOp);
+        txn.commit(metadata);
+
+        // Truncate the segment again.
         txn.preProcessOperation(createTruncate(op1.getStreamSegmentOffset() + 1));
         txn.preProcessOperation(createTruncate(SEGMENT_LENGTH));
     }


### PR DESCRIPTION
**Change log description**
Fixed a bug in `RollingStorage` where it was not possible to truncate a sealed segment if the given SegmentHandle was acquired after sealing the segment.
- When calling `openWrite` on a sealed segment, the returned handle is read-only (since no further changes are allowed on the segment)
- When calling `truncate`, `RollingStorage` expected a read-write handle, which was causing the problem described in the issue associated with this change.
    - This was changed to accept a read-only handle, but only if the Segment is Sealed (otherwise a read-write handle is required.
    - The only difference in truncation between a Sealed and Non-sealed segment is that for a Sealed segment we will not be able to fully truncate the whole segment. Since we cannot modify the header file for a Sealed segment, deleting the last chunk would cause us to lose valuable information required to compute the Segment's length. As such, for Sealed segments, if we have to truncate the whole thing, we will leave the last chunk in there.

**Purpose of the change**
Fixes #2438.

**What the code does**
Allows RollingStorage to truncate sealed segments.

**How to verify it**
New unit test added to verify this scenario.
