### PR TITLE
Issue 2706: Sporadic Unit test failure: RequestProcessorTest.testRequestProcessor 

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -32,7 +32,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
     @Override
     public int getThreadPoolSize() {
-        return 2;
+        return 5;
     }
 
     @Data
@@ -128,10 +128,12 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         String stream = "test";
         String scope = "test";
         CompletableFuture<Void> started1 = new CompletableFuture<>();
+        CompletableFuture<Void> started2 = new CompletableFuture<>();
         CompletableFuture<Void> waitForIt1 = new CompletableFuture<>();
         CompletableFuture<Void> waitForIt2 = new CompletableFuture<>();
 
         TestEvent1 event11 = new TestEvent1(scope, stream, () -> {
+            started1.complete(null);
             waitForIt1.join();
             return CompletableFuture.completedFuture(null);
         });
@@ -139,14 +141,14 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
         TestEvent2 event21 = new TestEvent2(scope, stream, () -> Futures.failedFuture(StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Failing processing")));
         TestEvent2 event22 = new TestEvent2(scope, stream, () -> {
-            started1.complete(null);
+            started2.complete(null);
             waitForIt2.join();
             return CompletableFuture.completedFuture(null);
         });
 
         // 1. start test event1 processing on processor 1. Don't let this complete.
         CompletableFuture<Void> processing11 = requestProcessor1.process(event11);
-        // wait to ensure it is started. 
+        // wait to ensure it is started.
         started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
@@ -172,7 +174,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
         // 5. now try processing event on processor 2. this should start successfully.
         CompletableFuture<Void> processing22 = requestProcessor2.process(event22);
-
+        started2.join();
         // 6. try to start a new processing on processor 1 while processing on `2` is ongoing. This should fail but should not be able
         // to change the processor name.
         AssertExtensions.assertThrows("This should fail without even starting", requestProcessor1.process(event12),

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -32,7 +32,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
     @Override
     public int getThreadPoolSize() {
-        return 5;
+        return 2;
     }
 
     @Data

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -127,6 +127,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
         String stream = "test";
         String scope = "test";
+        CompletableFuture<Void> started1 = new CompletableFuture<>();
         CompletableFuture<Void> waitForIt1 = new CompletableFuture<>();
         CompletableFuture<Void> waitForIt2 = new CompletableFuture<>();
 
@@ -138,12 +139,15 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
 
         TestEvent2 event21 = new TestEvent2(scope, stream, () -> Futures.failedFuture(StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Failing processing")));
         TestEvent2 event22 = new TestEvent2(scope, stream, () -> {
+            started1.complete(null);
             waitForIt2.join();
             return CompletableFuture.completedFuture(null);
         });
 
         // 1. start test event1 processing on processor 1. Don't let this complete.
         CompletableFuture<Void> processing11 = requestProcessor1.process(event11);
+        // wait to ensure it is started. 
+        started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
         AssertExtensions.assertThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21),


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
Fixes a race in test where it doesnt wait for processing to start before creating "waiting processor for 2nd processor". 

**Purpose of the change**
Fixes #2706 

**What the code does**
The code posts an event for processing (on processor 1) and then simulates condition such that a processing on another processor (processor 2). Processor 2 duly registers itself a "waiting processor". 
However, if processing 1 starts after the waiting processor has been set, it gets postponed. 
The test's intent is to start processing 1 and then postpone processing 2. 
So i had added a future latch called "started" that is used to coordinate and ensure we start the processing before creating "waiting processor"

**How to verify it**
The test should pass 100%