### PR TITLE
Issue 2631: Remove prefix from system properties/env vars for auth parameters

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -65,6 +65,18 @@ public class ClientConfig implements Serializable {
                 || this.controllerURI.getScheme().equals("pravegas");
     }
 
+    /**
+     * This class overrides the lombok builder. It adds some custom functionality on top of the builder.
+     * The additional behaviors include:
+     * 1. Defining a default controller URI when none is declared/
+     * 2. Extracting the credentials object from system properties/environment in following order of descending preference:
+     *       a. User provides a credential object. This overrides any other settings.
+     *       b. System properties: System properties are defined in the format: "pravega.client.auth.*"
+     *       c. Environment variables. Environment variables are defined under the format "pravega_client_auth_*"
+     *       d. In case of option 2 and 3, the caller can decide whether the class needs to be loaded dynamically by
+     *           setting property `pravega.client.auth.loadDynamic` to true.
+     *
+     */
     public static final class ClientConfigBuilder {
         private static final String AUTH_PROPS_PREFIX = "pravega.client.auth.";
         private static final String AUTH_METHOD = "method";
@@ -90,7 +102,7 @@ public class ClientConfig implements Serializable {
          * Here is the order of preference in descending order:
          * 1. User provides a credential object. This overrides any other settings.
          * 2. System properties: System properties are defined in the format: "pravega.client.auth.*"
-         * 3. Environment variables. Environment variables are defined under the format "PRAVEGA_CLIENT_AUTH_*"
+         * 3. Environment variables. Environment variables are defined under the format "pravega_client_auth_*"
          * 4. In case of option 2 and 3, the caller can decide whether the class needs to be loaded dynamically by
          *     setting property `pravega.client.auth.loadDynamic` to true.
          */

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -12,7 +12,6 @@ package io.pravega.client;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.stream.impl.Credentials;
-
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Collections;
@@ -68,8 +67,8 @@ public class ClientConfig implements Serializable {
 
     public static final class ClientConfigBuilder {
         private static final String AUTH_PROPS_START = "pravega.client.auth.";
-        private static final String AUTH_METHOD = AUTH_PROPS_START + "method";
-        private static final String AUTH_METHOD_LOAD_DYNAMIC = AUTH_PROPS_START + "loadDynamic";
+        private static final String AUTH_METHOD = "method";
+        private static final String AUTH_METHOD_LOAD_DYNAMIC = "loadDynamic";
 
         private static final String AUTH_PROPS_START_ENV = "pravega_client_auth_";
 
@@ -116,8 +115,9 @@ public class ClientConfig implements Serializable {
             Map<String, String> retVal = properties.entrySet()
                                                    .stream()
                                                    .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START))
-                                                   .collect(Collectors.toMap(entry ->
-                                                                   entry.getKey().toString(), value -> (String) value.getValue()));
+                                                   .collect(Collectors.toMap(entry -> entry.getKey().toString()
+                                                                                           .substring(AUTH_PROPS_START.length()),
+                                                                    value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);
             } else {
@@ -129,7 +129,9 @@ public class ClientConfig implements Serializable {
             Map<String, String> retVal = env.entrySet()
                                             .stream()
                                             .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START_ENV))
-                                            .collect(Collectors.toMap(entry -> (String) entry.getKey().toString().replace("_", "."),
+                                            .collect(Collectors.toMap(entry -> (String) entry.getKey().toString()
+                                                                                     .replace("_", ".")
+                                                                                     .substring(AUTH_PROPS_START.length()),
                                                     value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -66,11 +66,11 @@ public class ClientConfig implements Serializable {
     }
 
     public static final class ClientConfigBuilder {
-        private static final String AUTH_PROPS_START = "pravega.client.auth.";
+        private static final String AUTH_PROPS_PREFIX = "pravega.client.auth.";
         private static final String AUTH_METHOD = "method";
         private static final String AUTH_METHOD_LOAD_DYNAMIC = "loadDynamic";
 
-        private static final String AUTH_PROPS_START_ENV = "pravega_client_auth_";
+        private static final String AUTH_PROPS_PREFIX_ENV = "pravega_client_auth_";
 
         private boolean validateHostName = true;
 
@@ -114,9 +114,9 @@ public class ClientConfig implements Serializable {
         private Credentials extractCredentialsFromProperties(Properties properties) {
             Map<String, String> retVal = properties.entrySet()
                                                    .stream()
-                                                   .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START))
+                                                   .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_PREFIX))
                                                    .collect(Collectors.toMap(entry -> entry.getKey().toString()
-                                                                                           .substring(AUTH_PROPS_START.length()),
+                                                                                           .substring(AUTH_PROPS_PREFIX.length()),
                                                                     value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);
@@ -128,10 +128,10 @@ public class ClientConfig implements Serializable {
         private Credentials extractCredentialsFromEnv(Map<String, String> env) {
             Map<String, String> retVal = env.entrySet()
                                             .stream()
-                                            .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_START_ENV))
+                                            .filter(entry -> entry.getKey().toString().startsWith(AUTH_PROPS_PREFIX_ENV))
                                             .collect(Collectors.toMap(entry -> (String) entry.getKey().toString()
                                                                                      .replace("_", ".")
-                                                                                     .substring(AUTH_PROPS_START.length()),
+                                                                                     .substring(AUTH_PROPS_PREFIX.length()),
                                                     value -> (String) value.getValue()));
             if (retVal.containsKey(AUTH_METHOD)) {
                 return credentialFromMap(retVal);

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -41,9 +41,9 @@ public class CredentialsExtractorTest {
 
         AssertExtensions.assertMapEquals("Paramters are not same",
                 config.getCredentials().getAuthParameters(),
-                ImmutableMap.of("pravega.client.auth.prop1", "prop1",
-                        "pravega.client.auth.prop2", "prop2",
-                        "pravega.client.auth.method", "temp"));
+                ImmutableMap.of("prop1", "prop1",
+                        "prop2", "prop2",
+                        "method", "temp"));
 
         //If a credential is explicitly mentioned, do not override from properties
         config = ClientConfig.builder().credentials(new Credentials() {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -16,7 +16,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.TestUtils;
@@ -55,8 +54,6 @@ public class InProcPravegaClusterTest {
                                            .certFile("../config/cert.pem")
                                            .keyFile("../config/key.pem")
                                            .passwdFile("../config/passwd")
-                                           .userName("admin")
-                                           .passwd("1111_aaaa")
                                            .build();
         localPravega.start();
     }
@@ -74,9 +71,12 @@ public class InProcPravegaClusterTest {
         String streamName = "Stream";
         int numSegments = 10;
 
+        System.setProperty("pravega.client.auth.method", "Pravega-Default");
+        System.setProperty("pravega.client.auth.username", "admin");
+        System.setProperty("pravega.client.auth.password", "1111_aaaa");
+
         ClientConfig clientConfig = ClientConfig.builder()
                                                 .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                                                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
                                                 .trustStore("../config/cert.pem")
                                                 .validateHostName(false)
                                                 .build();

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -71,35 +71,41 @@ public class InProcPravegaClusterTest {
         String streamName = "Stream";
         int numSegments = 10;
 
-        System.setProperty("pravega.client.auth.method", "Pravega-Default");
-        System.setProperty("pravega.client.auth.username", "admin");
-        System.setProperty("pravega.client.auth.password", "1111_aaaa");
+        try {
+            System.setProperty("pravega.client.auth.method", "Pravega-Default");
+            System.setProperty("pravega.client.auth.username", "admin");
+            System.setProperty("pravega.client.auth.password", "1111_aaaa");
 
-        ClientConfig clientConfig = ClientConfig.builder()
-                                                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                                                .trustStore("../config/cert.pem")
-                                                .validateHostName(false)
-                                                .build();
-        @Cleanup
-        StreamManager streamManager = StreamManager.create(clientConfig);
+            ClientConfig clientConfig = ClientConfig.builder()
+                                                    .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                                                    .trustStore("../config/cert.pem")
+                                                    .validateHostName(false)
+                                                    .build();
+            @Cleanup
+            StreamManager streamManager = StreamManager.create(clientConfig);
 
-        streamManager.createScope(scope);
-        Assert.assertTrue("Stream creation is not successful ",
-                streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                                   .scope(scope)
-                                   .streamName(streamName)
-                                   .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                                   .build()));
-        log.info("Created stream: " + streamName);
+            streamManager.createScope(scope);
+            Assert.assertTrue("Stream creation is not successful ",
+                    streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                                                                                     .scope(scope)
+                                                                                     .streamName(streamName)
+                                                                                     .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                                                     .build()));
+            log.info("Created stream: " + streamName);
 
-        ClientFactory clientFactory = ClientFactory.withScope(scope, clientConfig);
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                new JavaSerializer<String>(),
-                EventWriterConfig.builder().build());
-        log.info("Created writer for stream: " + streamName);
+            ClientFactory clientFactory = ClientFactory.withScope(scope, clientConfig);
+            EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
+                    new JavaSerializer<String>(),
+                    EventWriterConfig.builder().build());
+            log.info("Created writer for stream: " + streamName);
 
-        writer.writeEvent("hello").get();
-        log.info("Wrote data to the stream");
+            writer.writeEvent("hello").get();
+            log.info("Wrote data to the stream");
+        } finally {
+            System.clearProperty("pravega.client.auth.method");
+            System.clearProperty("pravega.client.auth.username");
+            System.clearProperty("pravega.client.auth.password");
+        }
     }
 
     @After

--- a/standalone/src/test/java/io/pravega/local/PartialSecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/PartialSecurePravegaClusterTest.java
@@ -11,6 +11,7 @@ package io.pravega.local;
 
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
 import java.net.URI;
 import lombok.Cleanup;
@@ -44,6 +45,7 @@ public class PartialSecurePravegaClusterTest extends InProcPravegaClusterTest {
         int numSegments = 10;
 
         ClientConfig clientConfig = ClientConfig.builder()
+                                                .credentials(new DefaultCredentials("", ""))
                                                 .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
                                                 .build();
         @Cleanup


### PR DESCRIPTION
**Change log description**
This brings parameters supplied via system properties/environment variables on the same page as defined by a `Credentials` object. Earlier the prefix was sent along with the configuration.

**Purpose of the change**
This fixes #2631.

**What the code does**
Removes auth related prefix from auth parameters.

**How to verify it**
Unit tests are updated to cover this functionality. Unit tests should pass. 