### PR TITLE
Issue 2596: (SegmentStore) Not able to re-cache Extended Attribute with a value of NULL_VALUE

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -93,9 +93,9 @@ public interface StreamSegmentStore {
      *                          Metadata cache will be atomically added using a conditional update (comparing against a missing value).
      *                          This argument will be ignored if the StreamSegment is currently Sealed.
      * @param timeout           Timeout for the operation.
-     * @return A Completable future that, when completed, will contain a Map of Attribute Ids to their latest values. If
-     * an attribute does not exist, it will still be added to this map, but with a value set to Attributes.NULL_ATTRIBUTE_VALUE.
-     * If the operation failed, the future will be failed with the causing exception.
+     * @return A Completable future that, when completed, will contain a Map of Attribute Ids to their latest values. Any
+     * Attribute that is not set will also be returned (with a value equal to Attributes.NULL_ATTRIBUTE_VALUE). If the operation
+     * failed, the future will be failed with the causing exception.
      * @throws NullPointerException     If any of the arguments are null.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't check if the StreamSegment
      *                                  does not exist - that exception will be set in the returned CompletableFuture).

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -99,8 +99,8 @@ public interface StreamSegmentStore {
      *                          This argument will be ignored if the StreamSegment is currently Sealed.
      * @param timeout           Timeout for the operation.
      * @return A Completable future that, when completed, will contain a Map of Attribute Ids to their latest values. If
-     * an attribute does not exist, it will not be populated in this map. If the operation failed, the future will be failed
-     * with the causing exception.
+     * an attribute does not exist, it will still be added to this map, but with a NULL_ATTRIBUTE_VALUE. If the operation
+     * failed, the future will be failed with the causing exception.
      * @throws NullPointerException     If any of the arguments are null.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't check if the StreamSegment
      *                                  does not exist - that exception will be set in the returned CompletableFuture).

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -64,8 +65,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * Container for StreamSegments. All StreamSegments that are related (based on a hashing functions) will belong to the
@@ -574,8 +575,9 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         Map<UUID, Long> metadataAttributes = segmentMetadata.getAttributes();
         ArrayList<UUID> extendedAttributeIds = new ArrayList<>();
         attributeIds.forEach(attributeId -> {
-            Long v = metadataAttributes.getOrDefault(attributeId, Attributes.NULL_ATTRIBUTE_VALUE);
-            if (v != Attributes.NULL_ATTRIBUTE_VALUE) {
+            Long v = metadataAttributes.get(attributeId);
+            if (v != null) {
+                // This attribute cached in the Segment Metadata, even if it has a value equal to Attributes.NULL_ATTRIBUTE_VALUE.
                 result.put(attributeId, v);
             } else if (!Attributes.isCoreAttribute(attributeId)) {
                 extendedAttributeIds.add(attributeId);
@@ -585,7 +587,20 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         // Collect remaining Extended Attributes.
         CompletableFuture<Map<UUID, Long>> r = this.attributeIndex
                 .forSegment(segmentMetadata.getId(), timer.getRemaining())
-                .thenComposeAsync(idx -> idx.get(extendedAttributeIds, timer.getRemaining()), this.executor);
+                .thenComposeAsync(idx -> idx.get(extendedAttributeIds, timer.getRemaining()), this.executor)
+                .thenApplyAsync(extendedAttributes -> {
+                    if (extendedAttributeIds.size() == extendedAttributes.size()) {
+                        // We found a value for each Attribute Id. Nothing more to do.
+                        return extendedAttributes;
+                    }
+
+                    // Insert a NULL_ATTRIBUTE_VALUE for each missing value.
+                    Map<UUID, Long> allValues = new HashMap<>(extendedAttributes);
+                    extendedAttributeIds.stream()
+                                        .filter(id -> !extendedAttributes.containsKey(id))
+                                        .forEach(id -> allValues.put(id, Attributes.NULL_ATTRIBUTE_VALUE));
+                    return allValues;
+                }, this.executor);
 
         if (cache && !segmentMetadata.isSealed() && extendedAttributeIds.size() > 0) {
             // Add them to the cache if requested.
@@ -593,12 +608,10 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                 // Update the in-memory Segment Metadata using a special update (AttributeUpdateType.None, which should
                 // complete if the attribute is not currently set). If it has some value, then a concurrent update
                 // must have changed it and we cannot update anymore.
-                // Also make sure we insert (a NULL value) for those missing attributes as well).
-                ArrayList<AttributeUpdate> updates = new ArrayList<>();
-                extendedAttributes.forEach((id, value) -> updates.add(new AttributeUpdate(id, AttributeUpdateType.None, value)));
-                extendedAttributeIds.stream()
-                                    .filter(id -> !extendedAttributes.containsKey(id))
-                                    .forEach(id -> updates.add(new AttributeUpdate(id, AttributeUpdateType.None, Attributes.NULL_ATTRIBUTE_VALUE)));
+                List<AttributeUpdate> updates = extendedAttributes
+                        .entrySet().stream()
+                        .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, e.getValue()))
+                        .collect(Collectors.toList());
 
                 // We need to make sure not to update attributes via updateAttributes() as that method may indirectly
                 // invoke this one again.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -577,7 +577,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         attributeIds.forEach(attributeId -> {
             Long v = metadataAttributes.get(attributeId);
             if (v != null) {
-                // This attribute cached in the Segment Metadata, even if it has a value equal to Attributes.NULL_ATTRIBUTE_VALUE.
+                // This attribute is cached in the Segment Metadata, even if it has a value equal to Attributes.NULL_ATTRIBUTE_VALUE.
                 result.put(attributeId, v);
             } else if (!Attributes.isCoreAttribute(attributeId)) {
                 extendedAttributeIds.add(attributeId);


### PR DESCRIPTION
**Change log description**
Fixed a bug in `StreamSegmentContainer.getAttributes` where it would incorrectly try to re-cache an Attribute that has a value set to NULL_ATTRIBUTE_VALUE using a conditional update that ensures the value was not present.

**Purpose of the change**
Fixes #2596.

**What the code does**
Fixes a bug.

**How to verify it**
Unit tests updated to cover this case.
