### PR TITLE
Issue 2621: (SegmentStore) Multiple bug fixes relating to merging segments

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -147,8 +147,15 @@ public class ContainerReadIndex implements ReadIndex {
         Exceptions.checkNotClosed(this.closed.get(), this);
         log.debug("{}: completeMerge (TargetId = {}, SourceId = {}.", this.traceObjectId, targetStreamSegmentId, sourceStreamSegmentId);
 
+        SegmentMetadata sourceMetadata;
+        synchronized (this.lock) {
+            sourceMetadata = this.metadata.getStreamSegmentMetadata(sourceStreamSegmentId);
+        }
+
+        Preconditions.checkState(sourceMetadata != null, "No Metadata found for Segment Id %s.", sourceStreamSegmentId);
+
         StreamSegmentReadIndex targetIndex = getOrCreateIndex(targetStreamSegmentId);
-        targetIndex.completeMerge(sourceStreamSegmentId);
+        targetIndex.completeMerge(sourceMetadata);
         synchronized (this.lock) {
             // Do not clear the Cache after merger - we are reusing the cache entries from the source index in the target one.
             closeIndex(sourceStreamSegmentId, false);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -362,8 +362,9 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         Exceptions.checkArgument(sourceMetadata.isSealed(), "sourceStreamSegmentIndex", "Given StreamSegmentReadIndex refers to a StreamSegment that is not sealed.");
 
         long sourceLength = sourceStreamSegmentIndex.getSegmentLength();
+        RedirectIndexEntry newEntry = new RedirectIndexEntry(offset, sourceStreamSegmentIndex);
         if (sourceLength == 0) {
-            // Nothing to do.
+            // Nothing to do. Just record that there is a merge for this source Segment id.
             return;
         }
 
@@ -375,7 +376,6 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         Exceptions.checkArgument(endOffset <= ourLength, "offset", "The given range of bytes(%d-%d) is beyond the StreamSegment Length (%d).", offset, endOffset, ourLength);
 
         // Check and record the merger (optimistically).
-        RedirectIndexEntry newEntry = new RedirectIndexEntry(offset, sourceStreamSegmentIndex);
         synchronized (this.lock) {
             Exceptions.checkArgument(!this.mergeOffsets.containsKey(sourceMetadata.getId()), "sourceStreamSegmentIndex", "Given StreamSegmentReadIndex is already merged or in the process of being merged into this one.");
             this.mergeOffsets.put(sourceMetadata.getId(), newEntry.key());
@@ -400,29 +400,37 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      * The StreamSegments are physically merged in the Storage. The Source StreamSegment does not exist anymore.
      * The ReadIndex entries of the two Streams are actually joined together.
      *
-     * @param sourceStreamSegmentId The Id of the StreamSegment that was merged into this one.
+     * @param sourceMetadata The SegmentMetadata of the Segment that was merged into this one.
      */
-    void completeMerge(long sourceStreamSegmentId) {
-        long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "completeMerge", sourceStreamSegmentId);
+    void completeMerge(SegmentMetadata sourceMetadata) {
+        long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "completeMerge", sourceMetadata.getId());
         Exceptions.checkNotClosed(this.closed, this);
+        Exceptions.checkArgument(sourceMetadata.isDeleted(), "sourceSegmentStreamId",
+                "Given StreamSegmentReadIndex refers to a StreamSegment that has not been deleted yet.");
+
+        if (sourceMetadata.getLength() == 0) {
+            // beginMerge() does not take any action when the source Segment is empty, so there is nothing for us to do either.
+            return;
+        }
 
         // Find the appropriate redirect entry.
         RedirectIndexEntry redirectEntry;
         long mergeKey;
         synchronized (this.lock) {
-            mergeKey = this.mergeOffsets.getOrDefault(sourceStreamSegmentId, -1L);
-            Exceptions.checkArgument(mergeKey >= 0, "sourceSegmentStreamId", "Given StreamSegmentReadIndex's merger with this one has not been initiated using beginMerge. Cannot finalize the merger.");
+            mergeKey = this.mergeOffsets.getOrDefault(sourceMetadata.getId(), -1L);
+            Exceptions.checkArgument(mergeKey >= 0, "sourceSegmentStreamId",
+                    "Given StreamSegmentReadIndex's merger with this one has not been initiated using beginMerge. Cannot finalize the merger.");
 
             // Get the RedirectIndexEntry. These types of entries are sticky in the cache and DO NOT contribute to the
             // cache Stats. They are already accounted for in the other Segment's ReadIndex.
             ReadIndexEntry indexEntry = this.indexEntries.get(mergeKey);
-            assert indexEntry != null && !indexEntry.isDataEntry() : String.format("mergeOffsets points to a ReadIndexEntry that does not exist or is of the wrong type. sourceStreamSegmentId = %d, offset = %d, treeEntry = %s.", sourceStreamSegmentId, mergeKey, indexEntry);
+            assert indexEntry != null && !indexEntry.isDataEntry() :
+                    String.format("mergeOffsets points to a ReadIndexEntry that does not exist or is of the wrong type. sourceStreamSegmentId = %d, offset = %d, treeEntry = %s.",
+                            sourceMetadata.getId(), mergeKey, indexEntry);
             redirectEntry = (RedirectIndexEntry) indexEntry;
         }
 
         StreamSegmentReadIndex sourceIndex = redirectEntry.getRedirectReadIndex();
-        SegmentMetadata sourceMetadata = sourceIndex.metadata;
-        Exceptions.checkArgument(sourceMetadata.isDeleted(), "sourceSegmentStreamId", "Given StreamSegmentReadIndex refers to a StreamSegment that has not been deleted yet.");
 
         // Get all the entries from the source index and append them here.
         List<MergedIndexEntry> sourceEntries = sourceIndex.getAllEntries(redirectEntry.getStreamSegmentOffset());
@@ -430,7 +438,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         synchronized (this.lock) {
             // Remove redirect entry (again, no need to update the Cache Stats, as this is a RedirectIndexEntry).
             this.indexEntries.remove(mergeKey);
-            this.mergeOffsets.remove(sourceStreamSegmentId);
+            this.mergeOffsets.remove(sourceMetadata.getId());
             sourceEntries.forEach(this::addToIndex);
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -1658,7 +1658,15 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                 lengths.put(segmentName, lengths.getOrDefault(segmentName, 0L) + appendData.length);
                 recordAppend(segmentName, appendData, segmentContents);
 
+                boolean emptyTransaction = false;
                 for (String transactionName : transactionsBySegment.get(segmentName)) {
+                    if (!emptyTransaction) {
+                        lengths.put(transactionName, 0L);
+                        recordAppend(transactionName, new byte[0], segmentContents);
+                        emptyTransaction = true;
+                        continue;
+                    }
+
                     appendData = getAppendData(transactionName, i);
                     appendFutures.add(context.container.append(transactionName, appendData, null, TIMEOUT));
                     lengths.put(transactionName, lengths.getOrDefault(transactionName, 0L) + appendData.length);


### PR DESCRIPTION
**Change log description**
1. Fixed a bug in `SegmentAggregator` where it would swallow an exception thrown by the `ReadIndex` during recovery thus leading to a Segment Merge to not be completed (ever).
2. Fixed a bug  in `SegmentAggregator` where it would not take any action when processing an Merge operation for an empty Source Segment (in some situations).
3. Fixed a bug in the `ReadIndex` where `completeMerge` would incorrectly throw an exception if the Source Segment was empty (it should not, because its `beginMerge` counterpart takes no action on empty source Segments.

Reproduction steps for bug 1:
- In Container Epoch N, a `MergeSegmentOperation` is  received by the `StorageWriter` and applied to Tier2 Storage. The Container shuts down (or is fenced out) after the Tier2 concat operation is initiated, but before the operation is ack-ed to the `DurableLog` (and hence truncated out of Tier1).
- In Container Epoch N+1, the same `MergeSegmentOperation` is recovered from Tier1 and picked up by the `StorageWriter`. The writer's `SegmentAggregator` determines that the operation has already been applied to Tier2 Storage, and invokes `acknowledAlreadyProcessedOperation` without doing anything else.
- It turns out, `acknowledAlreadyProcessedOperation` was simply invoking the `ReadIndex`'s `completeMerge` method, without updating the source segment's metadata to indicate that it had been deleted from Tier2 storage.
- The `ReadIndex` correctly rejects the request because the metadata is inconsistent.
- `acknowledAlreadyProcessedOperation` swallows the exception and simply logs a warning, after which it happily moves on.

Fix for bug 1:
This has been fixed so `acknowledAlreadyProcessedOperation` uses the same metadata update method as the normal processing & reconciliation code, which properly updates the metadata. It has also been enhanced to throw a `DataCorruptionException` if it ever encounters this.

Bugs 2 and 3 are simpler and they can easily be reproduced by attempting to merge an empty transaction. Previously (due to bug 1), those exceptions would be swallowed and silently logged as warnings, but nothing got bubbled up.

**Purpose of the change**
Fixes #2621.

**What the code does**
Fixes  a bug.

**How to verify it**
Unit test updated to verify this case.