### PR TITLE
Issue 2559: Setting scheme to `tls` when `enableTls` is set `tcp` otherwise.

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -263,7 +263,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                         .with(ReadIndexConfig.CACHE_POLICY_MAX_TIME, 60 * 1000)
                         .with(ReadIndexConfig.CACHE_POLICY_MAX_SIZE, 128 * 1024 * 1024L))
                 .include(AutoScalerConfig.builder()
-                        .with(AutoScalerConfig.CONTROLLER_URI, (this.enableTls ? "tcp" : "tls") + "://localhost:"
+                        .with(AutoScalerConfig.CONTROLLER_URI, (this.enableTls ? "tls" : "tcp") + "://localhost:"
                                                                                 + controllerPorts[0])
                                          .with(AutoScalerConfig.AUTH_USERNAME, this.userName)
                                          .with(AutoScalerConfig.AUTH_PASSWORD, this.passwd)


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
Sets the scheme for autoscaler configuration.

**Purpose of the change**
This fixes #2559.

**What the code does**
Sets proper URI scheme for autoscaler config based on `enableTls` config.

**How to verify it**
The segmentstore is able to communicate to the controller in a standalone deployment.