### PR TITLE
Issue 2300: (SegmentStore) Fixed sporadically failing unit test

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -809,10 +810,15 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 ReadResult result = context.readIndex.read(segmentId, offset, appendSize, TIMEOUT);
                 ReadResultEntry resultEntry = result.next();
                 Assert.assertEquals("Unexpected type of ReadResultEntry when trying to load up data into the ReadIndex Cache.", ReadResultEntryType.Storage, resultEntry.getType());
+                CompletableFuture<Void> insertedInCache = new CompletableFuture<>();
+                context.cacheFactory.cache.insertCallback = ignored -> insertedInCache.complete(null);
                 resultEntry.requestContent(TIMEOUT);
                 ReadResultEntryContents contents = resultEntry.getContent().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                 Assert.assertFalse("Not expecting more data to be available for reading.", result.hasNext());
                 Assert.assertEquals("Unexpected ReadResultEntry length when trying to load up data into the ReadIndex Cache.", appendSize, contents.getLength());
+
+                // Wait for the entry to be inserted into the cache before moving on.
+                insertedInCache.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             }
 
             context.cacheManager.applyCachePolicy();
@@ -1347,6 +1353,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     //region TestCache
 
     private static class TestCache extends InMemoryCache {
+        Consumer<CacheKey> insertCallback;
         Consumer<CacheKey> removeCallback;
 
         TestCache(String id) {
@@ -1354,13 +1361,21 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         }
 
         @Override
+        public void insert(Cache.Key key, byte[] payload) {
+            super.insert(key, payload);
+            Consumer<CacheKey> callback = this.insertCallback;
+            if (callback != null) {
+                callback.accept((CacheKey) key);
+            }
+        }
+
+        @Override
         public void remove(Cache.Key key) {
+            super.remove(key);
             Consumer<CacheKey> callback = this.removeCallback;
             if (callback != null) {
                 callback.accept((CacheKey) key);
             }
-
-            super.remove(key);
         }
     }
 


### PR DESCRIPTION
**Change log description**
Fixed `ContainerReadIndexTests.testCacheEviction`:
- This is a pretty complex test, with a lot of subtleties, mostly due to the fact that it does not have visibility into all the Read Index's internals
- The cause for failure was that the `StreamSegmentReadIndex` class, when processing Tier2 Storage reads, it would execute events in this exact order (deliberately):
    1. Successful Tier2 read
    2. Ack the caller's Future with the data at hand (since it's already available)
    3. Insert into the cache  - this is done after step 2 since the caller does not need to wait on cache insertion if we already have the data.
- The code above is correct, and the problem does not lie in the main code; it is a test issue, for the following reasons
    - The test moves on as soon as an ack is received from step 2
    - The actual cache insertion (step 3) may not happen for a long time (which is OK), but the test may have already done further things, and assumed that it did happen
        - For example, it inserts data in a specific order and expects it to be evicted in that same order; if the cache is updated asynchronously, then this assumption goes out the door.

Fix:
- The test code uses a `TestCache` wrapper for the real cache, which allows hooking up into the `insert` and `remove` calls.
- The test now hooks into the `insert` method and makes it complete a Future that will be waited upon before the test moves on.

**Purpose of the change**
Fixes #2300.

**What the code does**
Fixes unit test.

**How to verify it**
Either:
- Run this test repeatedly in a local VM with 1 CPU at 75% of physical CPU speed
- Run this build a sufficient number of times to be confident enough that it is fixed.
