### PR TITLE
Issue 2518: Ensure BatchClient handles StreamCut.UNBOUNDED (BugFix)

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/BatchClient.java
+++ b/client/src/main/java/io/pravega/client/batch/BatchClient.java
@@ -41,8 +41,8 @@ public interface BatchClient {
 
     /**
      * Provide a list of segments for a given stream between fromStreamCut and toStreamCut.
-     * Passing null to fromStreamCut and toStreamCut will result in using the current start of stream and the
-     * current end of stream respectively.
+     * Passing StreamCut.UNBOUNDED or null to fromStreamCut and toStreamCut will result in using the current start of
+     * stream and the current end of stream respectively.
      *<p>
      * Note: In case of stream truncation: <p>
      * - Passing a null to fromStreamCut will result in using the current start of the Stream post truncation.<p>

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -15,6 +15,7 @@ import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -82,6 +83,16 @@ public class BatchClientImplTest {
         assertTrue(segments.hasNext());
         assertEquals(2, segments.next().asImpl().getSegment().getSegmentNumber());
         assertFalse(segments.hasNext());
+
+        Iterator<SegmentRange> unBoundedSegments = client.getSegments(stream, StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator();
+        assertTrue(unBoundedSegments.hasNext());
+        assertEquals(0, unBoundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(unBoundedSegments.hasNext());
+        assertEquals(1, unBoundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(unBoundedSegments.hasNext());
+        assertEquals(2, unBoundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertFalse(unBoundedSegments.hasNext());
+
     }
 
     @Test(timeout = 5000)

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -12,10 +12,12 @@ package io.pravega.client.batch.impl;
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.batch.StreamInfo;
 import io.pravega.client.netty.impl.ClientConnection;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -25,7 +27,10 @@ import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
 import io.pravega.shared.protocol.netty.WireCommands.GetStreamSegmentInfo;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentCreated;
 import io.pravega.shared.protocol.netty.WireCommands.StreamSegmentInfo;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -39,50 +44,17 @@ import static org.mockito.Mockito.mock;
 
 public class BatchClientImplTest {
 
+    private static final String SCOPE = "scope";
+    private static final String STREAM = "stream";
+
     @Test(timeout = 5000)
-    public void testSegmentIterator() throws ConnectionFailedException {
-        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        ClientConnection connection = mock(ClientConnection.class);
+    public void testGetSegmentsWithUnboundedStreamCut() throws Exception {
+
         PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                CreateSegment request = (CreateSegment) invocation.getArgument(0);
-                connectionFactory.getProcessor(location)
-                                 .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
-                return null;
-            }
-        }).when(connection).send(Mockito.any(CreateSegment.class));
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                GetStreamSegmentInfo request = (GetStreamSegmentInfo) invocation.getArgument(0);
-                connectionFactory.getProcessor(location)
-                                 .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
-                                                                false, false, 0, 0, 0));
-                return null;
-            }
-        }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));
-        connectionFactory.provideConnection(location, connection);
-        MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
-                                                           connectionFactory);
+        MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        Stream stream = createStream(SCOPE, STREAM, 3, mockController);
         BatchClientImpl client = new BatchClientImpl(mockController, connectionFactory);
-        Stream stream = new StreamImpl("scope", "stream");
-        mockController.createScope("scope");
-        mockController.createStream(StreamConfiguration.builder()
-                                                       .scope("scope")
-                                                       .streamName("stream")
-                                                       .scalingPolicy(ScalingPolicy.fixed(3))
-                                                       .build())
-                      .join();
-        Iterator<SegmentRange> segments = client.getSegments(stream, null, null).getIterator();
-        assertTrue(segments.hasNext());
-        assertEquals(0, segments.next().asImpl().getSegment().getSegmentNumber());
-        assertTrue(segments.hasNext());
-        assertEquals(1, segments.next().asImpl().getSegment().getSegmentNumber());
-        assertTrue(segments.hasNext());
-        assertEquals(2, segments.next().asImpl().getSegment().getSegmentNumber());
-        assertFalse(segments.hasNext());
 
         Iterator<SegmentRange> unBoundedSegments = client.getSegments(stream, StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator();
         assertTrue(unBoundedSegments.hasNext());
@@ -92,13 +64,50 @@ public class BatchClientImplTest {
         assertTrue(unBoundedSegments.hasNext());
         assertEquals(2, unBoundedSegments.next().asImpl().getSegment().getSegmentNumber());
         assertFalse(unBoundedSegments.hasNext());
+    }
 
+    @Test(timeout = 5000)
+    public void testGetSegmentsWithStreamCut() throws Exception {
+
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        Stream stream = createStream(SCOPE, STREAM, 3, mockController);
+        BatchClientImpl client = new BatchClientImpl(mockController, connectionFactory);
+
+        Iterator<SegmentRange> boundedSegments = client.getSegments(stream, getSreamCut(5L, 0, 1, 2), getSreamCut(15L, 0, 1, 2)).getIterator();
+        assertTrue(boundedSegments.hasNext());
+        assertEquals(0, boundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(boundedSegments.hasNext());
+        assertEquals(1, boundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(boundedSegments.hasNext());
+        assertEquals(2, boundedSegments.next().asImpl().getSegment().getSegmentNumber());
+        assertFalse(boundedSegments.hasNext());
+    }
+
+    @Test(timeout = 5000)
+    public void testGetSegmentsWithNullStreamCut() throws Exception {
+
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        Stream stream = createStream(SCOPE, STREAM, 3, mockController);
+        BatchClientImpl client = new BatchClientImpl(mockController, connectionFactory);
+
+        Iterator<SegmentRange> segments = client.getSegments(stream, null, null).getIterator();
+        assertTrue(segments.hasNext());
+        assertEquals(0, segments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(segments.hasNext());
+        assertEquals(1, segments.next().asImpl().getSegment().getSegmentNumber());
+        assertTrue(segments.hasNext());
+        assertEquals(2, segments.next().asImpl().getSegment().getSegmentNumber());
+        assertFalse(segments.hasNext());
     }
 
     @Test(timeout = 5000)
     public void testStreamInfo() throws Exception {
         final String scope = "scope";
-        final String streamName = "stream";
+        final String streamName = STREAM;
         final Stream stream = new StreamImpl(scope, streamName);
 
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
@@ -147,5 +156,51 @@ public class BatchClientImplTest {
         assertNotNull(info.getHeadStreamCut());
         assertEquals(stream, info.getHeadStreamCut().asImpl().getStream());
         assertEquals(3, info.getHeadStreamCut().asImpl().getPositions().size());
+    }
+
+    private Stream createStream(String scope, String streamName, int numSegments, MockController mockController) {
+        Stream stream = new StreamImpl(scope, streamName);
+        mockController.createScope(scope);
+        mockController.createStream(StreamConfiguration.builder()
+                                                       .scope(scope)
+                                                       .streamName(streamName)
+                                                       .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                       .build())
+                      .join();
+        return stream;
+    }
+
+    private MockConnectionFactoryImpl getMockConnectionFactory(PravegaNodeUri location) throws ConnectionFailedException {
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        ClientConnection connection = mock(ClientConnection.class);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                CreateSegment request = (CreateSegment) invocation.getArgument(0);
+                connectionFactory.getProcessor(location)
+                                 .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
+                return null;
+            }
+        }).when(connection).send(Mockito.any(CreateSegment.class));
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                GetStreamSegmentInfo request = (GetStreamSegmentInfo) invocation.getArgument(0);
+                connectionFactory.getProcessor(location)
+                                 .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
+                                                                false, false, 0, 0, 0));
+                return null;
+            }
+        }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));
+        connectionFactory.provideConnection(location, connection);
+        return connectionFactory;
+    }
+
+    private StreamCut getSreamCut(long offset, int... segments) {
+        final Map<Segment, Long> positionMap = Arrays.stream(segments).boxed()
+                                                     .collect(Collectors.toMap(s -> new Segment("scope", STREAM, s),
+                                                             s -> offset));
+
+        return new StreamCutImpl(Stream.of("scope", STREAM), positionMap);
     }
 }


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Ensure BatchClient handles StreamCut.UNBOUNDED.

**Purpose of the change**
Fixes #2518 

**What the code does**
Fixes the NPE thrown by BatchClient when StreamCut.UNBOUNDED is passed to `io.pravega.client.batch.BatchClient#getSegments`

**How to verify it**
All tests should continue to pass.
