### PR TITLE
issue-2353 ensure that the server process exits upon fatal startup error

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -227,6 +227,12 @@ public final class ServiceStarter {
 
         try {
             serviceStarter.get().start();
+        } catch (Throwable e) {
+            log.error("Could not start the Service, Aborting.", e);
+            System.exit(1);
+        }
+
+        try {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 log.info("Caught interrupt signal...");
                 serviceStarter.get().shutdown();
@@ -237,6 +243,7 @@ public final class ServiceStarter {
             log.info("Caught interrupt signal...");
         } finally {
             serviceStarter.get().shutdown();
+            System.exit(0);
         }
     }
 


### PR DESCRIPTION
**Change log description**
- Ensure that the server process exits upon fatal startup error.

**Purpose of the change**
- Closes #2353 
- Improve the robustness of Pravega in container environments.

**What the code does**

**How to verify it**
Manual test: 
1. Delete the BK ledger znode from BK, which will cause the segment store to fail during startup.  This replicates the valid scenario of BK and segment store being started simultaneously.
2. Start the segment store.
3. Observe that the segment store process exits as expected.   It is expected that the cluster manager will restart the segment store in this situation.