### PR TITLE
Issue 2700: (SegmentStore) Fixed sporadic failures in OperationProcessorTests.testWithDataCorruptionFailures

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -287,8 +287,8 @@ class DataFrameBuilder<T extends SequencedItemList.Element> implements AutoClose
 
         @Override
         public String toString() {
-            return String.format("LastFullySerializedSN = %d, LastStartedSN = %d, Address = %s, Length = %d",
-                    getLastFullySerializedSequenceNumber(), getLastStartedSequenceNumber(), this.logAddress, getDataFrameLength());
+            return String.format("TxnId = %d, LastFullySerializedSN = %d, LastStartedSN = %d, Address = %s, Length = %d",
+                    getMetadataTransactionId(), getLastFullySerializedSequenceNumber(), getLastStartedSequenceNumber(), this.logAddress, getDataFrameLength());
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -374,7 +374,6 @@ public class OperationProcessorTests extends OperationLogTestBase {
      * is generated.
      */
     @Test
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public void testWithDataCorruptionFailures() throws Exception {
         // If a DataCorruptionException is thrown for a particular Operation, the OperationQueueProcessor should
         // immediately shut down and stop accepting other ops.


### PR DESCRIPTION
**Change log description**
Fixed a (relatively harmless) bug in `OperationProcessor` that would incorrectly throw an `AssertionError` in certain conditions when a write failed to commit to memory.
- If a Tier1 write fails to commit to memory, a `DataCorruptionException` is thrown and the `OperationProcessor` needs to fail all operations in that write, all operations in subsequent writes, and shut down.
- Sometimes, due to lock acquisition reordering, the success callback for write N+1 would execute after the failed callback for write N (since the Tier1 write was already in flight and had nothing to do with our in-memory commit problem). 
- The callback for N would have already failed the operations for N+1 and canceled its associated `MetadataUpdateTransaction`, but it is possible that the callback for N+1 is already queued up (waiting for the lock to be released) and went past the "OperationProcessor is shutting down check". When it tries to fetch its own `MetadataUpdateTransaction`, it would not find it, and thus throw an `AssertionError`. 
    - There would be no point in getting it in the first place since we detected a critical error and must now shut down.
- This has been fixed to only log a warning in this case, and really fire an `AssertionError` if there is no evidence of any failure (which means we have a bug somewhere in our code).

**Purpose of the change**
Fixes #2700.

**What the code does**
Bug fix.

**How to verify it**
Run `OperationProcessorTests.testWithDataCorruptionFailures` a sufficient number of times (10,000) and verify this doesn't fail. Previously it would fail before reaching 500.
