### PR TITLE
Issue 2711: Fix possible attack surface from grpc header marshalling

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
@@ -18,6 +18,14 @@ import java.util.Map;
  * All implementations must support Java serialization.
  */
 public interface Credentials extends Serializable {
+
+    /**
+     * Prefix added by the client to the grpc header.
+     * Pravega client prefixes all the parameters with this before sending it over grpc.
+     * This will ensure that rest of the grpc parameters are not sent to the handlers.
+     */
+    String AUTH_HANDLER_PREFIX = "PRAVEG_AUTH_";
+
     /**
      * Returns the authentication type.
      * Pravega can support multiple authentication types in a single deployment.

--- a/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
@@ -24,7 +24,7 @@ public interface Credentials extends Serializable {
      * Pravega client prefixes all the parameters with this before sending it over grpc.
      * This will ensure that rest of the grpc parameters are not sent to the handlers.
      */
-    String AUTH_HANDLER_PREFIX = "PRAVEG_AUTH_";
+    String AUTH_HANDLER_PREFIX = "pravega_auth_";
 
     /**
      * Returns the authentication type.

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
@@ -32,12 +32,13 @@ public class PravegaCredsWrapper extends com.google.auth.Credentials {
     public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
         Map<String, String> metadata = creds.getAuthParameters();
 
-        Map<String, List<String>> retVal = metadata.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                e -> {
-                    List<String> list = Collections.singletonList(e.getValue());
-                    return list;
-                }));
-        retVal.put("method", Collections.singletonList(creds.getAuthenticationType()));
+        Map<String, List<String>> retVal = metadata.entrySet().stream().collect(
+                Collectors.toMap(entry -> Credentials.AUTH_HANDLER_PREFIX + entry.getKey(),
+                        e -> {
+                            List<String> list = Collections.singletonList(e.getValue());
+                            return list;
+                        }));
+        retVal.put(Credentials.AUTH_HANDLER_PREFIX + "method", Collections.singletonList(creds.getAuthenticationType()));
         return retVal;
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredsWrapper.java
@@ -34,10 +34,7 @@ public class PravegaCredsWrapper extends com.google.auth.Credentials {
 
         Map<String, List<String>> retVal = metadata.entrySet().stream().collect(
                 Collectors.toMap(entry -> Credentials.AUTH_HANDLER_PREFIX + entry.getKey(),
-                        e -> {
-                            List<String> list = Collections.singletonList(e.getValue());
-                            return list;
-                        }));
+                        e -> Collections.singletonList(e.getValue())));
         retVal.put(Credentials.AUTH_HANDLER_PREFIX + "method", Collections.singletonList(creds.getAuthenticationType()));
         return retVal;
     }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -21,6 +21,7 @@ import io.grpc.Status;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.pravega.auth.AuthHandler;
+import io.pravega.client.stream.impl.Credentials;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -50,10 +51,10 @@ public class PravegaInterceptor implements ServerInterceptor {
 
         Map<String, String> paramMap = new HashMap<>();
         headers.keys().stream()
-               .filter(key -> !key.endsWith(Metadata.BINARY_HEADER_SUFFIX))
+               .filter(key -> key.startsWith(Credentials.AUTH_HANDLER_PREFIX))
                .forEach(key -> {
                    try {
-                       paramMap.put(key,
+                       paramMap.put(key.substring(Credentials.AUTH_HANDLER_PREFIX.length()),
                                headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
                    } catch (IllegalArgumentException e) {
                        log.warn("Error while marshalling some of the headers {}", e.toString());

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -56,7 +56,6 @@ public class PravegaInterceptor implements ServerInterceptor {
                    try {
                        paramMap.put(key.substring(Credentials.AUTH_HANDLER_PREFIX.length()),
                                headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
-                       log.warn(key + " " + headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
                    } catch (IllegalArgumentException e) {
                        log.warn("Error while marshalling some of the headers {}", e.toString());
                    }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -56,6 +56,7 @@ public class PravegaInterceptor implements ServerInterceptor {
                    try {
                        paramMap.put(key.substring(Credentials.AUTH_HANDLER_PREFIX.length()),
                                headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
+                       log.warn(key + " " + headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
                    } catch (IllegalArgumentException e) {
                        log.warn("Error while marshalling some of the headers {}", e.toString());
                    }


### PR DESCRIPTION
**Change log description**
The plugin on the server side used to pass all the `grpc` headers to the plugin. This may introduce an attack where a plugin gets headers that it does not need.
This solution adds a prefix to Pravega auth headers and only these headers are passed on to the plugins.

**Purpose of the change**
This fixes #2711.

**What the code does**
Pass only the auth related headers. Earlier all the `grpc` headers were passed. This is more info than plugins need. With this change, the client prefixes auth related headers with a known string. The server passes on only these headers after stripping the prefix.

**How to verify it**
Unit tests.