### PR TITLE
Issue 2245: Updated docs with io.pravega links (remove old com.emc.pravega)

### DIFF
--- a/documentation/src/docs/state-synchronizer-design.md
+++ b/documentation/src/docs/state-synchronizer-design.md
@@ -8,16 +8,16 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 -->
 # StateSynchronizer
-A StateSynchronizer provides a means for data to be written and read by multiple processes, while consistency is guaranteed using optimistic checks. A rough version of this API is [checked in here.](https://github.com/emccode/pravega/blob/master/clients/streaming/src/main/java/com/emc/pravega/state/StateSynchronizer.java)
+A StateSynchronizer provides a means for data to be written and read by multiple processes, while consistency is guaranteed using optimistic checks. A rough version of this API is [checked in here.](https://github.com/pravega/pravega/blob/master/client/src/main/java/io/pravega/client/state/StateSynchronizer.java)
 
 This works by having each process keep a copy of the data. All updates are written through the StateSynchronizer which appends them to a Pravega segment. They can keep up to date of changes to the data by consuming from the segment. To provide consistency a conditional append is used. This ensures that the updates can only proceed if the process performing them has the most recent data. Finally to prevent the segment from growing without bound, we use have a compact operation that re-writes the latest data, and truncates the old data so it can be dropped.
 
 This model works well when most updates are small in comparison to the total data size being stored, as they can be written a small deltas. As with any optimistic concurrency system it would work worst when many processes are all contending to try to update the same information at the same time.
 
 # Example
-A concrete example synchroning the contents of a set is [checked in here](https://github.com/emccode/pravega/blob/master/clients/streaming/src/test/java/com/emc/pravega/state/examples/SetSynchronizer.java). We also have an example that is synchronizing [membership of a set of hosts](https://github.com/emccode/pravega/blob/master/clients/streaming/src/test/java/com/emc/pravega/state/examples/MembershipSynchronizer.java).
+A concrete example synchroning the contents of a set is [checked in here](https://github.com/pravega/pravega/blob/master/client/src/test/java/io/pravega/client/state/examples/SetSynchronizer.java). We also have an example that is synchronizing [membership of a set of hosts](https://github.com/pravega/pravega/blob/master/client/src/test/java/io/pravega/client/state/examples/MembershipSynchronizer.java).
 
-Imagine you want many processes to share a Map. This can be done by creating by a StateSynchronizer, which will help coordinate changes to the map. Each client has their own copy of the map in memory and can apply updates by passing a generator to the StateSynchronizer. Every time an update is attempted the updated is recorded to a segment. Updates will fail unless the Map passed into the update method is consistent with all of the updates that have been recorded to the segment. If this occurs the generator is called with the latest state to try again. Thus the order of updates is defined by the order in which they are written to the segment. 
+Imagine you want many processes to share a Map. This can be done by creating by a StateSynchronizer, which will help coordinate changes to the map. Each client has their own copy of the map in memory and can apply updates by passing a generator to the StateSynchronizer. Every time an update is attempted the updated is recorded to a segment. Updates will fail unless the Map passed into the update method is consistent with all of the updates that have been recorded to the segment. If this occurs the generator is called with the latest state to try again. Thus the order of updates is defined by the order in which they are written to the segment.
 
 # How this is implemented
 For this to work we use two features of the Pravega Segment Store Service.

--- a/documentation/src/docs/transactions.md
+++ b/documentation/src/docs/transactions.md
@@ -25,7 +25,7 @@ We have written a couple of applications, ConsoleReader and ConsoleWriter that
 help illustrate reading and writing data with Pravega and in particular to
 illustrate the Transaction facility in the Pravega programming model.  You can
 find those applications
-[here](https://github.com/pravega/pravega-samples/tree/master/standalone-examples/src/main/java/com/emc/pravega/example/consolerw).
+[here](https://github.com/pravega/pravega-samples/tree/master/standalone-examples/src/main/java/io/pravega/example/consolerw).
 
 ### ConsoleReader
 
@@ -44,9 +44,9 @@ below:
 **ConsoleWriter Help text**
 ```
 Enter one of the following commands at the command line prompt:
- 
+
 If no command is entered, the line is treated as a parameter to the WRITE_EVENT command.
- 
+
 WRITE_EVENT {event} - write the {event} out to the Stream or the current Transaction.
 WRITE_EVENT_RK <<{routingKey}>> , {event} - write the {event} out to the Stream or the current Transaction using {routingKey}. Note << and >> around {routingKey}.
 BEGIN [{transactionTimeout}] [, {maxExecutionTime}] [, {scaleGracePeriod}] begin a Transaction. Only one Transaction at a time is supported by the CLI.
@@ -58,7 +58,7 @@ ABORT - abort the Transaction (if a Transaction is running)
 STATUS - check the status of the Transaction(if a Transaction is running)
 HELP - print out a list of commands.
 QUIT - terminate the program.
- 
+
 examples/someStream >
 ```
 


### PR DESCRIPTION
Fixes #2445 

**Change log description**

A few places in the docs had the old com[./]emc[./]pravega naming and old package structure for clients. This updates them.

**Purpose of the change**

I wanted to know how to do something with Pravega. Links in some of the docs were broken which made it difficult to follow along. This fixes them.

**How to verify it**

Go to the links in the diff view, they work.