### PR TITLE
Issue 2661: Fix Pravega concepts broken link

### DIFF
--- a/documentation/src/docs/transactions.md
+++ b/documentation/src/docs/transactions.md
@@ -17,7 +17,7 @@ Samples
 readme](https://github.com/pravega/pravega-samples/blob/master/standalone-examples/README.md).
 
 You really should be familiar with Pravega Concepts (see [Pravega
-Concepts](http://pravega.io/Pravega-Concepts/index.html)) before continuing reading this page.
+Concepts](http://pravega.io/docs/latest/pravega-concepts/)) before continuing reading this page.
 
 ## Pravega Transactions and the Console Writer and Console Reader Apps
 


### PR DESCRIPTION
**Change log description**
* Replaces the concepts link in the transactions documentation with the correct one.

**Purpose of the change**
Fixes #2661 

**How to verify it**
Click the link
