### PR TITLE
Issue 2718: Substitute jsr311-api with javax.ws.rs-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ allprojects {
             force "com.google.guava:guava:" + guavaVersion
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
+       		dependencySubstitution {
+            	substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
+        	}
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,9 @@ allprojects {
             force "com.google.guava:guava:" + guavaVersion
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
-       		dependencySubstitution {
-            	substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
-        	}
+            dependencySubstitution {
+                substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
+            }
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
Substitute jsr311-api with javax.ws.rs-api.

**Purpose of the change**
Fixes #2718.
The jsr jar was causing exception when it was included in the classpath where the newer api was expected. This forces the resolution in favor of the newer API.

**What the code does**
Instructs gradle to substitute javax.ws.rs-api for jsr311-api. 

**How to verify it**
System tests.
