### PR TITLE
Issue 2520: Increase timeout of ContainerReadIndexTests

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -75,7 +75,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                                                     .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
                                                     .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024))
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TIMEOUT = Duration.ofSeconds(20);
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira <flavio.junqueira@emc.com>

**Change log description**
* Increases the timeout of ContainerReadIndexTests to 20 seconds.

**Purpose of the change**
Fixes #2520 

**What the code does**
Increases the global timeout of `ContainerReadIndexTests`.

**How to verify it**
Run unit tests.