### PR TITLE
Issue 2628: Fix events out of sequence due to scaling.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -306,8 +306,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             log.info("Received SegmentSealed {} on writer {}", segmentIsSealed, writerId);
             if (state.sealEncountered.compareAndSet(false, true)) {
                 Retry.indefinitelyWithExpBackoff(retrySchedule.getInitialMillis(), retrySchedule.getMultiplier(),
-                        retrySchedule.getMaxDelay(),
-                        t -> log.error(writerId + " to invoke sealed callback: ", t))
+                                                 retrySchedule.getMaxDelay(),
+                                                 t -> log.error(writerId + " to invoke sealed callback: ", t))
                      .runInExecutor(() -> {
                          log.debug("Invoking SealedSegment call back for {} on writer {}", segmentIsSealed, writerId);
                          callBackForSealed.accept(Segment.fromScopedName(getSegmentName()));

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -16,9 +16,12 @@ import io.pravega.client.netty.impl.ClientConnection.CompletedCallback;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.common.util.Retry.RetryWithBackoff;
+import io.pravega.common.util.ReusableLatch;
 import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
@@ -616,9 +619,51 @@ public class SegmentOutputStreamTest {
         });
         AssertExtensions.assertThrows(SegmentSealedException.class, () -> output.flush());
     }
-    
+
+    /**
+     * This test ensures that the flush() on a segment is released only after sealed segment callback is invoked.
+     * The callback implemented in EventStreamWriter appends this segment to its sealedSegmentQueue.
+     */
     @Test(timeout = 10000)
-    public void testFailDurringFlush() throws Exception {
+    public void testFlushIsBlockedUntilCallBackInvoked() throws Exception {
+
+        //Segment sealed callback will finish execution only when the latch is released;
+        ReusableLatch latch = new ReusableLatch(false);
+        final Consumer<Segment> segmentSealedCallback = segment ->  Exceptions.handleInterrupted(() -> latch.await());
+
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        @Cleanup("shutdown")
+        ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "testClientInternal");
+        cf.setExecutor(executor);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        InOrder order = Mockito.inOrder(connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        output.reconnect();
+        order.verify(connection).send(new SetupAppend(1, cid, SEGMENT, ""));
+        cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
+        ByteBuffer data = getBuffer("test");
+
+        CompletableFuture<Void> ack = new CompletableFuture<>();
+        output.write(new PendingEvent(null, data, ack));
+        order.verify(connection).send(new Append(SEGMENT, cid, 1, Unpooled.wrappedBuffer(data), null));
+        assertEquals(false, ack.isDone());
+
+        cf.getProcessor(uri).segmentIsSealed(new WireCommands.SegmentIsSealed(1, SEGMENT));
+        AssertExtensions.assertBlocks(() -> {
+            AssertExtensions.assertThrows(SegmentSealedException.class, () -> output.flush());
+        }, () -> {
+          latch.release(); //only after the callback completes does the flush get unblocked.
+        });
+
+        AssertExtensions.assertThrows(SegmentSealedException.class, () -> output.flush());
+    }
+
+    @Test(timeout = 10000)
+    public void testFailDuringFlush() throws Exception {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();


### PR DESCRIPTION
**Change log description**
In the event SegmentOutputStream receives a `io.pravega.shared.protocol.netty.WireCommands.SegmentIsSealed`, ensure `SegmentOutpuStream.flush()` is blocked until the `segmentSealedCallback` is invoked.

**Purpose of the change**
Fixes #2628 

**What the code does**
The `EventStreamWriterImpl#handleLogSealed()` replaces the sealed segment with its successors, resends all the inflight events of the sealed segment and invokes a `flush()` on all the current segment writers. Once a `flush()` is invoked on all the current writers it is possible that some of them also encounter a `SegmentIsSealed` at that time. Now these segments are appended to the sealedSegmentQueue  for sealed segment processing.

In older code the latch `state.waitingInflight` was released and `state.sealEncountered` was set to true as soon as `WireCommands.SegmentIsSealed` was received. This implied any `SegmentOutputStream.flush()` waiting for empty inflight events would have prematurely stopped waiting.

In this PR `state.waitingInflight` latch is released after we have invoked the callback (which internally appends the segment in sealedSegmentQueue), thereby ensuring that the lock held by the `handleLogSealed()` is held until the newer sealed segment is handled. This prevents newer events from being written (until all the sealed segments are handled) which would cause events being out of sequence.

**How to verify it**
All the existing and newly added tests should continue to pass.
