### PR TITLE
Issue 2478: Fix issue with extracting config from env vars.

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -107,8 +107,7 @@ public class ClientConfig {
                                                    .stream()
                                                    .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START))
                                                    .collect(Collectors.toMap(entry ->
-                                                                   entry.getKey().toString().replace("_", "."),
-                                                           value -> (String) value.getValue()));
+                                                                   entry.getKey().toString(), value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);
             } else {
@@ -120,7 +119,8 @@ public class ClientConfig {
             Map<String, String> retVal = env.entrySet()
                                             .stream()
                                             .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START_ENV))
-                                            .collect(Collectors.toMap(entry -> (String) entry.getKey(), value -> (String) value.getValue()));
+                                            .collect(Collectors.toMap(entry -> (String) entry.getKey().toString().replace("_", "."),
+                                                    value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);
             } else {


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
The env vars are generally in the format `pravega_client_auth_*`. The extractor code needs to replace `_` with `.`.

**Purpose of the change**
This fixes #2478.

**What the code does**
Fix issue with extracting config from env vars.
**How to verify it**
Set env vars before running the client.