### PR TITLE
Issue 2579: Improve the color code and format of code snippets in pravega.io documentation

### DIFF
--- a/documentation/src/docs/basic-reader-and-writer.md
+++ b/documentation/src/docs/basic-reader-and-writer.md
@@ -31,15 +31,15 @@ EventStreamWriter to write an Event to Pravega.
 Taking a look first at the HelloWorldWriter example application, the key part of
 the code is in the run() method:
 
-```
+```java
 public void run(String routingKey, String message) {
     StreamManager streamManager = StreamManager.create(controllerURI);
   
-    final boolean scopeIsNew = streamManager.createScope(scope);
+    final boolean scopeCreation = streamManager.createScope(scope);
     StreamConfiguration streamConfig = StreamConfiguration.builder()
             .scalingPolicy(ScalingPolicy.fixed(1))
             .build();
-    final boolean streamIsNew = streamManager.createStream(scope, streamName, streamConfig);
+    final boolean streamCreation = streamManager.createStream(scope, streamName, streamConfig);
   
     try (ClientFactory clientFactory = ClientFactory.withScope(scope, controllerURI);
          EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
@@ -222,7 +222,7 @@ representation of those Events onto the console.
 Just like the HelloWorldWriter example, the key part of the HelloWorldReader app
 is in the run() method:
 
-```
+```java
 public void run() {
    StreamManager streamManager = StreamManager.create(controllerURI);
  
@@ -377,13 +377,13 @@ When the data is read this way, rather than joining a reader group which automat
 Obviously this API is not for every application, the main advantage is that it allows for low level integration with batch processing frameworks such as MapReduce. 
 
 As an example to iterate over all the segments in the stream:
-```
+```java
 //Passing null to fromStreamCut and toStreamCut will result in using the current start of stream and the current end of stream respectively.
 Iterator<SegmentRange> segments = client.listSegments(stream, null, null).getIterator();
 SegmentRange segmentInfo = segments.next();
 ```
 Or to read the events from a segment:
-```
+```java
 SegmentIterator<T> events = client.readSegment(segmentInfo, deserializer);
 while (events.hasNext()) {
     processEvent(events.next());

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -13,7 +13,7 @@ There are three basic interfaces: StatsProvider, StatsLogger (short for Statisti
 StatsProvider provides us the whole Metric service; StatsLogger is the place at which we register and get required Metrics ([Counter](http://metrics.dropwizard.io/3.1.0/manual/core/#counters)/[Gauge](http://metrics.dropwizard.io/3.1.0/manual/core/#gauges)/[Timer](http://metrics.dropwizard.io/3.1.0/manual/core/#timers)/[Histograms](http://metrics.dropwizard.io/3.1.0/manual/core/#histograms)); while OpStatsLogger is a sub-metric for complex ones (Timer/Histograms).
 ## 1.1. Metrics Service Provider — Interface StatsProvider
 The starting point of Pravega Metric framework is the StatsProvider interface, it provides start and stop method for Metric service. Regarding the reporters, currently we have support for CSV reporter and StatsD reporter.
-```
+```java
 public interface StatsProvider {
     void start(MetricsConfig conf);
     void close();
@@ -26,7 +26,7 @@ public interface StatsProvider {
 
 ## 1.2. Example for starting a Metric service
 This example is from file io.pravega.segmentstore.server.host.ServiceStarter. It starts Pravega service and a Metrics service is started as a sub service.
-```
+```java
 public final class ServiceStarter {
     ...
     private StatsProvider statsProvider;
@@ -53,7 +53,7 @@ public final class ServiceStarter {
 ```
 ## 1.3. Metric Logger — interface StatsLogger
 Using this interface we can register required metrics for simple types like [Counter](http://metrics.dropwizard.io/3.1.0/manual/core/#counters) and [Gauge](http://metrics.dropwizard.io/3.1.0/manual/core/#gauges) and some complex statistics type of Metric OpStatsLogger, through which we provide [Timer](http://metrics.dropwizard.io/3.1.0/manual/core/#timers) and [Histogram](http://metrics.dropwizard.io/3.1.0/manual/core/#histograms).
-```
+```java
 public interface StatsLogger {
     OpStatsLogger createStats(String name);
     Counter createCounter(String name);
@@ -66,7 +66,7 @@ public interface StatsLogger {
 
 ### 1.3.1. Metric Sub Logger — OpStatsLogger
 OpStatsLogger provides complex statistics type of Metric, usually it is used in operations such as CreateSegment, ReadSegment, we could use it to record the number of operation, time/duration of each operation.
-```
+```java
 public interface OpStatsLogger {
     void reportSuccessEvent(Duration duration);
     void reportFailEvent(Duration duration);
@@ -81,7 +81,7 @@ public interface OpStatsLogger {
 
 ### 1.3.2. Example for Counter and OpStatsLogger(Timer/Histograms)
 This is an example from io.pravega.segmentstore.server.host.PravegaRequestProcessor. In this class, we registered four metrics: Two timers (createSegment/readSegment), one histograms (segmentReadBytes) and one counter (allReadBytes).
-```
+```java
 public class PravegaRequestProcessor extends FailingRequestProcessor implements RequestProcessor {
     …
     static final StatsLogger STATS_LOGGER = MetricsProvider.getStatsLogger(""); < === 1, get a statsLogger
@@ -167,7 +167,7 @@ t,count
 
 ### 1.3.4. Example for Gauge metrics
 This is an example from io.pravega.segmentstore.server.host.AppendProcessor. In this class, we registered a Gauge which represent current PendingReadBytes.
-```
+```java
 public class AppendProcessor extends DelegatingRequestProcessor {
     ...
     static final StatsLogger STATS_LOGGER = MetricsProvider.getStatsLogger(); < === 1. get logger from MetricsProvider
@@ -198,7 +198,7 @@ Reporters are the way through which we export all the measurements being made by
 CSV reporter will export each Metric out into one file. 
 StatsD reporter will export Metrics through UDP/TCP to a StatsD server.
 The reporter could be configured through MetricsConfig.
-```
+```java
 public class MetricsConfig extends ComponentConfig {
     //region Members
     public static final String COMPONENT_CODE = "metrics";
@@ -220,12 +220,12 @@ public class MetricsConfig extends ComponentConfig {
 
 # 3. Steps to add your own Metrics
 * Step 1. When start a segment store/controller service, start a Metrics service as a sub service. Reference above example in ServiceStarter.start()
-```
+```java
         statsProvider = MetricsProvider.getProvider();
         statsProvider.start(metricsConfig);    
 ```
 * Step 2. In the class that need Metrics: get StatsLogger through MetricsProvider; then get Metrics from StatsLogger; at last report it at the right place.
-```
+```java
     static final StatsLogger STATS_LOGGER = MetricsProvider.getStatsLogger(); < === 1
     public static class Metrics { < === 2
         static final OpStatsLogger CREATE_STREAM_SEGMENT = STATS_LOGGER.createStats(CREATE_SEGMENT);

--- a/documentation/src/docs/reader-group-notifications.md
+++ b/documentation/src/docs/reader-group-notifications.md
@@ -22,7 +22,7 @@ to change. The total number of segments can also change when the configuration
 of the reader group changes, for example, when it adds or removes a stream.
 
 The method for subscribing to segment notifications is shown below
-```
+```java
 @Cleanup
 ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
         connectionFactory);
@@ -58,7 +58,7 @@ data with a batch job where the application wants to read data of sealed
 stream(s).
 
 The method for subscribing to end of data notifications is shown below
-```
+```java
 @Cleanup
 ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
         connectionFactory);

--- a/documentation/src/docs/rest/restapis.md
+++ b/documentation/src/docs/rest/restapis.md
@@ -87,7 +87,7 @@ Create a new scope
 
 
 ##### Request body
-```
+```json
 json :
 {
   "scopeName" : "string"
@@ -98,7 +98,7 @@ json :
 #### Example HTTP response
 
 ##### Response 201
-```
+```json
 json :
 {
   "scopeName" : "string"
@@ -142,7 +142,7 @@ List all available scopes in pravega
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scopes" : [ {
@@ -196,7 +196,7 @@ Retrieve details of an existing scope
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scopeName" : "string"
@@ -285,7 +285,7 @@ List reader groups within the given scope
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "readerGroups" : [ "object" ]
@@ -338,7 +338,7 @@ Fetch the properties of an existing reader group
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scopeName" : "string",
@@ -407,7 +407,7 @@ Create a new stream
 
 
 ##### Request body
-```
+```json
 json :
 {
   "streamName" : "string",
@@ -428,7 +428,7 @@ json :
 #### Example HTTP response
 
 ##### Response 201
-```
+```json
 json :
 {
   "scopeName" : "string",
@@ -490,7 +490,7 @@ List streams within the given scope
 
 
 ##### Request query
-```
+```json
 json :
 {
   "showInternalStreams" : "string"
@@ -501,7 +501,7 @@ json :
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "streams" : [ {
@@ -567,7 +567,7 @@ Fetch the properties of an existing stream
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scopeName" : "string",
@@ -643,7 +643,7 @@ Update configuration of an existing stream
 
 
 ##### Request body
-```
+```json
 json :
 {
   "scalingPolicy" : {
@@ -663,7 +663,7 @@ json :
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scopeName" : "string",
@@ -765,7 +765,7 @@ Get scaling events for a given datetime period.
 
 
 ##### Request query
-```
+```json
 json :
 {
   "from" : 0,
@@ -777,7 +777,7 @@ json :
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "scalingEvents" : [ {
@@ -842,7 +842,7 @@ Updates the current state of the stream
 
 
 ##### Request body
-```
+```json
 json :
 {
   "streamState" : "string"
@@ -853,7 +853,7 @@ json :
 #### Example HTTP response
 
 ##### Response 200
-```
+```json
 json :
 {
   "streamState" : "string"

--- a/documentation/src/docs/state-synchronizer.md
+++ b/documentation/src/docs/state-synchronizer.md
@@ -176,7 +176,7 @@ invoked with the latest state object, and computes the updates to be applied.
 
 In our example, InitialUpdateT is implemented as:
 
-```
+```java
 /**
  * Create a Map. This is used by StateSynchronizer to initialize shared state.
  */
@@ -217,7 +217,7 @@ Class.  We define an abstract class, called StateUpdate, from which all of thes
 "operational" update classes inherit.  
 
 **StateUpdate abstract class**
-```
+```java
 /**
  * A base class for all updates to the shared state. This allows for several different types of updates.
  */
@@ -250,7 +250,7 @@ Here, for example, is the way we implement the Put(key,value) operation on the
 SharedMap object:
 
 **Put as an Update Object**
-```
+```java
 /**
  * Add a key/value pair to the State.
  */
@@ -287,7 +287,7 @@ subclasses of StateUpdate to perform state change (write) operations.
 
 **Creating a SharedMap**
 
-```
+```java
 /**
   * Creates the shared state using a synchronizer based on the given stream name.
   *
@@ -360,7 +360,7 @@ StateSynchronizer programming in a bit more detail:
 
 **Implementing put(key,value)**
 
-```
+```java
 /**
  * Associates the specified value with the specified key in this map.
  *

--- a/documentation/src/mkdocs.yml
+++ b/documentation/src/mkdocs.yml
@@ -15,6 +15,21 @@ edit_uri: 'tree/master/documentation/src/docs'
 
 theme: 'material'
 
+
+# Extensions
+markdown_extensions:
+  - admonition
+  - codehilite(guess_lang=false)
+  - footnotes
+  - meta
+  - toc(permalink=true)
+  - pymdownx.betterem(smart_enable=all)
+  - pymdownx.caret
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+
 pages:
   - Overview: 'index.md'
   - Getting Started: 'getting-started.md'

--- a/documentation/src/mkdocs.yml
+++ b/documentation/src/mkdocs.yml
@@ -55,6 +55,7 @@ pages:
       - 'Deployment in Docker Swarm': 'deployment/docker-swarm.md'
       - 'Deployment on DC/OS': 'deployment/dcos-install.md'
       - 'Running in the Cloud (AWS)': 'deployment/aws-install.md'
+      - 'Pravega Metrics': 'metrics.md'
   - Contributing to Pravega:
       - 'Coding guildelines': 'contributing.md'
       - 'Pravega Roadmap': 'roadmap.md'


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
The format of code blocks in the documentation is not appropriate and to the mark.
They are to be rendered with the language used in the code.

**Purpose of the change**
Fixes #2579 

**What the code does**
*  Adds few markdown extensions to `mkdocs.yml`  - the config used for conversion of `.md` files to `.html` files.
*  Adds the required changes  to the code snippets in the documentation

**How to verify it**
Visit  www.pravega.io/docs/latest
