### PR TITLE
Issue 2250: HDFSIntegrationTest.testEndToEnd failure

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -72,7 +72,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int ATTRIBUTE_UPDATES_PER_SEGMENT = 100;
     private static final List<UUID> ATTRIBUTES = Arrays.asList(Attributes.EVENT_COUNT, UUID.randomUUID(), UUID.randomUUID());
     private static final int EXPECTED_ATTRIBUTE_VALUE = APPENDS_PER_SEGMENT + ATTRIBUTE_UPDATES_PER_SEGMENT;
-    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration TIMEOUT = Duration.ofSeconds(120);
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds() * 10);
 
@@ -120,7 +120,6 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If an exception occurred.
      */
-    @Test(timeout = 300000)
     public void testEndToEnd() throws Exception {
 
         // Phase 1: Create segments and add some appends.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -120,6 +120,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
      *
      * @throws Exception If an exception occurred.
      */
+    @Test
     public void testEndToEnd() throws Exception {
 
         // Phase 1: Create segments and add some appends.


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira <flavio.junqueira@emc.com>

**Change log description**
* Increases `TIMEOUT` constant in StreamSegmentStoreTestBase

* Removes explicit timeout parameter from test case as there is a global timeout set up

**Purpose of the change**
Fixes #2250 

**What the code does**
This test case has been continuously failing in our internal jenkins build. I have been able to reproduce it on a VM with a single core, and increasing the timeout value makes the test case pass. There is also no indication of another problem, although it is suspicious that it is failing more often now. 

**How to verify it**
Run tests and jenkins build.
