### PR TITLE
Issue 2679: (SegmentStore) Bug fix for future reads from empty segments

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.reading;
 
 import io.pravega.common.Exceptions;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -115,7 +114,7 @@ class FutureReadResultEntryCollection implements AutoCloseable {
         }
 
         CancellationException ce = new CancellationException();
-        toCancel.forEach(e -> e.fail(ce));
+        toCancel.stream().filter(e -> !e.getContent().isDone()).forEach(e -> e.fail(ce));
     }
 
     static int entryComparator(FutureReadResultEntry e1, FutureReadResultEntry e2) {


### PR DESCRIPTION
**Change log description**
- Fixed a bug in `StreamSegmentReadIndex` where it would incorrectly not trigger future reads for a Sealed Segment if that segment had no entries in the read index (this includes empty segments).
- Fixed a bug in `FutureReadResultEntryCollection` where it would incorrectly attempt to cancel an already completed `ReadResultEntry`, which would lead to sporadic build failures or log spam.

**Purpose of the change**
Fixes #2679.

**What the code does**
Bug fix.

**How to verify it**
New unit test added.
