### PR TITLE
Issue 2540: StreamCuts system test

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -22,14 +22,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-
 import static java.util.stream.Collectors.toList;
 
 /**
  * Abstract class that provides convenient event read/write methods for testing purposes.
  */
 @Slf4j
-class AbstractReadWriteTest {
+abstract class AbstractReadWriteTest {
 
     private static final int READ_TIMEOUT = 1000;
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -32,7 +32,7 @@ abstract class AbstractReadWriteTest {
 
     private static final int READ_TIMEOUT = 1000;
 
-    protected void writeDummyEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
+    void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
         @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
@@ -42,7 +42,7 @@ abstract class AbstractReadWriteTest {
         }
     }
 
-    protected List<CompletableFuture<Integer>> readEventFutures(ClientFactory client, String rGroup, int numReaders) {
+    List<CompletableFuture<Integer>> readEventFutures(ClientFactory client, String rGroup, int numReaders) {
         List<EventStreamReader<String>> readers = new ArrayList<>();
         for (int i = 0; i < numReaders; i++) {
             readers.add(client.createReader(String.valueOf(i), rGroup, new JavaSerializer<>(), ReaderConfig.builder().build()));
@@ -51,7 +51,7 @@ abstract class AbstractReadWriteTest {
         return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r))).collect(toList());
     }
 
-    protected <T> int readEvents(EventStreamReader<T> reader) {
+    private <T> int readEvents(EventStreamReader<T> reader) {
         EventRead<T> event;
         int validEvents = 0;
         try {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.impl.JavaSerializer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Abstract class that provides convenient event read/write methods for testing purposes.
+ */
+@Slf4j
+class AbstractReadWriteTest {
+
+    private static final int READ_TIMEOUT = 1000;
+
+    protected void writeDummyEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        for (int i = 0; i < totalEvents; i++) {
+            writer.writeEvent(streamName + String.valueOf(i)).join();
+            log.debug("Writing event: {} to stream {}.", streamName + String.valueOf(i), streamName);
+        }
+    }
+
+    protected List<CompletableFuture<Integer>> readEventFutures(ClientFactory client, String rGroup, int numReaders) {
+        List<EventStreamReader<String>> readers = new ArrayList<>();
+        for (int i = 0; i < numReaders; i++) {
+            readers.add(client.createReader(String.valueOf(i), rGroup, new JavaSerializer<>(), ReaderConfig.builder().build()));
+        }
+
+        return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r))).collect(toList());
+    }
+
+    protected <T> int readEvents(EventStreamReader<T> reader) {
+        EventRead<T> event;
+        int validEvents = 0;
+        try {
+            do {
+                event = reader.readNextEvent(READ_TIMEOUT);
+                log.debug("Read event result in readEvents: {}.", event.getEvent());
+                if (event.getEvent() != null) {
+                    validEvents++;
+                }
+            } while (event.getEvent() != null || event.isCheckpoint());
+        } catch (ReinitializationRequiredException e) {
+            throw new RuntimeException(e);
+        } finally {
+            reader.close();
+        }
+
+        return validEvents;
+    }
+}

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -53,7 +53,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -58,12 +58,17 @@ import static org.junit.Assert.assertTrue;
 public class StreamCutsTest {
 
     private static final String STREAM_ONE = "streamCutsStreamOne";
+    private static final int PARALLELISM_ONE = 1;
     private static final String STREAM_TWO = "streamCutsStreamTwo";
+    private static final int PARALLELISM_TWO = 2;
     private static final String SCOPE = "streamCutsScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP = "streamCutsRG" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+
+    private static final int TOTAL_EVENTS = 1000;
+    private static final int CUT_SIZE = 100;
+
     @Rule
     public Timeout globalTimeout = Timeout.seconds(8 * 60);
-
     private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(4, "executor");
     private URI controllerURI;
     private StreamManager streamManager;
@@ -123,21 +128,21 @@ public class StreamCutsTest {
         streamManager = StreamManager.create(controllerURI);
         assertTrue("Creating scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream one", streamManager.createStream(SCOPE, STREAM_ONE,
-                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_ONE).scalingPolicy(ScalingPolicy.fixed(1)).build()));
+                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_ONE)
+                                   .scalingPolicy(ScalingPolicy.fixed(PARALLELISM_ONE)).build()));
         assertTrue("Creating stream two", streamManager.createStream(SCOPE, STREAM_TWO,
-                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_TWO).scalingPolicy(ScalingPolicy.fixed(2)).build()));
+                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_TWO)
+                                   .scalingPolicy(ScalingPolicy.fixed(PARALLELISM_TWO)).build()));
     }
 
     /**
      * This test verifies the correct operation of readers using StreamCuts. Concretely, the test creates two streams
-     * with different number of segments and it writes some events (totalEvents) in them. Afterwards, the test creates a
-     * list of StreamCuts that encompasses both streams every sliceSize events. The test asserts that new groups of
-     * readers can be initialized at these StreamCut intervals and that only sliceSize events are read.
+     * with different number of segments and it writes some events (TOTAL_EVENTS) in them. Afterwards, the test creates
+     * a list of StreamCuts that encompasses both streams every CUT_SIZE events. The test asserts that new groups of
+     * readers can be initialized at these StreamCut intervals and that only CUT_SIZE events are read.
      */
     @Test
     public void streamCutsTest() {
-        final int totalEvents = 1000;
-        final int sliceSize = 100;
         @Cleanup
         ClientFactory clientFactory = ClientFactory.withScope(SCOPE, controllerURI);
         @Cleanup
@@ -149,31 +154,35 @@ public class StreamCutsTest {
         ReaderGroup readerGroup = readerGroupManager.getReaderGroup(READER_GROUP);
 
         // First, write half of events in each Stream.
-        writeDummyEvents(clientFactory, STREAM_ONE, totalEvents / 2);
-        writeDummyEvents(clientFactory, STREAM_TWO, totalEvents / 2);
+        writeDummyEvents(clientFactory, STREAM_ONE, TOTAL_EVENTS / 2);
+        writeDummyEvents(clientFactory, STREAM_TWO, TOTAL_EVENTS / 2);
         log.debug("Finished writing events to streams.");
 
         // Second, get StreamCuts for each slice from both Streams at the same time (may be different in each execution).
-        List<Map<Stream, StreamCut>> streamSlices = getStreamCutSlices(clientFactory, readerGroup, sliceSize, executor);
+        List<Map<Stream, StreamCut>> streamSlices = getStreamCutSlices(clientFactory, readerGroup, executor);
         log.debug("Finished creating StreamCuts.");
 
         // Third, ensure that reader groups can correctly read slices from different Streams.
         int groupId = 0;
         Map<Stream, StreamCut> startingPoint = null;
-        for (Map<Stream, StreamCut> endingPoint: streamSlices) {
-            ReaderGroupConfig config = (groupId == 0) ?
-                    ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_ONE)).stream(Stream.of(SCOPE, STREAM_TWO))
-                                     .endingStreamCuts(endingPoint).build() :
-                    ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_ONE)).stream(Stream.of(SCOPE, STREAM_TWO))
-                                     .startingStreamCuts(startingPoint).endingStreamCuts(endingPoint).build();
+        ReaderGroupConfig.ReaderGroupConfigBuilder configBuilder = ReaderGroupConfig.builder()
+                                                                                    .stream(Stream.of(SCOPE, STREAM_ONE))
+                                                                                    .stream(Stream.of(SCOPE, STREAM_TWO));
+        for (Map<Stream, StreamCut> endingPoint : streamSlices) {
+            configBuilder = configBuilder.endingStreamCuts(endingPoint);
+            if (startingPoint != null) {
+                configBuilder = configBuilder.startingStreamCuts(startingPoint);
+            }
 
-            // Create a new reader group per stream cut slice and read only events within the cut.
-            String readerGroupId = READER_GROUP + String.valueOf(groupId);
-            readerGroupManager.createReaderGroup(readerGroupId, config);
-            int readEvents = readDummyEvents(clientFactory, readerGroupId, 3).stream().map(CompletableFuture::join)
-                                                                             .reduce((a, b) -> a + b).get();
-            log.debug("Read events by group {}: {}", readerGroupId, readEvents);
-            assertEquals("Expected events read: ", sliceSize, readEvents);
+            // Create a new reader group per stream cut slice and read in parallel only events within the cut.
+            final String readerGroupId = READER_GROUP + String.valueOf(groupId);
+            readerGroupManager.createReaderGroup(readerGroupId, configBuilder.build());
+            final int parallelSegments = PARALLELISM_ONE + PARALLELISM_TWO;
+            int readEvents = readDummyEvents(clientFactory, readerGroupId, parallelSegments).stream()
+                                                                                            .map(CompletableFuture::join)
+                                                                                            .reduce((a, b) -> a + b).get();
+            log.debug("Read events by group {}: {}.", readerGroupId, readEvents);
+            assertEquals("Expected events read: ", CUT_SIZE, readEvents);
             startingPoint = endingPoint;
             groupId++;
         }
@@ -190,30 +199,34 @@ public class StreamCutsTest {
     // Start utils region
 
     private <T extends Serializable> List<Map<Stream, StreamCut>> getStreamCutSlices(ClientFactory client, ReaderGroup readerGroup,
-                                                                                     int slice, ScheduledExecutorService executor) {
+                                                                                     ScheduledExecutorService executor) {
         @Cleanup
         EventStreamReader<T> reader = client.createReader("slicer", readerGroup.getGroupName(), new JavaSerializer<>(),
                 ReaderConfig.builder().build());
         List<Map<Stream, StreamCut>> streamCuts = new ArrayList<>();
         EventRead<T> event;
-        int validEvents = 1;
+        int validEvents = 0;
         try {
             do {
-                event = reader.readNextEvent(1000);
+                event = reader.readNextEvent(5000);
                 if (event.getEvent() != null) {
                     validEvents++;
+                } else {
+                    log.warn("Read unexpected null event at {}.", validEvents);
+                    continue;
                 }
 
-                // Get a StreamCut each for each slice.
-                if (validEvents % slice == 0) {
+                // Get a StreamCut each defined number of events.
+                if (validEvents % CUT_SIZE == 0 && validEvents > 0) {
+                    reader.close();
+                    log.debug("Starting checkpoint {}.", "checkpoint" + String.valueOf(validEvents));
                     Checkpoint cp = readerGroup.initiateCheckpoint("checkpoint" + String.valueOf(validEvents), executor).join();
-                    Map<Stream, StreamCut> newCut = cp.asImpl().getPositions();
-                    log.debug("Creating {} StreamCuts in a snapshot at event {}.", streamCuts.size(), validEvents);
-                    for (Stream stream: newCut.keySet())
-                        log.debug("Stream {}, StreamCut info: {}", stream.getScopedName(), newCut.get(stream).asImpl().toString());
-                    streamCuts.add(newCut);
+                    log.debug("Adding a StreamCut positioned at event {}.", validEvents);
+                    streamCuts.add( cp.asImpl().getPositions());
+                    reader = client.createReader("slicer", readerGroup.getGroupName(), new JavaSerializer<>(), ReaderConfig.builder().build());
                 }
-            } while (event.getEvent() != null || event.isCheckpoint());
+            } while (validEvents < TOTAL_EVENTS);
+
         } catch (ReinitializationRequiredException | RuntimeException e) {
             log.error("Exception while reading event: ", e);
         }

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -135,8 +135,9 @@ public class StreamCutsTest extends AbstractReadWriteTest {
      * This test verifies the correct operation of readers using StreamCuts. Concretely, the test creates two streams
      * with different number of segments and it writes some events (TOTAL_EVENTS) in them. Afterwards, the test creates
      * a list of StreamCuts that encompasses both streams every CUT_SIZE events. The test asserts that new groups of
-     * readers can be initialized at these StreamCut intervals and that only CUT_SIZE events are read. Finally, this
-     * test also verifies that an existing reader group can be reset to the starting position in the stream.
+     * readers can be initialized at these sequential StreamCut intervals and that only CUT_SIZE events are read. Also,
+     * the test checks the correctness of different combinations of intervals that has not been sequentially created.
+     * Finally, this test checks that an existing reader group can be reset to read from the first StreamCut created.
      */
     @Test
     public void streamCutsTest() {

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -61,7 +61,7 @@ public class StreamCutsTest extends AbstractReadWriteTest {
     private static final String READER_GROUP = "testStreamcutsStreamRG" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
 
     private static final int TOTAL_EVENTS = 5000;
-    private static final int CUT_SIZE = 1000;
+    private static final int CUT_SIZE = 500;
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(8 * 60);

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -156,10 +156,11 @@ public class StreamCutsTest extends AbstractReadWriteTest {
      * with different number of segments and it writes some events (TOTAL_EVENTS / 2) in them. Then, the test creates a
      * list of StreamCuts that encompasses both streams every CUT_SIZE events. The test asserts that new groups of
      * readers can be initialized at these sequential StreamCut intervals and that only CUT_SIZE events are read. Also,
-     * the test checks the correctness of different combinations of intervals that have not been sequentially created.
-     * The previous process is repeated twice (thus writing TOTAL_EVENTS): before and after scaling streams, to check if
-     * StreamCuts work correctly under scaling events. Finally, this test checks that an existing reader group can be
-     * reset to the first StreamCut created and checks different StreamCut combinations in both streams for all events.
+     * the test checks the correctness of different combinations of StreamCuts that have not been sequentially created.
+     * After creating StreamCuts and tests the correctness of reads, the test also checks resetting a reader group to a
+     * specific initial read point. The previous process is repeated twice: before and after scaling streams, to test if
+     * StreamCuts work correctly under scaling events (thus writing TOTAL_EVENTS). Finally, this test checks reading
+     * different StreamCut combinations in both streams for all events (encompassing events before and after scaling).
      */
     @Test
     public void streamCutsTest() {
@@ -238,7 +239,7 @@ public class StreamCutsTest extends AbstractReadWriteTest {
                                                               .startingStreamCuts(initialPosition)
                                                               .endingStreamCuts(streamSlices.get(streamSlices.size() - 1)).build();
         readerGroup.resetReaderGroup(firstSliceConfig);
-            log.info("Resetting existing reader group {} to stream cut {}.", READER_GROUP, initialPosition);
+        log.info("Resetting existing reader group {} to stream cut {}.", READER_GROUP, initialPosition);
         final int readEvents = readEventFutures(clientFactory, readerGroup.getGroupName(),
                 parallelSegments).stream().map(CompletableFuture::join).reduce((a, b) -> a + b).get();
         assertEquals("Expected read events: ", TOTAL_EVENTS / 2, readEvents);

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.hash.RandomFactory;
+import io.pravega.test.system.framework.Environment;
+import io.pravega.test.system.framework.SystemTestRunner;
+import io.pravega.test.system.framework.Utils;
+import io.pravega.test.system.framework.services.Service;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import mesosphere.marathon.client.MarathonException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+@RunWith(SystemTestRunner.class)
+public class StreamCutsTest {
+
+    private static final String STREAM_ONE = "streamCutsStreamOne";
+    private static final String STREAM_TWO = "streamCutsStreamTwo";
+    private static final String SCOPE = "streamCutsScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+    private static final String READER_GROUP = "streamCutsRG" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(8 * 60);
+
+    private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(4, "executor");
+    private URI controllerURI;
+    private StreamManager streamManager;
+
+    /**
+     * This is used to setup the services required by the system test framework.
+     *
+     * @throws MarathonException When error in setup.
+     */
+    @Environment
+    public static void initialize() throws MarathonException {
+
+        // 1. Check if zk is running, if not start it.
+        Service zkService = Utils.createZookeeperService();
+        if (!zkService.isRunning()) {
+            zkService.start(true);
+        }
+
+        List<URI> zkUris = zkService.getServiceDetails();
+        log.debug("Zookeeper service details: {}", zkUris);
+        // Get the zk ip details and pass it to bk, host, controller.
+        URI zkUri = zkUris.get(0);
+
+        // 2. Check if bk is running, otherwise start, get the zk ip.
+        Service bkService = Utils.createBookkeeperService(zkUri);
+        if (!bkService.isRunning()) {
+            bkService.start(true);
+        }
+
+        List<URI> bkUris = bkService.getServiceDetails();
+        log.debug("Bookkeeper service details: {}", bkUris);
+
+        // 3. Start controller.
+        Service conService = Utils.createPravegaControllerService(zkUri);
+        if (!conService.isRunning()) {
+            conService.start(true);
+        }
+
+        List<URI> conUris = conService.getServiceDetails();
+        log.debug("Pravega controller service details: {}", conUris);
+
+        // 4.Start segmentstore.
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
+        if (!segService.isRunning()) {
+            segService.start(true);
+        }
+
+        List<URI> segUris = segService.getServiceDetails();
+        log.debug("Pravega segmentstore service details: {}", segUris);
+    }
+
+    @Before
+    public void setup() {
+        Service conService = Utils.createPravegaControllerService(null);
+        List<URI> ctlURIs = conService.getServiceDetails();
+        controllerURI = ctlURIs.get(0);
+        streamManager = StreamManager.create(controllerURI);
+        assertTrue("Creating scope", streamManager.createScope(SCOPE));
+        assertTrue("Creating stream one", streamManager.createStream(SCOPE, STREAM_ONE,
+                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_ONE).scalingPolicy(ScalingPolicy.fixed(1)).build()));
+        assertTrue("Creating stream two", streamManager.createStream(SCOPE, STREAM_TWO,
+                StreamConfiguration.builder().scope(SCOPE).streamName(STREAM_TWO).scalingPolicy(ScalingPolicy.fixed(2)).build()));
+    }
+
+    /**
+     * This test verifies the correct operation of readers using StreamCuts. Concretely, the test creates two streams
+     * with different number of segments and it writes some events (totalEvents) in them. Afterwards, the test creates a
+     * list of StreamCuts that encompasses both streams every sliceSize events. The test asserts that new groups of
+     * readers can be initialized at these StreamCut intervals and that only sliceSize events are read.
+     */
+    @Test
+    public void batchClientSimpleTest() {
+        final int totalEvents = 1000;
+        final int sliceSize = 100;
+        @Cleanup
+        ClientFactory clientFactory = ClientFactory.withScope(SCOPE, controllerURI);
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        readerGroupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_ONE))
+                                                                            .stream(Stream.of(SCOPE, STREAM_TWO))
+                                                                            .build());
+        // First, write half of events in each Stream.
+        writeDummyEvents(clientFactory, STREAM_ONE, totalEvents / 2);
+        writeDummyEvents(clientFactory, STREAM_TWO, totalEvents / 2);
+
+        // Second, get StreamCuts for each slice from both Streams at the same time (may be different in each execution).
+        @Cleanup
+        ReaderGroup readerGroup = readerGroupManager.getReaderGroup(READER_GROUP);
+        List<Map<Stream, StreamCut>> streamSlices = getStreamCutSlices(clientFactory, readerGroup, sliceSize);
+
+        // Third, ensure that reader groups can correctly read slices from different Streams.
+        int groupId = 0;
+        Map<Stream, StreamCut> startingPoint = null;
+        for (Map<Stream, StreamCut> endingPoint : streamSlices) {
+            ReaderGroupConfig config = (groupId == 0) ? ReaderGroupConfig.builder().endingStreamCuts(endingPoint).build() :
+                    ReaderGroupConfig.builder().startingStreamCuts(startingPoint).endingStreamCuts(endingPoint).build();
+
+            // Create a new reader group per stream cut slice and read only events within the cut.
+            String readerGroupId = READER_GROUP + String.valueOf(groupId);
+            readerGroupManager.createReaderGroup(readerGroupId, config);
+            int readEvents = readDummyEvents(clientFactory, readerGroupId, 3).stream().map(CompletableFuture::join)
+                                                                             .reduce((a, b) -> a + b).get();
+            log.debug("Read events by group {}: {}", readerGroupId, readEvents);
+            assertEquals("Expected events read: ", sliceSize, readEvents);
+            startingPoint = endingPoint;
+            groupId++;
+        }
+
+        log.debug("All events correctly read from StreamCut slices on multiple Streams. StreamCuts test passed.");
+    }
+
+    @After
+    public void tearDown() {
+        streamManager.close();
+        ExecutorServiceHelpers.shutdown(executor);
+    }
+
+    // Start utils region
+
+    private <T extends Serializable> List<Map<Stream, StreamCut>> getStreamCutSlices(ClientFactory client, ReaderGroup readerGroup, int slice) {
+        @Cleanup
+        EventStreamReader<T> reader = client.createReader("slicer", readerGroup.getGroupName(), new JavaSerializer<>(),
+                ReaderConfig.builder().build());
+        List<Map<Stream, StreamCut>> streamCuts = new ArrayList<>();
+        EventRead<T> event;
+        int validEvents = 1;
+        try {
+            do {
+                event = reader.readNextEvent(1000);
+                if (event.getEvent() != null) {
+                    validEvents++;
+                }
+
+                // Get a StreamCut each for each slice.
+                if (validEvents % slice == 0) {
+                    log.debug("Creating StreamCuts snapshot at event {}.", validEvents);
+                    streamCuts.add(readerGroup.getStreamCuts());
+                }
+            } while (event.getEvent() != null || event.isCheckpoint());
+        } catch (ReinitializationRequiredException | RuntimeException e) {
+            log.error("Exception while reading event: ", e);
+        }
+
+        return streamCuts;
+    }
+
+    private void writeDummyEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        for (int i = 0; i < totalEvents; i++) {
+            writer.writeEvent(streamName + String.valueOf(i)).join();
+            log.debug("Writing event: {} to stream {}", streamName + String.valueOf(i), streamName);
+        }
+    }
+
+    private List<CompletableFuture<Integer>> readDummyEvents(ClientFactory client, String rGroup, int numReaders) {
+        List<EventStreamReader<String>> readers = new ArrayList<>();
+        for (int i = 0; i < numReaders; i++) {
+            readers.add(client.createReader(String.valueOf(i), rGroup, new JavaSerializer<>(), ReaderConfig.builder().build()));
+        }
+
+        return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r))).collect(toList());
+    }
+
+    private <T> int readEvents(EventStreamReader<T> reader) {
+        EventRead<T> event;
+        int validEvents = 0;
+        try {
+            do {
+                event = reader.readNextEvent(1000);
+                if (event.getEvent() != null) {
+                    validEvents++;
+                }
+            } while (event.getEvent() != null || event.isCheckpoint());
+
+            reader.close();
+        } catch (ReinitializationRequiredException | RuntimeException e) {
+            log.error("Exception while reading event: ", e);
+        }
+
+        return validEvents;
+    }
+
+    // End utils region
+}

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -157,8 +157,8 @@ public class StreamCutsTest extends AbstractReadWriteTest {
         ReaderGroup readerGroup = readerGroupManager.getReaderGroup(READER_GROUP);
 
         // First, write half of events in each Stream.
-        writeDummyEvents(clientFactory, STREAM_ONE, TOTAL_EVENTS / 2);
-        writeDummyEvents(clientFactory, STREAM_TWO, TOTAL_EVENTS / 2);
+        writeEvents(clientFactory, STREAM_ONE, TOTAL_EVENTS / 2);
+        writeEvents(clientFactory, STREAM_TWO, TOTAL_EVENTS / 2);
         log.debug("Finished writing events to streams.");
 
         // Second, get StreamCuts for each slice from both Streams at the same time (may be different in each execution).
@@ -172,8 +172,8 @@ public class StreamCutsTest extends AbstractReadWriteTest {
         combineSlicesAndVerify(readerGroupManager, clientFactory, streamSlices);
 
         // Finally, Test that a reader group can be reset correctly.
-        ReaderGroupConfig firsSliceConfig = baseRGConfigBuilder.startingStreamCuts(streamSlices.get(0)).build();
-        readerGroup.resetReaderGroup(firsSliceConfig);
+        ReaderGroupConfig firstSliceConfig = baseRGConfigBuilder.startingStreamCuts(streamSlices.get(0)).build();
+        readerGroup.resetReaderGroup(firstSliceConfig);
         log.info("Resetting existing reader group {} to stream cut {}.", READER_GROUP, streamSlices.get(0));
         final int parallelSegments = RG_PARALLELISM_ONE + RG_PARALLELISM_TWO;
         final int readEvents = readEventFutures(clientFactory, readerGroup.getGroupName(),
@@ -281,7 +281,7 @@ public class StreamCutsTest extends AbstractReadWriteTest {
                 // Get a StreamCut each defined number of events.
                 if (validEvents % CUT_SIZE == 0 && validEvents > 0) {
                     reader.close();
-                    log.debug("Adding a StreamCut positioned at event {}.", validEvents);
+                    log.info("Adding a StreamCut positioned at event {}.", validEvents);
                     streamCuts.add(readerGroup.getStreamCuts());
                     reader = client.createReader("slicer", readerGroup.getGroupName(), new JavaSerializer<>(),
                             ReaderConfig.builder().build());

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -181,7 +181,6 @@ public class StreamCutsTest extends AbstractReadWriteTest {
                 parallelismBeforeScale);
 
         // Now, we perform a manual scale on both streams and wait until it occurs.
-        log.info("Start scaling of streams.");
         CompletableFuture<Boolean> scaleStreamOne = scaleStream(SCOPE, STREAM_ONE, RG_PARALLELISM_ONE * 2, executor);
         checkScaleStatus(scaleStreamOne);
 
@@ -195,7 +194,7 @@ public class StreamCutsTest extends AbstractReadWriteTest {
                                                                                   .startingStreamCuts(streamCutBeforeScale).build());
         @Cleanup
         ReaderGroup newReaderGroup = readerGroupManager.getReaderGroup(newReaderGroupName);
-        log.debug("Checking slices again starting from {}.", streamCutBeforeScale);
+        log.info("Checking slices again starting from {}.", streamCutBeforeScale);
         List<Map<Stream, StreamCut>> slicesAfterScale = writeEventsAndCheckSlices(clientFactory, newReaderGroup, readerGroupManager,
                 parallelSegmentsAfterScale);
 
@@ -217,12 +216,12 @@ public class StreamCutsTest extends AbstractReadWriteTest {
         log.info("Finished writing events to streams.");
 
         Map<Stream, StreamCut> initialPosition = new HashMap<>(readerGroup.getStreamCuts());
-        log.debug("Creating StreamCuts from: {}.", initialPosition);
+        log.info("Creating StreamCuts from: {}.", initialPosition);
 
         // Get StreamCuts for each slice from both Streams at the same time (may be different in each execution).
         List<Map<Stream, StreamCut>> streamSlices = getStreamCutSlices(clientFactory, readerGroup, TOTAL_EVENTS / 2);
         streamSlices.add(0, initialPosition);
-        log.debug("Finished creating StreamCuts {}.", streamSlices);
+        log.info("Finished creating StreamCuts {}.", streamSlices);
 
         // Ensure that reader groups can correctly read slice by slice from different Streams.
         readSliceBySliceAndVerify(readerGroupManager, clientFactory, parallelSegments, streamSlices);


### PR DESCRIPTION
**Change log description**
Implemented a system test for StreamCuts (test/system/test/StreamCutsTest.java).

**Purpose of the change**
Fixes #2540.

**What the code does**
The test creates two streams with different number of segments and it writes some events in them. Given that, the system tests provides the following checks on the operation of StreamCuts API:

- The test checks the operation of `getStreamCuts` by creating a list of StreamCuts that encompasses both streams every certain number of events. 

- The test checks the operation of `endingStreamCuts` and `startingStreamCuts` by asserting that new groups of readers can be initialized at StreamCut intervals and that only events within that intervals are read. 

- The test also checks the operation of `resetReaderGroup` by resetting an existing reader group to a certain position in the stream.

**How to verify it**
Execute the contributed test (cluster mode).