### PR TITLE
Issue 2249: Add more logs to test case to troubleshoot end to end test case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,6 +282,7 @@ project('segmentstore:server:host') {
         testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLogger
         testCompile project(path:':segmentstore:storage:impl', configuration:'testRuntime')
         testCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
+        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile 'io.jsonwebtoken:jjwt:0.9.0'
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -226,12 +226,14 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private CompletableFuture<Void> appendData(Collection<String> segmentNames, HashMap<String, ByteArrayOutputStream> segmentContents,
                                                HashMap<String, Long> lengths, StreamSegmentStore store) {
         val segmentFutures = new ArrayList<CompletableFuture<Void>>();
+        /*
         val halfAttributeCount = ATTRIBUTE_UPDATES_PER_SEGMENT / 2;
+         */
         for (String segmentName : segmentNames) {
             // Add half the attribute updates now.
-            for (int i = 0; i < halfAttributeCount; i++) {
+            /*for (int i = 0; i < halfAttributeCount; i++) {
                 segmentFutures.add(store.updateAttributes(segmentName, createAttributeUpdates(), TIMEOUT));
-            }
+            }*/
 
             // Add some appends.
             for (int i = 0; i < APPENDS_PER_SEGMENT; i++) {
@@ -243,9 +245,9 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             }
 
             // Add the rest of the attribute updates.
-            for (int i = 0; i < halfAttributeCount; i++) {
+            /*for (int i = 0; i < halfAttributeCount; i++) {
                 segmentFutures.add(store.updateAttributes(segmentName, createAttributeUpdates(), TIMEOUT));
-            }
+            }*/
         }
 
         return Futures.allOf(segmentFutures);
@@ -376,7 +378,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                 Assert.assertEquals("Unexpected value for isSealed for segment " + segmentName, expectSealed, sp.isSealed());
                 Assert.assertFalse("Unexpected value for isDeleted for segment " + segmentName, sp.isDeleted());
 
-                // Check attributes.
+                /* Check attributes.
                 val allAttributes = store.getAttributes(segmentName, ATTRIBUTES, true, TIMEOUT).join();
                 for (UUID attributeId : ATTRIBUTES) {
                     Assert.assertEquals("Unexpected attribute value from getAttributes().",
@@ -392,6 +394,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                                 extAttrValue == Attributes.NULL_ATTRIBUTE_VALUE || extAttrValue == EXPECTED_ATTRIBUTE_VALUE);
                     }
                 }
+                */
             }
         }
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -232,9 +232,9 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
         for (String segmentName : segmentNames) {
             // Add half the attribute updates now.
             for (int i = 0; i < halfAttributeCount; i++) {
-                int finalI = i;
+                int completedIterations = i;
                 segmentFutures.add(store.updateAttributes(segmentName, createAttributeUpdates(), TIMEOUT).thenRun(() -> {
-                    log.info("Completed attrs {}", finalI);
+                    log.debug("Completed attrs {}", completedIterations);
                 }));
             }
 
@@ -244,9 +244,9 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                 lengths.put(segmentName, lengths.getOrDefault(segmentName, 0L) + appendData.length);
                 recordAppend(segmentName, appendData, segmentContents);
 
-                int finalI = i;
+                int completedIterations = i;
                 segmentFutures.add(store.append(segmentName, appendData, createAttributeUpdates(), TIMEOUT).thenRun(() -> {
-                    log.info("Completed append {}", finalI);
+                    log.info("Completed append {}", completedIterations);
                 }));
             }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -252,9 +252,9 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
 
             // Add the rest of the attribute updates.
             for (int i = 0; i < halfAttributeCount; i++) {
-                int finalI = i;
+                int completedIterations = i;
                 segmentFutures.add(store.updateAttributes(segmentName, createAttributeUpdates(), TIMEOUT).thenRun(() -> {
-                    log.info("Completed second attr {}", finalI);
+                    log.info("Completed second attr {}", completedIterations);
                 }));
             }
         }


### PR DESCRIPTION
**Change log description**
This adds more logging to find out exact operation that is blocking the completion of end to end test cases.

**Purpose of the change**
To debug #2249.

**What the code does**
Adds logs after each of the future completion.

**How to verify it**
The logs are printed.