### PR TITLE
Issue 2466: Accept standalone config through system properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -519,10 +519,11 @@ project('standalone') {
     mainClassName = "io.pravega.local.LocalPravegaEmulator"
     applicationDefaultJvmArgs = ["-server", "-Xmx4g", "-XX:+HeapDumpOnOutOfMemoryError",
                                  "-Dlogback.configurationFile=PRAVEGA_APP_HOME/conf/logback.xml",
+                                 "-Dsinglenode.configurationFile=PRAVEGA_APP_HOME/conf/standalone-config.properties",
                                  "-Dlog.dir=PRAVEGA_APP_HOME/logs",
                                  "-Dlog.name=pravega",
                                  "-Xdebug",
-                                 "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"]
+                                 "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n"]
     startScripts {
         classpath += files('./pluginlib')
         doLast {
@@ -568,6 +569,7 @@ project('standalone') {
         classpath = sourceSets.main.runtimeClasspath
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
+        systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
 
         if (systemProperties.get("extDirs") != null) {
             classpath += files(systemProperties.get("extDirs"))

--- a/config/standalone-config.properties
+++ b/config/standalone-config.properties
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+##region General Segment Store Settings
+
+# Port on which a ZK server is started
+#singlenode.zkPort=4000
+
+# Port on which segmentstore server is started.
+#singlenode.segmentstorePort=6000
+
+# Port on which the controller server grpc is started.
+#singlenode.controllerPort=9090
+
+# Port on which the controller REST service is started.
+#singlenode.restServerPort=9091
+
+# Cert file for TLS communication.
+#singlenode.certFile=../config/cert.pem
+
+# Key file for TLS communication
+#singlenode.keyFile=../config/key.pem
+
+# Password file for default password handler
+#singlenode.passwdFile=../config/passwd
+
+#Username for default password handler implementation
+#singlenode.userName=admin
+
+#Password associated with the default user
+#singlenode.passwd=1111_aaaa
+
+# Enable TLS for segmentstore and controller.
+#singlenode.enableTls=true
+
+# Enable authentication/authorization.
+#singlenode.enableAuth=true

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -112,11 +112,6 @@ configure_standalone() {
     add_system_property "singlenode.zkPort" "2181"
     add_system_property "singlenode.controllerPort" "9090"
     add_system_property "singlenode.segmentstorePort" "12345"
-    add_system_property "singlenode.certFile" "./config/cert.pem"
-    add_system_property "singlenode.keyFile" "./config/key.pem"
-    add_system_property "singlenode.passwdFile" "./config/passwd"
-    add_system_property "singlenode.userName" "admin"
-    add_system_property "singlenode.passwd" "1111_aaaa"
 
     echo "JAVA_OPTS=${JAVA_OPTS}"
 }

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -112,6 +112,12 @@ configure_standalone() {
     add_system_property "singlenode.zkPort" "2181"
     add_system_property "singlenode.controllerPort" "9090"
     add_system_property "singlenode.segmentstorePort" "12345"
+    add_system_property "singlenode.certFile" "./config/cert.pem"
+    add_system_property "singlenode.keyFile" "./config/key.pem"
+    add_system_property "singlenode.passwdFile" "./config/passwd"
+    add_system_property "singlenode.userName" "admin"
+    add_system_property "singlenode.passwd" "1111_aaaa"
+
     echo "JAVA_OPTS=${JAVA_OPTS}"
 }
 

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -112,7 +112,6 @@ configure_standalone() {
     add_system_property "singlenode.zkPort" "2181"
     add_system_property "singlenode.controllerPort" "9090"
     add_system_property "singlenode.segmentstorePort" "12345"
-
     echo "JAVA_OPTS=${JAVA_OPTS}"
 }
 

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -274,7 +274,8 @@ public class InProcPravegaCluster implements AutoCloseable {
                         .with(ReadIndexConfig.CACHE_POLICY_MAX_TIME, 60 * 1000)
                         .with(ReadIndexConfig.CACHE_POLICY_MAX_SIZE, 128 * 1024 * 1024L))
                 .include(AutoScalerConfig.builder()
-                        .with(AutoScalerConfig.CONTROLLER_URI, "tcp://localhost:" + controllerPorts[0])
+                        .with(AutoScalerConfig.CONTROLLER_URI, (this.enableTls ? "tcp" : "tls") + "://localhost:"
+                                                                                + controllerPorts[0])
                                          .with(AutoScalerConfig.AUTH_USERNAME, this.userName)
                                          .with(AutoScalerConfig.AUTH_PASSWORD, this.passwd)
                                          .with(AutoScalerConfig.TOKEN_SIGNING_KEY, "secret")

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.local;
 
-
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +21,9 @@ public class LocalPravegaEmulator implements AutoCloseable {
     private final InProcPravegaCluster inProcPravegaCluster;
 
     @Builder
-    private LocalPravegaEmulator(int zkPort, int controllerPort, int segmentStorePort, int restServerPort, boolean enableAuth, boolean enableTls) {
+    private LocalPravegaEmulator(int zkPort, int controllerPort, int segmentStorePort, int restServerPort,
+                                 boolean enableAuth, boolean enableTls, String certFile, String passwd, String userName,
+                                 String passwdFile, String keyFile) {
         inProcPravegaCluster = InProcPravegaCluster
                 .builder()
                 .isInProcZK(true)
@@ -39,6 +40,11 @@ public class LocalPravegaEmulator implements AutoCloseable {
                 .enableMetrics(false)
                 .enableAuth(enableAuth)
                 .enableTls(enableTls)
+                .certFile(certFile)
+                .keyFile(keyFile)
+                .passwdFile(passwdFile)
+                .userName(userName)
+                .passwd(passwd)
                 .build();
         inProcPravegaCluster.setControllerPorts(new int[] {controllerPort});
         inProcPravegaCluster.setSegmentStorePorts(new int[] {segmentStorePort});
@@ -59,6 +65,11 @@ public class LocalPravegaEmulator implements AutoCloseable {
                     .restServerPort(conf.getRestServerPort())
                     .enableAuth(true)
                     .enableTls(true)
+                    .certFile(conf.getCertFile())
+                    .keyFile(conf.getKeyFile())
+                    .passwdFile(conf.getPasswdFile())
+                    .userName(conf.getUserName())
+                    .passwd(conf.getPasswd())
                     .build();
 
             Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -54,6 +54,7 @@ public class LocalPravegaEmulator implements AutoCloseable {
         try {
             ServiceBuilderConfig config = ServiceBuilderConfig
                     .builder()
+                    .include(System.getProperty(SingleNodeConfig.PROPERTY_FILE, "./config/standalone-config.properties"))
                     .include(System.getProperties())
                     .build();
             SingleNodeConfig conf = config.getConfig(SingleNodeConfig::builder);
@@ -63,8 +64,8 @@ public class LocalPravegaEmulator implements AutoCloseable {
                     .segmentStorePort(conf.getSegmentStorePort())
                     .zkPort(conf.getZkPort())
                     .restServerPort(conf.getRestServerPort())
-                    .enableAuth(true)
-                    .enableTls(true)
+                    .enableAuth(conf.isEnableAuth())
+                    .enableTls(conf.isEnableTls())
                     .certFile(conf.getCertFile())
                     .keyFile(conf.getKeyFile())
                     .passwdFile(conf.getPasswdFile())

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -15,39 +15,53 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Builder
 public class LocalPravegaEmulator implements AutoCloseable {
+
+    private int zkPort;
+    private int controllerPort;
+    private int segmentStorePort;
+    private int restServerPort;
+    private boolean enableAuth;
+    private boolean enableTls;
+    private String certFile;
+    private String passwd;
+    private String userName;
+    private String passwdFile;
+    private String keyFile;
 
     @Getter
     private final InProcPravegaCluster inProcPravegaCluster;
 
-    @Builder
-    private LocalPravegaEmulator(int zkPort, int controllerPort, int segmentStorePort, int restServerPort,
-                                 boolean enableAuth, boolean enableTls, String certFile, String passwd, String userName,
-                                 String passwdFile, String keyFile) {
-        inProcPravegaCluster = InProcPravegaCluster
-                .builder()
-                .isInProcZK(true)
-                .zkUrl("localhost:" + zkPort)
-                .zkPort(zkPort)
-                .isInMemStorage(true)
-                .isInProcController(true)
-                .controllerCount(1)
-                .isInProcSegmentStore(true)
-                .segmentStoreCount(1)
-                .containerCount(4)
-                .startRestServer(true)
-                .restServerPort(restServerPort)
-                .enableMetrics(false)
-                .enableAuth(enableAuth)
-                .enableTls(enableTls)
-                .certFile(certFile)
-                .keyFile(keyFile)
-                .passwdFile(passwdFile)
-                .userName(userName)
-                .passwd(passwd)
-                .build();
-        inProcPravegaCluster.setControllerPorts(new int[] {controllerPort});
-        inProcPravegaCluster.setSegmentStorePorts(new int[] {segmentStorePort});
+    public static final class LocalPravegaEmulatorBuilder {
+        public LocalPravegaEmulator build() {
+            this.inProcPravegaCluster = InProcPravegaCluster
+                    .builder()
+                    .isInProcZK(true)
+                    .zkUrl("localhost:" + zkPort)
+                    .zkPort(zkPort)
+                    .isInMemStorage(true)
+                    .isInProcController(true)
+                    .controllerCount(1)
+                    .isInProcSegmentStore(true)
+                    .segmentStoreCount(1)
+                    .containerCount(4)
+                    .startRestServer(true)
+                    .restServerPort(restServerPort)
+                    .enableMetrics(false)
+                    .enableAuth(enableAuth)
+                    .enableTls(enableTls)
+                    .certFile(certFile)
+                    .keyFile(keyFile)
+                    .passwdFile(passwdFile)
+                    .userName(userName)
+                    .passwd(passwd)
+                    .build();
+            this.inProcPravegaCluster.setControllerPorts(new int[]{controllerPort});
+            this.inProcPravegaCluster.setSegmentStorePorts(new int[]{segmentStorePort});
+            return new LocalPravegaEmulator(zkPort, controllerPort, segmentStorePort, restServerPort, enableAuth, enableTls,
+                    certFile, passwd, userName, passwdFile, keyFile, inProcPravegaCluster);
+        }
     }
 
     public static void main(String[] args) {

--- a/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
+++ b/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
@@ -20,6 +20,12 @@ public class SingleNodeConfig {
     public final static Property<Integer> SEGMENTSTORE_PORT = Property.named("segmentstorePort", 6000);
     public final static Property<Integer> CONTROLLER_PORT = Property.named("controllerPort", 9090);
     public final static Property<Integer> REST_SERVER_PORT = Property.named("restServerPort", 9091);
+    public final static Property<String> CERT_FILE = Property.named("certFile", "../config/cert.pem");
+    public final static Property<String> KEY_FILE = Property.named("keyFile", "../config/key.pem");
+    public final static Property<String> PASSWD_FILE = Property.named("passwdFile", "../config/passwd");
+    public final static Property<String> USER_NAME = Property.named("userName", "admin");
+    public final static Property<String> PASSWD = Property.named("passwd", "1111_aaaa");
+
     private static final String COMPONENT_CODE = "singlenode";
     //end region
 
@@ -49,6 +55,36 @@ public class SingleNodeConfig {
     @Getter
     private final int restServerPort;
 
+    /**
+     * The file containing the client certificate.
+     */
+    @Getter
+    private String certFile;
+
+    /**
+     * File containing the certificate key for the server socket.
+     */
+    @Getter
+    private String keyFile;
+
+    /**
+     * File containing the username passwd db for default auth handler.
+     */
+    @Getter
+    private String passwdFile;
+
+    /**
+     * User for the authenticated interactions between segmentstore and controller.
+     */
+    @Getter
+    private String userName;
+
+    /**
+     * Password for the user.
+     */
+    @Getter
+    private String passwd;
+
     //end region
 
     //region constructor
@@ -57,6 +93,11 @@ public class SingleNodeConfig {
         this.segmentStorePort = properties.getInt(SEGMENTSTORE_PORT);
         this.controllerPort = properties.getInt(CONTROLLER_PORT);
         this.restServerPort = properties.getInt(REST_SERVER_PORT);
+        this.certFile = properties.get(CERT_FILE);
+        this.keyFile = properties.get(KEY_FILE);
+        this.passwdFile = properties.get(PASSWD_FILE);
+        this.userName = properties.get(USER_NAME);
+        this.passwd = properties.get(PASSWD);
     }
 
     /**

--- a/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
+++ b/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
@@ -20,11 +20,11 @@ public class SingleNodeConfig {
     public final static Property<Integer> SEGMENTSTORE_PORT = Property.named("segmentstorePort", 6000);
     public final static Property<Integer> CONTROLLER_PORT = Property.named("controllerPort", 9090);
     public final static Property<Integer> REST_SERVER_PORT = Property.named("restServerPort", 9091);
-    public final static Property<String> CERT_FILE = Property.named("certFile", "../config/cert.pem");
-    public final static Property<String> KEY_FILE = Property.named("keyFile", "../config/key.pem");
-    public final static Property<String> PASSWD_FILE = Property.named("passwdFile", "../config/passwd");
-    public final static Property<String> USER_NAME = Property.named("userName", "admin");
-    public final static Property<String> PASSWD = Property.named("passwd", "1111_aaaa");
+    public final static Property<String> CERT_FILE = Property.named("certFile", "");
+    public final static Property<String> KEY_FILE = Property.named("keyFile", "");
+    public final static Property<String> PASSWD_FILE = Property.named("passwdFile", "");
+    public final static Property<String> USER_NAME = Property.named("userName", "");
+    public final static Property<String> PASSWD = Property.named("passwd", "");
     public final static Property<Boolean> ENABLE_TLS = Property.named("enableTls", false);
     public final static Property<Boolean> ENABLE_AUTH = Property.named("enableAuth", false);
     public final static String PROPERTY_FILE = "singlenode.configurationFile";

--- a/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
+++ b/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
@@ -25,6 +25,9 @@ public class SingleNodeConfig {
     public final static Property<String> PASSWD_FILE = Property.named("passwdFile", "../config/passwd");
     public final static Property<String> USER_NAME = Property.named("userName", "admin");
     public final static Property<String> PASSWD = Property.named("passwd", "1111_aaaa");
+    public final static Property<Boolean> ENABLE_TLS = Property.named("enableTls", false);
+    public final static Property<Boolean> ENABLE_AUTH = Property.named("enableAuth", false);
+    public final static String PROPERTY_FILE = "singlenode.configurationFile";
 
     private static final String COMPONENT_CODE = "singlenode";
     //end region
@@ -85,6 +88,18 @@ public class SingleNodeConfig {
     @Getter
     private String passwd;
 
+    /**
+     * Flag to enable TLS.
+     */
+    @Getter
+    private boolean enableTls;
+
+    /**
+     * Flag to enable auth.
+     */
+    @Getter
+    private boolean enableAuth;
+
     //end region
 
     //region constructor
@@ -98,6 +113,8 @@ public class SingleNodeConfig {
         this.passwdFile = properties.get(PASSWD_FILE);
         this.userName = properties.get(USER_NAME);
         this.passwd = properties.get(PASSWD);
+        this.enableTls = properties.getBoolean(ENABLE_TLS);
+        this.enableAuth = properties.getBoolean(ENABLE_AUTH);
     }
 
     /**
@@ -108,5 +125,6 @@ public class SingleNodeConfig {
     public static ConfigBuilder<SingleNodeConfig> builder() {
         return new ConfigBuilder<>(COMPONENT_CODE, SingleNodeConfig::new);
     }
+
     //end region
 }

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -52,6 +52,11 @@ public class InProcPravegaClusterTest {
                                            .restServerPort(TestUtils.getAvailableListenPort())
                                            .enableAuth(authEnabled)
                                            .enableTls(tlsEnabled)
+                                           .certFile("../config/cert.pem")
+                                           .keyFile("../config/key.pem")
+                                           .passwdFile("../config/passwd")
+                                           .userName("admin")
+                                           .passwd("1111_aaaa")
                                            .build();
         localPravega.start();
     }


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
- Move security related config in standalone from hard coding to config.
- Update tests to use this.

**Purpose of the change**
This fixes #2466. The config can be specified through system properties. Currently standalone does not pick the config up from config properties.

**What the code does**
Removes hard coding of security related config from `standalone` and accepts it from system properties.

**How to verify it**
1. Unit tests 
2. Specify properties through system properties and see them changed in the standalone/