### PR TITLE
Issue 2694: Fix documentation on transaction timeout parameter

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -23,8 +23,23 @@ public class EventWriterConfig implements Serializable {
     private final int maxBackoffMillis;
     private final int retryAttempts;
     private final int backoffMultiple;
-    /**
-     * The maximum amount of time, in milliseconds, which a transaction can run before it is considered failed.
+    /*
+     * The transaction timeout parameter corresponds to the lease renewal period.
+     * In every period, the client must send at least one ping to keep the txn alive.
+     * If the client fails to do so, then Pravega aborts the txn automatically. The client
+     * sends pings internally and requires no application intervention, only that it sets
+     * this parameter accordingly.
+     *
+     * This parameter is additionally used to determine the total amount of time that
+     * a txn can remain open. Currently, we set the maximum amount of time for a
+     * txn to remain open to be the minimum between 1 day and 1,000 times the value
+     * of the lease renewal period. The 1,000 is hardcoded and has been chosen arbitrarily
+     * to be a large enough value.
+     *
+     * The maximum allowed lease time by default is 30s, which gives a maximum execution
+     * time of 30,000s (roughly 8 hours). The maximum allowed lease time is a configuration
+     * parameter of the controller and can be changed accordingly. Note that being a controller-
+     * wide parameter, it affects all transactions.
      */
     private final long transactionTimeoutTime;
 

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -36,10 +36,13 @@ public class EventWriterConfig implements Serializable {
      * of the lease renewal period. The 1,000 is hardcoded and has been chosen arbitrarily
      * to be a large enough value.
      *
-     * The maximum allowed lease time by default is 30s, which gives a maximum execution
-     * time of 30,000s (roughly 8 hours). The maximum allowed lease time is a configuration
-     * parameter of the controller and can be changed accordingly. Note that being a controller-
-     * wide parameter, it affects all transactions.
+     * The maximum allowed lease time by default is 120s, see:
+     *
+     * controller/src/main/resources/reference.conf
+     *
+     * The maximum allowed lease time is a configuration parameter of the controller
+     * and can be changed accordingly. Note that being a controller-wide parameter,
+     * it affects all transactions.
      */
     private final long transactionTimeoutTime;
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Fixes the description of the transaction timeout parameter in `EventWriterConfig`.

* Adds more detail about the semantics of the timeout parameter.

**Purpose of the change**
Fixes #2694 

**What the code does**
No code change, only comments.

**How to verify it**
Visual inspection, it should have no impact on the build.