### PR TITLE
Issue 2532: specify the default port

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -77,7 +77,7 @@ public class ClientConfig implements Serializable {
 
         public ClientConfig build() {
             if (controllerURI == null) {
-                controllerURI = URI.create("tcp://localhost");
+                controllerURI = URI.create("tcp://localhost:9090");
             }
             extractCredentials();
             if (credentials == null) {


### PR DESCRIPTION
**Change log description**
- use the correct default port in `ClientConfig`

**Purpose of the change**
- fix #2532 

**How to verify it**
- manual test using a sample program

Signed-off-by: Eron Wright <eronwright@gmail.com>
