### PR TITLE
Issue 2543: Segment range mismatch between auto scale request and range in metadata store

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
@@ -101,7 +101,8 @@ public class AutoScaleTask {
                         simpleEntries.add(new AbstractMap.SimpleEntry<>(segment.getKeyStart() + delta * i,
                                 segment.getKeyStart() + (delta * (i + 1))));
                     }
-                    // add the last entry such that is key end matches original segments key end. This is because of doubles preceision
+                    // add the last entry such that is key end matches original segments key end.
+                    // This is because of doubles precision which may mean `start + n * ((end - start) / n)` may not equal `end`.
                     simpleEntries.add(new AbstractMap.SimpleEntry<>(segment.getKeyStart() + delta * (numOfSplits -1),
                             segment.getKeyEnd()));
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
@@ -97,10 +97,14 @@ public class AutoScaleTask {
                     double delta = (segment.getKeyEnd() - segment.getKeyStart()) / numOfSplits;
 
                     final ArrayList<AbstractMap.SimpleEntry<Double, Double>> simpleEntries = new ArrayList<>();
-                    for (int i = 0; i < numOfSplits; i++) {
+                    for (int i = 0; i < numOfSplits - 1; i++) {
                         simpleEntries.add(new AbstractMap.SimpleEntry<>(segment.getKeyStart() + delta * i,
                                 segment.getKeyStart() + (delta * (i + 1))));
                     }
+                    // add the last entry such that is key end matches original segments key end. This is because of doubles preceision
+                    simpleEntries.add(new AbstractMap.SimpleEntry<>(segment.getKeyStart() + delta * (numOfSplits -1),
+                            segment.getKeyEnd()));
+
                     return postScaleRequest(request, Lists.newArrayList(request.getSegmentNumber()), simpleEntries);
                 }, executor);
     }

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.shared.controller.event;
 
-import com.google.common.base.Preconditions;
 import lombok.Data;
 
 import java.util.AbstractMap;
@@ -28,10 +27,6 @@ public class ScaleOpEvent implements ControllerEvent {
     private final long scaleTime;
 
     public ScaleOpEvent(String scope, String stream, List<Integer> segmentsToSeal, List<AbstractMap.SimpleEntry<Double, Double>> newRange, boolean runOnlyIfStarted, long scaleTime) {
-        Preconditions.checkNotNull(segmentsToSeal);
-        Preconditions.checkArgument(!segmentsToSeal.isEmpty());
-        Preconditions.checkNotNull(newRange);
-        Preconditions.checkArgument(!newRange.isEmpty());
         this.scope = scope;
         this.stream = stream;
         this.segmentsToSeal = segmentsToSeal;

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
@@ -9,11 +9,9 @@
  */
 package io.pravega.shared.controller.event;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.AbstractMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
@@ -13,19 +13,37 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.AbstractMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Data
-@AllArgsConstructor
 public class ScaleOpEvent implements ControllerEvent {
     private static final long serialVersionUID = 1L;
     private final String scope;
     private final String stream;
     private final List<Integer> segmentsToSeal;
-    private final List<AbstractMap.SimpleEntry<Double, Double>> newRanges;
+    private final List<AbstractMap.SimpleEntry<Long, Long>> newRanges;
     private final boolean runOnlyIfStarted;
     private final long scaleTime;
+
+    public ScaleOpEvent(String scope, String stream, List<Integer> segmentsToSeal, List<AbstractMap.SimpleEntry<Double, Double>> newRange, boolean runOnlyIfStarted, long scaleTime) {
+        this.scope = scope;
+        this.stream = stream;
+        this.segmentsToSeal = segmentsToSeal;
+        this.newRanges = newRange.stream()
+                .map(x -> new AbstractMap.SimpleEntry<>(Double.doubleToRawLongBits(x.getKey()), Double.doubleToRawLongBits(x.getValue())))
+                .collect(Collectors.toList());
+        this.runOnlyIfStarted = runOnlyIfStarted;
+        this.scaleTime = scaleTime;
+    }
+
+    public List<AbstractMap.SimpleEntry<Double, Double>> getNewRanges() {
+        return newRanges.stream()
+                .map(x -> new AbstractMap.SimpleEntry<>(Double.longBitsToDouble(x.getKey()), Double.longBitsToDouble(x.getValue())))
+                .collect(Collectors.toList());
+    }
 
     @Override
     public String getKey() {

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.shared.controller.event;
 
+import com.google.common.base.Preconditions;
 import lombok.Data;
 
 import java.util.AbstractMap;
@@ -27,6 +28,10 @@ public class ScaleOpEvent implements ControllerEvent {
     private final long scaleTime;
 
     public ScaleOpEvent(String scope, String stream, List<Integer> segmentsToSeal, List<AbstractMap.SimpleEntry<Double, Double>> newRange, boolean runOnlyIfStarted, long scaleTime) {
+        Preconditions.checkNotNull(segmentsToSeal);
+        Preconditions.checkArgument(!segmentsToSeal.isEmpty());
+        Preconditions.checkNotNull(newRange);
+        Preconditions.checkArgument(!newRange.isEmpty());
         this.scope = scope;
         this.stream = stream;
         this.segmentsToSeal = segmentsToSeal;


### PR DESCRIPTION
Signed-off-by: Shivesh <shivesh.ranjan@gmail.com>

**Change log description**
We observed that there was a mismatch between range posted in auto-scale event and the range present in metadata store. This led to scale input being declared invalid and hence hot segment was never scaled. 

**Purpose of the change**
Fixes #2543

**What the code does**
In autoscale task, to compute new ranges we actually did some computations using `double` which can cause precision loss and hence the ranges submitted in scale input did not match that in the metadata store.

The way we were earlier doing new range computation was as follows:
e.g. compute range for a segment S split in 2
```
delta = (s.keyEnd - s.keyStart)/2;
newRanges = [s.keystart, s.keyStart + delta) [s.keyStart + delta, s.keyStart + 2*delta)
```
Now mathematically, `s.keyStart+ 2*delta = s.keyStart + 2 * (s.keyEnd - s.keyStart)/2 = s.keyEnd`
However, since the computations are done using double, there could be precision errors causing last value to mismatch. 
So as a fix, we always use the last value as key.end rather than the computation. Elsewhere the computation is fine, because to each new subsequent segment getting created we supply the same value. 
 
We also thought the issue could have been induced by Java serialization of double causing some precision loss. So we have used the same approach that we use in metadata store where we serialize doubles by converting them to long. 
So now we have changed the ScaleOpEvent to internally use a long instead of double. Only the accessors are changed to take and return double. But the field stores a long so the serialization will serialize and deserialize long which does not suffer from precision problems. 

**How to verify it**
Issue should be fixed