### PR TITLE
Issue 2347: Match the bookkeeper server version used for system tests with the one used for integration tests

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 ENV BOOKKEEPER_VERSION=4.5.0 \
     ZOOKEEPER_VERSION=3.5.3-beta
 
-RUN wget https://archive.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
+RUN wget http://central.maven.org/maven2/org/apache/bookkeeper/bookkeeper-server/$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
 &&  tar xvzf  bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
 &&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bookkeeper
 

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 &&  mkdir -p /opt \
 &&  cd /opt
 
-ENV BOOKKEEPER_VERSION=4.6.1 \
+ENV BOOKKEEPER_VERSION=4.6.2 \
     ZOOKEEPER_VERSION=3.5.3-beta
 
 RUN wget http://www.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update \
 &&  mkdir -p /opt \
 &&  cd /opt
 
-ENV BOOKKEEPER_VERSION=4.6.2 \
+ENV BOOKKEEPER_VERSION=4.5.0 \
     ZOOKEEPER_VERSION=3.5.3-beta
 
-RUN wget http://www.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
+RUN wget https://archive.apache.org/dist/bookkeeper/bookkeeper-$BOOKKEEPER_VERSION/bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
 &&  tar xvzf  bookkeeper-server-$BOOKKEEPER_VERSION-bin.tar.gz \
 &&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bookkeeper
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,6 @@ dockerExecutable=/usr/bin/docker
 apacheCommonsCsvVersion=1.5
 apacheCuratorVersion=4.0.0
 checkstyleToolVersion=8.2
-#different bookkeeper versions
-#in system tests and actual deployment- 4.6.2 version of server against 4.5.0 client
-#in integration tests- same version(4.5.0) of client and server
 bookKeeperVersion=4.5.0
 commonsioVersion=2.5
 commonsLang3Version=3.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ apacheCommonsCsvVersion=1.5
 apacheCuratorVersion=4.0.0
 checkstyleToolVersion=8.2
 #different bookkeeper versions
-#in system tests and actual deployment- 4.6.1 version of server against 4.5.0 client
+#in system tests and actual deployment- 4.6.2 version of server against 4.5.0 client
 #in integration tests- same version(4.5.0) of client and server
 bookKeeperVersion=4.5.0
 commonsioVersion=2.5


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
The current Version 4.6.1 which we use in docker file of bookkeeper unavailable. Modifying the repo to fetch  the version which is used in `grade.properties`
Changing Bookkeeper v4.6.1 to v4.5.0 and pull it from a different repo.

**Purpose of the change**
Fixes #2347 

**What the code does**
* Changes bk version in 1. bookkeeper docker file
* Changing the repo from which bk server is downloaded in bookkeeper dockerfile.

**How to verify it**
Build and all tests should pass