### PR TITLE
Issue 2555: (SegmentStore) Fixed sporadic timeout in unit test

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -56,7 +56,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -104,7 +103,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
     HashSet<Long> createStreamSegmentsWithOperations(int streamSegmentCount, ContainerMetadata containerMetadata,
                                                      OperationLog durableLog, Storage storage) {
         StreamSegmentMapper mapper = new StreamSegmentMapper(containerMetadata, durableLog, new InMemoryStateStore(), NO_OP_METADATA_CLEANUP,
-                storage, ForkJoinPool.commonPool());
+                storage, executorService());
         HashSet<Long> result = new HashSet<>();
         for (int i = 0; i < streamSegmentCount; i++) {
             String name = getStreamSegmentName(i);
@@ -148,7 +147,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
                                                              ContainerMetadata containerMetadata, OperationLog durableLog, Storage storage) {
         HashMap<Long, Long> result = new HashMap<>();
         StreamSegmentMapper mapper = new StreamSegmentMapper(containerMetadata, durableLog, new InMemoryStateStore(), NO_OP_METADATA_CLEANUP,
-                storage, ForkJoinPool.commonPool());
+                storage, executorService());
         for (long streamSegmentId : streamSegmentIds) {
             String streamSegmentName = containerMetadata.getStreamSegmentMetadata(streamSegmentId).getName();
 


### PR DESCRIPTION
**Change log description**
- Increased segment expiration time in one of the unit tests in `StreamSegmentContainerTests` since it was causing the test to timeout on very slow machines.
    - The same pattern was applied on other tests in that class, however I left that expiration to the original value since they are passing correctly, and increasing this expiration would have led to a significant increase in unit test execution time.
- Fixed another set of unit tests by passing in the correct Executor in `OperationLogTestBase` (never use `ForkJoinPool` ...)

**Purpose of the change**
Fixes #2555. Note that this failure is due to a different reason than that already fixed by #2561. 

**What the code does**
Increases segment expiration timeout in a unit test.

**How to verify it**
Unit test must pass consistently.