### PR TITLE
Issue 2698: (SegmentStore) Incorrectly throwing DataCorruptionException for recoverable Tier1 errors

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
@@ -77,7 +77,7 @@ class DataFrameReader<T extends SequencedItemList.Element> implements CloseableI
      * @return A DataFrameRecord with the requested operation. If no more Operations are available, null is returned.
      */
     @Override
-    public DataFrameRecord<T> getNext() throws DataCorruptionException {
+    public DataFrameRecord<T> getNext() throws DataCorruptionException, DurableDataLogException {
         Exceptions.checkNotClosed(this.closed, closed);
 
         try {

--- a/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
@@ -10,10 +10,10 @@
 package io.pravega.test.common;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import lombok.SneakyThrows;
 
 /**
  * Simple count-based error injector.
@@ -56,11 +56,14 @@ public class ErrorInjector<T extends Throwable> {
      * @param injector The Error Injector to use.
      * @param <T>      The type of exception to throw.
      */
+    @SneakyThrows
     public static <T extends Throwable> void throwSyncExceptionIfNeeded(ErrorInjector<T> injector) {
         if (injector != null) {
             T ex = injector.generateExceptionIfNecessary();
             if (ex != null) {
-                throw new CompletionException(ex);
+                // Throw the exception directly (thanks to SneakyThrows), vs wrapping it in some other exception, which
+                // may not be handled or expected by the "catching" code.
+                throw ex;
             }
         }
     }


### PR DESCRIPTION
**Change log description**
1. Fixed a bug in `DataFrameInputStream` that was incorrectly wrapping a `DurableDataLogException` (Tier1 exception) into an `IOException`. 
    - The upstream code treats all `IOException`s as critical failures and stops recovery with a `DataCorruptionException`.
    - `DataCorruptionException` should only be thrown if there is something wrong with the data itself. It should not be thrown when there are transient Tier1 exceptions, such as timeouts.
2. Fixed a bug in `ErrorInjector` (Test code utils) that would incorrectly wrap exceptions in `CompletionException`, which could confuse exception handlers if they don't expect that.
    - If this had been working properly before, the bug described above would have been caught by unit tests a long time ago.

**Purpose of the change**
Fixes #2698.

**What the code does**
Bug fix.

**How to verify it**
Unit tests must pass.
System tests (run 1207) have passed.