### PR TITLE
Issue 2606: Added UTF-8 string serializer.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/UTF8StringSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/UTF8StringSerializer.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+import io.pravega.client.stream.Serializer;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * An implementation of {@link Serializer} that converts UTF-8 strings.
+ * Note that this is incompatible with {@link JavaSerializer} of String.
+ */
+public class UTF8StringSerializer implements Serializer<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+    @Override
+    public ByteBuffer serialize(String value) {
+        return ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String deserialize(ByteBuffer serializedValue) {
+        return StandardCharsets.UTF_8.decode(serializedValue).toString();
+    }
+}

--- a/client/src/test/java/io/pravega/client/stream/impl/UTF8StringSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/UTF8StringSerializerTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+import com.google.common.base.Strings;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class UTF8StringSerializerTest {
+
+    @Test
+    public void testString() {
+        UTF8StringSerializer serializer = new UTF8StringSerializer();
+        String one = "this is a test string";
+        String result = serializer.deserialize(serializer.serialize(one));
+        assertEquals(one, result);
+    }
+
+    @Test
+    public void testEmptyString() {
+        UTF8StringSerializer serializer = new UTF8StringSerializer();
+        String one = "";
+        String result = serializer.deserialize(serializer.serialize(one));
+        assertEquals(one, result);
+    }
+
+    @Test
+    public void testLargerThan1MBString() {
+        UTF8StringSerializer serializer = new UTF8StringSerializer();
+        String one = Strings.repeat("0123456789012345", 65537);
+        String result = serializer.deserialize(serializer.serialize(one));
+        assertEquals(one, result);
+    }
+
+    @Test
+    public void testByteArrayWithOffset() {
+        UTF8StringSerializer serializer = new UTF8StringSerializer();
+        byte[] part1 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        String part2Str = "this is a test string";
+        ByteBuffer part2 = serializer.serialize(part2Str);
+        int part2Length = part2.remaining();
+        byte[] part3 = new byte[] { 10, 11, 12 };
+        // Create a new buffer with parts 1, 2, and 3..
+        ByteBuffer buf = ByteBuffer.allocate(part1.length + part2Length + part3.length);
+        buf.put(part1);
+        buf.put(part2);
+        buf.put(part3);
+        // Set buffer's position and length so that it points to part 2 only.
+        buf.position(part1.length);
+        buf.limit(part1.length + part2Length);
+        String result = serializer.deserialize(buf);
+        assertEquals(part2Str, result);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Claudio Fahey <claudio.fahey@emc.com>

**Change log description**
Added UTF-8 string serializer.

**Purpose of the change**
Currently, events that consist of strings are serialized in Pravega using JavaSerializer. This is not ideal because it is difficult to use in non-Java environments and adds unnecessary framing. This change adds a new UTF-8 string serializer.

**What the code does**
This change adds a new UTF-8 string serializer.

**How to verify it**
See UTF8StringSerializerTest.