### PR TITLE
Issue 2491: EventWriterConfig.getTransactionTimeoutScaleGracePeriod defaults are larger than maximum allowed values on controller

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -37,7 +37,7 @@ public class EventWriterConfig implements Serializable {
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
-        private long transactionTimeoutTime = 60 * 60 * 1000;
+        private long transactionTimeoutTime = 30 * 1000 - 1;
         private long transactionTimeoutScaleGracePeriod = -1;
     }
     

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -102,10 +102,10 @@ public class EndToEndTxnWithTest {
     @Test(timeout = 10000)
     public void testTxnWithScale() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder()
-                .scope("test")
-                .streamName("test")
-                .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
-                .build();
+                                                        .scope("test")
+                                                        .streamName("test")
+                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
         controller.createStream(config).get();
@@ -150,10 +150,10 @@ public class EndToEndTxnWithTest {
     @Test(timeout = 10000)
     public void testTxnConfig() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scope("test")
-                                                        .streamName("test")
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
-                                                        .build();
+                .scope("test")
+                .streamName("test")
+                .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
         controller.createStream(config).get();


### PR DESCRIPTION
**Change log description**
Changes the default client config for transaction timeout. 

**Purpose of the change**
Fixes  #2491

**What the code does**
Changes the default writer client configuration value for transaction timeout. Presently default is set to 1 hour. And transaction timeout has to be bounded by scale grace period.  

**How to verify it**
New integration test added which tests different combinations of transaction timeout and scale grace period and verifies them against controller's defaults. 
