### PR TITLE
Issue 639: Adding persistent volume while deploying bookkeeper through marathon based deployment of system tests 

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/BookkeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/BookkeeperService.java
@@ -96,7 +96,7 @@ public class BookkeeperService extends MarathonBasedService {
         app.getContainer().getDocker().setImage(IMAGE_PATH + "/nautilus/bookkeeper:" + PRAVEGA_VERSION);
         Collection<Volume> volumeCollection = new ArrayList<>();
         volumeCollection.add(createVolume("/bk", "mnt", "RW"));
-        //TODO: add persistent volume  (see issue https://github.com/pravega/pravega/issues/639)
+        volumeCollection.add(createPersistentVolume("persistent", "RW"));
         app.getContainer().setVolumes(volumeCollection);
         app.setPorts(Arrays.asList(BK_PORT));
         app.setRequirePorts(true);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/MarathonBasedService.java
@@ -32,6 +32,7 @@ import mesosphere.marathon.client.model.v2.LocalVolume;
 import mesosphere.marathon.client.model.v2.PortDefinition;
 import mesosphere.marathon.client.model.v2.Volume;
 import mesosphere.marathon.client.model.v2.Result;
+import mesosphere.marathon.client.model.v2.PersistentLocalVolume;
 import mesosphere.marathon.client.MarathonException;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
@@ -141,6 +142,13 @@ public abstract class MarathonBasedService implements Service {
         v.setHostPath(hostPath);
         v.setMode(mode);
         return v;
+    }
+
+    Volume createPersistentVolume(final String containerPath, final String mode) {
+        PersistentLocalVolume pv = new PersistentLocalVolume();
+        pv.setContainerPath(containerPath);
+        pv.setMode(mode);
+        return pv;
     }
 
     HealthCheck setHealthCheck(final int gracePeriodSeconds, final String protocol,


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
The latest marathon client , supports persistent volume feature to be deployed programmatically.
Add it to the bookkeeper deployment.

**Purpose of the change**
Fixes #639

**What the code does**
* Creates persistent volume when bookkeeper is deployed

**How to verify it**
See that persistent volume attribute is added when bookkeeper is deployed