### PR TITLE
Issue 2470: Flush outstanding writes in response to a segment seal

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -571,7 +571,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
     public List<PendingEvent> getUnackedEventsOnSeal() {
         // close connection and update the exception to SegmentSealed, this ensures future writes receive a
         // SegmentSealedException.
-        log.trace("GetUnackedEventsOnSeal called on {}", writerId);
+        log.debug("GetUnackedEventsOnSeal called on {}", writerId);
         synchronized (writeOrderLock) {   
             state.failConnection(new SegmentSealedException(this.segmentName));
             return Collections.unmodifiableList(state.getAllInflightEvents());

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -306,13 +306,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         public void segmentIsSealed(SegmentIsSealed segmentIsSealed) {
             log.info("Received SegmentSealed {}", segmentIsSealed);
             if (state.sealEncountered.compareAndSet(false, true)) {
-                Retry.indefinitelyWithExpBackoff(retrySchedule.getInitialMillis(), retrySchedule.getMultiplier(),
-                                                 retrySchedule.getMaxDelay(),
-                                                 t -> log.error(writerId + " to invoke sealed callback: ", t))
-                     .runInExecutor(() -> {
-                         log.debug("Invoking SealedSegment call back for {}", segmentIsSealed);
-                         callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));
-                     }, connectionFactory.getInternalExecutor());
+                log.debug("Invoking SealedSegment call back for {}", segmentIsSealed);
+                callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));
             }
         }
 

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -188,7 +188,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                     waitingInflight.release();
                 } 
                 if (!closed) {
-                    log.warn("Connection for segment {} failed due to: {}", segmentName, throwable.getMessage());
+                    String message = throwable.getMessage() == null ? throwable.getClass().toString() : throwable.getMessage();
+                    log.warn("Connection for segment {} on writer {} failed due to: {}", segmentName, writerId, message);
                 }
             }
             if (throwable instanceof SegmentSealedException || throwable instanceof NoSuchSegmentException) {
@@ -304,13 +305,13 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
          */
         @Override
         public void segmentIsSealed(SegmentIsSealed segmentIsSealed) {
-            log.info("Received SegmentSealed {}", segmentIsSealed);
+            log.info("Received SegmentSealed {} on writer {}", segmentIsSealed, writerId);
             if (state.sealEncountered.compareAndSet(false, true)) {
                 Retry.indefinitelyWithExpBackoff(retrySchedule.getInitialMillis(), retrySchedule.getMultiplier(),
                                                  retrySchedule.getMaxDelay(),
                                                  t -> log.error(writerId + " to invoke sealed callback: ", t))
                      .runInExecutor(() -> {
-                         log.debug("Invoking SealedSegment call back for {}", segmentIsSealed);
+                         log.debug("Invoking SealedSegment call back for {} on writer {}", segmentIsSealed, writerId);
                          callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));
                      }, connectionFactory.getInternalExecutor());
             }
@@ -320,7 +321,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         public void noSuchSegment(NoSuchSegment noSuchSegment) {
             String segment = noSuchSegment.getSegment();
             checkArgument(segmentName.equals(segment), "Wrong segment name %s, %s", segmentName, segment);
-            log.warn("Segment being written to {} no longer exists. Failing all writes", segment);
+            log.warn("Segment being written to {} by writer {} no longer exists. Failing all writes", segment, writerId);
             state.setClosed(true);
             NoSuchSegmentException exception = new NoSuchSegmentException(segment);
             state.failConnection(exception);
@@ -548,7 +549,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          }
                          return connectionSetupFuture.exceptionally(t -> {
                              if (Exceptions.unwrap(t) instanceof SegmentSealedException) {
-                                 log.info("Ending reconnect attempts to {} because segment is sealed", segmentName);
+                                 log.info("Ending reconnect attempts on writer {} to {} because segment is sealed", writerId, segmentName);
                                  return null;
                              }
                              throw Lombok.sneakyThrow(t);

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -114,9 +114,9 @@ public class ClientFactoryImpl implements ClientFactory {
     public <T> EventStreamWriter<T> createEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {
         log.info("Creating writer for stream: {} with configuration: {}", streamName, config);
         Stream stream = new StreamImpl(scope, streamName);
-        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"
+        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(100, "ScalingRetransmition-"
                 + stream.getScopedName());
-        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, executor);
+        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, connectionFactory.getInternalExecutor(), executor);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -87,19 +87,15 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     EventStreamWriterImpl(Stream stream, Controller controller, SegmentOutputStreamFactory outputStreamFactory,
             Serializer<Type> serializer, EventWriterConfig config, ScheduledExecutorService backgroundThreadPool,
             ExecutorService retransmitPool) {
-        Preconditions.checkNotNull(stream);
-        Preconditions.checkNotNull(controller);
-        Preconditions.checkNotNull(outputStreamFactory);
-        Preconditions.checkNotNull(serializer);
-        this.stream = stream;
-        this.controller = controller;
+        this.stream = Preconditions.checkNotNull(stream);
+        this.controller = Preconditions.checkNotNull(controller);
         this.segmentSealedCallBack = this::handleLogSealed;
-        this.outputStreamFactory = outputStreamFactory;
+        this.outputStreamFactory = Preconditions.checkNotNull(outputStreamFactory);;
         this.selector = new SegmentSelector(stream, controller, outputStreamFactory, config);
-        this.serializer = serializer;
+        this.serializer = Preconditions.checkNotNull(serializer);
         this.config = config;
-        this.backgroundThreadPool = backgroundThreadPool;
-        this.retransmitPool = retransmitPool;
+        this.backgroundThreadPool = Preconditions.checkNotNull(backgroundThreadPool);
+        this.retransmitPool = Preconditions.checkNotNull(retransmitPool);
         this.pinger = new Pinger(config, stream, controller);
         List<PendingEvent> failedEvents = selector.refreshSegmentEventWriters(segmentSealedCallBack);
         assert failedEvents.isEmpty() : "There should not be any events to have failed";

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -166,9 +166,9 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
          * Using segmentSealedLock prevents concurrent segmentSealedCallback for different segments
          * from being invoked concurrently.
          * 
-         * By calling flush when while the write lock is held we can ensure that any inflight
+         * By calling flush while the write lock is held we can ensure that any inflight
          * entries that will succeed in being written to a new segment are written and any
-         * segmentSealedCallbacks will be be called happen before the next write is invoked.
+         * segmentSealedCallbacks that will be called happen before the next write is invoked.
          */
         writeFlushLock.readLock().lock();
         Retry.indefinitelyWithExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -22,6 +22,7 @@ import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.Transaction.Status;
 import io.pravega.client.stream.TxnFailedException;
 import io.pravega.common.Exceptions;
+import io.pravega.common.util.Retry;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,10 +31,11 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.ToString;
@@ -63,7 +65,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
      * f. When a Close is being invoked, write cannot be executed concurrently.
      * g. When a Close is being invoked, Flush and segmentSealedCallback can be executed concurrently.
      */
-    private final ReadWriteLock writeFlushLock = new ReentrantReadWriteLock();
+    private final ReadWriteLock writeFlushLock = new StampedLock().asReadWriteLock();
     /*
      * This lock is to ensure two segmentSealed Callbacks (for different segments) are not invoked simultaneously.
      */
@@ -78,11 +80,13 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     @GuardedBy("writeFlushLock")
     private final SegmentSelector selector;
     private final Consumer<Segment> segmentSealedCallBack;
+    private final ScheduledExecutorService backgroundThreadPool;
     private final ExecutorService retransmitPool;
     private final Pinger pinger;
     
     EventStreamWriterImpl(Stream stream, Controller controller, SegmentOutputStreamFactory outputStreamFactory,
-            Serializer<Type> serializer, EventWriterConfig config, ExecutorService retransmitPool) {
+            Serializer<Type> serializer, EventWriterConfig config, ScheduledExecutorService backgroundThreadPool,
+            ExecutorService retransmitPool) {
         Preconditions.checkNotNull(stream);
         Preconditions.checkNotNull(controller);
         Preconditions.checkNotNull(outputStreamFactory);
@@ -94,6 +98,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
         this.selector = new SegmentSelector(stream, controller, outputStreamFactory, config);
         this.serializer = serializer;
         this.config = config;
+        this.backgroundThreadPool = backgroundThreadPool;
         this.retransmitPool = retransmitPool;
         this.pinger = new Pinger(config, stream, controller);
         List<PendingEvent> failedEvents = selector.refreshSegmentEventWriters(segmentSealedCallBack);
@@ -157,22 +162,37 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
      * message find which new segment it should go to and send it there. 
      */
     private void handleLogSealed(Segment segment) {
-        retransmitPool.submit(() -> {
-            writeFlushLock.readLock().lock();
-            /* Using segmentSealedLock the following behaviour is enforced
-               - Prevent concurrent segmentSealedCallback for different segments from being invoked concurrently.
-               - Ensure waiting segmentSealedCallbacks are invoked before the next write is invoked.
-               This ensures that resend() would be invoked again if we observe a segment sealed exception.
-             */
-            segmentSealedLock.lock();
-            try {
-                List<PendingEvent> toResend = selector.refreshSegmentEventWritersUponSealed(segment, segmentSealedCallBack);
-                resend(toResend);
-            } finally {
-                segmentSealedLock.unlock();
-                writeFlushLock.readLock().unlock();
-            }
-        });
+        /*
+         * Using segmentSealedLock prevents concurrent segmentSealedCallback for different segments
+         * from being invoked concurrently.
+         * 
+         * By calling flush when while the write lock is held we can ensure that any inflight
+         * entries that will succeed in being written to a new segment are written and any
+         * segmentSealedCallbacks will be be called happen before the next write is invoked.
+         */
+        writeFlushLock.readLock().lock();
+        Retry.indefinitelyWithExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+                                         config.getMaxBackoffMillis(),
+                                         t -> log.error("Encountered excemption when handeling a sealed segment: ", t))
+             .runAsync(() -> {
+                 // Running in the shrinking pool as this operation is infrequent and slow.
+                 return CompletableFuture.runAsync(() -> {
+                     segmentSealedLock.lock();
+                     try {
+                         resend(selector.refreshSegmentEventWritersUponSealed(segment, segmentSealedCallBack));
+                     } finally {
+                         segmentSealedLock.unlock();
+                     }
+                     /* In the case of segments merging Flush ensures there can't be anything left
+                      * inflight that will need to be resent to the new segment when the write lock
+                      * is released. (To preserve order)
+                      */
+                     flushInternal();
+                 }, retransmitPool);
+             }, backgroundThreadPool).handle((r, t) -> {
+                 writeFlushLock.readLock().unlock();
+                 return null;
+             });
     }
 
     @GuardedBy("writeFlushLock")
@@ -339,27 +359,27 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     @Override
     public void flush() {
         Preconditions.checkState(!closed.get());
-        flushInternal();
-    }
-    
-    private void flushInternal() {
         writeFlushLock.readLock().lock();
-        boolean success = false;
         try {
-            while (!success) {
-                success = true;
-                for (SegmentOutputStream writer : selector.getWriters()) {
-                    try {
-                        writer.flush();
-                    } catch (SegmentSealedException e) {
-                        // Segment sealed exception observed during a flush. Re-run flush on all the available writers.
-                        success = false;
-                        log.warn("Flush failed due to {}, it will be retried.", e.getMessage());
-                    }
-                }
-            }
+            flushInternal();
         } finally {
             writeFlushLock.readLock().unlock();
+        }
+    }
+
+    private void flushInternal() {
+        boolean success = false;
+        while (!success) {
+            success = true;
+            for (SegmentOutputStream writer : selector.getWriters()) {
+                try {
+                    writer.flush();
+                } catch (SegmentSealedException e) {
+                    // Segment sealed exception observed during a flush. Re-run flush on all the available writers.
+                    success = false;
+                    log.warn("Flush failed due to {}, it will be retried.", e.getMessage());
+                }
+            }
         }
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -90,7 +90,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
         this.stream = Preconditions.checkNotNull(stream);
         this.controller = Preconditions.checkNotNull(controller);
         this.segmentSealedCallBack = this::handleLogSealed;
-        this.outputStreamFactory = Preconditions.checkNotNull(outputStreamFactory);;
+        this.outputStreamFactory = Preconditions.checkNotNull(outputStreamFactory);
         this.selector = new SegmentSelector(stream, controller, outputStreamFactory, config);
         this.serializer = Preconditions.checkNotNull(serializer);
         this.config = config;

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -95,6 +95,7 @@ public class SegmentSelector {
      *         re-sent.
      */
     public List<PendingEvent> refreshSegmentEventWriters(Consumer<Segment> segmentSealedCallBack) {
+        log.info("Refreshing segments for stream {}", stream);
         return updateSegments(Futures.getAndHandleExceptions(
                 controller.getCurrentSegments(stream.getScope(), stream.getStreamName()), RuntimeException::new),
                 segmentSealedCallBack);
@@ -111,6 +112,7 @@ public class SegmentSelector {
             Entry<Segment, SegmentOutputStream> entry = iter.next();
             if (!currentSegments.getSegments().contains(entry.getKey())) {
                 SegmentOutputStream writer = entry.getValue();
+                log.info("Closing writer {} on segment {} during segment refresh", writer, entry.getKey());
                 iter.remove();
                 try {
                     writer.close();
@@ -128,7 +130,7 @@ public class SegmentSelector {
                                                         Consumer<Segment> segmentSealedCallback) {
         currentSegments = newStreamSegments;
         createMissingWriters(segmentSealedCallback, newStreamSegments.getDelegationToken());
-        log.trace("Fetch unacked events for segment :{}", sealedSegment);
+        log.debug("Fetch unacked events for segment :{}", sealedSegment);
         List<PendingEvent> toResend = writers.get(sealedSegment).getUnackedEventsOnSeal();
         writers.remove(sealedSegment); //remove this sealed segment writer.
         return toResend;
@@ -137,6 +139,7 @@ public class SegmentSelector {
     private void createMissingWriters(Consumer<Segment> segmentSealedCallBack, String delegationToken) {
         for (Segment segment : currentSegments.getSegments()) {
             if (!writers.containsKey(segment)) {
+                log.debug("Creating writer for segment {}", segment);
                 SegmentOutputStream out = outputStreamFactory.createOutputStreamForSegment(segment, segmentSealedCallBack, config, delegationToken);
                 writers.put(segment, out);
             }

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -130,7 +130,7 @@ public class SegmentSelector {
                                                         Consumer<Segment> segmentSealedCallback) {
         currentSegments = newStreamSegments;
         createMissingWriters(segmentSealedCallback, newStreamSegments.getDelegationToken());
-        log.debug("Fetch unacked events for segment :{}", sealedSegment);
+        log.debug("Fetch unacked events for segment: {}, and adding new segments {}", sealedSegment, newStreamSegments);
         List<PendingEvent> toResend = writers.get(sealedSegment).getUnackedEventsOnSeal();
         writers.remove(sealedSegment); //remove this sealed segment writer.
         return toResend;

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -82,4 +82,9 @@ public class StreamSegments {
         }
         return new StreamSegments(result, delegationToken);
     }
+    
+    @Override
+    public String toString() {
+        return "StreamSegments:" + segments.toString();
+    }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
+import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -48,6 +49,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 public class EventStreamWriterTest {
+    
+    private static final InlineExecutor EXECUTOR = new InlineExecutor();
+    
+    @AfterClass
+    public static void cleanup() {
+        EXECUTOR.shutdown();
+    }
 
     @Test
     public void testWrite() {
@@ -62,7 +70,7 @@ public class EventStreamWriterTest {
         MockSegmentIoStreams outputStream = new MockSegmentIoStreams(segment);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
-                new JavaSerializer<>(), config, new InlineExecutor());
+                new JavaSerializer<>(), config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
         writer.close();
@@ -103,7 +111,7 @@ public class EventStreamWriterTest {
         SegmentOutputStream outputStream = Mockito.mock(SegmentOutputStream.class);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
-                new JavaSerializer<>(), config, new InlineExecutor());
+                new JavaSerializer<>(), config, EXECUTOR, EXECUTOR);
         Mockito.doThrow(new RuntimeException("Intentional exception")).when(outputStream).close();
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
@@ -126,8 +134,10 @@ public class EventStreamWriterTest {
     private static final class FakeSegmentOutputStream implements SegmentOutputStream {
         private final Segment segment;
         private Consumer<Segment> callBackForSealed;
-        private final ArrayList<PendingEvent> writes = new ArrayList<>();
-
+        private final ArrayList<PendingEvent> acked = new ArrayList<>();
+        private final ArrayList<PendingEvent> unacked = new ArrayList<>();
+        private boolean sealed = false;
+ 
         private void invokeSealedCallBack() {
             if (callBackForSealed != null) {
                 callBackForSealed.accept(segment);
@@ -136,7 +146,7 @@ public class EventStreamWriterTest {
 
         @Override
         public void write(PendingEvent event) {
-            writes.add(event);
+            unacked.add(event);
         }
 
         @Override
@@ -145,12 +155,16 @@ public class EventStreamWriterTest {
 
         @Override
         public void flush() throws SegmentSealedException  {
-            writes.clear();
+            if (!sealed) {
+                acked.addAll(unacked);
+                unacked.clear();
+            }
         }
 
         @Override
         public List<PendingEvent> getUnackedEventsOnSeal() {
-            return Collections.unmodifiableList(writes);
+            sealed = true;
+            return Collections.unmodifiableList(unacked);
         }
 
         @Override
@@ -236,7 +250,7 @@ public class EventStreamWriterTest {
                .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -249,9 +263,10 @@ public class EventStreamWriterTest {
         writer.writeEvent(routingKey, "Bar");
         Mockito.verify(controller, Mockito.times(1)).getCurrentSegments(any(), any());
 
-        assertEquals(2, outputStream2.getUnackedEventsOnSeal().size());
-        assertEquals("Foo", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(0).getData()));
-        assertEquals("Bar", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(1).getData()));
+        assertEquals(1, outputStream2.acked.size());
+        assertEquals(1, outputStream2.unacked.size());
+        assertEquals("Foo", serializer.deserialize(outputStream2.acked.get(0).getData()));
+        assertEquals("Bar", serializer.deserialize(outputStream2.unacked.get(0).getData()));
     }
 
     @Test
@@ -286,7 +301,7 @@ public class EventStreamWriterTest {
                 .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -296,17 +311,18 @@ public class EventStreamWriterTest {
         writer.writeEvent(routingKey, "Bar");
         Mockito.verify(controller, Mockito.times(1)).getCurrentSegments(any(), any());
 
-        assertEquals(2, outputStream1.getUnackedEventsOnSeal().size());
-        assertEquals("Foo", serializer.deserialize(outputStream1.getUnackedEventsOnSeal().get(0).getData()));
-        assertEquals("Bar", serializer.deserialize(outputStream1.getUnackedEventsOnSeal().get(1).getData()));
+        assertEquals(2, outputStream1.unacked.size());
+        assertEquals("Foo", serializer.deserialize(outputStream1.unacked.get(0).getData()));
+        assertEquals("Bar", serializer.deserialize(outputStream1.unacked.get(1).getData()));
 
         outputStream1.invokeSealedCallBack(); // simulate a segment sealed callback.
         writer.writeEvent(routingKey, "TestData");
         //This time the actual handleLogSealed is invoked and the resend method resends data to outputStream2.
-        assertEquals(3, outputStream2.getUnackedEventsOnSeal().size());
-        assertEquals("Foo", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(0).getData()));
-        assertEquals("Bar", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(1).getData()));
-        assertEquals("TestData", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(2).getData()));
+        assertEquals(2, outputStream2.acked.size());
+        assertEquals("Foo", serializer.deserialize(outputStream2.acked.get(0).getData()));
+        assertEquals("Bar", serializer.deserialize(outputStream2.acked.get(1).getData()));
+        assertEquals(1, outputStream2.unacked.size());
+        assertEquals("TestData", serializer.deserialize(outputStream2.unacked.get(0).getData()));
 
     }
 
@@ -338,16 +354,16 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         Transaction<String> txn = writer.beginTxn();
         txn.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertTrue(bad.getUnackedEventsOnSeal().isEmpty());
-        assertEquals(1, outputStream.getUnackedEventsOnSeal().size());
-        outputStream.getUnackedEventsOnSeal().get(0).getAckFuture().complete(true);
+        assertTrue(bad.unacked.isEmpty());
+        assertEquals(1, outputStream.unacked.size());
+        outputStream.unacked.get(0).getAckFuture().complete(true);
         txn.flush();
-        assertTrue(bad.getUnackedEventsOnSeal().isEmpty());
-        assertTrue(outputStream.getUnackedEventsOnSeal().isEmpty());
+        assertTrue(bad.unacked.isEmpty());
+        assertTrue(outputStream.unacked.isEmpty());
     }
 
     @Test
@@ -372,7 +388,7 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         Transaction<String> txn = writer.beginTxn();
         outputStream.invokeSealedCallBack();
         try {
@@ -381,8 +397,8 @@ public class EventStreamWriterTest {
             // Expected
         }
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertTrue(bad.getUnackedEventsOnSeal().isEmpty());
-        assertEquals(1, outputStream.getUnackedEventsOnSeal().size());
+        assertTrue(bad.unacked.isEmpty());
+        assertEquals(1, outputStream.unacked.size());
     }
 
     @Test
@@ -401,12 +417,49 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
+        assertTrue(outputStream.unacked.size() > 0);
         writer.flush();
-        assertTrue(outputStream.getUnackedEventsOnSeal().isEmpty());
+        assertTrue(outputStream.unacked.isEmpty());
+    }
+    
+    @Test
+    public void testSealInvokesFlush() {
+        String scope = "scope";
+        String streamName = "stream";
+        StreamImpl stream = new StreamImpl(scope, streamName);
+        Segment segment1 = new Segment(scope, streamName, 0);
+        Segment segment2 = new Segment(scope, streamName, 1);
+        EventWriterConfig config = EventWriterConfig.builder().build();
+
+        SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+        FakeSegmentOutputStream outputStream1 = new FakeSegmentOutputStream(segment1);
+        FakeSegmentOutputStream outputStream2 = new FakeSegmentOutputStream(segment2);
+        Mockito.when(controller.getCurrentSegments(scope, streamName))
+                .thenReturn(getSegmentsFuture(segment1));
+        Mockito.when(controller.getSuccessors(segment1)).thenReturn(getReplacement(segment1, segment2));
+        Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment1), any(), any(), any())).thenAnswer(i -> {
+            outputStream1.callBackForSealed = i.getArgument(1);
+            return outputStream1;
+        });
+        Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment2), any(), any(), any())).thenAnswer(i -> {
+            outputStream2.callBackForSealed = i.getArgument(1);
+            return outputStream2;
+        });
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        @Cleanup
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
+                config, EXECUTOR, EXECUTOR);
+        writer.writeEvent("Foo");
+        Mockito.verify(controller).getCurrentSegments(any(), any());
+        assertEquals(1, outputStream1.unacked.size());
+        assertEquals(0, outputStream1.acked.size());
+        outputStream1.invokeSealedCallBack();
+        assertEquals(0, outputStream2.unacked.size());
+        assertEquals(1, outputStream2.acked.size());
     }
 
     @Test
@@ -432,10 +485,10 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
+        assertTrue(outputStream.unacked.size() > 0);
 
         MockSegmentIoStreams outputStream2 = new MockSegmentIoStreams(segment2);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment2), any(), any(), any())).thenReturn(outputStream2);
@@ -471,7 +524,7 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -514,7 +567,7 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -559,10 +612,10 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertTrue(outputStream1.getUnackedEventsOnSeal().size() > 0);
+        assertTrue(outputStream1.unacked.size() > 0);
 
         MockSegmentIoStreams outputStream2 = new MockSegmentIoStreams(segment2);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment2), any(), any(), any())).thenReturn(outputStream2);
@@ -614,10 +667,10 @@ public class EventStreamWriterTest {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, new InlineExecutor());
+                config, EXECUTOR, EXECUTOR);
         writer.writeEvent(routingKey, "Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
-        assertEquals(1, outputStream1.getUnackedEventsOnSeal().size());
+        assertEquals(1, outputStream1.unacked.size());
         assertTrue(outputStream2.getUnackedEventsOnSeal().isEmpty());
 
         outputStream1.invokeSealedCallBack();
@@ -627,10 +680,12 @@ public class EventStreamWriterTest {
 
         Mockito.verify(controller, Mockito.times(1)).getCurrentSegments(any(), any());
 
-        assertEquals(1, outputStream2.getUnackedEventsOnSeal().size());
-        assertEquals("Foo", serializer.deserialize(outputStream2.getUnackedEventsOnSeal().get(0).getData()));
-        assertEquals(2, outputStream3.getUnackedEventsOnSeal().size());
-        assertEquals("Foo", serializer.deserialize(outputStream3.getUnackedEventsOnSeal().get(0).getData()));
-        assertEquals("Bar", serializer.deserialize(outputStream3.getUnackedEventsOnSeal().get(1).getData()));
+        assertEquals(0, outputStream2.acked.size());
+        assertEquals(1, outputStream2.unacked.size());
+        assertEquals("Foo", serializer.deserialize(outputStream2.unacked.get(0).getData()));
+        assertEquals(1, outputStream3.acked.size());
+        assertEquals(1, outputStream3.unacked.size());
+        assertEquals("Foo", serializer.deserialize(outputStream3.acked.get(0).getData()));
+        assertEquals("Bar", serializer.deserialize(outputStream3.unacked.get(0).getData()));
     }
 }

--- a/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
@@ -101,8 +101,14 @@ public final class ExecutorServiceHelpers {
         }
     }
     
-    public static ThreadPoolExecutor getShrinkingExecutor(int maxThreads, int threadTimeout, String poolName) {
-        return new ThreadPoolExecutor(0, maxThreads, threadTimeout, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
+    /**
+     * Operates like Executors.cachedThreadPool but with a custom thread timeout and pool name.
+     * @return A new threadPool
+     * @param threadTimeout the number of milliseconds that a thread should sit idle before shutting down.
+     * @param poolName The name of the threadpool.
+     */
+    public static ThreadPoolExecutor getShrinkingExecutor(int threadTimeout, String poolName) {
+        return new ThreadPoolExecutor(0, Short.MAX_VALUE, threadTimeout, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
                 getThreadFactory(poolName), new CallerRuns()); // Caller runs only occurs after shutdown, as queue size is unbounded.
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -410,7 +410,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                createStreamsSegment.getDelegationToken(), READ_UPDATE, "Create Segment")) {
             return;
        }
-
+       log.debug("Creating stream segment {}", createStreamsSegment);
         segmentStore.createStreamSegment(createStreamsSegment.getSegment(), attributes, TIMEOUT)
                 .thenAccept(v -> {
                     createStreamSegment.reportSuccessEvent(timer.getElapsed());


### PR DESCRIPTION
**Change log description**
Flush outstanding writes in response to a segment seal

**Purpose of the change**
Fixes at least one cause of #2470. In the event of a segment merge, when the first segment seal is encountered it is possible that a second segment has events inflight. If the segment is replaced in EventStreamWriter with its replacement, a new event could arrive and be published to the new segment before the segmentSealed response arrives for the old segment. This would result in the event written after the seal for the other segment and before the seal is received to be out of order.

**What the code does**
When the segmentSealed arrives the EventStreamWriter now invokes flush. This should force any outstanding events to be processed (or result in their own segmentSealed) before the event write lock is released.

**How to verify it**
A new unit test is added