### PR TITLE
Issue 2678: (SegmentStore) Bugfix for StreamSegmentNotExists after container failover

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
@@ -44,9 +44,12 @@ class FutureReadResultEntryCollection {
 
     //endregion
 
-    //region AutoCloseable Implementation
-
-    List<FutureReadResultEntry> close() {
+    /**
+     * Closes this instance of the FutureReadResultEntryCollection class.
+     *
+     * @return A List containing all currently registered FutureReadResultEntries.
+     */
+    public List<FutureReadResultEntry> close() {
         List<FutureReadResultEntry> result;
         synchronized (this.reads) {
             if (this.closed) {
@@ -60,9 +63,6 @@ class FutureReadResultEntryCollection {
 
         return result;
     }
-    //endregion
-
-    //region Operations
 
     /**
      * Adds a new Result Entry.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/PendingMerge.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/PendingMerge.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.reading;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Holds information about a pending Segment merge.
+ */
+@ThreadSafe
+@RequiredArgsConstructor
+class PendingMerge {
+    /**
+     * The offset in the Target Segment where the merge is executed at.
+     */
+    @Getter
+    private final long mergeOffset;
+    @GuardedBy("this")
+    private final List<FutureReadResultEntry> reads = new ArrayList<>();
+    @GuardedBy("this")
+    private boolean sealed = false;
+
+    /**
+     * Seals this PendingMerge instance and returns a list of all the registered FutureReadResultEntries associated with it.
+     * After this method returns, all calls to register() will return false.
+     * @return A List of all the registered FutureReadResultEntries recorded.
+     */
+    synchronized List<FutureReadResultEntry> seal() {
+        this.sealed = true;
+        List<FutureReadResultEntry> result = new ArrayList<>(this.reads);
+        this.reads.clear();
+        return result;
+    }
+
+    /**
+     * Registers the given FutureReadResultEntry into this PendingMerge.
+     * @param entry The entry to register.
+     * @return True if the entry was registered (i.e., seal() was not invoked), false otherwise.
+     */
+    synchronized boolean register(FutureReadResultEntry entry) {
+        if (!this.sealed) {
+            this.reads.add(entry);
+        }
+
+        return !this.sealed;
+    }
+
+    @Override
+    public synchronized String toString() {
+        return String.format("Offset = %d, ReadCount = %d", this.mergeOffset, this.reads.size());
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
@@ -9,37 +9,33 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
+import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
-import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.BiFunction;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * A ReadResultEntry that wraps an inner Entry, but allows for offset adjustment. Useful for returning read results
  * that point to Transaction Read Indices.
  */
-@Slf4j
 class RedirectedReadResultEntry implements CompletableReadResultEntry {
     //region Members
 
-    private static final Duration RETRY_TIMEOUT = Duration.ofSeconds(30); // TODO: these two should either be dynamic or configurable.
-    private static final Duration EXCEPTION_DELAY = Duration.ofMillis(1000);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
     private final CompletableReadResultEntry firstEntry;
     private final long adjustedOffset;
     private CompletableReadResultEntry secondEntry;
+    private TimeoutTimer timer;
     private final CompletableFuture<ReadResultEntryContents> result;
     private final GetEntry retryGetEntry;
-    private final ScheduledExecutorService executorService;
 
     //endregion
 
@@ -52,17 +48,12 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
      * @param offsetAdjustment The amount to adjust the offset by. This value, added to the entry's SegmentOffset, should
      *                         equal the offset in the Parent Segment where the read is thought to be at.
      * @param retryGetEntry    A BiFunction to invoke when needing to retry an entry. First argument: offset, Second: length.
-     * @param executorService  An executor service to execute background operations on.
      */
-    RedirectedReadResultEntry(CompletableReadResultEntry entry, long offsetAdjustment, GetEntry retryGetEntry, ScheduledExecutorService executorService) {
-        Preconditions.checkNotNull(entry, "entry");
-        Preconditions.checkNotNull(retryGetEntry, "retryGetEntry");
-        Preconditions.checkNotNull(executorService, "executorService");
-        this.firstEntry = entry;
+    RedirectedReadResultEntry(CompletableReadResultEntry entry, long offsetAdjustment, GetEntry retryGetEntry) {
+        this.firstEntry = Preconditions.checkNotNull(entry, "entry");
         this.adjustedOffset = entry.getStreamSegmentOffset() + offsetAdjustment;
         Preconditions.checkArgument(this.adjustedOffset >= 0, "Given offset adjustment would result in a negative offset.");
-        this.retryGetEntry = retryGetEntry;
-        this.executorService = executorService;
+        this.retryGetEntry = Preconditions.checkNotNull(retryGetEntry, "retryGetEntry");
         if (Futures.isSuccessful(entry.getContent())) {
             this.result = entry.getContent();
         } else {
@@ -74,11 +65,7 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
     private void linkFirstEntryToResult() {
         this.firstEntry.getContent()
                        .thenAccept(this.result::complete)
-                       .exceptionally(ex -> {
-                           Futures.delayedFuture(getExceptionDelay(ex), this.executorService)
-                                  .thenAccept(v -> handleGetContentFailure(ex));
-                           return null;
-                       });
+                       .exceptionally(this::handleGetContentFailure);
     }
 
     //endregion
@@ -107,10 +94,11 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
 
     @Override
     public void requestContent(Duration timeout) {
+        this.timer = new TimeoutTimer(timeout);
         try {
-            this.firstEntry.requestContent(timeout);
+            this.firstEntry.requestContent(timer.getRemaining());
         } catch (Throwable ex) {
-            if (!handle(ex, timeout)) {
+            if (!handle(ex)) {
                 // Unable to swap or ineligible exception; rethrow immediately.
                 throw ex;
             }
@@ -131,11 +119,6 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
 
     //region Helpers
 
-    protected Duration getExceptionDelay(Throwable ex) {
-        boolean requiresDelay = this.secondEntry == null && Exceptions.unwrap(ex) instanceof StreamSegmentNotExistsException;
-        return requiresDelay ? EXCEPTION_DELAY : Duration.ZERO;
-    }
-
     /**
      * Handles an exception that was caught. If this is the first exception ever caught, and it is eligible for retries,
      * then this method will invoke the retryGetEntry that was passed through the constructor to get a new entry.
@@ -145,17 +128,17 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
      * same situation again).
      *
      * @param ex      The exception to inspect.
-     * @param timeout Timeout for the operation (a new call to requestContent will be made).
      * @return True if the exception was handled properly and the base entry swapped, false otherwise.
      */
-    private boolean handle(Throwable ex, Duration timeout) {
+    private boolean handle(Throwable ex) {
         ex = Exceptions.unwrap(ex);
         if (this.secondEntry == null && isRetryable(ex)) {
             // This is the first attempt and we caught a retry-eligible exception; issue the query for the new entry.
-            CompletableReadResultEntry newEntry = this.retryGetEntry.apply(getStreamSegmentOffset(), this.firstEntry.getRequestedReadLength());
+            CompletableReadResultEntry newEntry = this.retryGetEntry.apply(getStreamSegmentOffset(), this.firstEntry.getRequestedReadLength(),
+                    getStreamSegmentOffset() - this.firstEntry.getStreamSegmentOffset());
             if (!(newEntry instanceof RedirectedReadResultEntry)) {
                 // Request the content for the new entry (if that fails, we do not change any state).
-                newEntry.requestContent(timeout);
+                newEntry.requestContent(this.timer == null ? DEFAULT_TIMEOUT : timer.getRemaining());
                 assert newEntry.getStreamSegmentOffset() == this.adjustedOffset : "new entry's StreamSegmentOffset does not match the adjusted offset of this entry";
                 assert newEntry.getRequestedReadLength() == this.firstEntry.getRequestedReadLength() : "new entry does not have the same RequestedReadLength";
 
@@ -175,11 +158,11 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
      * it is invoked from an exceptionally() callback, so proper care has to be taken in order to guarantee that
      * the result future will complete one way or another.
      */
-    private void handleGetContentFailure(Throwable ex) {
+    private Void handleGetContentFailure(Throwable ex) {
         ex = Exceptions.unwrap(ex);
         boolean success;
         try {
-            success = handle(ex, RETRY_TIMEOUT);
+            success = handle(ex);
         } catch (Throwable ex2) {
             ex.addSuppressed(ex2);
             success = false;
@@ -192,6 +175,8 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
             // Unable to switch.
             this.result.completeExceptionally(ex);
         }
+
+        return null;
     }
 
     /**
@@ -215,6 +200,11 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
         Futures.exceptionListener(sourceFuture, this.result::completeExceptionally);
     }
 
+    @VisibleForTesting
+    boolean hasSecondEntrySet() {
+        return this.secondEntry != null;
+    }
+
     @Override
     public String toString() {
         return String.format("%s, AdjustedOffset = %s", getActiveEntry(), this.adjustedOffset);
@@ -223,6 +213,7 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
     //endregion
 
     @FunctionalInterface
-    public interface GetEntry extends BiFunction<Long, Integer, CompletableReadResultEntry> {
+    public interface GetEntry {
+        CompletableReadResultEntry apply(long readOffset, int requestedReadLength, long offsetAdjustment);
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -33,7 +33,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -66,7 +68,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     private final Cache cache;
     private final FutureReadResultEntryCollection futureReads;
     @GuardedBy("lock")
-    private final HashMap<Long, Long> mergeOffsets; //Key = StreamSegmentId (Merged), Value = Merge offset.
+    private final HashMap<Long, PendingMerge> mergeOffsets; //Key = Source Segment Id, Value = Pending Merge Info.
     private final StorageReadManager storageReadManager;
     private final ReadIndexSummary summary;
     private final ScheduledExecutorService executor;
@@ -138,8 +140,14 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             // Close storage reader (and thus cancel those reads).
             this.storageReadManager.close();
 
-            // Cancel future reads.
-            this.futureReads.close();
+            // Cancel registered future reads and any reads pertaining to incomplete mergers.
+            ArrayList<Iterator<FutureReadResultEntry>> futureReads = new ArrayList<>();
+            futureReads.add(this.futureReads.close().iterator());
+            synchronized (this.lock) {
+                this.mergeOffsets.values().forEach(pm -> futureReads.add(pm.seal().iterator()));
+            }
+            cancelFutureReads(Iterators.concat(futureReads.iterator()));
+
             if (cleanCache) {
                 this.executor.execute(() -> {
                     removeAllEntries();
@@ -147,6 +155,16 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 });
             } else {
                 log.info("{}: Closed (no cache cleanup).", this.traceObjectId);
+            }
+        }
+    }
+
+    private void cancelFutureReads(Iterator<FutureReadResultEntry> toCancel) {
+        CancellationException ce = new CancellationException();
+        while (toCancel.hasNext()) {
+            FutureReadResultEntry e = toCancel.next();
+            if (!e.getContent().isDone()) {
+                e.fail(ce);
             }
         }
     }
@@ -376,7 +394,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         // Check and record the merger (optimistically).
         synchronized (this.lock) {
             Exceptions.checkArgument(!this.mergeOffsets.containsKey(sourceMetadata.getId()), "sourceStreamSegmentIndex", "Given StreamSegmentReadIndex is already merged or in the process of being merged into this one.");
-            this.mergeOffsets.put(sourceMetadata.getId(), newEntry.key());
+            this.mergeOffsets.put(sourceMetadata.getId(), new PendingMerge(newEntry.key()));
         }
 
         try {
@@ -413,18 +431,18 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
         // Find the appropriate redirect entry.
         RedirectIndexEntry redirectEntry;
-        long mergeKey;
+        PendingMerge pendingMerge;
         synchronized (this.lock) {
-            mergeKey = this.mergeOffsets.getOrDefault(sourceMetadata.getId(), -1L);
-            Exceptions.checkArgument(mergeKey >= 0, "sourceSegmentStreamId",
+            pendingMerge = this.mergeOffsets.getOrDefault(sourceMetadata.getId(), null);
+            Exceptions.checkArgument(pendingMerge != null, "sourceSegmentStreamId",
                     "Given StreamSegmentReadIndex's merger with this one has not been initiated using beginMerge. Cannot finalize the merger.");
 
             // Get the RedirectIndexEntry. These types of entries are sticky in the cache and DO NOT contribute to the
             // cache Stats. They are already accounted for in the other Segment's ReadIndex.
-            ReadIndexEntry indexEntry = this.indexEntries.get(mergeKey);
+            ReadIndexEntry indexEntry = this.indexEntries.get(pendingMerge.getMergeOffset());
             assert indexEntry != null && !indexEntry.isDataEntry() :
                     String.format("mergeOffsets points to a ReadIndexEntry that does not exist or is of the wrong type. sourceStreamSegmentId = %d, offset = %d, treeEntry = %s.",
-                            sourceMetadata.getId(), mergeKey, indexEntry);
+                            sourceMetadata.getId(), pendingMerge.getMergeOffset(), indexEntry);
             redirectEntry = (RedirectIndexEntry) indexEntry;
         }
 
@@ -435,10 +453,13 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
         synchronized (this.lock) {
             // Remove redirect entry (again, no need to update the Cache Stats, as this is a RedirectIndexEntry).
-            this.indexEntries.remove(mergeKey);
+            this.indexEntries.remove(pendingMerge.getMergeOffset());
             this.mergeOffsets.remove(sourceMetadata.getId());
             sourceEntries.forEach(this::addToIndex);
         }
+
+        List<FutureReadResultEntry> pendingReads = pendingMerge.seal();
+        triggerFutureReads(pendingReads);
 
         LoggerHelpers.traceLeave(log, this.traceObjectId, "completeMerge", traceId);
     }
@@ -540,6 +561,15 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             log.debug("{}: triggerFutureReads (Count = {}, Offset = {}, Sealed = False).", this.traceObjectId, futureReads.size(), lastEntry.getLastStreamSegmentOffset());
         }
 
+        triggerFutureReads(futureReads);
+    }
+
+    /**
+     * Triggers all the Future Reads in the given collection.
+     *
+     * @param futureReads The Future Reads to trigger.
+     */
+    private void triggerFutureReads(Collection<FutureReadResultEntry> futureReads) {
         for (FutureReadResultEntry r : futureReads) {
             ReadResultEntry entry = getSingleReadResultEntry(r.getStreamSegmentOffset(), r.getRequestedReadLength());
             assert entry != null : "Serving a StorageReadResultEntry with a null result";
@@ -688,9 +718,9 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
     /**
      * Returns the first ReadResultEntry that matches the specified search parameters.
-     * <p>
+     *
      * Compared to getMultiReadResultEntry(), this method returns exactly one ReadResultEntry.
-     * <p>
+     *
      * Compared to getSingleMemoryReadResultEntry(), this method will return a CompletableReadResultEntry regardless of
      * whether the data is cached or not. This may involve registering a future read or triggering a Storage read if necessary,
      * as well as redirecting the read to a Transaction if necessary.
@@ -839,7 +869,34 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             // yield the right result. However, in order to recover from this without the caller's intervention, we pass
             // a pointer to getSingleReadResultEntry to the RedirectedReadResultEntry in case it fails with such an exception;
             // that class has logic in it to invoke it if needed and get the right entry.
-            result = new RedirectedReadResultEntry(result, entry.getStreamSegmentOffset(), this::getSingleReadResultEntry, this.executor);
+            result = new RedirectedReadResultEntry(result, entry.getStreamSegmentOffset(), this::getOrRegisterRedirectedRead);
+        }
+
+        return result;
+    }
+
+    private CompletableReadResultEntry getOrRegisterRedirectedRead(long resultStartOffset, int maxLength, long mergeOffset) {
+        CompletableReadResultEntry result = getSingleReadResultEntry(resultStartOffset, maxLength);
+        if (result instanceof RedirectedReadResultEntry) {
+            // The merger isn't completed yet. Register the read so that it is completed when the merger is done.
+            PendingMerge pendingMerge;
+            synchronized (this.lock) {
+                pendingMerge = this.mergeOffsets.getOrDefault(mergeOffset, null);
+            }
+
+            // Transform the read result entry into a Future Read, instead of adding it to futureReads, associate it
+            // with this pendingMerge, so that a completeMerge() would finalize it.
+            FutureReadResultEntry futureResult = new FutureReadResultEntry(result.getStreamSegmentOffset(), result.getRequestedReadLength());
+            if (pendingMerge != null && pendingMerge.register(futureResult)) {
+                // We were able to register the result.
+                result = futureResult;
+                log.debug("{}: Registered Pending Merge Future Read %s.", this.traceObjectId, result);
+            } else {
+                // The merge has been unregistered. Our only hope now is that the index has settled and re-invoking this
+                // will yield the sought-after result.
+                log.debug("{}: Could not find Pending Merge or it was sealed for %s; re-issuing.", this.traceObjectId, result);
+                result = getSingleReadResultEntry(resultStartOffset, maxLength);
+            }
         }
 
         return result;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -459,7 +459,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         }
 
         List<FutureReadResultEntry> pendingReads = pendingMerge.seal();
-        triggerFutureReads(pendingReads);
+        if (pendingReads.size() > 0) {
+            log.debug("{}: triggerFutureReads for Pending Merge (Count = {}, MergeOffset = {}, MergeLength = {}).",
+                    this.traceObjectId, pendingReads.size(), pendingMerge.getMergeOffset(), sourceIndex.getSegmentLength());
+            triggerFutureReads(pendingReads);
+        }
 
         LoggerHelpers.traceLeave(log, this.traceObjectId, "completeMerge", traceId);
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -890,11 +890,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             if (pendingMerge != null && pendingMerge.register(futureResult)) {
                 // We were able to register the result.
                 result = futureResult;
-                log.debug("{}: Registered Pending Merge Future Read %s.", this.traceObjectId, result);
+                log.debug("{}: Registered Pending Merge Future Read {}.", this.traceObjectId, result);
             } else {
                 // The merge has been unregistered. Our only hope now is that the index has settled and re-invoking this
                 // will yield the sought-after result.
-                log.debug("{}: Could not find Pending Merge or it was sealed for %s; re-issuing.", this.traceObjectId, result);
+                log.debug("{}: Could not find Pending Merge or it was sealed for {}; re-issuing.", this.traceObjectId, result);
                 result = getSingleReadResultEntry(resultStartOffset, maxLength);
             }
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1230,6 +1230,16 @@ class SegmentAggregator implements OperationProcessor, AutoCloseable {
                     int newCount = this.mergeTransactionCount.decrementAndGet();
                     assert newCount >= 0 : "Negative value for mergeTransactionCount";
 
+                    // Since the operation is already reconciled, the StorageLength of this Segment must be at least
+                    // the last offset of the operation. We are about to invoke ReadIndex.completeMerge(), which requires
+                    // that this value be set to at least the last offset of the merged Segment, so we need to ensure it's
+                    // set now. This will also be set at the end of reconciliation, but we cannot wait until then to invoke
+                    // the callbacks.
+                    long minStorageLength = processedOperation.getLastStreamSegmentOffset();
+                    if (this.metadata.getStorageLength() < minStorageLength) {
+                        this.metadata.setStorageLength(minStorageLength);
+                    }
+
                     updateMetadataForTransactionPostMerger(transactionMeta, processedOperation.getStreamSegmentId());
                     return new FlushResult().withMergedBytes(op.getLength());
                 }, this.executor);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -1529,11 +1529,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
 
         // Append continuously to an existing segment in order to trigger truncations (these are necessary for forced evictions).
         val appendFuture = localContainer.appendRandomly(appendSegment, false, () -> !successfulMap.isDone());
-        //Futures.exceptionListener(appendFuture, successfulMap::completeExceptionally);
-        Futures.exceptionListener(appendFuture, ex -> {
-            System.err.println("AppendEx: " + ex);
-            successfulMap.completeExceptionally(ex);
-        });
+        Futures.exceptionListener(appendFuture, successfulMap::completeExceptionally);
 
         // Repeatedly try to get info on 'segment1' (activate it), until we succeed or time out.
         TimeoutTimer remaining = new TimeoutTimer(TIMEOUT);
@@ -1544,7 +1540,6 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                         .thenCompose(v -> localContainer.getStreamSegmentInfo(targetSegment, false, TIMEOUT))
                         .thenAccept(successfulMap::complete)
                         .exceptionally(ex -> {
-                            System.err.println("EXCaught: " + ex);
                             if (!(Exceptions.unwrap(ex) instanceof TooManyActiveSegmentsException)) {
                                 // Some other error.
                                 successfulMap.completeExceptionally(ex);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.logs;
 
 import com.google.common.collect.Iterators;
-import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.SequencedItemList;
@@ -56,7 +55,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.Cleanup;
@@ -398,17 +396,6 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
         return result;
     }
 
-    protected void await(Supplier<Boolean> condition, int checkFrequencyMillis) throws TimeoutException {
-        long remainingMillis = TIMEOUT.toMillis();
-        while (!condition.get() && remainingMillis > 0) {
-            Exceptions.handleInterrupted(() -> Thread.sleep(checkFrequencyMillis));
-            remainingMillis -= checkFrequencyMillis;
-        }
-
-        if (!condition.get() && remainingMillis <= 0) {
-            throw new TimeoutException("Timeout expired prior to the condition becoming true.");
-        }
-    }
     //endregion
 
     //region FailedStreamSegmentAppendOperation

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -46,6 +46,7 @@ import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ErrorInjector;
 import io.pravega.test.common.IntentionalException;
+import io.pravega.test.common.TestUtils;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.AbstractMap;
@@ -547,7 +548,7 @@ public class OperationProcessorTests extends OperationLogTestBase {
         if (successfulOps.size() > 0) {
             // Writing to the memory log is asynchronous and we don't have any callbacks to know when it was written to.
             // We check periodically until the last item has been written.
-            await(() -> memoryLog.read(successfulOps.get(successfulOps.size() - 1).getSequenceNumber() - 1, 1).hasNext(), 10);
+            TestUtils.await(() -> memoryLog.read(successfulOps.get(successfulOps.size() - 1).getSequenceNumber() - 1, 1).hasNext(), 10, TIMEOUT.toMillis());
         }
 
         Iterator<Operation> memoryLogIterator = memoryLog.read(-1, operations.size() + 1);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import lombok.Cleanup;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,22 +64,6 @@ public class FutureReadResultEntryCollectionTests {
     }
 
     /**
-     * Tests the ability for all the pending reads to be canceled.
-     */
-    @Test
-    public void testCancelAll() {
-        @Cleanup
-        FutureReadResultEntryCollection c = new FutureReadResultEntryCollection();
-        List<FutureReadResultEntry> entries = generateEntries();
-        entries.forEach(c::add);
-        c.cancelAll();
-
-        for (FutureReadResultEntry e : entries) {
-            Assert.assertTrue("StorageReadResultEntry is not canceled.", e.getContent().isCancelled());
-        }
-    }
-
-    /**
      * Tests the ability for all the pending reads to be canceled when the Collection is closed.
      */
     @Test
@@ -86,11 +71,13 @@ public class FutureReadResultEntryCollectionTests {
         FutureReadResultEntryCollection c = new FutureReadResultEntryCollection();
         List<FutureReadResultEntry> entries = generateEntries();
         entries.forEach(c::add);
-        c.close();
+        val result = c.close();
 
         for (FutureReadResultEntry e : entries) {
-            Assert.assertTrue("StorageReadResultEntry is not canceled.", e.getContent().isCancelled());
+            Assert.assertFalse("StorageReadResultEntry is completed.", e.getContent().isCancelled());
         }
+
+        AssertExtensions.assertListEquals("Unexpected result from close().", entries, result, Object::equals);
     }
 
     private List<FutureReadResultEntry> generateEntries() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/PendingMergeTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/PendingMergeTests.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.reading;
+
+import io.pravega.test.common.AssertExtensions;
+import java.util.Arrays;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the PendingMerge class.
+ */
+public class PendingMergeTests {
+    /**
+     * Tests the functionality of the PendingMerge class.
+     */
+    @Test
+    public void testFunctionality() {
+        val m = new PendingMerge(123);
+        Assert.assertEquals("Unexpected value from getMergeOffset().", 123, m.getMergeOffset());
+
+        val toRegister = Arrays.asList(
+                new FutureReadResultEntry(1, 10),
+                new FutureReadResultEntry(2, 20),
+                new FutureReadResultEntry(3, 30));
+        for (val e : toRegister) {
+            boolean result = m.register(e);
+            Assert.assertTrue("Unexpected return value from register() when not sealed.", result);
+        }
+
+        val sealResult = m.seal();
+        AssertExtensions.assertListEquals("Unexpected result from seal().", toRegister, sealResult, Object::equals);
+        Assert.assertFalse("Not expecting new calls to register() to work after calling seal().",
+                m.register(new FutureReadResultEntry(4, 40)));
+        val seal2Result = m.seal();
+        Assert.assertEquals("Not expecting any items after the second call to seal().", 0, seal2Result.size());
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
@@ -16,10 +16,8 @@ import io.pravega.segmentstore.contracts.ReadResultEntryType;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
-import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.val;
 import org.junit.Assert;
@@ -30,7 +28,7 @@ import org.junit.rules.Timeout;
 /**
  * Unit tests for RedirectedReadResultEntry.
  */
-public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
+public class RedirectedReadResultEntryTests {
     private static final Duration TIMEOUT = Duration.ofSeconds(3);
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10);
@@ -48,16 +46,16 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
 
         AssertExtensions.assertThrows(
                 "Constructor allowed changing to a negative offset.",
-                () -> new RedirectedReadResultEntry(baseEntry, -originalOffset - 1, this::illegalGetNext, executorService()),
+                () -> new RedirectedReadResultEntry(baseEntry, -originalOffset - 1, this::illegalGetNext),
                 ex -> ex instanceof IllegalArgumentException);
 
         // Adjust up.
-        RedirectedReadResultEntry redirectedEntry = new TestRedirectedReadResultEntry(baseEntry, positiveDelta, this::illegalGetNext, executorService());
+        RedirectedReadResultEntry redirectedEntry = new RedirectedReadResultEntry(baseEntry, positiveDelta, this::illegalGetNext);
         Assert.assertEquals("Unexpected value for getStreamSegmentOffset after up-adjustment.", originalOffset + positiveDelta, redirectedEntry.getStreamSegmentOffset());
         Assert.assertEquals("Unexpected value for getRequestedReadLength after up-adjustment (no change expected).", originalLength, redirectedEntry.getRequestedReadLength());
 
         // Adjust down.
-        redirectedEntry = new TestRedirectedReadResultEntry(baseEntry, negativeDelta, this::illegalGetNext, executorService());
+        redirectedEntry = new RedirectedReadResultEntry(baseEntry, negativeDelta, this::illegalGetNext);
         Assert.assertEquals("Unexpected value for getStreamSegmentOffset after down-adjustment.", originalOffset + negativeDelta, redirectedEntry.getStreamSegmentOffset());
         Assert.assertEquals("Unexpected value for getRequestedReadLength after down-adjustment (no change expected).", originalLength, redirectedEntry.getRequestedReadLength());
 
@@ -82,7 +80,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         FailureReadResultEntry f1 = new FailureReadResultEntry(ReadResultEntryType.Cache, 1, 1, () -> {
             throw new ObjectClosedException(this);
         });
-        RedirectedReadResultEntry e1 = new TestRedirectedReadResultEntry(f1, 0, (o, l) -> f1, executorService());
+        RedirectedReadResultEntry e1 = new RedirectedReadResultEntry(f1, 0, (o, l, m) -> f1);
         AssertExtensions.assertThrows(
                 "requestContent did not throw when attempting to retry more than once.",
                 () -> e1.requestContent(TIMEOUT),
@@ -92,23 +90,23 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         FailureReadResultEntry f2 = new FailureReadResultEntry(ReadResultEntryType.Cache, 1, 1, () -> {
             throw new IllegalArgumentException();
         });
-        RedirectedReadResultEntry e2 = new TestRedirectedReadResultEntry(f1, 0, (o, l) -> f2, executorService());
+        RedirectedReadResultEntry e2 = new RedirectedReadResultEntry(f1, 0, (o, l, m) -> f2);
         AssertExtensions.assertThrows(
                 "requestContent did not throw when an ineligible exception got thrown.",
                 () -> e2.requestContent(TIMEOUT),
                 ex -> ex instanceof IllegalArgumentException);
 
         // Given back another Redirect.
-        RedirectedReadResultEntry e3 = new TestRedirectedReadResultEntry(f1, 0, (o, l) -> e1, executorService());
+        RedirectedReadResultEntry e3 = new RedirectedReadResultEntry(f1, 0, (o, l, m) -> e1);
         AssertExtensions.assertThrows(
                 "requestContent did not throw when retry yielded another RedirectReadResultEntry.",
                 () -> e3.requestContent(TIMEOUT),
                 ex -> ex instanceof ObjectClosedException);
 
         // Given redirect function fails.
-        RedirectedReadResultEntry e4 = new TestRedirectedReadResultEntry(f1, 0, (o, l) -> {
+        RedirectedReadResultEntry e4 = new RedirectedReadResultEntry(f1, 0, (o, l, m) -> {
             throw new IntentionalException();
-        }, executorService());
+        });
         AssertExtensions.assertThrows(
                 "requestContent did not throw when retry failed.",
                 () -> e4.requestContent(TIMEOUT),
@@ -119,7 +117,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         FailureReadResultEntry f5 = new FailureReadResultEntry(ReadResultEntryType.Cache, 2, 1, () -> requestInvoked.set(true));
         f1.setCompletionCallback(i -> { // Do nothing.
         });
-        RedirectedReadResultEntry e5 = new TestRedirectedReadResultEntry(f1, 1, (o, l) -> f5, executorService());
+        RedirectedReadResultEntry e5 = new RedirectedReadResultEntry(f1, 1, (o, l, m) -> f5);
         e5.requestContent(TIMEOUT);
         Assert.assertTrue("requestTimeout was not invoked for successful redirect.", requestInvoked.get());
         Assert.assertEquals("Unexpected result from getCompletionCallback after successful redirect.", f5.getCompletionCallback(), f1.getCompletionCallback());
@@ -134,7 +132,10 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
     public void testGetContent() {
         // More than one retry (by design, it will only retry one time; the next time it will simply throw).
         MockReadResultEntry t1 = new MockReadResultEntry(1, 1);
-        RedirectedReadResultEntry e1 = new TestRedirectedReadResultEntry(t1, 0, (o, l) -> t1, executorService());
+        RedirectedReadResultEntry e1 = new RedirectedReadResultEntry(t1, 0, (o, l, m) -> {
+            Assert.assertEquals("Unexpected merge offset.", 1, m);
+            return t1;
+        });
         t1.getContent().completeExceptionally(new StreamSegmentNotExistsException("foo"));
         AssertExtensions.assertThrows(
                 "getContent() did not throw when attempting to retry more than once.",
@@ -143,7 +144,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
 
         // Ineligible exception.
         MockReadResultEntry t2 = new MockReadResultEntry(1, 1);
-        RedirectedReadResultEntry e2 = new TestRedirectedReadResultEntry(t2, 0, (o, l) -> t2, executorService());
+        RedirectedReadResultEntry e2 = new RedirectedReadResultEntry(t2, 0, (o, l, m) -> t2);
         t2.getContent().completeExceptionally(new IntentionalException());
         AssertExtensions.assertThrows(
                 "getContent() did not throw when an ineligible exception got thrown.",
@@ -152,7 +153,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
 
         // Given back another Redirect.
         MockReadResultEntry t3 = new MockReadResultEntry(1, 1);
-        RedirectedReadResultEntry e3 = new TestRedirectedReadResultEntry(t3, 0, (o, l) -> e1, executorService());
+        RedirectedReadResultEntry e3 = new RedirectedReadResultEntry(t3, 0, (o, l, m) -> e1);
         t3.getContent().completeExceptionally(new StreamSegmentNotExistsException("foo"));
         AssertExtensions.assertThrows(
                 "getContent() did not throw when a retry yielded another RedirectReadResultEntry.",
@@ -162,9 +163,9 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         // Given redirect function fails.
         MockReadResultEntry t4 = new MockReadResultEntry(1, 1);
         t4.getContent().completeExceptionally(new StreamSegmentNotExistsException("foo"));
-        RedirectedReadResultEntry e4 = new TestRedirectedReadResultEntry(t4, 0, (o, l) -> {
+        RedirectedReadResultEntry e4 = new RedirectedReadResultEntry(t4, 0, (o, l, m) -> {
             throw new IntentionalException();
-        }, executorService());
+        });
         AssertExtensions.assertThrows(
                 "getContent() did not throw when retry failed.",
                 e4::getContent,
@@ -177,7 +178,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         t1.setCompletionCallback(i -> { // Do nothing.
         });
         t5Good.getContent().complete(new ReadResultEntryContents(new ByteArrayInputStream(new byte[1]), 1));
-        RedirectedReadResultEntry e5 = new TestRedirectedReadResultEntry(t5Bad, 1, (o, l) -> t5Good, executorService());
+        RedirectedReadResultEntry e5 = new RedirectedReadResultEntry(t5Bad, 1, (o, l, m) -> t5Good);
         val finalResult = e5.getContent().join();
         Assert.assertEquals("Unexpected result from getCompletionCallback after successful redirect.", t5Bad.getCompletionCallback(), t5Good.getCompletionCallback());
         Assert.assertEquals("Unexpected result from getRequestedReadLength after successful redirect.", t5Bad.getRequestedReadLength(), e5.getRequestedReadLength());
@@ -185,7 +186,7 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         Assert.assertEquals("Unexpected result from getContent after successful redirect.", t5Good.getContent().join(), finalResult);
     }
 
-    private CompletableReadResultEntry illegalGetNext(long offset, int length) {
+    private CompletableReadResultEntry illegalGetNext(long offset, int length, long mergeOffset) {
         throw new IllegalStateException("Cannot invoke this operation at this time.");
     }
 
@@ -211,17 +212,6 @@ public class RedirectedReadResultEntryTests extends ThreadPooledTestSuite {
         @Override
         public void requestContent(Duration timeout) {
             this.getContent().complete(null);
-        }
-    }
-
-    private static class TestRedirectedReadResultEntry extends RedirectedReadResultEntry {
-        TestRedirectedReadResultEntry(CompletableReadResultEntry baseEntry, long offsetAdjustment, GetEntry retryGetEntry, ScheduledExecutorService executorService) {
-            super(baseEntry, offsetAdjustment, retryGetEntry, executorService);
-        }
-
-        @Override
-        protected Duration getExceptionDelay(Throwable ex) {
-            return Duration.ZERO;
         }
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -86,7 +86,7 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
     private static final int TRANSACTION_COUNT = 10;
     private static final UUID CORE_ATTRIBUTE_ID = Attributes.EVENT_COUNT;
     private static final UUID EXTENDED_ATTRIBUTE_ID = UUID.randomUUID();
-    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TIMEOUT = Duration.ofSeconds(20);
     private static final WriterConfig DEFAULT_CONFIG = WriterConfig
             .builder()
             .with(WriterConfig.FLUSH_THRESHOLD_BYTES, 100)

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -9,11 +9,14 @@
  */
 package io.pravega.test.common;
 
-import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility class for Tests.
@@ -48,4 +51,24 @@ public class TestUtils {
                 String.format("Could not assign port in range %d - %d", BASE_PORT, MAX_PORT_COUNT + BASE_PORT));
     }
 
+    /**
+     * Awaits the given condition to become true.
+     *
+     * @param condition            A Supplier that indicates when the condition is true. When this happens, this method will return.
+     * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
+     * @param timeoutMillis        The maximum amount of time to wait.
+     * @throws TimeoutException If the condition was not met during the allotted time.
+     */
+    @SneakyThrows(InterruptedException.class)
+    public static void await(Supplier<Boolean> condition, int checkFrequencyMillis, long timeoutMillis) throws TimeoutException {
+        long remainingMillis = timeoutMillis;
+        while (!condition.get() && remainingMillis > 0) {
+            Thread.sleep(checkFrequencyMillis);
+            remainingMillis -= checkFrequencyMillis;
+        }
+
+        if (!condition.get() && remainingMillis <= 0) {
+            throw new TimeoutException("Timeout expired prior to the condition becoming true.");
+        }
+    }
 }


### PR DESCRIPTION
**Change log description**
Fixed a bug in the Segment Store where, in some scenarios, it would cancel a Read request with a `StreamSegmentNotExistsException` immediately after a `SegmentContainer` recovery.

**Background**
What happens during a Segment Merge (high-level steps; there's more detail underneath):
1. Consider two segments, S1, and S2. We want to merge S2 into S1 at offset N.
2. We request the merge into the Segment Store. The merge request is recorded in the Segment Store, and the Read Index for S1 is updated with `beginMerge(S2, N)`, which indicates that offsets [N, N+len(S2)) within S1 will be redirected to S2[0, len(S2)).
    - This is because S2 is not yet merged into S1 in Tier2, hence we need this redirect.
3. Some time later, the StorageWriter picks up the operation and executes the `concat(S2->S1 @ N)` in Tier2.
4. Immediately afterwards, the StorageWriter invokes `completeMerge(S2)` onto S1's read index to notify it of the fact that S2 has been physically merged into S1.
5. Eventually the merge operation is truncated out of Tier1.

Due to the fact that operations 3 and 4 are not atomic, it is possible that a concurrent read arrives at S1@N in the time interval between these two. This can happen in one of two cases:
- Case 1: During normal operations. In this case the delay between 3 and 4 is usually a few milliseconds.
- Case 2: Immediately after recovery. If step 3 has happened, but 5 hasn't happened yet, then immediately after recovery, until the StorageWriter reconciles the state of S1 and S2 in Tier2 with the metadata, if a read comes in at S1@N, it will not be able to be fulfilled until the reconciliation.

Previously there was a hacked solution addressing Case 1 (and Case 2, if the Tier2 reconciliation was just after the read). That solution could not scale gracefully to solve Case 2.

**Fix:**
- If such a read comes in (between steps 3 and 4), there is a chance it will be served from the cache (in which case no problem). But if it needs to be served from Tier2, it will result in a `StreamSegmentNotExistsException`. 
- The same mechanism as before will be used. If we end up in such as situation, instead of retrying after 1 second, we will register a Future Read for the "missing" offset range and associate it with the source segment that was stuffed in there.
- When `completeMerge` is invoked, any Future Reads associated with that merge will be triggered (after the index is updated), which should finally return the correct data.

**Purpose of the change**
Fixes #2678.

**What the code does**
See description.

**How to verify it**
New unit test added and existing test updated to verify this particular behavior.
System tests must pass.