### PR TITLE
Issue #2609: Increase default buffer size to 1MB.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -35,7 +35,7 @@ import static io.pravega.client.segment.impl.EndOfSegmentException.ErrorType.END
 @Slf4j
 @ToString
 class SegmentInputStreamImpl implements SegmentInputStream {
-    private static final int DEFAULT_READ_LENGTH = 64 * 1024;
+    private static final int DEFAULT_READ_LENGTH = 256 * 1024;
     private static final long UNBOUNDED_END_OFFSET = Long.MAX_VALUE;
     static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
 

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -35,9 +35,9 @@ import static io.pravega.client.segment.impl.EndOfSegmentException.ErrorType.END
 @Slf4j
 @ToString
 class SegmentInputStreamImpl implements SegmentInputStream {
+    static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
     private static final int DEFAULT_READ_LENGTH = 256 * 1024;
     private static final long UNBOUNDED_END_OFFSET = Long.MAX_VALUE;
-    static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
 
     private final AsyncSegmentInputStream asyncInput;
     private final int readLength;

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -37,7 +37,7 @@ import static io.pravega.client.segment.impl.EndOfSegmentException.ErrorType.END
 class SegmentInputStreamImpl implements SegmentInputStream {
     private static final int DEFAULT_READ_LENGTH = 64 * 1024;
     private static final long UNBOUNDED_END_OFFSET = Long.MAX_VALUE;
-    static final int DEFAULT_BUFFER_SIZE = 2 * SegmentInputStreamImpl.DEFAULT_READ_LENGTH;
+    static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
 
     private final AsyncSegmentInputStream asyncInput;
     private final int readLength;


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
This increases the default reader buffer size to 1MB, and the default read size to 256KB.

**Purpose of the change**
This should decrease the chances that the application reading data needs to have it's thread block while calling readNextEvent()

**What the code does**
Changes size of the memory buffer from 128kb to 1mb.
Changes the size of the data fetched from 64kb to 256kb.

**How to verify it**
Performance tests.