### PR TITLE
Issue 2414: Pravega client should log a warning in case no credentials are supplied/extracted

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -73,6 +73,9 @@ public class ClientConfig {
                 controllerURI = URI.create("tcp://localhost");
             }
             extractCredentials();
+            if (credentials == null) {
+                log.info("The credentials are not specified/could not be extracted");
+            }
             return new ClientConfig(controllerURI, credentials, trustStore, validateHostName);
         }
 


### PR DESCRIPTION
**Purpose of the change**

Logs a warning when no credentials are provided.
This fixes #2414. 

**What the code does**
Logs a warning when no credentials are provided.

**How to verify it**
See the log while running `standalone`.