### PR TITLE
Issue 2396 : Adding pluginlib to classpath to pickup plugin config.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -447,7 +447,7 @@ project('controller') {
         classpath += files('$APP_HOME/pluginlib')
         doLast {
             def scriptFile = file getUnixScript()
-            scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
+            scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*:$APP_HOME/pluginlib')
         }
     }
     applicationDistribution.from('src/conf') {
@@ -526,7 +526,7 @@ project('standalone') {
         classpath += files('./pluginlib')
         doLast {
             def scriptFile = file getUnixScript()
-            scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
+            scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*:$APP_HOME/pluginlib')
         }
     }
 


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
Adding the `pluginlib` path to ensure that the plugin can load its config files and load these.

**Purpose of the change**
This PR fixes #2396.

**What the code does**
Adds the `pluginlib` path to the classpath.

**How to verify it**
The plugin config gets picked.