### PR TITLE
Issue 2488: Some fixes for the E2E integration tests (do not merge please)

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
@@ -124,8 +124,8 @@ public class ServiceBuilder implements AutoCloseable {
         closeComponent(this.readIndexFactory);
         closeComponent(this.cacheFactory);
         this.threadPoolMetrics.close();
-        this.storageExecutor.shutdown();
-        this.coreExecutor.shutdown();
+        this.storageExecutor.shutdownNow();
+        this.coreExecutor.shutdownNow();
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -261,7 +261,7 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
                         // * We already processed a Segment Deletion but did not have a chance to checkpoint metadata
                         // * We processed a TransactionMergeOperation but did not have a chance to ack/truncate the DataSource
                         this.metadata.markDeleted(); // Update metadata, just in case it is not already updated.
-                        log.warn("{}: Segment does not exist in Storage. Ignoring all further operations on it.", this.traceObjectId, ex);
+                        log.warn("{}: Segment '{}' does not exist in Storage. Ignoring all further operations on it.", this.traceObjectId, this.metadata.getName());
                         setState(AggregatorState.Writing);
                         LoggerHelpers.traceLeave(log, this.traceObjectId, "initialize", traceId);
                     } else {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -58,6 +58,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     // Even though this should work with just 1-2 threads, doing so would cause this test to run for a long time. Choosing
     // a decent size so that the tests do finish up within a few seconds.
     private static final int THREADPOOL_SIZE_SEGMENT_STORE = 20;
+    private static final int THREADPOOL_SIZE_SEGMENT_STORE_STORAGE = 10;
     private static final int THREADPOOL_SIZE_TEST = 3;
     private static final int SEGMENT_COUNT = 10;
     private static final int TRANSACTIONS_PER_SEGMENT = 1;
@@ -70,7 +71,8 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             .builder()
             .include(ServiceConfig.builder()
                                   .with(ServiceConfig.CONTAINER_COUNT, 4)
-                                  .with(ServiceConfig.THREAD_POOL_SIZE, THREADPOOL_SIZE_SEGMENT_STORE))
+                                  .with(ServiceConfig.THREAD_POOL_SIZE, THREADPOOL_SIZE_SEGMENT_STORE)
+                                  .with(ServiceConfig.STORAGE_THREAD_POOL_SIZE, THREADPOOL_SIZE_SEGMENT_STORE_STORAGE))
             .include(ContainerConfig
                     .builder()
                     .with(ContainerConfig.SEGMENT_METADATA_EXPIRATION_SECONDS, ContainerConfig.MINIMUM_SEGMENT_METADATA_EXPIRATION_SECONDS))


### PR DESCRIPTION
**Change log description**
1. Removed unnecessary exception stack trace logging.
2. Defining Storage Thread pool size.
3. Passing the correct executor to ExtendedS3Test
4. Invoking shutdownNow() instead of shutdown() in ServiceBuilder in the hope that it will stop any ongoing tasks before returning.

**Purpose of the change**
Fixes #2488 

**What the code does**
See change log description.

**How to verify it**
Many builds should pass.