### PR TITLE
Issue 2538: (SegmentStore) Do not auto-delete Attribute Segment if main Segment is deleted

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
@@ -451,20 +451,13 @@ class SegmentAttributeIndex implements AttributeIndex {
     }
 
     /**
-     * Determines whether the main segment has been deleted.
-     */
-    private boolean isMainSegmentDeleted() {
-        return this.segmentMetadata.isDeleted() || this.segmentMetadata.isMerged();
-    }
-
-    /**
      * Verifies that the main Segment still exists (is not deleted). If it doesn't, it aborts the current operation by
      * throwing a StreamSegmentNotExistsException. If the main Segment is deleted, the owning SegmentContainer will be
      * deleting this Attribute Segment soon, so do not bother making any more changes to it.
      */
     @SneakyThrows(StreamSegmentNotExistsException.class)
     private void ensureMainSegmentExists() {
-        if (isMainSegmentDeleted()) {
+        if (this.segmentMetadata.isDeleted() || this.segmentMetadata.isMerged()) {
             log.info("{}: Main Segment ({}) is Deleted. Aborting operation.", this.traceObjectId, this.segmentMetadata.getName());
             throw new StreamSegmentNotExistsException(this.segmentMetadata.getName());
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
@@ -269,11 +269,7 @@ class SegmentAttributeIndex implements AttributeIndex {
      */
     private CompletableFuture<AttributeCollection> readAllSinceLastSnapshot(Duration timeout) {
         CompletableFuture<AttributeCollection> result = READ_RETRY.runAsync(() -> {
-            if (isMainSegmentDeleted()) {
-                // Verify if the main segment has been deleted and stop now if needed.
-                return handleMainSegmentDeleted(timeout);
-            }
-
+            ensureMainSegmentExists();
             long lastSnapshotOffset = getLastSnapshotOffset();
             int readLength = (int) Math.min(Integer.MAX_VALUE, this.attributeSegment.get().getLength() - lastSnapshotOffset);
             CompletableFuture<AttributeCollection> r = new CompletableFuture<>();
@@ -344,12 +340,8 @@ class SegmentAttributeIndex implements AttributeIndex {
                 .add(op, timer.getRemaining())
                 .thenComposeAsync(v -> {
                     log.debug("{}: Snapshot location updated in main segment's metadata ({}).", this.traceObjectId, writeInfo);
-                    if (isMainSegmentDeleted()) {
-                        // Verify if the main segment has been deleted and stop now if needed.
-                        return handleMainSegmentDeleted(timer.getRemaining());
-                    } else {
-                        return this.storage.truncate(this.attributeSegment.get().handle, writeInfo.offset, timer.getRemaining());
-                    }
+                    ensureMainSegmentExists();
+                    return this.storage.truncate(this.attributeSegment.get().handle, writeInfo.offset, timer.getRemaining());
                 }, this.executor);
 
         if (!mustComplete) {
@@ -398,10 +390,7 @@ class SegmentAttributeIndex implements AttributeIndex {
         // a concurrent change, we will need to re-generate the serialization in order to guarantee that we always write
         // the latest data.
         AttributeSegment as = this.attributeSegment.get();
-        if (isMainSegmentDeleted()) {
-            // Verify if the main segment has been deleted and stop now if needed.
-            return handleMainSegmentDeleted(timer.getRemaining());
-        }
+        ensureMainSegmentExists();
 
         long offset = as.getLength();
         return getSerialization.get().thenComposeAsync(data ->
@@ -469,17 +458,16 @@ class SegmentAttributeIndex implements AttributeIndex {
     }
 
     /**
-     * Performs any necessary cleanup after the main segment has been determined to have been deleted. This will
-     * delete the AttributeSegment as well.
-     *
-     * @param timeout Timeout for the operation.
+     * Verifies that the main Segment still exists (is not deleted). If it doesn't, it aborts the current operation by
+     * throwing a StreamSegmentNotExistsException. If the main Segment is deleted, the owning SegmentContainer will be
+     * deleting this Attribute Segment soon, so do not bother making any more changes to it.
      */
-    private <T> CompletableFuture<T> handleMainSegmentDeleted(Duration timeout) {
-        Preconditions.checkState(isMainSegmentDeleted(), "Main segment is not deleted.");
-        log.info("{}: Main Segment is Deleted. Attempting to delete Attribute Segment.", this.traceObjectId);
-        return Futures
-                .exceptionallyExpecting(this.storage.delete(this.attributeSegment.get().handle, timeout), ex -> ex instanceof StreamSegmentNotExistsException, null)
-                .thenCompose(v -> Futures.failedFuture(new StreamSegmentNotExistsException(this.segmentMetadata.getName())));
+    @SneakyThrows(StreamSegmentNotExistsException.class)
+    private void ensureMainSegmentExists() {
+        if (isMainSegmentDeleted()) {
+            log.info("{}: Main Segment ({}) is Deleted. Aborting operation.", this.traceObjectId, this.segmentMetadata.getName());
+            throw new StreamSegmentNotExistsException(this.segmentMetadata.getName());
+        }
     }
 
     private void ensureInitialized() {


### PR DESCRIPTION
**Change log description**
`SegmentAttributeIndex` checks if the main Segment's `isDeleted` flag has been set before making any changes to the Attribute Segment. If so, it automatically deletes the Attribute Segment file. This was originally done as a preemptive operation to make sure this file isn't left orphan.

It turns out that, in some scenarios, this is trying to prematurely delete this Segment. When doing so, the `StorageWriter` stubbornly tries to recreate it, however that operation clashes with this check (again) which tries to delete it. Since neither Create nor Delete are atomic operations in `RollingStorage`, it's possible that concurrent calls to these for the same segment will clash at one point and produce weird results. This is exactly what happened in the error reported in the attached issue: a call to `create` interfered with a call to `delete` (this may be the `delete` from the Segment Container or the auto-delete). The likely order of (concurrent) operations was this:
1. `create` was invoked: a new empty header file was made.
2. `delete` was invoked, the header file was sealed.
3. `openWrite` was invoked; a read-only handle was returned since the header was sealed.
4. `delete` finished, thus deleting the header file
5. Subsequent calls to `write` failed due to the handle being read-only (it never made it to the actual Tier2)

With this change, we are no longer auto-deleting the Attribute Segment anymore in case we detect the main segment was deleted. This will eliminate the vicious cycle of delete-create-delete-create-... that lead to the `StorageWriter` getting stuck on this.

The Attribute Segment will be deleted anyway by the Segment Container when the main segment is deleted. This is well-handled by the `StorageWriter`; when it detects that, it automatically terminates all operations on the affected Segment and skips over the future ones (this is different from the AttributeIndex getting ahead of itself and deleting the Attribute Segment prematurely).

**Purpose of the change**
Fixes #2538.

**What the code does**
See Description.

**How to verify it**
Many runs of E2E integration tests should yield no failure due to this problem.
