### PR TITLE
Issue 2460: When sending no credentials, exception returned has UNKNOWN status

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -21,7 +21,6 @@ import io.grpc.Status;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.pravega.auth.AuthHandler;
-import io.pravega.common.auth.AuthenticationException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -71,7 +70,7 @@ public class PravegaInterceptor implements ServerInterceptor {
                 context = context.withValue(INTERCEPTOR_OBJECT, this);
             }
         } else {
-            throw new RuntimeException(new AuthenticationException("Handler not specified"));
+            call.close(Status.fromCode(Status.Code.UNAUTHENTICATED), headers);
         }
         return Contexts.interceptCall(context, call, headers, next);
     }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -21,6 +21,7 @@ import io.grpc.Status;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.pravega.auth.AuthHandler;
+import io.pravega.common.auth.AuthenticationException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -69,6 +70,8 @@ public class PravegaInterceptor implements ServerInterceptor {
                 context = context.withValue(AUTH_CONTEXT_PARAMS, paramMap);
                 context = context.withValue(INTERCEPTOR_OBJECT, this);
             }
+        } else {
+            throw new RuntimeException(new AuthenticationException("Handler not specified"));
         }
         return Contexts.interceptCall(context, call, headers, next);
     }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -71,6 +71,7 @@ public class PravegaInterceptor implements ServerInterceptor {
             }
         } else {
             call.close(Status.fromCode(Status.Code.UNAUTHENTICATED), headers);
+            return null;
         }
         return Contexts.interceptCall(context, call, headers, next);
     }


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
In case of grpc based authentication, when an auth handler is not specified, the grpc handler code loops through all the handlers and then fails with `UNKNOWN` status. In case of no headers present, the handlers should throw exception.

**Purpose of the change**
This fixes #2460.

**What the code does**

Throw exception when authentication method is not selected.
**How to verify it**
In case the method is not specified, authentication error is observed.