### PR TITLE
Issue 2450: Separate 401 and 403 returns for REST API.

### DIFF
--- a/common/src/main/java/io/pravega/common/auth/AuthException.java
+++ b/common/src/main/java/io/pravega/common/auth/AuthException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.auth;
+
+//Represents exceptions during authorization/authentication
+
+public class AuthException extends Exception {
+    private static final long serialVersionUID = 1L;
+    private final int responseCode;
+
+    public AuthException(String message, int responseCode) {
+        super(message);
+        this.responseCode = responseCode;
+    }
+
+    public AuthException(Exception e, int responseCode) {
+        super(e);
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+}

--- a/common/src/main/java/io/pravega/common/auth/AuthorizationException.java
+++ b/common/src/main/java/io/pravega/common/auth/AuthorizationException.java
@@ -10,23 +10,23 @@
 package io.pravega.common.auth;
 
 /**
- * Exception thrown when there is any error during authentication.
+ * Exception thrown when there is any error during authorization.
  */
-public class AuthenticationException extends AuthException {
+public class AuthorizationException extends AuthException {
     private static final long serialVersionUID = 1L;
-    public AuthenticationException(String message) {
+    public AuthorizationException(String message) {
         this(message, 401);
     }
 
-    public AuthenticationException(String message, int responseCode) {
+    public AuthorizationException(String message, int responseCode) {
         super(message, responseCode);
     }
 
-    public AuthenticationException(Exception e) {
-        this(e, 401);
+    public AuthorizationException(Exception e) {
+        this(e, 403);
     }
 
-    public AuthenticationException(Exception e, int responseCode) {
+    public AuthorizationException(Exception e, int responseCode) {
         super(e, responseCode);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -104,7 +104,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         }
 
         if (!authenticate(createScopeRequest.getScopeName(), READ_UPDATE, asyncResponse)) {
-            log.warn("Create scope for {} failed due to authentication failure {}.", createScopeRequest.getScopeName());
+            log.warn("Create scope for {} failed due to authentication failure.", createScopeRequest.getScopeName());
             LoggerHelpers.traceLeave(log, "createScope", traceId);
             return;
         }
@@ -156,7 +156,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
     }
 
     private String scopedStreamName(String scopeName, String streamName) {
-        return scopeName + " /" + streamName;
+        return scopeName + "/" + streamName;
     }
 
     /**
@@ -303,7 +303,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         long traceId = LoggerHelpers.traceEnter(log, "getReaderGroup");
 
         if (!authenticate(scopedStreamName(scopeName, readerGroupName), READ, asyncResponse)) {
-            log.warn("Get reader group for {} failed due to authentication failure.", scopeName + "/" + readerGroupName);
+            log.warn("Get reader group for {}/{} failed due to authentication failure.", scopeName, readerGroupName);
             LoggerHelpers.traceLeave(log, "getReaderGroup", traceId);
             return;
         }
@@ -382,7 +382,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         long traceId = LoggerHelpers.traceEnter(log, "getStream");
 
         if (!authenticate(scopedStreamName(scopeName, streamName), READ, asyncResponse)) {
-            log.warn("Get stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
+            log.warn("Get stream for {}/{} failed due to authentication failure.", scopeName, streamName);
             LoggerHelpers.traceLeave(log, "getStream", traceId);
             return;
         }
@@ -523,7 +523,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         long traceId = LoggerHelpers.traceEnter(log, "updateStream");
 
         if (!authenticate(scopedStreamName(scopeName, streamName), READ_UPDATE, asyncResponse)) {
-            log.warn("Update stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
+            log.warn("Update stream for {}/{} failed due to authentication failure.", scopeName, streamName);
             LoggerHelpers.traceLeave(log, "Update stream", traceId);
             return;
         }
@@ -565,7 +565,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         long traceId = LoggerHelpers.traceEnter(log, "updateStreamState");
 
         if (!authenticate(scopedStreamName(scopeName, streamName), READ_UPDATE, asyncResponse)) {
-            log.warn("Update stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
+            log.warn("Update stream for {}/{} failed due to authentication failure.", scopeName, streamName);
             LoggerHelpers.traceLeave(log, "Update stream", traceId);
             return;
         }
@@ -613,7 +613,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         long traceId = LoggerHelpers.traceEnter(log, "getScalingEvents");
 
         if (!authenticate(scopedStreamName(scopeName, streamName), READ, asyncResponse)) {
-            log.warn("Get scaling events for {} failed due to authentication failure.", scopeName + "/" + streamName);
+            log.warn("Get scaling events for {}/{} failed due to authentication failure.", scopeName, streamName);
             LoggerHelpers.traceLeave(log, "Get scaling events", traceId);
             return;
         }

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -155,6 +155,10 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         return true;
     }
 
+    private String scopedStreamName(String scopeName, String streamName) {
+        return scopeName + " /" + streamName;
+    }
+
     /**
      * Implementation of createStream REST API.
      *
@@ -177,7 +181,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             return;
         }
 
-        if (!authenticate(scopeName + "/" + createStreamRequest.getStreamName(), READ_UPDATE, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, createStreamRequest.getStreamName()), READ_UPDATE, asyncResponse)) {
             log.warn("Create stream for {} failed due to authentication failure.", createStreamRequest.getStreamName());
             LoggerHelpers.traceLeave(log, "createStream", traceId);
             return;
@@ -212,6 +216,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                 }).thenApply(asyncResponse::resume)
                 .thenAccept(x -> LoggerHelpers.traceLeave(log, "createStream", traceId));
     }
+
 
     /**
      * Implementation of deleteScope REST API.
@@ -265,7 +270,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "deleteStream");
 
-        if (!authenticate(scopeName + "/" + streamName, READ_UPDATE, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, streamName), READ_UPDATE, asyncResponse)) {
             log.warn("Delete stream for {} failed due to authentication failure.", streamName);
             LoggerHelpers.traceLeave(log, "deleteStream", traceId);
             return;
@@ -297,7 +302,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                                final SecurityContext securityContext, final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "getReaderGroup");
 
-        if (!authenticate(scopeName + "/" + readerGroupName, READ, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, readerGroupName), READ, asyncResponse)) {
             log.warn("Get reader group for {} failed due to authentication failure.", scopeName + "/" + readerGroupName);
             LoggerHelpers.traceLeave(log, "getReaderGroup", traceId);
             return;
@@ -376,7 +381,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "getStream");
 
-        if (!authenticate(scopeName + "/" + streamName, READ, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, streamName), READ, asyncResponse)) {
             log.warn("Get stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
             LoggerHelpers.traceLeave(log, "getStream", traceId);
             return;
@@ -517,7 +522,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "updateStream");
 
-        if (!authenticate(scopeName + "/" + streamName, READ_UPDATE, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, streamName), READ_UPDATE, asyncResponse)) {
             log.warn("Update stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
             LoggerHelpers.traceLeave(log, "Update stream", traceId);
             return;
@@ -559,7 +564,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             final StreamState updateStreamStateRequest, SecurityContext securityContext, AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "updateStreamState");
 
-        if (!authenticate(scopeName + "/" + streamName, READ_UPDATE, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, streamName), READ_UPDATE, asyncResponse)) {
             log.warn("Update stream for {} failed due to authentication failure.", scopeName + "/" + streamName);
             LoggerHelpers.traceLeave(log, "Update stream", traceId);
             return;
@@ -607,7 +612,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                                  final SecurityContext securityContext, final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "getScalingEvents");
 
-        if (!authenticate(scopeName + "/" + streamName, READ, asyncResponse)) {
+        if (!authenticate(scopedStreamName(scopeName, streamName), READ, asyncResponse)) {
             log.warn("Get scaling events for {} failed due to authentication failure.", scopeName + "/" + streamName);
             LoggerHelpers.traceLeave(log, "Get scaling events", traceId);
             return;

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
@@ -69,7 +69,7 @@ public class PravegaAuthManager {
      * @param level    Expected level of access.
      * @return         Returns true if the entity represented by the custom auth headers had given level of access to the resource.
      *                 Returns false if the entity does not have access.
-     * @throws AuthenticationException Exception faced during authentication.
+     * @throws AuthenticationException Exception if an authentication failure occured.
      */
     public boolean authenticate(String resource, Map<String, String> paramMap, AuthHandler.Permissions level) throws AuthenticationException {
         boolean retVal = false;

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
@@ -68,15 +68,19 @@ public class PravegaAuthManager {
      * @param paramMap  Custom headers used for authentication.
      * @param level    Expected level of access.
      * @return         Returns true if the entity represented by the custom auth headers had given level of access to the resource.
-     * @throws AuthenticationException Exception faced during authentication/authorization.
+     *                 Returns false if the entity does not have access.
+     * @throws AuthenticationException Exception faced during authentication.
      */
     public boolean authenticate(String resource, Map<String, String> paramMap, AuthHandler.Permissions level) throws AuthenticationException {
         boolean retVal = false;
         try {
             String method = paramMap.get("method");
             AuthHandler handler = getHandler(method);
-            retVal = handler.authenticate(paramMap) &&
-                    handler.authorize(resource, paramMap).ordinal() >= level.ordinal();
+
+            if (!handler.authenticate(paramMap)) {
+                throw new AuthenticationException("Authentication failure");
+            }
+            retVal = handler.authorize(resource, paramMap).ordinal() >= level.ordinal();
         } catch (RuntimeException e) {
             throw new AuthenticationException(e);
         }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
@@ -27,7 +27,11 @@ public class TestAuthHandler implements AuthHandler {
 
     @Override
     public Permissions authorize(String resource, Map<String, String> headers) {
-        return Permissions.READ_UPDATE;
+        if (headers.get("username").equals("dummy")) {
+            return Permissions.NONE;
+        } else {
+            return Permissions.READ_UPDATE;
+        }
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.rest.v1;
+
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import org.junit.Before;
+
+public class Failing403StreamMetaDataTests extends  FailingSecureStreamMetaDataTests {
+    @Override
+    @Before
+    public void setup() {
+        expectedResult = 403;
+        super.setup();
+    }
+
+    @Override
+    protected Invocation.Builder addAuthHeaders(Invocation.Builder request) {
+        MultivaluedMap<String, Object> map = new MultivaluedHashMap<>();
+        map.addAll(HttpHeaders.AUTHORIZATION, "method:testHandler", "username:dummy", "password:1111_aaaa");
+        return request.headers(map);
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
+    protected int expectedResult = 401;
+
     @Override
     @Before
     public void setup() {
@@ -45,7 +47,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
     public void testCreateStream() {
         String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
         Response response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
-        assertEquals("Create Stream Status", 401, response.getStatus());
+        assertEquals("Create Stream Status", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -55,7 +57,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1/state";
         StreamState streamState = new StreamState().streamState(StreamState.StreamStateEnum.SEALED);
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildPut(Entity.json(streamState)).invoke();
-        assertEquals("Update Stream State response code", 401, response.getStatus());
+        assertEquals("Update Stream State response code", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -66,7 +68,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to delete a scope.
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildDelete().invoke();
-        assertEquals("Delete Scope response code", 401, response.getStatus());
+        assertEquals("Delete Scope response code", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -78,7 +80,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to get existent scope
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
-        assertEquals("Get existent scope", 401, response.getStatus());
+        assertEquals("Get existent scope", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -90,7 +92,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to create a new scope.
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildPost(Entity.json(createScopeRequest)).invoke();
-        assertEquals("Create Scope response code", 401, response.getStatus());
+        assertEquals("Create Scope response code", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -101,7 +103,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to update an existing stream
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildPut(Entity.json(updateStreamRequest)).invoke();
-        assertEquals("Update Stream Status", 401, response.getStatus());
+        assertEquals("Update Stream Status", expectedResult, response.getStatus());
     }
 
     @Override
@@ -109,7 +111,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
     public void testListReaderGroups() {
         final String resourceURI = getURI() + "v1/scopes/scope1/readergroups";
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
-        assertEquals("List Reader Groups response code", 401, response.getStatus());
+        assertEquals("List Reader Groups response code", expectedResult, response.getStatus());
     }
 
     @Override
@@ -119,7 +121,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to delete a sealed stream
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildDelete().invoke();
-        assertEquals("Delete Stream response code", 401, response.getStatus());
+        assertEquals("Delete Stream response code", expectedResult, response.getStatus());
         response.close();
     }
 
@@ -141,7 +143,7 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
 
         // Test to get an existing stream
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
-        assertEquals("Get Stream Config Status", 401, response.getStatus());
+        assertEquals("Get Stream Config Status", expectedResult, response.getStatus());
     }
 
     @Override
@@ -150,6 +152,6 @@ public class FailingSecureStreamMetaDataTests extends  StreamMetaDataTests {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams";
 
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
-        assertEquals("List Streams response code", 401, response.getStatus());
+        assertEquals("List Streams response code", expectedResult, response.getStatus());
     }
 }


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
* Modifies the signature of the `authenticate` method in `StreamMetadataResourceImpl` to throw `AuthException` containing the appropriate return code.

**Purpose of the change**
Fixes #2450 

**What the code does**
When a user calls a REST API,  a future course of action may depend on the type of authentication error. (a 401 error will suggest authentication error where as a 403 error will suggest authorization error).
In case of grpc this is not necessary as the caller need not know whether this is authorization error or authentication error as it may give rogue user a chance to advance attacks by validating his guessed password.

The changes here modify the signature of the `authenticate` method in `StreamMetadataResourceImpl` to throw `AuthException` containing the appropriate return code.

**How to verify it**
REST API should show expected behavior.