### PR TITLE
Issue 2481: ZkStreamStore.getCurrentTxns should not throw DataNotFoundException 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.store.stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 /**
@@ -55,6 +57,7 @@ class ZKStream extends PersistentStreamBase<Integer> {
     private static final String RETENTION_PATH = STREAM_PATH + "/retention";
     private static final String SEALED_SEGMENTS_PATH = STREAM_PATH + "/sealedSegments";
     private static final String MARKER_PATH = STREAM_PATH + "/markers";
+    private static final Data<Integer> EMPTY_DATA = new Data<>(null, -1);
 
     private final ZKStoreHelper store;
     private final String creationPath;
@@ -330,8 +333,17 @@ class ZKStream extends PersistentStreamBase<Integer> {
         return getActiveEpoch(false)
                 .thenCompose(epoch -> store.getChildren(getEpochPath(epoch.getKey()))
                         .thenCompose(txIds -> Futures.allOfWithResults(txIds.stream().collect(
-                                Collectors.toMap(txId -> txId, txId -> cache.getCachedData(getActiveTxPath(epoch.getKey(), txId))))
-                        )));
+                                Collectors.toMap(txId -> txId, txId -> cache.getCachedData(getActiveTxPath(epoch.getKey(), txId))
+                                       .exceptionally(e -> {
+                                           if (Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException) {
+                                               return EMPTY_DATA;
+                                           } else {
+                                               throw new CompletionException(e);
+                                           }
+                                       })))
+                        ).thenApply(txnMap -> txnMap.entrySet().stream().filter(x -> !x.getValue().equals(EMPTY_DATA))
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                        ));
     }
 
     @Override
@@ -563,7 +575,8 @@ class ZKStream extends PersistentStreamBase<Integer> {
     // endregion
 
     // region private helpers
-    private String getActiveTxPath(final long epoch, final String txId) {
+    @VisibleForTesting
+    String getActiveTxPath(final long epoch, final String txId) {
         return ZKPaths.makePath(ZKPaths.makePath(activeTxRoot, Long.toString(epoch)), txId);
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -10,6 +10,9 @@
 package io.pravega.controller.store.stream;
 
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.controller.store.stream.tables.Data;
+import io.pravega.controller.store.stream.tables.TableHelper;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.controller.store.stream.tables.State;
@@ -47,6 +50,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.reset;
 
 public class ZkStreamTest {
     private static final String SCOPE = "scope";
@@ -514,6 +521,41 @@ public class ZkStreamTest {
 
         assert store.transactionStatus(ZkStreamTest.SCOPE, streamName, UUID.randomUUID(), context, executor)
                 .get().equals(TxnStatus.UNKNOWN);
+    }
+
+    @Test(timeout = 10000)
+    public void testGetActiveTxn() throws Exception {
+        ZKStoreHelper storeHelper = spy(new ZKStoreHelper(cli, executor));
+        ZKStream stream = new ZKStream("scope", "stream", storeHelper);
+        // create epoch
+        stream.createEpochNodeIfAbsent(0).join();
+
+        byte[] historyTable = TableHelper.createHistoryTable(1L, Lists.newArrayList(0, 1));
+        stream.createHistoryTableIfAbsent(new Data<>(historyTable, 0)).join();
+        stream.createStateIfAbsent(State.ACTIVE).join();
+        UUID txId = UUID.randomUUID();
+        stream.createTransaction(txId, 1000L, 1000L, 1000L).join();
+
+        String activeTxPath = stream.getActiveTxPath(0, txId.toString());
+        // throw DataNotFoundException for txn path
+        doReturn(Futures.failedFuture(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "txn data not found")))
+                .when(storeHelper).getData(eq(activeTxPath));
+
+        Map<String, Data<Integer>> result = stream.getCurrentTxns().join();
+        // verify that call succeeds and no active txns were found
+        assertTrue(result.isEmpty());
+
+        // throw generic exception for txn path
+        doReturn(Futures.failedFuture(new RuntimeException())).when(storeHelper).getData(eq(activeTxPath));
+
+        ZKStream stream2 = new ZKStream("scope", "stream", storeHelper);
+        // verify that the call fails
+        AssertExtensions.assertThrows("", stream2.getCurrentTxns(), e -> Exceptions.unwrap(e) instanceof RuntimeException);
+
+        reset(storeHelper);
+        ZKStream stream3 = new ZKStream("scope", "stream", storeHelper);
+        result = stream3.getCurrentTxns().join();
+        assertEquals(1, result.size());
     }
 
     private void testCommitFailure(StreamMetadataStore store, String scope, String stream, int epoch, UUID txnId,


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
Handles DataNotFoundException in getCurrentTransactions store api. 
Removes all transactions for which DataNotFoundException was thrown and returns the remainder. 

**Purpose of the change**
Fixes #2481 

**What the code does**
ZkStreamStore.getCurrentTxns is a two step process-

    gets all txn ids by querying path for children of active epoch znode.
    gets records for each txn id.

If between 1 and 2 txns records are deleted (by virtue of txn completing) then we can get DataNotFoundException

So in getCurrentTransactions, we check if DataNotFoundExcecption is thrown, and ignore it and remove such transactions from the response. 

**How to verify it**
Unit test added