### PR TITLE
Issue 2670: Reset state conditionally

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
@@ -63,7 +63,7 @@ public class TruncateStreamTask implements StreamTask<TruncateStreamEvent> {
                     if (!property.isUpdating()) {
                         // if the state is TRUNCATING but the truncation record is not updating, we should reset the state to ACTIVE.
                         return streamMetadataStore.resetStateConditionally(scope, stream, State.TRUNCATING, context, executor)
-                                .thenApply(x -> {
+                                .thenRun(() -> {
                                     throw new TaskExceptions.StartException("Truncate Stream not started yet.");
                                 });
                     } else {

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
@@ -61,7 +61,11 @@ public class TruncateStreamTask implements StreamTask<TruncateStreamEvent> {
         return streamMetadataStore.getTruncationRecord(scope, stream, true, context, executor)
                 .thenCompose(property -> {
                     if (!property.isUpdating()) {
-                        throw new TaskExceptions.StartException("Truncate Stream not started yet.");
+                        // if the state is TRUNCATING but the truncation record is not updating, we should reset the state to ACTIVE.
+                        return streamMetadataStore.resetStateConditionally(scope, stream, State.TRUNCATING, context, executor)
+                                .thenApply(x -> {
+                                    throw new TaskExceptions.StartException("Truncate Stream not started yet.");
+                                });
                     } else {
                         return processTruncate(scope, stream, property, context,
                                 this.streamMetadataTasks.retrieveDelegationToken());

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
@@ -56,7 +56,7 @@ public class UpdateStreamTask implements StreamTask<UpdateStreamEvent> {
                     if (!configProperty.isUpdating()) {
                         // if the state is updating but the configuration record is not updating, we should reset the state to ACTIVE.
                         return streamMetadataStore.resetStateConditionally(scope, stream, State.UPDATING, context, executor)
-                                .thenApply(x -> {
+                                .thenRun(() -> {
                                     throw new TaskExceptions.StartException("Update Stream not started yet.");
                                 });
                     } else {

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -276,6 +276,9 @@ public class StreamMetadataTasksTest {
         assertTrue(configProp.getStreamConfiguration().equals(streamConfiguration1) && !configProp.isUpdating());
 
         streamStorePartialMock.setState(SCOPE, stream1, State.UPDATING, null, executor).join();
+        UpdateStreamEvent event = new UpdateStreamEvent(SCOPE, stream1);
+        AssertExtensions.assertThrows("", updateStreamTask.execute(event), e -> Exceptions.unwrap(e) instanceof TaskExceptions.StartException);
+        assertEquals(State.ACTIVE, streamStorePartialMock.getState(SCOPE, stream1, true, null, executor).join());
     }
 
     @Test(timeout = 30000)
@@ -382,6 +385,13 @@ public class StreamMetadataTasksTest {
 
         truncProp = streamStorePartialMock.getTruncationRecord(SCOPE, "test", true, null, executor).join();
         assertTrue(truncProp.getStreamCut().equals(streamCut3) && !truncProp.isUpdating());
+
+        streamStorePartialMock.setState(SCOPE, "test", State.TRUNCATING, null, executor).join();
+
+        TruncateStreamEvent event = new TruncateStreamEvent(SCOPE, "test");
+        AssertExtensions.assertThrows("", truncateStreamTask.execute(event), e -> Exceptions.unwrap(e) instanceof TaskExceptions.StartException);
+
+        assertEquals(State.ACTIVE, streamStorePartialMock.getState(SCOPE, "test", true, null, executor).join());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
There is a bug in TruncateStreamTask and UpdateStreamTask where, upon completion of processing, if we fail before resetting the state, when the processing is retried it will find that the work is already complete and it exits. It should also check and reset the state conditionally in such scenarios. (Note: we already handle this situation correctly for scale. but it is not handled in update and truncate stream tasks).

**Purpose of the change**
Fixes #2670 

**What the code does**
In UpdateStreamTask and TruncateStreamTask we should never have the state set to UPDATING or TRUNCATING if the corresponding records are not in updating states. 
We can reach such situations if, in previous attempt to process the event, we update the metadata record but crashed before resetting the state. The event's processing will be retried and if we encounter stream state to refer to a processing but the work is already complete, then we should reset the state. 

**How to verify it**
Unit tests added