### PR TITLE
Issue 2501: Ensure that the race for rename is resolved

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -413,7 +413,7 @@ class HDFSStorage implements SyncStorage {
                 throw HDFSExceptionHelpers.convertException(streamSegmentName, e);
             }
             // Looping for the maximum possible number.
-        } while (fencedCount < MAX_EPOCH);
+        } while (fencedCount < (int) (MAX_EPOCH - 1));
         LoggerHelpers.traceLeave(log, "openWrite", traceId, epoch);
         throw new StorageNotPrimaryException("Not able to fence out other writers.");
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -413,7 +413,7 @@ class HDFSStorage implements SyncStorage {
                 throw HDFSExceptionHelpers.convertException(streamSegmentName, e);
             }
             // Looping for the maximum possible number.
-        } while (fencedCount < MAX_EPOCH);
+        } while (fencedCount <= this.epoch);
         LoggerHelpers.traceLeave(log, "openWrite", traceId, epoch);
         throw new StorageNotPrimaryException("Not able to fence out other writers.");
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -396,10 +396,10 @@ class HDFSStorage implements SyncStorage {
                         } catch (FileNotFoundException e) {
                             //This happens when more than one host is trying to fence and only one of the host goes through.
                             //Retry the rename so that host with the highest epoch gets access.
-                            //In the worst case, the current owner of the segment will win this race after retries equal
-                            //to the number of segmentstores in the race. Total number of segmentstores in the deployment
-                            // is the higher bound for this number.
-                            //It is safe to retry for MAX_INT times as we are sure that the loop will never go that long.
+                            //In the worst case, the current owner of the segment will win this race after a number of attempts
+                            //  equal to the number of Segment Stores in the race. The high bound for this number of attempts
+                            // is the total number of Segment Store instances in the cluster.
+                            //It is safe to retry for MAX_EPOCH times as we are sure that the loop will never go that long.
                             log.warn("Race in fencing. More than two hosts trying to own the segment. Retrying");
                             fencedCount++;
                             continue;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -379,7 +379,7 @@ class HDFSStorage implements SyncStorage {
     @Override
     public SegmentHandle openWrite(String streamSegmentName) throws StreamSegmentException {
         long traceId = LoggerHelpers.traceEnter(log, "openWrite", streamSegmentName);
-        int fencedCount = 0;
+        long fencedCount = 0;
         do {
             try {
                 FileStatus fileStatus = findStatusForSegment(streamSegmentName, true);
@@ -413,7 +413,7 @@ class HDFSStorage implements SyncStorage {
                 throw HDFSExceptionHelpers.convertException(streamSegmentName, e);
             }
             // Looping for the maximum possible number.
-        } while (fencedCount < (int) (MAX_EPOCH - 1));
+        } while (fencedCount < MAX_EPOCH);
         LoggerHelpers.traceLeave(log, "openWrite", traceId, epoch);
         throw new StorageNotPrimaryException("Not able to fence out other writers.");
     }


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
The correct owner will get the owership after this loop goes on for a number equal to the number of segmentstore instances in the race. The upper bound for this is the number of segmentstores in the deployment.
It would be a major change in the segmentstore to determine and pass the number of segment store instances down to the Storage Adapter. Also these details are not necessary for a tier-2 stoarge to know.
I think a compromise can be where we keep the number of retries high enough that the number of segmentstores in a deployment never passes this number. It can be either a very high integer (e.g MAX_INT).

**Purpose of the change**
This fixes #2501.

**What the code does**
Loop till the race for rename is resolved for the owner.

**How to verify it**
System tests pass.
The correct owner always ends up with onwership of the segment.