### PR TITLE
Issue 2474

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
@@ -23,7 +23,6 @@ import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
 import io.pravega.shared.controller.event.SealStreamEvent;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -115,18 +114,14 @@ public class SealStreamTask implements StreamTask<SealStreamEvent> {
                                         .abortTxn(scope, stream, txIdPair.getKey(), null, context)
                                         .exceptionally(e -> {
                                             Throwable cause = Exceptions.unwrap(e);
-                                            if (cause instanceof StoreException.IllegalStateException ||
-                                                    cause instanceof StoreException.WriteConflictException) {
-                                                // IllegalStateException : The transaction is already in the process of being
-                                                // completed. Ignore
-                                                // WriteConflictException : Another thread is updating the transaction record.
-                                                // ignore. We will effectively retry cleaning up the transaction if it is not
-                                                // already being aborted.
-                                                return null;
-                                            } else {
-                                                // throw the original exception
-                                                throw new CompletionException(e);
-                                            }
+                                            log.debug("Exception thrown during seal stream while trying to abort transaction " +
+                                                    "on stream {}/{}", scope, stream, cause);
+                                            // Note: we can ignore this error because if there are transactions found on a stream,
+                                            // seal stream reposts the event back into request stream.
+                                            // So in subsequent iteration it will reattempt to abort all active transactions.
+                                            // This is a valid course of action because it is important to understand that
+                                            // all transactions are completable (either via abort of commit).
+                                            return null;
                                         }));
                             } else {
                                 voidCompletableFuture = CompletableFuture.completedFuture(null);


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**

We have changed SealStreamTask to handle all exceptions in abortTransaction to be logged and ignored as sealStream task is reattempted if transactions are found on the stream and abort will be retried in subsequent attempts.

**Purpose of the change**
Fixes issue 2474

**What the code does**
Abort transaction can fail with three specific errors (WriteConflict, IllegalState, DataNotFound) and general retryable exceptions related to connection failures or inability to write event to abortstream. 

Retryable exceptions are implicitly handled by the framework and we were only explicitly handling WriteConflict and IllegalState exceptions in seal task. 

We have handled all exceptions from abortTransaction call to be ignored instead of specific ones because if some changes to abort transaction method is made in future and it throws some newer exceptions, we may miss handling it in seal stream task. And seal stream task doesnt really care for the type of exception anyway.  
**How to verify it**
Unit test added