### PR TITLE
Issue 2717: Bump version for release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ typesafeConfigVersion=1.3.1
 gradleGitPluginVersion=2.2.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.3.0-SNAPSHOT
+pravegaVersion=0.4.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Bumping version from 0.3.0-SNAPSHOT to 0.4.0-SNAPSHOT
Fixes #2717 

**Purpose of the change**
Release 0.3.0

**What the code does**
Changes master to be defined in terms of the unreleased 0.4 version

**How to verify it**
Manually.