### PR TITLE
Issue 2502: Enable `equals` for StreamCut.UNBOUNDED.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamCut.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream;
 
 import io.pravega.client.stream.impl.StreamCutInternal;
 import java.io.Serializable;
+import lombok.EqualsAndHashCode;
 
 /**
  * A set of segment/offset pairs for a single stream that represent a consistent position in the
@@ -24,7 +25,7 @@ public interface StreamCut extends Serializable {
      * This is used represents an unbounded StreamCut. This is used when the user wants to refer to the current HEAD
      * of the stream or the current TAIL of the stream.
      */
-    StreamCut UNBOUNDED = () -> null;
+    StreamCut UNBOUNDED = new UnboundedStreamCut();
 
     /**
      * Used internally. Do not call.
@@ -32,4 +33,12 @@ public interface StreamCut extends Serializable {
      * @return Implementation of EventPointer interface
      */
     StreamCutInternal asImpl();
+
+    @EqualsAndHashCode
+    final class UnboundedStreamCut implements StreamCut {
+        @Override
+        public StreamCutInternal asImpl() {
+            return null;
+        }
+    }
 }

--- a/client/src/main/java/io/pravega/client/stream/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamCut.java
@@ -10,8 +10,8 @@
 package io.pravega.client.stream;
 
 import io.pravega.client.stream.impl.StreamCutInternal;
+import io.pravega.client.stream.impl.UnboundedStreamCut;
 import java.io.Serializable;
-import lombok.EqualsAndHashCode;
 
 /**
  * A set of segment/offset pairs for a single stream that represent a consistent position in the
@@ -33,12 +33,4 @@ public interface StreamCut extends Serializable {
      * @return Implementation of EventPointer interface
      */
     StreamCutInternal asImpl();
-
-    @EqualsAndHashCode
-    final class UnboundedStreamCut implements StreamCut {
-        @Override
-        public StreamCutInternal asImpl() {
-            return null;
-        }
-    }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/UnboundedStreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/UnboundedStreamCut.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+import io.pravega.client.stream.StreamCut;
+import lombok.EqualsAndHashCode;
+
+/**
+ * This is used represents an unbounded StreamCut. This is used when the user wants to refer to the current HEAD
+ * of the stream or the current TAIL of the stream.
+ */
+@EqualsAndHashCode
+public final class UnboundedStreamCut implements StreamCut {
+
+    @Override
+    public StreamCutInternal asImpl() {
+        return null;
+    }
+}

--- a/client/src/main/java/io/pravega/client/stream/impl/UnboundedStreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/UnboundedStreamCut.java
@@ -13,7 +13,7 @@ import io.pravega.client.stream.StreamCut;
 import lombok.EqualsAndHashCode;
 
 /**
- * This is used represents an unbounded StreamCut. This is used when the user wants to refer to the current HEAD
+ * This class represents an unbounded StreamCut. This is used when the user wants to refer to the current HEAD
  * of the stream or the current TAIL of the stream.
  */
 @EqualsAndHashCode

--- a/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream;
+
+import com.google.common.collect.ImmutableMap;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.impl.StreamCutImpl;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import lombok.Cleanup;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamCutTest {
+
+    @Test
+    public void testStreamCutSerialization() throws Exception {
+        StreamCut sc = new StreamCutImpl(Stream.of("scope", "stream"),
+                ImmutableMap.of(new Segment("scope", "stream", 0), 10L,
+                        new Segment("scope", "stream", 1), 20L));
+
+        byte[] buf = serialize(sc);
+        assertEquals(sc, deSerializeStreamCut(buf));
+    }
+
+    @Test
+    public void testUnboundedStreamCutSerialization() throws Exception {
+        StreamCut sc = StreamCut.UNBOUNDED;
+        final byte[] buf = serialize(sc);
+        assertEquals(sc, deSerializeStreamCut(buf));
+    }
+
+    private byte[] serialize(StreamCut sc) throws IOException {
+        @Cleanup
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        @Cleanup
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(sc);
+        return baos.toByteArray();
+    }
+
+    private StreamCut deSerializeStreamCut(final byte[] buf) throws Exception {
+        @Cleanup
+        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+        @Cleanup
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        return (StreamCut) ois.readObject();
+    }
+}

--- a/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
@@ -21,6 +21,7 @@ import lombok.Cleanup;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class StreamCutTest {
 
@@ -39,6 +40,7 @@ public class StreamCutTest {
         StreamCut sc = StreamCut.UNBOUNDED;
         final byte[] buf = serialize(sc);
         assertEquals(sc, deSerializeStreamCut(buf));
+        assertNull(deSerializeStreamCut(buf).asImpl());
     }
 
     private byte[] serialize(StreamCut sc) throws IOException {


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Enable `equals()` for StreamCut.UNBOUNDED.

**Purpose of the change**
Fixes #2502 

**What the code does**
At present `StreamCut.UNBOUNDED` is defined as a lambda. Since equals() for a lambda uses a reference equals does not work for `StreamCut.UNBOUNDED`. Now `StreamCut.UNBOUNDED` is represented by a class which supports equals.

**How to verify it**
All existing tests should pass, new tests have been added to cover the new API