### PR TITLE
Issue 2487: Remove suspend flag from debug options for standalone.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -520,7 +520,7 @@ project('standalone') {
                                  "-Dlog.dir=PRAVEGA_APP_HOME/logs",
                                  "-Dlog.name=pravega",
                                  "-Xdebug",
-                                 "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"]
+                                 "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n"]
     startScripts {
         classpath += files('./pluginlib')
         doLast {


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
The suspend flag was turned on for debug option for `standalone` in one of the recent changes. Setting it back.
**Purpose of the change**
This fixes #2487.
**What the code does**
Sets the flag to `suspend=n`
**How to verify it**
Build the standalone distribution and run the standalone process.