### PR TITLE
Issue 2594: Ensure SegmentMetadataClient#getSegmentInfo propagates NoSuchSegmentException.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -190,7 +190,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         val future = RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class)
                                    .throwingOn(NoSuchSegmentException.class)
                                    .runAsync(() -> getStreamSegmentInfo(delegationToken), connectionFactory.getInternalExecutor());
-        StreamSegmentInfo info = future.join();
+        StreamSegmentInfo info = Futures.getThrowingException(future);
         return new SegmentInfo(segmentId, info.getStartOffset(), info.getWriteOffset(), info.isSealed(),
                                info.getLastModified());
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -12,12 +12,15 @@ package io.pravega.client.stream.impl;
 import com.google.common.collect.ImmutableMap;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.NoSuchEventException;
+import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentInputStream;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
 import io.pravega.client.segment.impl.SegmentOutputStream;
 import io.pravega.client.segment.impl.SegmentSealedException;
+import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
@@ -297,7 +300,7 @@ public class EventStreamReaderTest {
         assertTrue(reader.getReaders().isEmpty());
         reader.close();
     }
-    
+
     @Test(timeout = 10000)
     public void testDataTruncated() throws SegmentSealedException, ReinitializationRequiredException {
         AtomicLong clock = new AtomicLong();
@@ -332,5 +335,44 @@ public class EventStreamReaderTest {
         AssertExtensions.assertThrows(NoSuchEventException.class, () -> reader.fetchEvent(event1.getEventPointer()));
         reader.close();
     }
-    
+
+    /**
+     * This test tests a scenario where a lagging reader's SegmentInputStream receives a SegmentTruncatedException and
+     * when the reader tries to fetch the start offset of this segment the SegmentStore returns a NoSuchSegmentException.
+     */
+    @Test
+    public void testTruncatedSegmentDeleted() throws Exception {
+        AtomicLong clock = new AtomicLong();
+        Segment segment = Segment.fromScopedName("Foo/Bar/0");
+
+        // Setup mock.
+        SegmentInputStreamFactory segInputStreamFactory = Mockito.mock(SegmentInputStreamFactory.class);
+        SegmentMetadataClientFactory segmentMetadataClientFactory = Mockito.mock(SegmentMetadataClientFactory.class);
+        SegmentMetadataClient metadataClient = Mockito.mock(SegmentMetadataClient.class);
+        SegmentInputStream segmentInputStream = Mockito.mock(SegmentInputStream.class);
+        Mockito.when(segmentMetadataClientFactory.createSegmentMetadataClient(any(Segment.class), any())).thenReturn(metadataClient);
+        Mockito.when(segmentInputStream.getSegmentId()).thenReturn(segment);
+        Mockito.when(segInputStreamFactory.createInputStreamForSegment(any(Segment.class), anyLong())).thenReturn(segmentInputStream);
+        // Ensure segmentInputStream.read() returns SegmentTruncatedException.
+        Mockito.when(segmentInputStream.read(anyLong())).thenThrow(SegmentTruncatedException.class);
+        // Ensure SegmentInfo returns NoSuchSegmentException.
+        Mockito.when(metadataClient.getSegmentInfo()).thenThrow(NoSuchSegmentException.class);
+
+        Orderer orderer = new Orderer();
+        ReaderGroupStateManager groupState = Mockito.mock(ReaderGroupStateManager.class);
+        EventStreamReaderImpl<byte[]> reader = new EventStreamReaderImpl<>(segInputStreamFactory, segmentMetadataClientFactory,
+                new ByteArraySerializer(), groupState,
+                orderer, clock::get,
+                ReaderConfig.builder().build());
+        Mockito.when(groupState.acquireNewSegmentsIfNeeded(0L))
+                .thenReturn(ImmutableMap.of(segment, 0L))
+                .thenReturn(Collections.emptyMap());
+
+        // Validate that TruncatedDataException is thrown.
+        AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
+        // Ensure this segment is closed.
+        Mockito.verify(segmentInputStream, Mockito.times(1)).close();
+        // Ensure groupstate is updated ot handle end of segment.
+        Mockito.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment, true);
+    }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -372,7 +372,7 @@ public class EventStreamReaderTest {
         AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
         // Ensure this segment is closed.
         Mockito.verify(segmentInputStream, Mockito.times(1)).close();
-        // Ensure groupstate is updated ot handle end of segment.
+        // Ensure groupstate is updated to handle end of segment.
         Mockito.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment, true);
     }
 }


### PR DESCRIPTION
**Change log description**
Ensure `SegmentMetadataClient#getSegmentInfo` propagates NoSuchSegmentException.

**Purpose of the change**
Fixes #2594 

**What the code does**
`EventStreamReader.readNext()` throws a `TruncatedDataException` if the stream is truncated based on its stream retention policy. Invoking the `readNext()` again will cause the reader to read from the new start offset of the segment.

In case of a lagging reader it can so happen that a reader can encounter `SegmentTruncatedException` and when it tries to fetch the segment's new start offset the segment might have been deleted. Since the segment is deleted the `SegmentMetadataClient#getSegmentInfo` will receive a `NoSuchSegmentException`. The change ensures that this exception is not wrapped inside a `CompletionException`.

**How to verify it**
All the existing and newly added tests should pass.