### PR TITLE
Issue 2659: Fix segment read bytes metric issue

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -295,9 +295,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 //Update the parent segment metrics, once the transaction is merged
                 //TODO: https://github.com/pravega/pravega/issues/2570
                 if (!StreamSegmentNameUtils.isTransactionSegment(append.getSegment())) {
-                    log.info("delta for segment write bytes {}", append.getDataLength());
                     DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
-                    log.info("delta for segment write events {}", append.getEventCount());
                     DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
                 }
             }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -295,7 +295,9 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 //Update the parent segment metrics, once the transaction is merged
                 //TODO: https://github.com/pravega/pravega/issues/2570
                 if (!StreamSegmentNameUtils.isTransactionSegment(append.getSegment())) {
+                    log.info("delta for segment write bytes {}", append.getDataLength());
                     DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
+                    log.info("delta for segment write events {}", append.getEventCount());
                     DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
                 }
             }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -239,7 +239,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                     })
                     .exceptionally(e -> handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e));
         }
-
     }
 
     /**

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -174,7 +174,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                     LoggerHelpers.traceLeave(log, "readSegment", trace, readResult);
                     handleReadResult(readSegment, readResult);
                     //DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), readResult.getConsumedLength());
-
                     readStreamSegment.reportSuccessEvent(timer.getElapsed());
                 })
                 .exceptionally(ex -> handleException(readSegment.getOffset(), segment, "Read segment", ex));
@@ -210,6 +209,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             // We managed to collect some data. Send it.
             ByteBuffer data = copyData(cachedEntries);
             SegmentRead reply = new SegmentRead(segment, request.getOffset(), atTail, endOfSegment, data);
+            DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length);
             connection.send(reply);
         } else if (truncated) {
             // We didn't collect any data, instead we determined that the current read offset was truncated.
@@ -239,7 +239,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                     .exceptionally(e -> handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e));
         }
 
-        DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), result.getConsumedLength());
     }
 
     /**

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -169,10 +169,14 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         final int readSize = min(MAX_READ_SIZE, max(TYPE_PLUS_LENGTH_SIZE, readSegment.getSuggestedLength()));
         long trace = LoggerHelpers.traceEnter(log, "readSegment", readSegment);
+        log.info("read size {}", readSize);
         segmentStore.read(segment, readSegment.getOffset(), readSize, TIMEOUT)
                 .thenAccept(readResult -> {
                     LoggerHelpers.traceLeave(log, "readSegment", trace, readResult);
                     handleReadResult(readSegment, readResult);
+                    log.info("delta for segment read bytes: {}", readResult.getConsumedLength());
+                    log.info("segment name:  {}", readSegment.getSegment());
+                    log.info("metric name from segment: {}", nameFromSegment(SEGMENT_READ_BYTES, segment));
                     //DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), readResult.getConsumedLength());
                     readStreamSegment.reportSuccessEvent(timer.getElapsed());
                 })
@@ -208,9 +212,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         if (!cachedEntries.isEmpty() || endOfSegment) {
             // We managed to collect some data. Send it.
             ByteBuffer data = copyData(cachedEntries);
+            log.info("byte buffer data size from cached entries {}", data.array().length);
             SegmentRead reply = new SegmentRead(segment, request.getOffset(), atTail, endOfSegment, data);
-            DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length);
             connection.send(reply);
+            log.info("reply length size from cached entries {}", reply.getData().array().length);
+            DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length);
         } else if (truncated) {
             // We didn't collect any data, instead we determined that the current read offset was truncated.
             // Determine the current Start Offset and send that back.
@@ -224,7 +230,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             nonCachedEntry.getContent()
                     .thenAccept(contents -> {
                         ByteBuffer data = copyData(Collections.singletonList(contents));
-                        connection.send(new SegmentRead(segment, nonCachedEntry.getStreamSegmentOffset(), false, endOfSegment, data));
+                        log.info("byte buffer data size from non cached entries {}", data.array().length);
+                        SegmentRead reply = new SegmentRead(segment, nonCachedEntry.getStreamSegmentOffset(), false, endOfSegment, data);
+                        connection.send(reply);
+                        log.info("reply length size from non cached entries {}", reply.getData().array().length);
+                        DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length);
                     })
                     .exceptionally(e -> {
                         if (Exceptions.unwrap(e) instanceof StreamSegmentTruncatedException) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -173,7 +173,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 .thenAccept(readResult -> {
                     LoggerHelpers.traceLeave(log, "readSegment", trace, readResult);
                     handleReadResult(readSegment, readResult);
-                    DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), readResult.getConsumedLength());
+                    //DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), readResult.getConsumedLength());
+
                     readStreamSegment.reportSuccessEvent(timer.getElapsed());
                 })
                 .exceptionally(ex -> handleException(readSegment.getOffset(), segment, "Read segment", ex));
@@ -237,6 +238,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                     })
                     .exceptionally(e -> handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e));
         }
+
+        DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), result.getConsumedLength());
     }
 
     /**


### PR DESCRIPTION
**Change log description**
*  Increases the `segment_read_bytes` metric counter value in the `handleReadResult` method, rather than from `readResult` length. 

**Purpose of the change**
Fixes #2659 

**What the code does**
*  Increases the `segment_read_bytes` metric counter value in the `handleReadResult` method, rather than from `readResult` length. 

**How to verify it**
`segment_ready_bytes`  should be reported correctly and match with `segment_write_bytes` in a period of time.