### PR TITLE
issue 2399 : Create a custom classpath for Windows executable as well.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -449,6 +449,8 @@ project('controller') {
         doLast {
             def scriptFile = file getUnixScript()
             scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
+            def winScriptFile = file getWindowsScript()
+            winScriptFile.text = scriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
         }
     }
     applicationDistribution.from('src/conf') {


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
This fixes #2399. Though pravega does not support windows as a base system, this is a very small and relatively nonintrusive change.
`build.gradle` creates a custom path where custom authplugin implementation jars can be dropped.
Extending the same logic to create custom path for windows executable as well. 

**Purpose of the change**
Support authplugin on windows.

**What the code does**
Creates a custom classpath where implementation of authplugin can be dropped.

**How to verify it**
1. Create a distribution. (`.\gradlew distTar`)
2. Ensure that the `pluginlib` directory exists in the `CLASSPATH` variable in controller `bat` file.
