### PR TITLE
Issue 2696: Introduce fairness in processing on different event processors for same stream

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -129,6 +129,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamMetadataStore, executor),
                 new DeleteStreamTask(streamMetadataTasks, streamMetadataStore, executor),
                 new TruncateStreamTask(streamMetadataTasks, streamMetadataStore, executor),
+                streamMetadataStore,
                 executor);
         this.commitRequestHandler = new CommitRequestHandler(streamMetadataStore, streamMetadataTasks, streamTransactionMetadataTasks, executor);
         this.abortRequestHandler = new AbortRequestHandler(streamMetadataStore, streamMetadataTasks, executor);

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -137,7 +137,7 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
                                     } else {
                                         // Processing was done for this event, whether it succeeded or failed, we should remove
                                         // the waiting request if it matches the current processor.
-                                        // If we dont delete it then some other processor will never be able to do the work.
+                                        // If we don't delete it then some other processor will never be able to do the work.
                                         // So we need to retry indefinitely until deleted.
                                         retryIndefinitelyThenComplete(() -> streamMetadataStore.deleteWaitingRequestConditionally(scope,
                                                 stream, getProcessorName(), context, executor), resultFuture, ex);

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.controller.eventProcessor.impl.SerializedRequestHandler;
@@ -35,15 +36,15 @@ import java.util.function.Supplier;
 import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.withRetries;
 
 /**
- * Base class for all request processing done over SerializedRequestHandler.
+ * Abstract common class for all request processing done over SerializedRequestHandler.
  * This implements RequestProcessor interface and implements failing request processing for all ControllerEvent types with
  * RequestUnsupported.
  * Its derived classes should implement specific processing that they wish to handle.
  *
  * This class provides a common completion method which implements mechanisms that allow multiple event processors
  * working on same stream to get fairness in their scheduling and avoid starvation.
- * To do this, before starting any processing, it fetches waiting request processor record from the store and if there is a record in the store
- * and it doesnt match current processing request, then it simply postpones the current processing.
+ * To do this, before starting any processing, it fetches waiting request processor record from the store and if there
+ * is a record in the store and it doesnt match current processing request, then it simply postpones the current processing.
  * Otherwise it attempts to process the event. If the event fails in its processing because of contention with another
  * process on a different processor, then it sets itself as the waiting request processor in the stream metadata. This will
  * ensure that when other event processors complete their processing, they will not pick newer work until this processor
@@ -52,12 +53,12 @@ import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.wit
  * was set against its name.
  */
 @Slf4j
-public abstract class RequestProcessorBase<T extends ControllerEvent> extends SerializedRequestHandler<T> implements RequestProcessor {
-    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> e instanceof StoreException.OperationNotAllowedException;
+public abstract class AbstractRequestProcessor<T extends ControllerEvent> extends SerializedRequestHandler<T> implements RequestProcessor {
+    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException;
 
     protected final StreamMetadataStore streamMetadataStore;
 
-    public RequestProcessorBase(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor) {
+    public AbstractRequestProcessor(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor) {
         super(executor);
         this.streamMetadataStore = streamMetadataStore;
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -158,7 +158,7 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
 
     private <R> CompletableFuture<R> suppressException(CompletableFuture<R> future, R returnOnException, String message) {
         return Futures.exceptionallyExpecting(future, e -> {
-            log.debug(message, e);
+            log.warn(message, e);
             return true;
         }, returnOnException);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -61,10 +61,13 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
 
     public AbstractRequestProcessor(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor) {
         super(executor);
+        Preconditions.checkNotNull(streamMetadataStore);
         this.streamMetadataStore = streamMetadataStore;
     }
 
-    abstract String getProcessorName();
+    public String getProcessorName() {
+        return this.getClass().getSimpleName();
+    }
 
     @Override
     public CompletableFuture<Void> processEvent(ControllerEvent controllerEvent) {
@@ -73,50 +76,42 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
 
     @Override
     public CompletableFuture<Void> processAbortTxnRequest(AbortEvent abortEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processCommitTxnRequest(CommitEvent commitEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processAutoScaleRequest(AutoScaleEvent autoScaleEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processScaleOpRequest(ScaleOpEvent scaleOpEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processUpdateStream(UpdateStreamEvent updateStreamEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processTruncateStream(TruncateStreamEvent truncateStreamEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processSealStream(SealStreamEvent sealStreamEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     @Override
     public CompletableFuture<Void> processDeleteStream(DeleteStreamEvent deleteStreamEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "Request Unsupported"));
+        return Futures.failedFuture(new RequestUnsupportedException("Request Unsupported"));
     }
 
     protected <T extends ControllerEvent> CompletableFuture<Void> withCompletion(StreamTask<T> task, T event, String scope, String stream,
@@ -162,10 +157,10 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
     }
 
     private <R> CompletableFuture<R> suppressException(CompletableFuture<R> future, R returnOnException, String message) {
-        return future.exceptionally(e -> {
+        return Futures.exceptionallyExpecting(future, e -> {
             log.debug(message, e);
-            return returnOnException;
-        });
+            return true;
+        }, returnOnException);
     }
 
     private CompletableFuture<Void> retryIndefinitelyThenComplete(Supplier<CompletableFuture<Void>> futureSupplier, CompletableFuture<Void> toComplete,

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -72,11 +72,6 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
     }
 
     @Override
-    public String getProcessorName() {
-        return this.getClass().getSimpleName();
-    }
-
-    @Override
     public CompletableFuture<Void> processCommitTxnRequest(CommitEvent event) {
         return withCompletion(this, event, event.getScope(), event.getStream(), OPERATION_NOT_ALLOWED_PREDICATE);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -42,7 +42,7 @@ import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
  * Request handler for processing commit events in commit-stream.
  */
 @Slf4j
-public class CommitRequestHandler extends RequestProcessorBase<CommitEvent> implements StreamTask<CommitEvent> {
+public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> implements StreamTask<CommitEvent> {
     private final StreamMetadataTasks streamMetadataTasks;
     private final StreamTransactionMetadataTasks streamTransactionMetadataTasks;
     private final ScheduledExecutorService executor;
@@ -73,7 +73,7 @@ public class CommitRequestHandler extends RequestProcessorBase<CommitEvent> impl
 
     @Override
     String getProcessorName() {
-        return this.getClass().getName();
+        return this.getClass().getSimpleName();
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -72,7 +72,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
     }
 
     @Override
-    String getProcessorName() {
+    public String getProcessorName() {
         return this.getClass().getSimpleName();
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
@@ -34,6 +34,23 @@ import java.util.function.Supplier;
 
 import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.withRetries;
 
+/**
+ * Base class for all request processing done over SerializedRequestHandler.
+ * This implements RequestProcessor interface and implements failing request processing for all ControllerEvent types with
+ * RequestUnsupported.
+ * Its derived classes should implement specific processing that they wish to handle.
+ *
+ * This class provides a common completion method which implements mechanisms that allow multiple event processors
+ * working on same stream to get fairness in their scheduling and avoid starvation.
+ * To do this, before starting any processing, it fetches waiting request processor record from the store and if there is a record in the store
+ * and it doesnt match current processing request, then it simply postpones the current processing.
+ * Otherwise it attempts to process the event. If the event fails in its processing because of contention with another
+ * process on a different processor, then it sets itself as the waiting request processor in the stream metadata. This will
+ * ensure that when other event processors complete their processing, they will not pick newer work until this processor
+ * processes at least one event.
+ * At the end of processing, each processor attempts to clean up waiting request processor record from the store if it
+ * was set against its name.
+ */
 @Slf4j
 public abstract class RequestProcessorBase<T extends ControllerEvent> extends SerializedRequestHandler<T> implements RequestProcessor {
     protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> e instanceof StoreException.OperationNotAllowedException;
@@ -142,8 +159,8 @@ public abstract class RequestProcessorBase<T extends ControllerEvent> extends Se
         });
     }
 
-    private <T extends ControllerEvent> CompletableFuture<Void> retryIndefinitelyThenComplete(Supplier<CompletableFuture<Void>> futureSupplier,
-                                                                                              CompletableFuture<Void> toComplete, Throwable e) {
+    private CompletableFuture<Void> retryIndefinitelyThenComplete(Supplier<CompletableFuture<Void>> futureSupplier, CompletableFuture<Void> toComplete,
+                                                                  Throwable e) {
         String failureMessage = String.format("Error writing event back into stream from processor %s", getProcessorName());
         return Retry.indefinitelyWithExpBackoff(failureMessage)
                 .runAsync(futureSupplier, executor)

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.eventProcessor.requesthandlers;
+
+import io.pravega.common.concurrent.Futures;
+import io.pravega.common.util.Retry;
+import io.pravega.controller.eventProcessor.impl.SerializedRequestHandler;
+import io.pravega.controller.store.stream.OperationContext;
+import io.pravega.controller.store.stream.StoreException;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.shared.controller.event.AbortEvent;
+import io.pravega.shared.controller.event.AutoScaleEvent;
+import io.pravega.shared.controller.event.CommitEvent;
+import io.pravega.shared.controller.event.ControllerEvent;
+import io.pravega.shared.controller.event.DeleteStreamEvent;
+import io.pravega.shared.controller.event.RequestProcessor;
+import io.pravega.shared.controller.event.ScaleOpEvent;
+import io.pravega.shared.controller.event.SealStreamEvent;
+import io.pravega.shared.controller.event.TruncateStreamEvent;
+import io.pravega.shared.controller.event.UpdateStreamEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.withRetries;
+
+@Slf4j
+public abstract class RequestProcessorBase<T extends ControllerEvent> extends SerializedRequestHandler<T> implements RequestProcessor {
+    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> e instanceof StoreException.OperationNotAllowedException;
+
+    protected final StreamMetadataStore streamMetadataStore;
+
+    public RequestProcessorBase(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor) {
+        super(executor);
+        this.streamMetadataStore = streamMetadataStore;
+    }
+
+    abstract String getProcessorName();
+
+    @Override
+    public CompletableFuture<Void> processEvent(ControllerEvent controllerEvent) {
+        return controllerEvent.process(this);
+    }
+
+    @Override
+    public CompletableFuture<Void> processAbortTxnRequest(AbortEvent abortEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processCommitTxnRequest(CommitEvent commitEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processAutoScaleRequest(AutoScaleEvent autoScaleEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processScaleOpRequest(ScaleOpEvent scaleOpEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processUpdateStream(UpdateStreamEvent updateStreamEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processTruncateStream(TruncateStreamEvent truncateStreamEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processSealStream(SealStreamEvent sealStreamEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    @Override
+    public CompletableFuture<Void> processDeleteStream(DeleteStreamEvent deleteStreamEvent) {
+        return Futures.failedFuture(new RequestUnsupportedException(
+                "Request Unsupported"));
+    }
+
+    protected <T extends ControllerEvent> CompletableFuture<Void> withCompletion(StreamTask<T> task, T event, String scope, String stream,
+                                                                                 Predicate<Throwable> writeBackPredicate) {
+        CompletableFuture<Void> resultFuture = new CompletableFuture<>();
+
+        OperationContext context = streamMetadataStore.createContext(scope, stream);
+        suppressException(streamMetadataStore.getWaitingRequest(scope, stream, context, executor), null, "Exception while trying to fetch waiting request. Logged and ignored.")
+                .thenAccept(waitingRequest -> {
+                    if (waitingRequest == null || waitingRequest.equals(getProcessorName())) {
+                        withRetries(() -> task.execute(event), executor)
+                                .whenComplete((r, ex) -> {
+                                    if (ex != null && writeBackPredicate.test(ex)) {
+                                        suppressException(streamMetadataStore.createWaitingRequestIfAbsent(scope, stream, getProcessorName(), context, executor),
+                                                null, "Exception while trying to create waiting request. Logged and ignored.")
+                                                .thenCompose(ignore ->  retryIndefinitelyThenComplete(() -> task.writeBack(event), resultFuture, ex));
+                                    } else {
+                                        // Processing was done for this event, whether it succeeded or failed, we should remove
+                                        // the waiting request if it matches the current processor.
+                                        // If we dont delete it then some other processor will never be able to do the work.
+                                        // So we need to retry indefinitely until deleted.
+                                        retryIndefinitelyThenComplete(() -> streamMetadataStore.deleteWaitingRequestConditionally(scope,
+                                                stream, getProcessorName(), context, executor), resultFuture, ex);
+                                    }
+                                });
+                    } else {
+                        log.debug("Found another processing requested by a different processor. Will postpone the event.");
+                        // This is done to guarantee fairness. If another processor has requested for processing
+                        // on this stream, we will back off and postpone the work for later.
+                        retryIndefinitelyThenComplete(() -> task.writeBack(event), resultFuture,
+                                StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Wait for "));
+                    }
+                });
+
+        return resultFuture;
+    }
+
+    private <R> CompletableFuture<R> suppressException(CompletableFuture<R> future, R returnOnException, String message) {
+        return future.exceptionally(e -> {
+            log.debug(message, e);
+            return returnOnException;
+        });
+    }
+
+    private <T extends ControllerEvent> CompletableFuture<Void> retryIndefinitelyThenComplete(Supplier<CompletableFuture<Void>> futureSupplier,
+                                                                                              CompletableFuture<Void> toComplete, Throwable e) {
+        String failureMessage = String.format("Error writing event back into stream from processor %s", getProcessorName());
+        return Retry.indefinitelyWithExpBackoff(failureMessage)
+                .runAsync(futureSupplier, executor)
+                .thenRun(() -> {
+                    if (e != null) {
+                        toComplete.completeExceptionally(e);
+                    } else {
+                        toComplete.complete(null);
+                    }
+                });
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorBase.java
@@ -145,7 +145,7 @@ public abstract class RequestProcessorBase<T extends ControllerEvent> extends Se
                         // This is done to guarantee fairness. If another processor has requested for processing
                         // on this stream, we will back off and postpone the work for later.
                         retryIndefinitelyThenComplete(() -> task.writeBack(event), resultFuture,
-                                StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Wait for "));
+                                StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Postpone so other processor can work. "));
                     }
                 });
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -10,17 +10,11 @@
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.common.Exceptions;
-import io.pravega.common.concurrent.Futures;
-import io.pravega.common.util.Retry;
-import io.pravega.controller.eventProcessor.impl.SerializedRequestHandler;
 import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
-import io.pravega.controller.store.stream.StoreException;
-import io.pravega.shared.controller.event.AbortEvent;
+import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.shared.controller.event.AutoScaleEvent;
-import io.pravega.shared.controller.event.CommitEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.shared.controller.event.DeleteStreamEvent;
-import io.pravega.shared.controller.event.RequestProcessor;
 import io.pravega.shared.controller.event.ScaleOpEvent;
 import io.pravega.shared.controller.event.SealStreamEvent;
 import io.pravega.shared.controller.event.TruncateStreamEvent;
@@ -30,13 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Predicate;
-
-import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.withRetries;
 
 @Slf4j
-public class StreamRequestHandler extends SerializedRequestHandler<ControllerEvent> implements RequestProcessor {
-    private static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> e instanceof StoreException.OperationNotAllowedException;
+public class StreamRequestHandler extends RequestProcessorBase<ControllerEvent> {
     private final AutoScaleTask autoScaleTask;
     private final ScaleOperationTask scaleOperationTask;
     private final UpdateStreamTask updateStreamTask;
@@ -50,19 +40,15 @@ public class StreamRequestHandler extends SerializedRequestHandler<ControllerEve
                                 SealStreamTask sealStreamTask,
                                 DeleteStreamTask deleteStreamTask,
                                 TruncateStreamTask truncateStreamTask,
+                                StreamMetadataStore streamMetadataStore,
                                 ScheduledExecutorService executor) {
-        super(executor);
+        super(streamMetadataStore, executor);
         this.autoScaleTask = autoScaleTask;
         this.scaleOperationTask = scaleOperationTask;
         this.updateStreamTask = updateStreamTask;
         this.sealStreamTask = sealStreamTask;
         this.deleteStreamTask = deleteStreamTask;
         this.truncateStreamTask = truncateStreamTask;
-    }
-
-    @Override
-    public CompletableFuture<Void> processEvent(ControllerEvent controllerEvent) {
-        return controllerEvent.process(this);
     }
 
     @Override
@@ -73,15 +59,8 @@ public class StreamRequestHandler extends SerializedRequestHandler<ControllerEve
     }
 
     @Override
-    public CompletableFuture<Void> processAbortTxnRequest(AbortEvent abortEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "StreamRequestHandler: abort txn received on Stream Request Multiplexer"));
-    }
-
-    @Override
-    public CompletableFuture<Void> processCommitTxnRequest(CommitEvent commitEvent) {
-        return Futures.failedFuture(new RequestUnsupportedException(
-                "StreamRequestHandler: commit txn received on Stream Request Multiplexer"));
+    String getProcessorName() {
+        return this.getClass().getName();
     }
 
     @Override
@@ -91,50 +70,31 @@ public class StreamRequestHandler extends SerializedRequestHandler<ControllerEve
 
     @Override
     public CompletableFuture<Void> processScaleOpRequest(ScaleOpEvent scaleOpEvent) {
-        return withCompletion(scaleOperationTask, scaleOpEvent,
+        return withCompletion(scaleOperationTask, scaleOpEvent, scaleOpEvent.getScope(), scaleOpEvent.getStream(),
                 OPERATION_NOT_ALLOWED_PREDICATE.or(e -> e instanceof EpochTransitionOperationExceptions.ConflictException));
     }
 
     @Override
     public CompletableFuture<Void> processUpdateStream(UpdateStreamEvent updateStreamEvent) {
-        return withCompletion(updateStreamTask, updateStreamEvent, OPERATION_NOT_ALLOWED_PREDICATE);
+        return withCompletion(updateStreamTask, updateStreamEvent, updateStreamEvent.getScope(), updateStreamEvent.getStream(),
+                OPERATION_NOT_ALLOWED_PREDICATE);
     }
 
     @Override
     public CompletableFuture<Void> processTruncateStream(TruncateStreamEvent truncateStreamEvent) {
-        return withCompletion(truncateStreamTask, truncateStreamEvent, OPERATION_NOT_ALLOWED_PREDICATE);
+        return withCompletion(truncateStreamTask, truncateStreamEvent, truncateStreamEvent.getScope(), truncateStreamEvent.getStream(),
+                OPERATION_NOT_ALLOWED_PREDICATE);
     }
 
     @Override
     public CompletableFuture<Void> processSealStream(SealStreamEvent sealStreamEvent) {
-        return withCompletion(sealStreamTask, sealStreamEvent, OPERATION_NOT_ALLOWED_PREDICATE);
+        return withCompletion(sealStreamTask, sealStreamEvent, sealStreamEvent.getScope(), sealStreamEvent.getStream(),
+                OPERATION_NOT_ALLOWED_PREDICATE);
     }
 
     @Override
     public CompletableFuture<Void> processDeleteStream(DeleteStreamEvent deleteStreamEvent) {
-        return withCompletion(deleteStreamTask, deleteStreamEvent, OPERATION_NOT_ALLOWED_PREDICATE);
-    }
-
-    private <T extends ControllerEvent> CompletableFuture<Void> withCompletion(StreamTask<T> task,
-                                                                               T event,
-                                                                               Predicate<Throwable> writeBackPredicate) {
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        withRetries(() -> task.execute(event), executor)
-                .whenCompleteAsync((r, e) -> {
-                    if (e != null) {
-                        Throwable cause = Exceptions.unwrap(e);
-                        if (writeBackPredicate.test(cause)) {
-                            Retry.indefinitelyWithExpBackoff("Error writing event back into requeststream")
-                                    .runAsync(() -> task.writeBack(event), executor)
-                                    .thenAccept(v -> result.completeExceptionally(cause));
-                        } else {
-                            result.completeExceptionally(cause);
-                        }
-                    } else {
-                        result.complete(r);
-                    }
-                }, executor);
-
-        return result;
+        return withCompletion(deleteStreamTask, deleteStreamEvent, deleteStreamEvent.getScope(), deleteStreamEvent.getStream(),
+                OPERATION_NOT_ALLOWED_PREDICATE);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -59,11 +59,6 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
     }
 
     @Override
-    String getProcessorName() {
-        return this.getClass().getSimpleName();
-    }
-
-    @Override
     public CompletableFuture<Void> processAutoScaleRequest(AutoScaleEvent autoScaleEvent) {
         return autoScaleTask.execute(autoScaleEvent);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
 @Slf4j
-public class StreamRequestHandler extends RequestProcessorBase<ControllerEvent> {
+public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEvent> {
     private final AutoScaleTask autoScaleTask;
     private final ScaleOperationTask scaleOperationTask;
     private final UpdateStreamTask updateStreamTask;
@@ -60,7 +60,7 @@ public class StreamRequestHandler extends RequestProcessorBase<ControllerEvent> 
 
     @Override
     String getProcessorName() {
-        return this.getClass().getName();
+        return this.getClass().getSimpleName();
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -697,8 +697,8 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<String> getWaitingRequest(String scope, String stream, OperationContext context, ScheduledExecutorService executor) {
-        return withCompletion(getStream(scope, stream, context).getWaitingRequest(), executor);
+    public CompletableFuture<String> getWaitingRequestProcessor(String scope, String stream, OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).getWaitingRequestProcessor(), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -690,6 +690,23 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
         return withCompletion(getStream(scope, stream, context).getTransactionsInEpoch(epoch), executor);
     }
 
+    @Override
+    public CompletableFuture<Void> createWaitingRequestIfAbsent(String scope, String stream, String processorName,
+                                                                OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).createWaitingRequestIfAbsent(processorName), executor);
+    }
+
+    @Override
+    public CompletableFuture<String> getWaitingRequest(String scope, String stream, OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).getWaitingRequest(), executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteWaitingRequestConditionally(String scope, String stream, String processorName,
+                                                                     OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).deleteWaitingRequestConditionally(processorName), executor);
+    }
+
     protected Stream getStream(String scope, final String name, OperationContext context) {
         Stream stream;
         if (context != null) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -10,7 +10,6 @@
 package io.pravega.controller.store.stream;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Utf8;
 import com.google.common.collect.ImmutableSet;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -44,6 +44,7 @@ import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1308,7 +1309,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
                             throw new CompletionException(e);
                         }
                     } else {
-                        return String.valueOf(data.getData());
+                        return new String(data.getData());
                     }
                 });
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -44,7 +44,6 @@ import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1299,7 +1298,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
     }
 
     @Override
-    public CompletableFuture<String> getWaitingRequest() {
+    public CompletableFuture<String> getWaitingRequestProcessor() {
         return getWaitingRequestNode()
                 .handle((data, e) -> {
                     if (e != null) {
@@ -1316,7 +1315,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
 
     @Override
     public CompletableFuture<Void> deleteWaitingRequestConditionally(String processorName) {
-        return getWaitingRequest()
+        return getWaitingRequestProcessor()
             .thenCompose(waitingRequest -> {
                 if (waitingRequest != null && waitingRequest.equals(processorName)) {
                     return deleteWaitingRequestNode();

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -445,22 +445,27 @@ interface Stream {
     CompletableFuture<Map<UUID, ActiveTxnRecord>> getTransactionsInEpoch(final int epoch);
 
     /**
-     * TODO: shivesh
-     * @param processorName
-     * @return
+     * This method attempts to create a new Waiting Request node and set the processor's name in the node.
+     * If a node already exists, this attempt is ignored.
+     *
+     * @param processorName name of the request processor that is waiting to get an opportunity for processing.
+     * @return CompletableFuture which indicates that a node was either created successfully or records the failure.
      */
     CompletableFuture<Void> createWaitingRequestIfAbsent(String processorName);
 
     /**
-     * TODO: shivesh
-     * @return
+     * This method fetches existing waiting request processor's name if any. It returns null if no processor is waiting.
+     *
+     * @return CompletableFuture which has the name of the processor that had requested for a wait, or null if there was no
+     * such request.
      */
     CompletableFuture<String> getWaitingRequest();
 
     /**
-     * TODO: shivesh
-     * @param processorName
-     * @return
+     * Delete existing waiting request processor if the name of the existing matches suppied processor name.
+     *
+     * @param processorName processor whose record is to be deleted.
+     * @return CompletableFuture which indicates completion of processing.
      */
     CompletableFuture<Void> deleteWaitingRequestConditionally(String processorName);
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -445,6 +445,26 @@ interface Stream {
     CompletableFuture<Map<UUID, ActiveTxnRecord>> getTransactionsInEpoch(final int epoch);
 
     /**
+     * TODO: shivesh
+     * @param processorName
+     * @return
+     */
+    CompletableFuture<Void> createWaitingRequestIfAbsent(String processorName);
+
+    /**
+     * TODO: shivesh
+     * @return
+     */
+    CompletableFuture<String> getWaitingRequest();
+
+    /**
+     * TODO: shivesh
+     * @param processorName
+     * @return
+     */
+    CompletableFuture<Void> deleteWaitingRequestConditionally(String processorName);
+
+    /**
      * Refresh the stream object. Typically to be used to invalidate any caches.
      * This allows us reuse of stream object without having to recreate a new stream object for each new operation
      */

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -459,7 +459,7 @@ interface Stream {
      * @return CompletableFuture which has the name of the processor that had requested for a wait, or null if there was no
      * such request.
      */
-    CompletableFuture<String> getWaitingRequest();
+    CompletableFuture<String> getWaitingRequestProcessor();
 
     /**
      * Delete existing waiting request processor if the name of the existing matches suppied processor name.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -966,7 +966,7 @@ public interface StreamMetadataStore {
      * @return CompletableFuture which has the name of the processor that had requested for a wait, or null if there was no
      * such request.
      */
-    CompletableFuture<String> getWaitingRequest(String scope, String stream, OperationContext context, ScheduledExecutorService executor);
+    CompletableFuture<String> getWaitingRequestProcessor(String scope, String stream, OperationContext context, ScheduledExecutorService executor);
 
     /**
      * Delete existing waiting request processor if the name of the existing matches suppied processor name.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -943,7 +943,6 @@ public interface StreamMetadataStore {
                                                                          final OperationContext context, final ScheduledExecutorService executor);
 
     /**
-     /**
      * This method attempts to create a new Waiting Request node and set the processor's name in the node.
      * If a node already exists, this attempt is ignored.
      *

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -944,34 +944,40 @@ public interface StreamMetadataStore {
                                                                          final OperationContext context, final ScheduledExecutorService executor);
 
     /**
-     * TODO: shivesh
-     * @param scope
-     * @param stream
-     * @param processorName
-     * @param context
-     * @param executor
-     * @return
+     /**
+     * This method attempts to create a new Waiting Request node and set the processor's name in the node.
+     * If a node already exists, this attempt is ignored.
+     *
+     * @param scope scope
+     * @param stream stream
+     * @param processorName name of the request processor that is waiting to get an opportunity for processing.
+     * @param context operation context
+     * @param executor executor
+     * @return CompletableFuture which indicates that a node was either created successfully or records the failure.
      */
     CompletableFuture<Void> createWaitingRequestIfAbsent(String scope, String stream, String processorName, OperationContext context, ScheduledExecutorService executor);
 
     /**
-     * TODO: shivesh
-     * @param scope
-     * @param stream
-     * @param context
-     * @param executor
-     * @return
+     * This method fetches existing waiting request processor's name if any. It returns null if no processor is waiting.
+     *
+     * @param scope scope
+     * @param stream stream
+     * @param context operation context
+     * @param executor executor
+     * @return CompletableFuture which has the name of the processor that had requested for a wait, or null if there was no
+     * such request.
      */
     CompletableFuture<String> getWaitingRequest(String scope, String stream, OperationContext context, ScheduledExecutorService executor);
 
     /**
-     * TODO shivesh
-     * @param scope
-     * @param stream
-     * @param processorName
-     * @param context
-     * @param executor
-     * @return
+     * Delete existing waiting request processor if the name of the existing matches suppied processor name.
+     *
+     * @param scope scope
+     * @param stream stream
+     * @param processorName processor name which is to be deleted if it matches the name in waiting record in the store.
+     * @param context operation context
+     * @param executor executor
+     * @return CompletableFuture which indicates completion of processing.
      */
     CompletableFuture<Void> deleteWaitingRequestConditionally(String scope, String stream, String processorName, OperationContext context, ScheduledExecutorService executor);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -941,4 +942,36 @@ public interface StreamMetadataStore {
      */
     CompletableFuture<Map<UUID, ActiveTxnRecord>> getTransactionsInEpoch(final String scope, final String stream, final int epoch,
                                                                          final OperationContext context, final ScheduledExecutorService executor);
+
+    /**
+     * TODO: shivesh
+     * @param scope
+     * @param stream
+     * @param processorName
+     * @param context
+     * @param executor
+     * @return
+     */
+    CompletableFuture<Void> createWaitingRequestIfAbsent(String scope, String stream, String processorName, OperationContext context, ScheduledExecutorService executor);
+
+    /**
+     * TODO: shivesh
+     * @param scope
+     * @param stream
+     * @param context
+     * @param executor
+     * @return
+     */
+    CompletableFuture<String> getWaitingRequest(String scope, String stream, OperationContext context, ScheduledExecutorService executor);
+
+    /**
+     * TODO shivesh
+     * @param scope
+     * @param stream
+     * @param processorName
+     * @param context
+     * @param executor
+     * @return
+     */
+    CompletableFuture<Void> deleteWaitingRequestConditionally(String scope, String stream, String processorName, OperationContext context, ScheduledExecutorService executor);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -577,8 +577,8 @@ class ZKStream extends PersistentStreamBase<Integer> {
 
     @Override
     CompletableFuture<Void> createWaitingRequestNodeIfAbsent(byte[] waitingRequestProcessor) {
-        return store.createZNodeIfNotExist(committingTxnsPath, waitingRequestProcessor)
-                .thenApply(x -> cache.invalidateCache(committingTxnsPath));
+        return store.createZNodeIfNotExist(waitingRequestProcessorPath, waitingRequestProcessor)
+                .thenApply(x -> cache.invalidateCache(waitingRequestProcessorPath));
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithZKStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithZKStreamTest.java
@@ -112,6 +112,7 @@ public class ControllerServiceWithZKStreamTest {
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executor),
                 new DeleteStreamTask(streamMetadataTasks, streamStore, executor),
                 new TruncateStreamTask(streamMetadataTasks, streamStore, executor),
+                streamStore,
                 executor);
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executor));

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -163,7 +163,7 @@ public class ScaleRequestHandlerTest {
     public void testScaleRequest() throws ExecutionException, InterruptedException {
         AutoScaleTask requestHandler = new AutoScaleTask(streamMetadataTasks, streamStore, executor);
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
-        StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler, null, null, null, null, executor);
+        StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler, null, null, null, null, streamStore, executor);
         // Send number of splits = 1
         EventWriterMock writer = new EventWriterMock();
 
@@ -260,7 +260,7 @@ public class ScaleRequestHandlerTest {
 
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
         StreamRequestHandler requestHandler = new StreamRequestHandler(null, scaleRequestHandler,
-                null, null, null, null, executor);
+                null, null, null, null, streamStore, executor);
         CommitRequestHandler commitRequestHandler = new CommitRequestHandler(streamStore, streamMetadataTasks, streamTransactionMetadataTasks, executor);
 
         // 1 create transaction on old epoch and set it to committing
@@ -325,7 +325,7 @@ public class ScaleRequestHandlerTest {
 
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
         StreamRequestHandler requestHandler = new StreamRequestHandler(null, scaleRequestHandler,
-                null, null, null, null, executor);
+                null, null, null, null, streamStore, executor);
         CommitRequestHandler commitRequestHandler = new CommitRequestHandler(streamStore, streamMetadataTasks, streamTransactionMetadataTasks, executor);
 
         // 1 create transaction on old epoch and set it to committing
@@ -382,7 +382,7 @@ public class ScaleRequestHandlerTest {
 
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
         StreamRequestHandler requestHandler = new StreamRequestHandler(null, scaleRequestHandler,
-                null, null, null, null, executor);
+                null, null, null, null, streamStore, executor);
         CommitRequestHandler commitRequestHandler = new CommitRequestHandler(streamStore, streamMetadataTasks, streamTransactionMetadataTasks, executor);
 
         // 1 create transaction on old epoch and set it to committing
@@ -435,7 +435,8 @@ public class ScaleRequestHandlerTest {
 
         AutoScaleTask requestHandler = new AutoScaleTask(streamMetadataTasks, streamStore, executor);
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
-        StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler, null, null, null, null, executor);
+        StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler, null,
+                null, null, null, streamStore, executor);
         // Send number of splits = 1
         EventWriterMock writer = new EventWriterMock();
 

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -1,0 +1,188 @@
+package io.pravega.controller.server.eventProcessor.requesthandlers;
+
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.controller.store.stream.StoreException;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.shared.controller.event.ControllerEvent;
+import io.pravega.shared.controller.event.RequestProcessor;
+import io.pravega.test.common.AssertExtensions;
+import lombok.Data;
+import org.junit.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class RequestProcessorTest {
+
+    @Data
+    public class TestEvent1 implements ControllerEvent {
+        private final String scope;
+        private final String stream;
+        private final Supplier<CompletableFuture<Void>> toExecute;
+
+        @Override
+        public String getKey() {
+            return scope + stream;
+        }
+
+        @Override
+        public CompletableFuture<Void> process(RequestProcessor processor) {
+            return ((TestRequestProcessor1) processor).testProcess(this);
+        }
+    }
+
+    @Data
+    public class TestEvent2 implements ControllerEvent {
+        private final String scope;
+        private final String stream;
+        private final Supplier<CompletableFuture<Void>> toExecute;
+
+        @Override
+        public String getKey() {
+            return scope + stream;
+        }
+
+        @Override
+        public CompletableFuture<Void> process(RequestProcessor processor) {
+            return ((TestRequestProcessor2) processor).testProcess(this);
+        }
+    }
+
+    public class TestRequestProcessor1 extends AbstractRequestProcessor<TestEvent1> implements StreamTask<TestEvent1> {
+        private final BlockingQueue<TestEvent1> queue;
+        public TestRequestProcessor1(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor, BlockingQueue<TestEvent1> queue) {
+            super(streamMetadataStore, executor);
+            this.queue = queue;
+        }
+
+        @Override
+        String getProcessorName() {
+            return this.getClass().getSimpleName();
+        }
+
+        public CompletableFuture<Void> testProcess(TestEvent1 event) {
+            return withCompletion(this, event, event.scope, event.stream, OPERATION_NOT_ALLOWED_PREDICATE);
+        }
+
+        @Override
+        public CompletableFuture<Void> execute(TestEvent1 event) {
+            return event.toExecute.get();
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBack(TestEvent1 event) {
+            queue.add(event);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public class TestRequestProcessor2 extends AbstractRequestProcessor<TestEvent2> implements StreamTask<TestEvent2> {
+        private final BlockingQueue<TestEvent2> queue;
+        public TestRequestProcessor2(StreamMetadataStore streamMetadataStore, ScheduledExecutorService executor, BlockingQueue<TestEvent2> queue) {
+            super(streamMetadataStore, executor);
+            this.queue = queue;
+        }
+
+        @Override
+        String getProcessorName() {
+            return this.getClass().getSimpleName();
+        }
+
+        public CompletableFuture<Void> testProcess(TestEvent2 event) {
+            return withCompletion(this, event, event.scope, event.stream, OPERATION_NOT_ALLOWED_PREDICATE);
+        }
+
+        @Override
+        public CompletableFuture<Void> execute(TestEvent2 event) {
+            return event.toExecute.get();
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBack(TestEvent2 event) {
+            queue.add(event);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    abstract StreamMetadataStore getStore();
+    abstract ScheduledExecutorService getExecutor();
+
+    @Test(timeout = 30000)
+    public void testRequestProcessor() throws InterruptedException {
+        BlockingQueue<TestEvent1> queue1 = new LinkedBlockingQueue<>();
+        TestRequestProcessor1 requestProcessor1 = new TestRequestProcessor1(getStore(), getExecutor(), queue1);
+
+        BlockingQueue<TestEvent2> queue2 = new LinkedBlockingQueue<>();
+        TestRequestProcessor2 requestProcessor2 = new TestRequestProcessor2(getStore(), getExecutor(), queue2);
+
+        String stream = "test";
+        String scope = "test";
+        CompletableFuture<Void> waitForIt1 = new CompletableFuture<>();
+        CompletableFuture<Void> waitForIt2 = new CompletableFuture<>();
+
+        TestEvent1 event11 = new TestEvent1(scope, stream, () -> {
+            waitForIt1.join();
+            return CompletableFuture.completedFuture(null);
+        });
+        TestEvent1 event12 = new TestEvent1(scope, stream, () -> CompletableFuture.completedFuture(null));
+
+        TestEvent2 event21 = new TestEvent2(scope, stream, () -> Futures.failedFuture(StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Failing processing")));
+        TestEvent2 event22 = new TestEvent2(scope, stream, () -> {
+            waitForIt2.join();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        // 1. start test event1 processing on processor 1.. dont let this complete.
+        CompletableFuture<Void> processing11 = requestProcessor1.process(event11);
+
+        // 2. start test event2 processing on processor 2.. make this fail with OperationNotAllowed and verify that it gets postponed.
+        AssertExtensions.assertThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
+        // also verify that store has set the processor name of processor 2.
+        String waitingProcessor = getStore().getWaitingRequest(scope, stream, null, getExecutor()).join();
+        assertEquals(TestRequestProcessor2.class.getSimpleName(), waitingProcessor);
+        TestEvent2 taken2 = requestProcessor2.queue.take();
+        assertEquals(taken2, event21);
+
+        // 3. signal processing on processor 1 to complete.
+        waitForIt1.complete(null);
+
+        // processing11 should complete successfully.
+        processing11.join();
+
+        // 4. submit another processing for processor1. this should get postponed too but processor name should not change.
+        AssertExtensions.assertThrows("This should fail and event should be reposted", requestProcessor1.process(event12),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
+        TestEvent1 taken1 = requestProcessor1.queue.take();
+        assertEquals(taken1, event12);
+
+        // 5. now try processing event on processor 2. this should start successfully.
+        CompletableFuture<Void> processing22 = requestProcessor2.process(event22);
+
+        // 6. try to start a new processing on processor 1 while processing on `2` is ongoing. This should fail but should not be able
+        // to change the processor name.
+        AssertExtensions.assertThrows("This should fail without even starting", requestProcessor1.process(event12),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
+
+        waitingProcessor = getStore().getWaitingRequest(scope, stream, null, getExecutor()).join();
+        assertEquals(TestRequestProcessor2.class.getSimpleName(), waitingProcessor);
+        taken1 = requestProcessor1.queue.take();
+        assertEquals(taken1, event12);
+
+        // 7. complete processing on `2`.
+        waitForIt2.complete(null);
+        processing22.join();
+
+        // 8. verify that wait processor name is cleaned up.
+        waitingProcessor = getStore().getWaitingRequest(scope, stream, null, getExecutor()).join();
+        assertEquals(null, waitingProcessor);
+    }
+
+}

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -142,10 +142,10 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
             return CompletableFuture.completedFuture(null);
         });
 
-        // 1. start test event1 processing on processor 1.. dont let this complete.
+        // 1. start test event1 processing on processor 1. Don't let this complete.
         CompletableFuture<Void> processing11 = requestProcessor1.process(event11);
 
-        // 2. start test event2 processing on processor 2.. make this fail with OperationNotAllowed and verify that it gets postponed.
+        // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
         AssertExtensions.assertThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // also verify that store has set the processor name of processor 2.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
@@ -19,26 +19,14 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class RequestProcessorWithInMemoryStore extends RequestProcessorTest {
     private StreamMetadataStore store;
-    private ScheduledExecutorService executorService;
 
     @Before
     public void setUp() {
-        executorService = Executors.newScheduledThreadPool(2);
-        store = StreamStoreFactory.createInMemoryStore(executorService);
-    }
-
-    @After
-    public void tearDown() {
-        executorService.shutdown();
+        store = StreamStoreFactory.createInMemoryStore(executorService());
     }
 
     @Override
     StreamMetadataStore getStore() {
         return store;
-    }
-
-    @Override
-    ScheduledExecutorService getExecutor() {
-        return executorService;
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
@@ -1,0 +1,35 @@
+package io.pravega.controller.server.eventProcessor.requesthandlers;
+
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class RequestProcessorWithInMemoryStore extends RequestProcessorTest {
+    private StreamMetadataStore store;
+    private ScheduledExecutorService executorService;
+
+    @Before
+    public void setUp() {
+        executorService = Executors.newScheduledThreadPool(2);
+        store = StreamStoreFactory.createInMemoryStore(executorService);
+    }
+
+    @After
+    public void tearDown() {
+        executorService.shutdown();
+    }
+
+    @Override
+    StreamMetadataStore getStore() {
+        return store;
+    }
+
+    @Override
+    ScheduledExecutorService getExecutor() {
+        return executorService;
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
@@ -11,11 +11,7 @@ package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.StreamStoreFactory;
-import org.junit.After;
 import org.junit.Before;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class RequestProcessorWithInMemoryStore extends RequestProcessorTest {
     private StreamMetadataStore store;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.controller.store.stream.StreamMetadataStore;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
@@ -25,35 +25,27 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class RequestProcessorWithZkStore extends RequestProcessorTest {
     private StreamMetadataStore store;
-    private ScheduledExecutorService executorService;
     private CuratorFramework client;
     private TestingServer zkServer;
 
     @Before
     public void setUp() throws Exception {
-        executorService = Executors.newScheduledThreadPool(2);
         zkServer = new TestingServerStarter().start();
         client = CuratorFrameworkFactory.newClient(zkServer.getConnectString(),
             new ExponentialBackoffRetry(200, 10, 5000));
         client.start();
 
-    store = StreamStoreFactory.createZKStore(client, executorService);
+    store = StreamStoreFactory.createZKStore(client, executorService());
     }
 
     @After
     public void tearDown() throws IOException {
         client.close();
         zkServer.close();
-        executorService.shutdown();
     }
 
     @Override
     StreamMetadataStore getStore() {
         return store;
-    }
-
-    @Override
-    ScheduledExecutorService getExecutor() {
-        return executorService;
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
@@ -20,8 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class RequestProcessorWithZkStore extends RequestProcessorTest {
     private StreamMetadataStore store;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
@@ -1,0 +1,50 @@
+package io.pravega.controller.server.eventProcessor.requesthandlers;
+
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import io.pravega.test.common.TestingServerStarter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class RequestProcessorWithZkStore extends RequestProcessorTest {
+    private StreamMetadataStore store;
+    private ScheduledExecutorService executorService;
+    private CuratorFramework client;
+    private TestingServer zkServer;
+
+    @Before
+    public void setUp() throws Exception {
+        executorService = Executors.newScheduledThreadPool(2);
+        zkServer = new TestingServerStarter().start();
+        client = CuratorFrameworkFactory.newClient(zkServer.getConnectString(),
+            new ExponentialBackoffRetry(200, 10, 5000));
+        client.start();
+
+    store = StreamStoreFactory.createZKStore(client, executorService);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        client.close();
+        zkServer.close();
+        executorService.shutdown();
+    }
+
+    @Override
+    StreamMetadataStore getStore() {
+        return store;
+    }
+
+    @Override
+    ScheduledExecutorService getExecutor() {
+        return executorService;
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.controller.store.stream.StreamMetadataStore;

--- a/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
@@ -79,6 +79,7 @@ public class InMemoryControllerServiceImplTest extends ControllerServiceImplTest
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executorService),
                 new DeleteStreamTask(streamMetadataTasks, streamStore, executorService),
                 new TruncateStreamTask(streamMetadataTasks, streamStore, executorService),
+                streamStore,
                 executorService);
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));

--- a/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
@@ -101,6 +101,7 @@ public class ZKControllerServiceImplTest extends ControllerServiceImplTest {
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executorService),
                 new DeleteStreamTask(streamMetadataTasks, streamStore, executorService),
                 new TruncateStreamTask(streamMetadataTasks, streamStore, executorService),
+                streamStore,
                 executorService);
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -153,6 +153,7 @@ public class StreamMetadataTasksTest {
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStorePartialMock, executor),
                 new DeleteStreamTask(streamMetadataTasks, streamStorePartialMock, executor),
                 new TruncateStreamTask(streamMetadataTasks, streamStorePartialMock, executor),
+                streamStorePartialMock,
                 executor);
         consumer = new ControllerService(streamStorePartialMock, hostStore, streamMetadataTasks,
                 streamTransactionMetadataTasks, segmentHelperMock, executor, null);


### PR DESCRIPTION
**Change log description**
* Since CommitEventProcessor and StreamEventProcessor run concurrently, each trying to acquire processing rights by setting the state, we have introduced a fairness mechanism so that one processing does not starve another. 

**Purpose of the change**
Fixes #2696 

**What the code does**
It introduces a common parent class for all request-processors called `AbstractRequestProcessor`.
This implements failing request processing for each type of event by default. It also provides a common method called `withCompletion` which ensures that a task is processed only if "fairness" allows for it. 
Fairness is ensured by making sure that if a task fails because it is unable to start processing due to conflict with other processing, it "tries" to set its processors name as the waitingProcessor. 
Any new event processing on a request processor that does not share the name in the waitingProcessor is postponed. 
This ensures that if there are processors waiting to process events, we do not allow any other processor to run away with all processing cycles and starve other processors. 
So now CommitRequestHandler and StreamRequestHandler derives from this AbstractRequestProcessor and make use of the withCompletion method. 
The store interfaces and implementations are also changed to include new apis for creating, getting and conditionally cleaning the "waiting processor" node. 

Here is a rough flow:
```
1. getWaitingProcessor
2. if waitingProcessor == null OR waitingProcessor == currentProcessor
attempt to process event
else postpone processing
3. upon processing completion, 
if processing failed with predicate that tells us to postpone, then try to create waiting processor = curentProcessor
else if processing succeed or failed with any other exception, delete waiting processor if it is equal to current processor. 
```
**How to verify it**
Unit tests added. 