### PR TITLE
Issue 2441: Ensure SegmentTruncatedException is thrown by AsyncSegmentInputStream.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
@@ -29,7 +29,11 @@ abstract class AsyncSegmentInputStream implements AutoCloseable {
      * @param offset The offset in the segment to read from
      * @param length The suggested number of bytes to read. (Note the result may contain either more or less than this
      *            value.)
-     * @return A future for the result of the read call. 
+     * @return A future for the result of the read call. If an exception occurred, it will be completed with the causing
+     * exception. Notable exceptions:
+     * * {@link SegmentTruncatedException} If the segment is truncated or it does not exist.
+     * * {@link io.pravega.client.stream.impl.ConnectionClosedException} If the connection is closed due an exception while performing the read.
+     * * {@link io.pravega.common.util.RetriesExhaustedException} If the configured number of retry attempts to read failed.
      */
     public abstract CompletableFuture<SegmentRead> read(long offset, int length);
 

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -169,7 +169,8 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
                     return getConnection()
                             .whenComplete((connection, ex) -> {
                                 if (ex != null) {
-                                    log.warn("Exception while establishing connection with Pravega node", ex);
+                                    log.warn("Exception while establishing connection with Pravega " +
+                                            "node", ex);
                                     closeConnection(new ConnectionFailedException(ex));
                                 }
                             }).thenCompose(c -> sendRequestOverConnection(request, c));

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -164,7 +164,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
             Throwable ex = Exceptions.unwrap(t);
             log.warn("Exception while reading from Segment : {}", segmentId, ex);
             return ex instanceof Exception && !(ex instanceof ConnectionClosedException) && !(ex instanceof SegmentTruncatedException);
-        }).throwingOn(ConnectionClosedException.class)
+        }).throwingOn(RuntimeException.class)
                 .runAsync(() -> {
                     return getConnection()
                             .whenComplete((connection, ex) -> {

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -99,7 +100,7 @@ public class AsyncSegmentInputStreamTest {
         CompletableFuture<SegmentRead> read = in.read(1234, 5678);
         assertFalse(read.isDone());
         in.close();
-        AssertExtensions.assertThrows(ConnectionClosedException.class, () -> Futures.getThrowingException(read));
+        assertThrows(ConnectionClosedException.class, () -> Futures.getThrowingException(read));
         verify(c).close();
     }
 
@@ -124,6 +125,33 @@ public class AsyncSegmentInputStreamTest {
         verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(segmentRead, readFuture.join());
+        verifyNoMoreInteractions(c);
+    }
+
+    @Test(timeout = 10000)
+    public void testSegmentTruncated() throws ConnectionFailedException {
+        Segment segment = new Segment("scope", "testRead", 1);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+
+        @Cleanup
+        AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
+        ClientConnection c = mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, c);
+
+        //segment truncated response from Segment store.
+        WireCommands.SegmentIsTruncated segmentIsTruncated = new WireCommands.SegmentIsTruncated(1234L, segment.getScopedName(), 1234);
+        //Trigger read.
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+
+        //verify that a response from Segment store completes the readFuture and the future completes with SegmentTruncatedException.
+        AssertExtensions.assertBlocks(() -> assertThrows(SegmentTruncatedException.class, () -> readFuture.get()), () -> {
+            ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+            processor.segmentIsTruncated(segmentIsTruncated);
+        });
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
         verifyNoMoreInteractions(c);
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -290,6 +290,8 @@ public class BoundedStreamReaderTest {
                 ReaderConfig.builder().build());
 
         assertThrows(TruncatedDataException.class, () -> reader2.readNextEvent(10000));
+        //subsequent read should return data present post truncation, Event3 is returned here since stream was truncated @ offset 30 * 2.
+        readAndVerify(reader2, 3);
     }
 
     /*

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -26,6 +25,7 @@ import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamCutImpl;
@@ -56,7 +56,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNull;
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -288,8 +288,8 @@ public class BoundedStreamReaderTest {
         @Cleanup
         EventStreamReader<String> reader2 = clientFactory.createReader("readerId2", "group", serializer,
                 ReaderConfig.builder().build());
-        EventRead<String> res = reader2.readNextEvent(10000);
-        assertNull("Null is expected since the stream is already truncated", res.getEvent());
+
+        assertThrows(TruncatedDataException.class, () -> reader2.readNextEvent(10000));
     }
 
     /*


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**
Ensure SegmentTruncatedException is thrown by AsyncSegmentInputStream on receiving WireCommands.SegmentIsTruncated from SegmentStore.

**Purpose of the change**
Fixes #2441 
Fixes #2512 

**What the code does**
The changes in this pull request ensures
- `AsyncSegmentInputStream `does not retry if `WireCommands.SegmentIsTruncated` message is sent by Segment Store.
- AsyncSegmentInputStream completes the read future with `SegmentTruncatedException`
- `TruncatedDataException` is thrown by `EventStreamReader.readNextEvent()`. On receiving this exception the next `readNextEvent() `api call will cause the reader to read from the next available event.
- `NoSuchEventException` is thrown when EventStreamReader.fetchEvent is invoked with an event pointer pointing to the truncated part of the stream.


**How to verify it**
All the existing tests and the newly added tests should continue to pass.