### PR TITLE
Issue 2697: Handle case where buffer returned from a serializer does not implement .array()

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.client.stream.impl;
 
 import io.pravega.client.stream.Serializer;

--- a/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
@@ -1,0 +1,21 @@
+package io.pravega.client.stream.impl;
+
+import io.pravega.client.stream.Serializer;
+import java.nio.ByteBuffer;
+
+/**
+ * An implementation of {@link Serializer} that accepts byteBuffers.
+ */
+public class ByteBufferSerializer implements Serializer<ByteBuffer> {
+
+    @Override
+    public ByteBuffer serialize(ByteBuffer value) {
+        return value.slice().asReadOnlyBuffer();
+    }
+
+    @Override
+    public ByteBuffer deserialize(ByteBuffer serializedValue) {
+        return serializedValue.slice();
+    }
+
+}

--- a/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
@@ -1,0 +1,43 @@
+package io.pravega.client.stream.impl;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ByteSerializerTest {
+
+    @Test
+    public void testByteArraySerializer() {
+        ByteArraySerializer arraySerializer = new ByteArraySerializer();
+        byte[] array = new byte[] { 1, 2, 3 };
+        ByteBuffer serialized = arraySerializer.serialize(array);
+        assertTrue(Arrays.equals(array, arraySerializer.deserialize(serialized)));
+        byte[] emptyArray = new byte[] { };
+        serialized = arraySerializer.serialize(emptyArray);
+        assertTrue(Arrays.equals(emptyArray, arraySerializer.deserialize(serialized)));
+    }
+
+    @Test
+    public void testByteBufferSerializer() {
+        ByteBufferSerializer serializer = new ByteBufferSerializer();
+        ByteBuffer buff = ByteBuffer.wrap(new byte[] { 1, 2, 3 });
+        ByteBuffer serialized = serializer.serialize(buff);
+        assertEquals(buff, serializer.deserialize(serialized));
+        
+        serialized.position(serialized.position()+1);
+        assertEquals(2, serialized.remaining());
+        assertEquals(3, buff.remaining());
+        
+        ByteBuffer subBuffer = serializer.serialize(serialized);
+        assertEquals(2, serializer.deserialize(subBuffer).capacity());
+       
+        
+        ByteBuffer empty = ByteBuffer.allocate(0);
+        serialized = serializer.serialize(empty);
+        assertEquals(empty, serializer.deserialize(serialized));
+    }
+    
+}

--- a/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.client.stream.impl;
 
 import java.nio.ByteBuffer;
@@ -26,18 +35,16 @@ public class ByteSerializerTest {
         ByteBuffer buff = ByteBuffer.wrap(new byte[] { 1, 2, 3 });
         ByteBuffer serialized = serializer.serialize(buff);
         assertEquals(buff, serializer.deserialize(serialized));
-        
+
         serialized.position(serialized.position()+1);
         assertEquals(2, serialized.remaining());
         assertEquals(3, buff.remaining());
-        
+
         ByteBuffer subBuffer = serializer.serialize(serialized);
         assertEquals(2, serializer.deserialize(subBuffer).capacity());
-       
-        
+
         ByteBuffer empty = ByteBuffer.allocate(0);
         serialized = serializer.serialize(empty);
         assertEquals(empty, serializer.deserialize(serialized));
     }
-    
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -18,6 +18,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -392,7 +393,7 @@ public final class WireCommands {
         public void writeFields(DataOutput out) throws IOException {
             out.writeInt(type.getCode());
             out.writeInt(data.readableBytes());
-            out.write(data.array(), data.arrayOffset(), data.readableBytes());
+            data.getBytes(data.readerIndex(), (OutputStream) out, data.readableBytes());
         }
 
         public static Event readFrom(DataInput in, int length) throws IOException {

--- a/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.test.integration;
 
 import io.netty.util.internal.logging.InternalLoggerFactory;

--- a/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
@@ -1,0 +1,98 @@
+package io.pravega.test.integration;
+
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.Slf4JLoggerFactory;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ByteBufferSerializer;
+import io.pravega.client.stream.mock.MockClientFactory;
+import io.pravega.client.stream.mock.MockStreamManager;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IdleSegmentTest {
+
+    private ServiceBuilder serviceBuilder;
+
+    @Before
+    public void setup() throws Exception {
+        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
+        this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        this.serviceBuilder.initialize();
+    }
+
+    @After
+    public void teardown() {
+        this.serviceBuilder.close();
+    }
+
+    @Test(timeout = 5000)
+    public void testByteBufferEventsWithIdleSegments() throws ReinitializationRequiredException {
+        String endpoint = "localhost";
+        String streamName = "abc";
+        String readerName = "reader";
+        String readerGroup = "group";
+        int port = TestUtils.getAvailableListenPort();
+        ByteBuffer testPayload = ByteBuffer.allocate(100);
+        String scope = "Scope1";
+        StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();
+        @Cleanup
+        PravegaConnectionListener server = new PravegaConnectionListener(false, port, store);
+        server.startListening();
+        @Cleanup
+        MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
+        MockClientFactory clientFactory = streamManager.getClientFactory();
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
+                                                         .stream(Stream.of(scope, streamName))
+                                                         .disableAutomaticCheckpoints()
+                                                         .build();
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName,
+                                   StreamConfiguration.builder()
+                                                      .scope(scope)
+                                                      .streamName(streamName)
+                                                      .scalingPolicy(ScalingPolicy.fixed(20))
+                                                      .build());
+        streamManager.createReaderGroup(readerGroup, groupConfig);
+        Serializer<ByteBuffer> serializer = new ByteBufferSerializer();
+        EventStreamWriter<ByteBuffer> producer = clientFactory.createEventWriter(streamName, serializer,
+                                                                             EventWriterConfig.builder().build());
+        List<CompletableFuture<Void>> results = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            results.add(producer.writeEvent("FixedRoutingKey", testPayload));
+            System.out.println("Writing event " + i);
+        }
+        producer.flush();
+        System.err.println(results);
+
+        @Cleanup
+        EventStreamReader<ByteBuffer> reader = clientFactory.createReader(readerName, readerGroup, serializer,
+                                                                      ReaderConfig.builder().build());
+        for (int i = 0; i < 10; i++) {
+            ByteBuffer read = reader.readNextEvent(10000).getEvent();
+            assertEquals(testPayload, read);
+        }
+    }
+
+}


### PR DESCRIPTION
**Change log description**
* Allow serializers to produces a ByteBuffer not backed by an array.
* Add a ByteBufferSerializer

**Purpose of the change**
Fixes #2697. 
Previously if a ByteBuffer that did not allow calling .array() was emitted by a serializer it would result in an exception being thrown. 

**What the code does**
This deals with that case by using a method provided by byteBuffer to write itself to an output stream. 
Unfortunately this involves a cast. (While it is always hold true, it cannot be avoided because there are multiple implementation for the output streams passed depending on the write which don't share a common super class)

**How to verify it**
The newly added integration test should pass. (It does not without the change)