### PR TITLE
Issue 2547: Ensure ClientFactory.close() always closes the Controller client.

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ClientFactory.java
@@ -27,8 +27,6 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.ControllerImpl;
-import io.pravega.client.stream.impl.ControllerImplConfig;
 import java.net.URI;
 import lombok.val;
 
@@ -74,8 +72,7 @@ public interface ClientFactory extends AutoCloseable {
      */
     static ClientFactory withScope(String scope, ClientConfig config) {
         val connectionFactory = new ConnectionFactoryImpl(config);
-        return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
-                connectionFactory.getInternalExecutor()), connectionFactory);
+        return new ClientFactoryImpl(scope, config, connectionFactory);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/ClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ClientFactory.java
@@ -27,6 +27,8 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
 import java.net.URI;
 import lombok.val;
 
@@ -72,7 +74,8 @@ public interface ClientFactory extends AutoCloseable {
      */
     static ClientFactory withScope(String scope, ClientConfig config) {
         val connectionFactory = new ConnectionFactoryImpl(config);
-        return new ClientFactoryImpl(scope, config, connectionFactory);
+        return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
+                connectionFactory.getInternalExecutor()), connectionFactory);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -121,9 +121,6 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     @Override
     public void close() {
-        if (this.controller != null) {
-            this.controller.close();
-        }
         clientFactory.close();
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -89,6 +89,7 @@ public class ClientFactoryImpl implements ClientFactory {
 
     /**
      * Creates a new instance of the ClientFactory class.
+     * Note: ConnectionFactory is closed when {@link ConnectionFactory#close()} is invoked.
      *
      * @param scope             The scope string.
      * @param controller        The reference to Controller.
@@ -133,7 +134,6 @@ public class ClientFactoryImpl implements ClientFactory {
         this.condFactory = condFactory;
         this.metaFactory = metaFactory;
     }
-
 
     @Override
     public <T> EventStreamWriter<T> createEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -207,7 +207,7 @@ public class ClientFactoryImpl implements ClientFactory {
 
     @Override
     public void close() {
-        if(closeController.get()) {
+        if (closeController.get()) {
             controller.close();
         }
         connectionFactory.close();

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -101,18 +101,6 @@ public class ClientFactoryImpl implements ClientFactory {
                 new SegmentMetadataClientFactoryImpl(controller, connectionFactory));
     }
 
-    /**
-     * Creates a new instance of ClientFactory class.
-     * Note: ConnectionFactory is closed when {@link ClientFactoryImpl#close()} is invoked.
-     * @param scope             The scope string.
-     * @param config            The ClientConfig.
-     * @param connectionFactory The reference to Connection Factory implementation.
-     */
-    public ClientFactoryImpl(String scope, ClientConfig config, ConnectionFactory connectionFactory) {
-        this(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
-                connectionFactory.getInternalExecutor()), connectionFactory);
-    }
-
     @VisibleForTesting
     public ClientFactoryImpl(String scope, Controller controller, ConnectionFactory connectionFactory,
             SegmentInputStreamFactory inFactory, SegmentOutputStreamFactory outFactory,

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -20,7 +20,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URI;
 
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -33,14 +32,6 @@ public class ClientFactoryTest {
     private Controller controllerClient;
 
     @Test
-    public void testCloseWithExternalController() {
-        ClientFactory clientFactory = new ClientFactoryImpl("scope", controllerClient, connectionFactory);
-        clientFactory.close();
-        verify(connectionFactory, times(1)).close();
-        verify(controllerClient, never()).close();
-    }
-
-    @Test
     public void testCloseWithInternalController() throws Exception {
         URI uri = new URI("tcp://localhost:9090");
         ClientConfig config = ClientConfig.builder().controllerURI(uri).build();
@@ -48,9 +39,20 @@ public class ClientFactoryTest {
         ClientFactory clientFactory = new ClientFactoryImpl("scope", config, connectionFactory);
         clientFactory.close();
         verify(connectionFactory, times(1)).close();
+    }
 
-        clientFactory = new ClientFactoryImpl("scope", controllerClient);
+    @Test
+    public void testCloseWithExternalController() {
+        ClientFactory clientFactory = new ClientFactoryImpl("scope", controllerClient);
         clientFactory.close();
-        verify(controllerClient, never()).close();
+        verify(controllerClient, times(1)).close();
+    }
+
+    @Test
+    public void testCloseWithExternalControllerConnectionFactory() {
+        ClientFactory clientFactory = new ClientFactoryImpl("scope", controllerClient, connectionFactory);
+        clientFactory.close();
+        verify(connectionFactory, times(1)).close();
+        verify(controllerClient, times(1)).close();
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.ClientFactory;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.URI;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientFactoryTest {
+
+    @Mock
+    private ConnectionFactory connectionFactory;
+    @Mock
+    private Controller controllerClient;
+
+    @Test
+    public void testCloseWithExternalController() {
+        ClientFactory clientFactory = new ClientFactoryImpl("scope", controllerClient, connectionFactory);
+        clientFactory.close();
+        verify(connectionFactory, times(1)).close();
+        verify(controllerClient, never()).close();
+    }
+
+    @Test
+    public void testCloseWithInternalController() throws Exception {
+        URI uri = new URI("tcp://localhost:9090");
+        ClientConfig config = ClientConfig.builder().controllerURI(uri).build();
+
+        ClientFactory clientFactory = new ClientFactoryImpl("scope", config, connectionFactory);
+        clientFactory.close();
+        verify(connectionFactory, times(1)).close();
+
+        clientFactory = new ClientFactoryImpl("scope", controllerClient);
+        clientFactory.close();
+        verify(controllerClient, never()).close();
+    }
+}

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -10,15 +10,12 @@
 package io.pravega.client.stream.impl;
 
 
-import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.net.URI;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,16 +27,6 @@ public class ClientFactoryTest {
     private ConnectionFactory connectionFactory;
     @Mock
     private Controller controllerClient;
-
-    @Test
-    public void testCloseWithInternalController() throws Exception {
-        URI uri = new URI("tcp://localhost:9090");
-        ClientConfig config = ClientConfig.builder().controllerURI(uri).build();
-
-        ClientFactory clientFactory = new ClientFactoryImpl("scope", config, connectionFactory);
-        clientFactory.close();
-        verify(connectionFactory, times(1)).close();
-    }
 
     @Test
     public void testCloseWithExternalController() {

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -312,8 +312,9 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             return;
         }
 
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scopeName, this.localController);
         ReaderGroupManager readerGroupManager = new ReaderGroupManagerImpl(scopeName, this.localController,
-                new ClientFactoryImpl(scopeName, this.localController), this.connectionFactory);
+                clientFactory, this.connectionFactory);
         ReaderGroupProperty readerGroupProperty = new ReaderGroupProperty();
         readerGroupProperty.setScopeName(scopeName);
         readerGroupProperty.setReaderGroupName(readerGroupName);
@@ -334,6 +335,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
         }).thenAccept(response -> {
             asyncResponse.resume(response);
             readerGroupManager.close();
+            clientFactory.close();
             LoggerHelpers.traceLeave(log, "getReaderGroup", traceId);
         });
     }


### PR DESCRIPTION
**Change log description**
- Ensure `ClientFactory.close()` always closes the controller client.
- Ensure `StreamMetadataResourceImpl` closes `ClientFactory` which is created while processing `getReaderGroup()` API.

**Purpose of the change**
Fixes #2547 

**What the code does**
- Ensure `ClientFactory.close()` always closes the controller client, irrespective of whether the controllerclient is created internally or passed to it.
- Ensure `StreamMetadataResourceImpl` closes `ClientFactory` which is created while processing `getReaderGroup()` API.

**How to verify it**
All the existing tests should pass. Verified that the open sockets are closed after invocation of close() using netstat command.