### PR TITLE
Issue 2636: Adding preconditions on input arguments in ScalingPolicy

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.stream;
 
+import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -51,6 +52,7 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy fixed(int numSegments) {
+        Preconditions.checkArgument(numSegments > 0, "Number of segments should be > 0.");
         return new ScalingPolicy(ScaleType.FIXED_NUM_SEGMENTS, 0, 0, numSegments);
     }
 
@@ -88,6 +90,9 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byEventRate(int targetRate, int scaleFactor, int minNumSegments) {
+        Preconditions.checkArgument(targetRate > 0, "Target rate should be > 0.");
+        Preconditions.checkArgument(scaleFactor > 0, "Scale factor should be > 0. Otherwise use fixed scaling policy.");
+        Preconditions.checkArgument(minNumSegments > 0, "Minimum number of segments should be > 0.");
         return new ScalingPolicy(ScaleType.BY_RATE_IN_EVENTS_PER_SEC, targetRate, scaleFactor, minNumSegments);
     }
 
@@ -124,6 +129,9 @@ public class ScalingPolicy implements Serializable {
      * @return Scaling policy object.
      */
     public static ScalingPolicy byDataRate(int targetKBps, int scaleFactor, int minNumSegments) {
+        Preconditions.checkArgument(targetKBps > 0, "KBps should be > 0.");
+        Preconditions.checkArgument(scaleFactor > 0, "Scale factor should be > 0. Otherwise use fixed scaling policy.");
+        Preconditions.checkArgument(minNumSegments > 0, "Minimum number of segments should be > 0.");
         return new ScalingPolicy(ScaleType.BY_RATE_IN_KBYTES_PER_SEC, targetKBps, scaleFactor, minNumSegments);
     }
 }

--- a/client/src/test/java/io/pravega/client/admin/impl/ScalingPolicyTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/ScalingPolicyTest.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.admin.impl;
+
+import io.pravega.client.stream.ScalingPolicy;
+import org.junit.Test;
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+
+public class ScalingPolicyTest {
+
+    @Test
+    public void testScalingPolicyArguments() {
+        // Check that we do not allow incorrect arguments for creating a scaling policy.
+        assertThrows(RuntimeException.class, () -> ScalingPolicy.fixed(0));
+        assertThrows(RuntimeException.class, () -> ScalingPolicy.byEventRate(0, 1, 1));
+        assertThrows(RuntimeException.class, () -> ScalingPolicy.byDataRate(1, 0, 0));
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -147,7 +147,7 @@ public class SegmentHelperTest {
     @Test
     public void updatePolicy() {
         MockConnectionFactory factory = new MockConnectionFactory();
-        CompletableFuture<Void> retVal = helper.updatePolicy("", "", ScalingPolicy.fixed(0), 0,
+        CompletableFuture<Void> retVal = helper.updatePolicy("", "", ScalingPolicy.fixed(1), 0,
                 new MockHostControllerStore(), factory, "");
         factory.rp.authTokenCheckFailed(new WireCommands.AuthTokenCheckFailed(0));
         AssertExtensions.assertThrows("",

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -78,7 +78,7 @@ public class ScaleRequestHandlerTest {
     private final String scope = "scope";
     private final String stream = "stream";
     StreamConfiguration config = StreamConfiguration.builder().scope(scope).streamName(stream).scalingPolicy(
-            ScalingPolicy.byEventRate(0, 2, 3)).build();
+            ScalingPolicy.byEventRate(1, 2, 3)).build();
 
     private ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
     private StreamMetadataStore streamStore;


### PR DESCRIPTION
**Change log description**
Added precondition checks prior to instantiate `ScalingPolicy` objects (`ScalingPolicy.java`). Moreover, a new test has been added (`ScalingPolicyTest.java`) and two tests have been modified as they were using wrong input parameters to instantiate scaling policies (`SegmentHelperTest.java` , `ScaleRequestHandlerTest.java`)

**Purpose of the change**
Fixes #2636.

**What the code does**
The code checks that all input parameters to instantiate a `ScalingPolicy` are `>0`. This does not only include to check the number of segments (`numSegments`) as reported in the issue, but also:
- `scaleFactor`: A `scale factor` with value 0 would mean that no split will be created when the scaling event is processed. For actually performing a scale on a segment, this parameter should be `>0`.
-  `targetRate`: A `target rate` with value 0 may lead the system to scale even if not workload is received, which can cause problems if not properly handled.

**How to verify it**
Execute new unit test. The rest of tests should be passing.