### PR TITLE
Issue 2690 Inconsistent epoch transition not caught in first step of scale post rolling txn 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -572,7 +572,10 @@ public abstract class PersistentStreamBase<T> implements Stream {
 
                                         final SegmentRecord latestSegment = TableHelper.getLatestSegmentRecord(segmentIndex.getData(),
                                                 segmentTable.getData());
-                                        if (latestSegment.getCreationEpoch() < newEpoch) {
+                                        final HistoryRecord activeEpoch = TableHelper.getActiveEpoch(historyIndex.getData(),
+                                                historyTable.getData());
+
+                                        if (latestSegment.getCreationEpoch() < newEpoch && activeEpoch.getEpoch() == epochTransition.getActiveEpoch()) {
                                             log.info("Scale {}/{} for segments started. Creating new segments. SegmentsToSeal {}",
                                                     scope, name, epochTransition.getSegmentsToSeal());
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
We missed a condition check if epoch transition is not migrated to new epoch post RollingTxn, (it is only migrated for manual scale) then it becomes inconsistent. We should catch the inconsistency in first step but we missed a condition on active epoch being equal to epochTransitionRecord. 

**Purpose of the change**
Fixes #2690 

**What the code does**
For autoscale request, the epoch transition is not migrated, and we should verify not just the latest segment record but also the active epoch. 

**How to verify it**
New unit tests added