### PR TITLE
Issue 2728: Change pravegaVersion to 0.3.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ typesafeConfigVersion=1.3.1
 gradleGitPluginVersion=2.2.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.3.0
+pravegaVersion=0.3.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**
Change pravegaVersion from 0.3.0 to 0.3.1-SNAPSHOT

**Purpose of the change**
Ensures any future changes are considered part of the 0.3.1 pre-release as opposed to being part of 0.3.0.

**What the code does**
Changes the version used by gradle in it's tasks.

**How to verify it**
Manually