### PR TITLE
Issue 2601: Checking status of HDFS before public methods are executed

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -186,7 +186,6 @@ class HDFSStorage implements SyncStorage {
     }
 
     private boolean isSealed(Path path) throws FileNameFormatException {
-        ensureInitializedAndNotClosed();
         return getEpochFromPath(path) == MAX_EPOCH;
     }
 


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
The public APIs for `HDFSStorage` does not check for status of the service before executing public method.

**Purpose of the change**
This fixes #2601.

**What the code does**
Checks status of HDFS.
 
**How to verify it**
