### PR TITLE
Issue 2490: Enable textual representation of a StreamCut.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/Segment.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/Segment.java
@@ -12,6 +12,7 @@ package io.pravega.client.segment.impl;
 import com.google.common.base.Strings;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.common.Exceptions;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -36,8 +37,9 @@ public class Segment implements Serializable, Comparable<Segment> {
      * @param number     ID number for the segment.
      */
     public Segment(String scope, String streamName, int number) {
-        this.scope = scope;
-        this.streamName = streamName;
+        this.scope = Exceptions.checkNotNullOrEmpty(scope, "scope");
+        this.streamName = Exceptions.checkNotNullOrEmpty(streamName, "streamName");
+        Exceptions.checkArgument(number >= 0, "segmentNumber", "Segment numbers cannot be negative");
         this.segmentNumber = number;
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
@@ -15,16 +15,13 @@ import io.pravega.client.stream.Stream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 /**
  * Implementation of {@link io.pravega.client.stream.StreamCut} interface. {@link StreamCutInternal} abstract class is
  * used as in intermediate class to make StreamCut instances opaque.
  */
 @EqualsAndHashCode(callSuper = false)
-@ToString
 public class StreamCutImpl extends StreamCutInternal {
     private static final long serialVersionUID = 1L;
 
@@ -59,7 +56,18 @@ public class StreamCutImpl extends StreamCutInternal {
                 return false;
             }
         }
-
         return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder(stream.getScopedName());
+        positions.forEach((key, value) -> {
+            builder.append(';');
+            builder.append(key.getSegmentNumber());
+            builder.append("=");
+            builder.append(value);
+        });
+        return builder.toString();
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream;
+
+import com.google.common.collect.ImmutableMap;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.impl.StreamCutImpl;
+import org.junit.Test;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.junit.Assert.*;
+
+public class StreamCutTest {
+
+    private static final String SCOPE = "scope";
+    private static final String STREAM = "stream";
+
+    @Test
+    public void testValidStreamCut() {
+        StreamCut sc = new StreamCutImpl(Stream.of(SCOPE, STREAM),
+                ImmutableMap.of(new Segment(SCOPE, STREAM, 0), 10L));
+        String textualRepresentation = "scope/stream;0=10";
+        assertEquals(textualRepresentation, sc.toString());
+        assertEquals(sc, StreamCut.of(textualRepresentation));
+
+        StreamCut sc2 = new StreamCutImpl(Stream.of(SCOPE, STREAM),
+                ImmutableMap.of(new Segment(SCOPE, STREAM, 0), 10L,
+                        new Segment(SCOPE, STREAM, 1), 15L));
+        String textualRepresentation2 = "scope/stream;0=10;1=15";
+        assertEquals(textualRepresentation2, sc2.toString());
+        assertEquals(sc2, StreamCut.of(textualRepresentation2));
+    }
+
+    @Test
+    public void testInvalidStreamCutRepresentation() {
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scope/stream"));
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scope/stream;"));
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scope/stream;0"));
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scopestream;0=20"));
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scope/stream;0=-20"));
+        assertThrows(IllegalArgumentException.class, () -> StreamCut.of("scope/stream;0=20;-1=10"));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Enable a textual representation of a `StreamCut` which can also be used to reconstruct the streamcut object.

**Purpose of the change**
Fixes #2490 

**What the code does**
Enables a textual representation of a StreamCut. This will enable a simpler way to pass StreamCut to connectors.
* `StreamCut#toString()` will return the textual representation.
* `StreamCut#of(String)` will construct the StreamCut object. 

An example: `scope/stream;0=10;1=15`

**How to verify it**
All existing tests should pass, new tests have been added to cover the new API