### PR TITLE
Issue 2655: (SegmentStore) Various bug fixes

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndex.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.attributes;
 
 import io.pravega.segmentstore.server.AttributeIndex;
-import io.pravega.segmentstore.server.SegmentMetadata;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -31,11 +30,11 @@ public interface ContainerAttributeIndex {
     /**
      * Deletes any existing attribute data pertaining to the given Segment.
      *
-     * @param metadata The SegmentMetadata for the Segment whose Attribute data to delete.
-     * @param timeout  Timeout for the operation.
+     * @param segmentName The name of the Segment whose attribute data should be deleted.
+     * @param timeout     Timeout for the operation.
      * @return A CompletableFuture that, when completed, will indicate that the operation finished.
      */
-    CompletableFuture<Void> delete(SegmentMetadata metadata, Duration timeout);
+    CompletableFuture<Void> delete(String segmentName, Duration timeout);
 
     /**
      * Removes all internal indices that point to the given StreamSegments from memory. This does not delete the data itself.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexImpl.java
@@ -118,10 +118,8 @@ class ContainerAttributeIndexImpl implements ContainerAttributeIndex {
     }
 
     @Override
-    public CompletableFuture<Void> delete(SegmentMetadata sm, Duration timeout) {
-        // Check if the Segment is deleted or merged (in other words, unusable or inaccessible).
-        Preconditions.checkArgument(sm.isDeleted() || sm.isMerged(), "Segment %s is not deleted.", sm.getId());
-        return SegmentAttributeIndex.delete(sm, this.storage, timeout);
+    public CompletableFuture<Void> delete(String segmentName, Duration timeout) {
+        return SegmentAttributeIndex.delete(segmentName, this.storage, timeout);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeIndex.java
@@ -150,14 +150,14 @@ class SegmentAttributeIndex implements AttributeIndex {
     /**
      * Deletes all the Attribute data associated with the given Segment.
      *
-     * @param segmentMetadata The SegmentMetadata for the Segment whose attribute data should be deleted.
-     * @param storage         A Storage Adapter to execute the deletion on.
-     * @param timeout         Timeout for the operation.
+     * @param segmentName The name of the Segment whose attribute data should be deleted.
+     * @param storage     A Storage Adapter to execute the deletion on.
+     * @param timeout     Timeout for the operation.
      * @return A CompletableFuture that, when completed, will indicate that the operation finished successfully.
      */
-    static CompletableFuture<Void> delete(SegmentMetadata segmentMetadata, Storage storage, Duration timeout) {
+    static CompletableFuture<Void> delete(String segmentName, Storage storage, Duration timeout) {
         TimeoutTimer timer = new TimeoutTimer(timeout);
-        String attributeSegmentName = StreamSegmentNameUtils.getAttributeSegmentName(segmentMetadata.getName());
+        String attributeSegmentName = StreamSegmentNameUtils.getAttributeSegmentName(segmentName);
         return Futures.exceptionallyExpecting(
                 storage.openWrite(attributeSegmentName)
                        .thenCompose(handle -> storage.delete(handle, timer.getRemaining())),

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -401,12 +401,15 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         // exceptions or ignore it altogether (such as StorageWriter).
         SegmentMetadata toDelete = this.metadata.deleteStreamSegment(streamSegmentName);
         CompletableFuture<Void> deletionFuture = this.storage
-                .openWrite(toDelete.getName())
+                .openWrite(streamSegmentName)
                 .thenComposeAsync(handle -> this.storage.delete(handle, timer.getRemaining()), this.executor)
-                .thenComposeAsync(v -> this.attributeIndex.delete(toDelete, timer.getRemaining()), this.executor)
-                .thenComposeAsync(v -> this.stateStore.remove(toDelete.getName(), timer.getRemaining()), this.executor);
+                .thenComposeAsync(v -> this.attributeIndex.delete(streamSegmentName, timer.getRemaining()), this.executor)
+                .thenComposeAsync(v -> this.stateStore.remove(streamSegmentName, timer.getRemaining()), this.executor);
 
-        notifyMetadataRemoved(Collections.singleton(toDelete));
+        if (toDelete != null) {
+            notifyMetadataRemoved(Collections.singleton(toDelete));
+        }
+
         return deletionFuture;
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
@@ -110,7 +110,7 @@ public class StorageWriterFactory implements WriterFactory {
 
         @Override
         public CompletableFuture<Void> deleteAllAttributes(SegmentMetadata segmentMetadata, Duration timeout) {
-            return this.attributeIndex.delete(segmentMetadata, timeout);
+            return this.attributeIndex.delete(segmentMetadata.getName(), timeout);
         }
 
         @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexTests.java
@@ -157,16 +157,9 @@ public class ContainerAttributeIndexTests extends ThreadPooledTestSuite {
         val sm = context.containerMetadata.getStreamSegmentMetadata(SEGMENT_ID);
         val idx = context.index.forSegment(SEGMENT_ID, TIMEOUT).join();
 
-        AssertExtensions.assertThrows(
-                "delete() allowed deleting data for a non-deleted segment.",
-                () -> context.index.delete(sm, TIMEOUT),
-                ex -> ex instanceof IllegalArgumentException);
-
-        sm.markDeleted();
-
         // We intentionally delete twice to make sure the operation is idempotent.
-        context.index.delete(sm, TIMEOUT).join();
-        context.index.delete(sm, TIMEOUT).join();
+        context.index.delete(sm.getName(), TIMEOUT).join();
+        context.index.delete(sm.getName(), TIMEOUT).join();
 
         AssertExtensions.assertThrows(
                 "put() worked after delete().",


### PR DESCRIPTION
**Change log description**
1. Fixed a bug where a Segment may not be deleted if it is not active in the metadata or if the metadata isDeleted() flag is out-of-sync with Tier2 Storage
    - This would manifest itself by a `NullPointerException` being thrown when `StreamSegmentContainer.deleteSegment` is invoked on such a segment. 
    - This is believed to be the cause of the system test runs since #2557 has been merged.
2. Fixed a bug where the `SegmentAttributeIndex` may incorrectly throw a `StreamSegmentMergedException`, `StreamSegmentSealedException` or `StreamSegmentNotExistsException` if it tries to create a snapshot and update that snapshot's location in the main segment's attributes, but the main segment is concurrently being merged, sealed or deleted.
    - This would only happen in the background and not affect direct calls into the Segment Store. Eventually they would subside, but it would be nice for such issues not to pollute the logs at all.

**Purpose of the change**
Fixes #2655.

**What the code does**
Fixes two bugs.

**How to verify it**
Unit tests were enhanced to test these problems.
Builds must pass.
Branch system tests must pass.
