### PR TITLE
Issue 2648: Correct the number of segments for request stream

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -14,7 +14,6 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactory;
-import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -240,7 +240,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                 StreamConfiguration.builder()
                         .scope(config.getScopeName())
                         .streamName(Config.SCALE_STREAM_NAME)
-                        .scalingPolicy(ScalingPolicy.fixed(1))
+                        .scalingPolicy(config.getRequestStreamScalingPolicy())
                         .build();
 
         return createScope(config.getScopeName())


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
Fix the scaling policy of request stream.

**Purpose of the change**
Fixes #2648. 

**What the code does**
*   Use the scaling policy configuration from `ControllerEventProcessorConfig`, while creating `_requeststream`.

**How to verify it**
Request stream should  be created with 2 segments.