### PR TITLE
Issue 2626: Fix variable charset bug.

### DIFF
--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataOutputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataOutputStreamTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.common.io.serialization;
 
+import com.google.common.base.Charsets;
 import io.pravega.common.io.EnhancedByteArrayOutputStream;
 import io.pravega.common.io.FixedByteArrayOutputStream;
 import io.pravega.common.io.SerializationException;
@@ -187,8 +188,9 @@ public class RevisionDataOutputStreamTests {
         final int n = 123456;
         final long l = (long) Integer.MAX_VALUE + 1;
         final String s = getUTFString();
-        final byte[] array = s.getBytes();
-        int expectedLength = Byte.BYTES + Short.BYTES + Integer.BYTES + Long.BYTES + impl.getUTFLength(s) + array.length + Short.BYTES + array.length;
+        final byte[] array = s.getBytes(Charsets.UTF_8);
+        int expectedLength = Byte.BYTES + Short.BYTES + Integer.BYTES + Long.BYTES + impl.getUTFLength(s) + array.length
+                + impl.getCompactIntLength(array.length) + array.length;
 
         if (impl.requiresExplicitLength()) {
             // Verify a few methods that shouldn't be allowed to run without setting length beforehand.


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Change RevisionDataOutputStreamTests to avoid calling String.getBytes()  (because the default charset varies) and calculate length correctly.

**Purpose of the change**
RevisionDataOutputStreamTests was wrongly assuming that String.getBytes() would return arrays of the same length everywhere. 

**What the code does**
Fixes the charset to utf-8.
Calculates the length of the compact Int properly, rather than just assuming it's length.

**How to verify it**
The unit test should pass everywhere reguardless of default charset.