### PR TITLE
Issue 2564: Fix the issue with using cleanUp for controller client in multicontroller system test

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Cleanup;


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
As a part of the changes of the PR #2542 ,
`@cleanup` was introduced for controller client unintentionally. 
This is a problem because the createScope method returns a completable future, and we are closing the client before the future returns.

**Purpose of the change**
Fixes #2564 

**What the code does**
*  Changes the return value of `createScope()`  and `createScopeWithSimpleRetry()` from `CompletableFuture<Boolean>` to `boolean`.
*  Creates `controllerclient` seperately for both `createScope()` and `createScopeWithSimpleRetry()`
as there is some issue in passing around the `controllerclient` from former to later.
* Using `@cleanup` in both the places to ensure client is closed after the scope creation is successful.

**How to verify it**
System tests should pass