### PR TITLE
Issue 2556: Expand client batch size to half server latency

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
@@ -64,7 +64,7 @@ class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
     }
 
     /**
-     * Returns a block size that in an estimate of how much data will be written in the next
+     * Returns a block size that is an estimate of how much data will be written in the next
      * {@link #MAX_BATCH_TIME_MILLIS} or half the server round trip time (whichever is less).
      */
     @Override
@@ -74,7 +74,7 @@ class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
             return 0;
         }
         double appendsInMaxBatch = Math.max(1.0, MAX_BATCH_TIME_MILLIS / millisBetweenAppends.getCurrentValue());
-        double targetAppendsOutstanding = MathHelpers.minMax(appendsOutstanding.getCurrentValue() / 2.0, 1.0,
+        double targetAppendsOutstanding = MathHelpers.minMax(appendsOutstanding.getCurrentValue() * 0.5, 1.0,
                                                              appendsInMaxBatch);
         return (int) MathHelpers.minMax((long) (targetAppendsOutstanding * eventSize.getCurrentValue()), 0,
                                         MAX_BATCH_SIZE);

--- a/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
@@ -24,12 +24,12 @@ import java.util.function.Supplier;
  * 2. The size of each append
  * 3. The number of unackedAppends there are outstanding
  * 
- * If the number of unacked appends is <= 1 batching is disabled. This improves latency for low volume and synchronus writers.
- * Otherwise the batch size is set to the amount of data that will be written in the next {@link #TARGET_BATCH_TIME_MILLIS}
+ * If the number of unacked appends is <= 1 batching is disabled. This improves latency for low volume and 
+ * synchronous writers. Otherwise the batch size is set to the amount of data that will be written in the next
+ * {@link #MAX_BATCH_TIME_MILLIS} or half the server round trip time (whichever is less)
  */
 class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
     private static final int MAX_BATCH_TIME_MILLIS = 100;
-    private static final int TARGET_BATCH_TIME_MILLIS = 10;
     private static final int MAX_BATCH_SIZE = 32 * 1024;
 
     private final Supplier<Long> clock;
@@ -38,6 +38,7 @@ class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
     private final AtomicLong lastAckNumber;
     private final ExponentialMovingAverage eventSize = new ExponentialMovingAverage(1024, 0.1, true);
     private final ExponentialMovingAverage millisBetweenAppends = new ExponentialMovingAverage(10, 0.1, false);
+    private final ExponentialMovingAverage appendsOutstanding = new ExponentialMovingAverage(2, 0.05, false);
 
     AppendBatchSizeTrackerImpl() {
         clock = System::currentTimeMillis;
@@ -52,16 +53,19 @@ class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
         long last = lastAppendTime.getAndSet(now);
         lastAppendNumber.set(eventNumber);
         millisBetweenAppends.addNewSample(now - last);
+        appendsOutstanding.addNewSample(eventNumber - lastAckNumber.get());
         eventSize.addNewSample(size);
     }
 
     @Override
     public void recordAck(long eventNumber) {
         lastAckNumber.getAndSet(eventNumber);
+        appendsOutstanding.addNewSample(lastAppendNumber.get() - eventNumber);
     }
 
     /**
-     * Returns a block size that in an estimate of how much data will be written in the next {@link #TARGET_BATCH_TIME_MILLIS}
+     * Returns a block size that in an estimate of how much data will be written in the next
+     * {@link #MAX_BATCH_TIME_MILLIS} or half the server round trip time (whichever is less).
      */
     @Override
     public int getAppendBlockSize() {
@@ -69,8 +73,11 @@ class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
         if (numInflight <= 1) {
             return 0;
         }
-        return (int) MathHelpers.minMax((long) (TARGET_BATCH_TIME_MILLIS / millisBetweenAppends.getCurrentValue()
-                * eventSize.getCurrentValue()), 0, MAX_BATCH_SIZE);
+        double appendsInMaxBatch = Math.max(1.0, MAX_BATCH_TIME_MILLIS / millisBetweenAppends.getCurrentValue());
+        double targetAppendsOutstanding = MathHelpers.minMax(appendsOutstanding.getCurrentValue() / 2.0, 1.0,
+                                                             appendsInMaxBatch);
+        return (int) MathHelpers.minMax((long) (targetAppendsOutstanding * eventSize.getCurrentValue()), 0,
+                                        MAX_BATCH_SIZE);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Change the client batch target from 10ms to half server latency.

**Purpose of the change**
This is a replacement for #2531 by @ack72tdp

Fixes #2556.
When the server is under load, latency for the client increases rapidly. Depending on the event size this may cause the server to be CPU bound. This change automatically adjusts the batch size based on the server latency. This ensures the server has less work to perform when it is under load. This should lower append latency on moderately heavily loaded servers.

**What the code does**
Changes the batch size target from 10ms fixed to a variable size based on how long the server takes to respond.

**How to verify it**
@ack72tdp performed performance tests.