### PR TITLE
Issue 2718: Substitute jsr311-api with javax.ws.rs-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ allprojects {
             force "com.google.guava:guava:" + guavaVersion
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
+       		dependencySubstitution {
+            	substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
+        	}
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,9 @@ allprojects {
             force "com.google.guava:guava:" + guavaVersion
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
-       		dependencySubstitution {
-            	substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
-        	}
+            dependencySubstitution {
+                substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
+            }
         }
     }
 }


### PR DESCRIPTION
**Change log description**
Substitute jsr311-api with javax.ws.rs-api.

**Purpose of the change**
This is the same as #2723 but for the release branch.

**What the code does**
see #2723

**How to verify it**
System tests.
