### PR TITLE
Issue 2634: Ensure timeouts are applicable to @Before and @After methods in system tests.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -43,7 +43,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
@@ -51,9 +53,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SystemTestRunner.class)
 public class AutoScaleTest extends AbstractScaleTests {
 
-    private final static String SCALE_UP_STREAM_NAME = "testScaleUp";
-    private final static String SCALE_UP_TXN_STREAM_NAME = "testTxnScaleUp";
-    private final static String SCALE_DOWN_STREAM_NAME = "testScaleDown";
+    private static final String SCALE_UP_STREAM_NAME = "testScaleUp";
+    private static final String SCALE_UP_TXN_STREAM_NAME = "testTxnScaleUp";
+    private static final String SCALE_DOWN_STREAM_NAME = "testScaleDown";
 
     private static final ScalingPolicy SCALING_POLICY = ScalingPolicy.byEventRate(1, 2, 1);
     private static final StreamConfiguration CONFIG_UP = StreamConfiguration.builder().scope(SCOPE)
@@ -65,6 +67,10 @@ public class AutoScaleTest extends AbstractScaleTests {
     private static final StreamConfiguration CONFIG_DOWN = StreamConfiguration.builder().scope(SCOPE)
             .streamName(SCALE_DOWN_STREAM_NAME).scalingPolicy(SCALING_POLICY).build();
     private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(5);
+
+    //The execution time for @Before + @After + @Test methods should be less than 10 mins. Else the test will timeout.
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10 * 60);
 
     @Environment
     public static void setup() {
@@ -147,7 +153,7 @@ public class AutoScaleTest extends AbstractScaleTests {
         log.debug("create stream status for txn stream {}", createStreamStatus);
     }
 
-    @Test (timeout = 300000) // 5 minutes
+    @Test
     public void scaleTests() {
         CompletableFuture<Void> scaleup = scaleUpTest();
         CompletableFuture<Void> scaleDown = scaleDownTest();

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -41,7 +41,9 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
@@ -54,6 +56,10 @@ public class PravegaTest {
     private final static String STREAM_SCOPE = "testScopeSampleY";
     private final static String READER_GROUP = "ExampleReaderGroupY";
     private final static int NUM_EVENTS = 100;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(12 * 60);
+
     private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(4);
     private final StreamConfiguration config = StreamConfiguration.builder().scope(STREAM_SCOPE).streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
 
@@ -144,7 +150,7 @@ public class PravegaTest {
      * @throws InterruptedException if interrupted
      * @throws URISyntaxException   If URI is invalid
      */
-    @Test(timeout = 10 * 60 * 1000)
+    @Test
     public void simpleTest() throws InterruptedException {
 
         Service conService = Utils.createPravegaControllerService(null);

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -42,7 +42,9 @@ import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
@@ -53,6 +55,10 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
 
     private static final int NUM_READERS = 5;
     private static final int NUM_WRITERS = 5;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(32 * 60);
+
     private final String scope = "testReadTxnWriteScaleScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private final String stream = "testReadTxnWriteScaleStream";
     private final String readerGroupName = "testReadTxnWriteScaleReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
@@ -136,7 +142,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 30 * 60 * 1000)
+    @Test
     public void readTxnWriteScaleWithFailoverTest() throws Exception {
         try {
             createWriters(clientFactory, NUM_WRITERS, scope, stream);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -47,7 +47,9 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static java.time.Duration.ofSeconds;
@@ -68,6 +70,9 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
             .streamName(STREAM_NAME).scalingPolicy(SCALING_POLICY).build();
 
     private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(12 * 60);
 
     @Environment
     public static void setup() {
@@ -127,7 +132,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         log.debug("Create stream status {}", createStreamStatus);
     }
 
-    @Test(timeout = 10 * 60 * 1000) //timeout of 10 mins.
+    @Test
     public void scaleTestsWithReader() {
 
         URI controllerUri = getControllerURI();


### PR DESCRIPTION
**Change log description**
Ensure test timeouts are applicable to `@Before` and `@After` methods in system tests.

**Purpose of the change**
Fixes #2634 

**What the code does**
This change ensures that the system test run does not wait indefinitely for `@Before` / `@After` method of system tests to complete.

**How to verify it**
The system test run should timeout incase `@After` / `@Before` methods never complete.