### PR TITLE
Issue 2493: Implement deleteObjects API in S3FileSystemImpl, call it in the wrapper.

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
@@ -43,7 +43,7 @@ class S3ClientWrapper extends S3JerseyClient {
 
     @Override
     public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) {
-        return new DeleteObjectsResult();
+        return s3Impl.deleteObject(request);
     }
 
     @Synchronized

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
@@ -43,7 +43,7 @@ class S3ClientWrapper extends S3JerseyClient {
 
     @Override
     public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) {
-        return s3Impl.deleteObject(request);
+        return s3Impl.deleteObjects(request);
     }
 
     @Synchronized

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3FileSystemImpl.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3FileSystemImpl.java
@@ -18,6 +18,7 @@ import com.emc.object.s3.bean.CopyPartResult;
 import com.emc.object.s3.bean.DeleteObjectsResult;
 import com.emc.object.s3.bean.GetObjectResult;
 import com.emc.object.s3.bean.ListObjectsResult;
+import com.emc.object.s3.bean.ObjectKey;
 import com.emc.object.s3.bean.PutObjectResult;
 import com.emc.object.s3.bean.S3Object;
 import com.emc.object.s3.request.CompleteMultipartUploadRequest;
@@ -154,12 +155,20 @@ public class S3FileSystemImpl extends S3ImplBase {
 
     @Override
     public void deleteObject(String bucketName, String key) {
-
+        Path path = Paths.get(this.baseDir, bucketName, key);
+        try {
+                Files.delete(path);
+        } catch (IOException e) {
+            throw new S3Exception("NoSuchKey", HttpStatus.SC_NOT_FOUND, "NoSuchKey", "");
+        }
     }
 
     @Override
     public DeleteObjectsResult deleteObject(DeleteObjectsRequest request) {
-        return null;
+        for (ObjectKey obj : request.getDeleteObjects().getKeys()) {
+            this.deleteObject(request.getBucketName(), obj.getKey());
+        }
+        return new DeleteObjectsResult();
     }
 
     @Override

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3FileSystemImpl.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3FileSystemImpl.java
@@ -157,14 +157,14 @@ public class S3FileSystemImpl extends S3ImplBase {
     public void deleteObject(String bucketName, String key) {
         Path path = Paths.get(this.baseDir, bucketName, key);
         try {
-                Files.delete(path);
+            Files.delete(path);
         } catch (IOException e) {
             throw new S3Exception("NoSuchKey", HttpStatus.SC_NOT_FOUND, "NoSuchKey", "");
         }
     }
 
     @Override
-    public DeleteObjectsResult deleteObject(DeleteObjectsRequest request) {
+    public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) {
         for (ObjectKey obj : request.getDeleteObjects().getKeys()) {
             this.deleteObject(request.getBucketName(), obj.getKey());
         }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3ImplBase.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3ImplBase.java
@@ -51,7 +51,7 @@ public abstract class S3ImplBase {
 
     public abstract void deleteObject(String bucketName, String key);
 
-    public abstract DeleteObjectsResult deleteObject(DeleteObjectsRequest request);
+    public abstract DeleteObjectsResult deleteObjects(DeleteObjectsRequest request);
 
     public abstract ListObjectsResult listObjects(String bucketName, String prefix);
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3JerseyClientWrapper.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3JerseyClientWrapper.java
@@ -77,6 +77,6 @@ public class S3JerseyClientWrapper extends S3JerseyClient {
     @Synchronized
     @Override
     public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) {
-        return proxy.deleteObject(request);
+        return proxy.deleteObjects(request);
     }
 }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3ProxyImpl.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/S3ProxyImpl.java
@@ -174,7 +174,7 @@ public class S3ProxyImpl extends S3ImplBase {
     }
 
     @Override
-    public DeleteObjectsResult deleteObject(DeleteObjectsRequest request) {
+    public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) {
         request.getDeleteObjects().getKeys().forEach(key -> aclMap.remove(key));
         return client.deleteObjects(request);
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -76,6 +76,25 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the delete() method.
+     */
+    @Test
+    public void testDelete() {
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+
+            //Delete the segment.
+            s.openWrite(segmentName).thenCompose(handle -> s.delete(handle, null)).join();
+            Assert.assertFalse("Expected the segment to not exist.", s.exists(segmentName, null).join());
+            assertThrows("getStreamSegmentInfo() did not throw for deleted StreamSegment.",
+                    () -> s.getStreamSegmentInfo(segmentName, null).join(),
+                    ex -> ex instanceof StreamSegmentNotExistsException);
+        }
+    }
+
+    /**
      * Tests the openRead() and openWrite() methods.
      */
     @Test


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
Implement `deleteObjects` function in `S3FileSystemImpl`.

**Purpose of the change**
Fixes #2493.

**What the code does**
Implements `deleteObject` functionality.

**How to verify it**
The warning message `Unable to acknowledge already processed operation ...` is not observed during `ExtendedS3IntegrationTest`