### PR TITLE
Issue 2719: Changing default value for `bookkeeper.zkAddress`.

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -218,7 +218,7 @@ metrics.enableStatistics=false
 
 # Endpoint address (hostname:port) where the ZooKeeper controlling BookKeeper for this cluster can be found at.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
-bookkeeper.zkAddress=master.mesos:2181
+bookkeeper.zkAddress=localhost:2181
 
 # Default root path for BookKeeper Ledger metadata.  This property tells the BookKeeper client where to look up
 # Ledger Metadata for the BookKeeper cluster it is connecting to. If this property isn't uncommented, then the

--- a/config/config.properties
+++ b/config/config.properties
@@ -218,7 +218,7 @@ metrics.enableStatistics=false
 
 # Endpoint address (hostname:port) where the ZooKeeper controlling BookKeeper for this cluster can be found at.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
-bookkeeper.zkAddress=localhost:2181
+#bookkeeper.zkAddress=localhost:2181
 
 # Default root path for BookKeeper Ledger metadata.  This property tells the BookKeeper client where to look up
 # Ledger Metadata for the BookKeeper cluster it is connecting to. If this property isn't uncommented, then the


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
Changing value of `bookkeeper.zkAddress` from `master.mesos` to `localhost.`

**Purpose of the change**
Fixes #2719.

**What the code does**
Changing value of `bookkeeper.zkAddress` from `master.mesos` to `localhost.`

**How to verify it**
