### PR TITLE
Issue 2585: (SegmentStore) Reduce excessive logging in some situations

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -354,6 +354,11 @@ class BookKeeperLog implements DurableDataLog {
      * Write Processor main loop. This method is not thread safe and should only be invoked as part of the Write Processor.
      */
     private void processWritesSync() {
+        if (this.closed.get()) {
+            // BookKeeperLog is closed. No point in trying anything else.
+            return;
+        }
+
         if (getWriteLedger().ledger.isClosed()) {
             // Current ledger is closed. Execute the rollover processor to safely create a new ledger. This will reinvoke
             // the write processor upon finish, so the writes can be reattempted.
@@ -374,18 +379,42 @@ class BookKeeperLog implements DurableDataLog {
 
         // Clean up the write queue of all finished writes that are complete (successfully or failed for good)
         val cs = this.writes.removeFinishedWrites();
-        if (cs.contains(WriteQueue.CleanupStatus.WriteFailed)) {
+        if (cs == WriteQueue.CleanupStatus.WriteFailed) {
             // We encountered a failed write. As such, we must close immediately and not process anything else.
             // Closing will automatically cancel all pending writes.
             close();
-            LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, WriteQueue.CleanupStatus.WriteFailed);
+            LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, cs);
             return false;
-        } else if (cs.contains(WriteQueue.CleanupStatus.QueueEmpty)) {
+        } else if (cs == WriteQueue.CleanupStatus.QueueEmpty) {
             // Queue is empty - nothing else to do.
-            LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, WriteQueue.CleanupStatus.QueueEmpty);
+            LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, cs);
             return true;
         }
 
+        // Get the writes to execute from the queue.
+        List<Write> toExecute = getWritesToExecute();
+
+        // Execute the writes, if any.
+        boolean success = true;
+        if (!toExecute.isEmpty()) {
+            success = executeWrites(toExecute);
+
+            if (success) {
+                // After every run where we did write, check if need to trigger a rollover.
+                this.rolloverProcessor.runAsync();
+            }
+        }
+
+        LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, toExecute.size(), success);
+        return success;
+    }
+
+    /**
+     * Collects an ordered list of Writes to execute to BookKeeper.
+     *
+     * @return The list of Writes to execute.
+     */
+    private List<Write> getWritesToExecute() {
         // Calculate how much estimated space there is in the current ledger.
         final long maxTotalSize = this.config.getBkLedgerMaxSize() - getWriteLedger().ledger.getLength();
 
@@ -400,40 +429,45 @@ class BookKeeperLog implements DurableDataLog {
             toExecute = this.writes.getWritesToExecute(maxTotalSize);
         }
 
-        if (toExecute.size() > 0) {
-            // Execute the writes.
-            log.debug("{}: Executing {} writes.", this.traceObjectId, toExecute.size());
-            for (int i = 0; i < toExecute.size(); i++) {
-                Write w = toExecute.get(i);
-                try {
-                    // Record the beginning of a new attempt.
-                    int attemptCount = w.beginAttempt();
-                    if (attemptCount > this.config.getMaxWriteAttempts()) {
-                        // Retried too many times.
-                        throw new RetriesExhaustedException(w.getFailureCause());
-                    }
+        return toExecute;
+    }
 
-                    // Invoke the BookKeeper write.
-                    w.getWriteLedger().ledger.asyncAddEntry(w.data.array(), w.data.arrayOffset(), w.data.getLength(), this::addCallback, w);
-                } catch (Throwable ex) {
-                    // Synchronous failure (or RetriesExhausted). Fail current write.
-                    boolean isFinal = !isRetryable(ex);
-                    w.fail(ex, isFinal);
-
-                    // And fail all remaining writes as well.
-                    for (int j = i + 1; j < toExecute.size(); j++) {
-                        toExecute.get(j).fail(new DurableDataLogException("Previous write failed.", ex), isFinal);
-                    }
-
-                    LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, i);
-                    return false;
+    /**
+     * Executes the given Writes to BookKeeper.
+     *
+     * @param toExecute The Writes to execute.
+     * @return True if all the writes succeeded, false if at least one failed (if a Write failed, all subsequent writes
+     * will be failed as well).
+     */
+    private boolean executeWrites(List<Write> toExecute) {
+        log.debug("{}: Executing {} writes.", this.traceObjectId, toExecute.size());
+        for (int i = 0; i < toExecute.size(); i++) {
+            Write w = toExecute.get(i);
+            try {
+                // Record the beginning of a new attempt.
+                int attemptCount = w.beginAttempt();
+                if (attemptCount > this.config.getMaxWriteAttempts()) {
+                    // Retried too many times.
+                    throw new RetriesExhaustedException(w.getFailureCause());
                 }
-            }
 
-            // After every run where we did write, check if need to trigger a rollover.
-            this.rolloverProcessor.runAsync();
+                // Invoke the BookKeeper write.
+                w.getWriteLedger().ledger.asyncAddEntry(w.data.array(), w.data.arrayOffset(), w.data.getLength(), this::addCallback, w);
+            } catch (Throwable ex) {
+                // Synchronous failure (or RetriesExhausted). Fail current write.
+                boolean isFinal = !isRetryable(ex);
+                w.fail(ex, isFinal);
+
+                // And fail all remaining writes as well.
+                for (int j = i + 1; j < toExecute.size(); j++) {
+                    toExecute.get(j).fail(new DurableDataLogException("Previous write failed.", ex), isFinal);
+                }
+
+                return false;
+            }
         }
-        LoggerHelpers.traceLeave(log, this.traceObjectId, "processPendingWrites", traceId, toExecute.size());
+
+        // Success.
         return true;
     }
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
@@ -16,7 +16,6 @@ import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -130,8 +129,8 @@ public class WriteQueueTests {
             val write = writes.pollFirst();
             if (!write.isDone()) {
                 val result1 = q.removeFinishedWrites();
-                AssertExtensions.assertContainsSameElements("Unexpected value from removeFinishedWrites when there were writes left in the queue.",
-                        EnumSet.of(WriteQueue.CleanupStatus.QueueNotEmpty), result1);
+                Assert.assertEquals("Unexpected value from removeFinishedWrites when there were writes left in the queue.",
+                        WriteQueue.CleanupStatus.QueueNotEmpty, result1);
                 val stats1 = q.getStatistics();
                 Assert.assertEquals("Unexpected size after removeFinishedWrites with no effect.", writes.size() + 1, stats1.getSize());
 
@@ -150,8 +149,8 @@ public class WriteQueueTests {
             expectedElapsed = (time.get() * removed - expectedElapsed) / AbstractTimer.NANOS_TO_MILLIS / removed;
 
             val result2 = q.removeFinishedWrites();
-            val expectedResult = EnumSet.of(writes.isEmpty() ? WriteQueue.CleanupStatus.QueueEmpty : WriteQueue.CleanupStatus.QueueNotEmpty);
-            AssertExtensions.assertContainsSameElements("Unexpected result from removeFinishedWrites.", expectedResult, result2);
+            val expectedResult = writes.isEmpty() ? WriteQueue.CleanupStatus.QueueEmpty : WriteQueue.CleanupStatus.QueueNotEmpty;
+            Assert.assertEquals("Unexpected result from removeFinishedWrites.", expectedResult, result2);
             val stats2 = q.getStatistics();
             Assert.assertEquals("Unexpected size after removeFinishedWrites.", writes.size(), stats2.getSize());
             Assert.assertEquals("Unexpected getExpectedProcessingTimeMillis after clear.", expectedElapsed, stats2.getExpectedProcessingTimeMillis());
@@ -162,8 +161,8 @@ public class WriteQueueTests {
         q.add(w3);
         w3.fail(new IntentionalException(), true);
         val result3 = q.removeFinishedWrites();
-        AssertExtensions.assertContainsSameElements("Unexpected value from removeFinishedWrites when there were failed writes.",
-                EnumSet.of(WriteQueue.CleanupStatus.QueueEmpty, WriteQueue.CleanupStatus.WriteFailed), result3);
+        Assert.assertEquals("Unexpected value from removeFinishedWrites when there were failed writes.",
+                WriteQueue.CleanupStatus.WriteFailed, result3);
 
     }
 


### PR DESCRIPTION
**Change log description**
- Fixed a condition in `BookKeeperLog.processPendingWrites` (Write Processor) where it would continuously invoke itself in cases when there was no work to be done.
    - Even if it doesn't call itself directly, it always invokes the Rollover Processor, which, in turn, always invokes the Write Processor.
    - This was fixed by not attempting to execute any writes or invoke the Rollover Processor if we currently have no writes to execute. 
- Fixed a condition in the Write Processor where it would log spurious, yet harmless `ObjectClosedException` or `NullPointerException` when closing the `BookKeeperLog` and there are still writes pending in the queue.


**Purpose of the change**
Fixes #2585.

**What the code does**
1. Not attempting to execute writes or invoke the Rollover Processor if there aren't any writes to execute.
2. Not executing the Write Processor if BookKeeperLog is closed.

**How to verify it**
Existing unit and integration tests must pass.