### PR TITLE
Issue 2658: Refresh `delegationToken` for metadataclient during truncation

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -222,7 +222,7 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     private void handleSegmentTruncated(SegmentInputStream segmentReader) throws ReinitializationRequiredException, TruncatedDataException {
         Segment segmentId = segmentReader.getSegmentId();
         log.info("{} encountered truncation for segment {} ", this, segmentId);
-        String delegationToken = groupState.refreshDelegationToken(segmentId);
+        String delegationToken = groupState.getOrRefreshDelegationTokenFor(segmentId);
 
         @Cleanup
         SegmentMetadataClient metadataClient = metadataClientFactory.createSegmentMetadataClient(segmentId, delegationToken);

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -222,7 +222,8 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     private void handleSegmentTruncated(SegmentInputStream segmentReader) throws ReinitializationRequiredException, TruncatedDataException {
         Segment segmentId = segmentReader.getSegmentId();
         log.info("{} encountered truncation for segment {} ", this, segmentId);
-        String delegationToken = groupState.getLatestDelegationToken();
+        String delegationToken = groupState.refreshDelegationToken(segmentId);
+
         @Cleanup
         SegmentMetadataClient metadataClient = metadataClientFactory.createSegmentMetadataClient(segmentId, delegationToken);
         try {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -416,8 +416,6 @@ public class ReaderGroupStateManager {
     }
 
     public String refreshDelegationToken(Segment segmentId) {
-        synchronized (this) {
             return getAndHandleExceptions(controller.getOrRefreshDelegationTokenFor(segmentId.getScope(), segmentId.getStreamName()), RuntimeException::new);
-        }
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -39,8 +39,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Getter;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.RandomUtils;
 
 import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
@@ -419,6 +419,15 @@ public class ReaderGroupStateManager {
         });
         if (reinitRequired.get()) {
             throw new ReinitializationRequiredException();
+        }
+    }
+
+    public String refreshDelegationToken(Segment segmentId) {
+        synchronized (this) {
+            if (this.latestDelegationToken == null ) {
+                this.latestDelegationToken = getAndHandleExceptions(controller.getOrRefreshDelegationTokenFor(segmentId.getScope(), segmentId.getStreamName()), RuntimeException::new);
+            }
+            return this.latestDelegationToken;
         }
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -415,7 +415,7 @@ public class ReaderGroupStateManager {
         }
     }
 
-    public String refreshDelegationToken(Segment segmentId) {
+    public String getOrRefreshDelegationTokenFor(Segment segmentId) {
             return getAndHandleExceptions(controller.getOrRefreshDelegationTokenFor(segmentId.getScope(), segmentId.getStreamName()), RuntimeException::new);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import javax.annotation.concurrent.GuardedBy;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -81,9 +80,6 @@ public class ReaderGroupStateManager {
     private final TimeoutTimer acquireTimer;
     private final TimeoutTimer fetchStateTimer;
     private final TimeoutTimer checkpointTimer;
-    @Getter
-    @GuardedBy("this")
-    private String latestDelegationToken;
 
     ReaderGroupStateManager(String readerId, StateSynchronizer<ReaderGroupState> sync, Controller controller, Supplier<Long> nanoClock) {
         Preconditions.checkNotNull(readerId);
@@ -162,9 +158,6 @@ public class ReaderGroupStateManager {
         final Map<Segment, List<Long>> segmentToPredecessor;
         if (fetchSuccesors) {
             val successors = getAndHandleExceptions(controller.getSuccessors(segmentCompleted), RuntimeException::new);
-            synchronized (this) {
-                latestDelegationToken = successors.getDelegationToken();
-            }
             segmentToPredecessor = successors.getSegmentToPredecessor();
         } else {
             segmentToPredecessor = Collections.emptyMap();
@@ -424,10 +417,7 @@ public class ReaderGroupStateManager {
 
     public String refreshDelegationToken(Segment segmentId) {
         synchronized (this) {
-            if (this.latestDelegationToken == null ) {
-                this.latestDelegationToken = getAndHandleExceptions(controller.getOrRefreshDelegationTokenFor(segmentId.getScope(), segmentId.getStreamName()), RuntimeException::new);
-            }
-            return this.latestDelegationToken;
+            return getAndHandleExceptions(controller.getOrRefreshDelegationTokenFor(segmentId.getScope(), segmentId.getStreamName()), RuntimeException::new);
         }
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -15,6 +15,7 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -25,6 +26,7 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
@@ -251,4 +253,64 @@ public class ReaderGroupNotificationTest {
         assertTrue("Listener invoked", listenerInvoked.get());
     }
 
+    @Test(timeout = 40000)
+    public void testSegmentTruncatedNotifications() throws Exception {
+        final String streamName = "stream2";
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scope(SCOPE)
+                                                        .streamName(streamName)
+                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .build();
+        Controller controller = controllerWrapper.getController();
+        controllerWrapper.getControllerService().createScope(SCOPE).get();
+        controller.createStream(config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                                    .controllerURI(URI.create("tcp://localhost"))
+                                                                                    .build());
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        writer.writeEvent("0", "data1").get();
+
+        // truncate
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
+                connectionFactory);
+        groupManager.createReaderGroup("reader", ReaderGroupConfig
+                .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, streamName)).build());
+        @Cleanup
+        ReaderGroup readerGroup = groupManager.getReaderGroup("reader");
+        @Cleanup
+        EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
+                ReaderConfig.builder().build());
+        Checkpoint cp = readerGroup.initiateCheckpoint("myCheckpoint", executor).join();
+        StreamCut streamCut = cp.asImpl().getPositions().values().iterator().next();
+        Boolean result = controller.truncateStream(SCOPE, streamName, streamCut).get();
+        assertTrue(result);
+        writer.writeEvent("0", "data2").get();
+        assertTrue(controller.sealStream(SCOPE, streamName).get()); // seal stream
+        /*Add segment event listener
+        Listener<EndOfDataNotification> l1 = notification -> {
+            listenerInvoked.set(true);
+            listenerLatch.release();
+        };
+        readerGroup.getSegmentNotifier()
+                           getEndOfDataNotifier(executor).registerListener(l1);*/
+
+        EventRead<String> event1 = reader1.readNextEvent(10000);
+        EventRead<String> event2 = reader1.readNextEvent(10000);
+        EventRead<String> event3 = reader1.readNextEvent(10000);
+        assertNotNull(event1);
+        assertEquals("data1", event1.getEvent());
+        assertNotNull(event2);
+        assertEquals("data2", event2.getEvent());
+        assertNull(event3.getEvent());
+
+       // listenerLatch.await();
+        //assertTrue("Listener invoked", listenerInvoked.get());
+    }
 }


### PR DESCRIPTION
Signed-off-by: arvindkandhare <arvind.kandhare@emc.com>

**Change log description**
This change ensures that we create a delegationToken for the metadata client before it is used.
This is for testing whether this is the reason for the current longetivity failures. There can be a better way of doing this. 

**Purpose of the change**
Try out setting `delegationToken` for `metadataclient` of a `readergroup` before it is used during truncation.

**What the code does**
Extracts the latest delegation token for metadataclient before it is used in the scenario where segment is truncated.

**How to verify it**
The longetivity failures are not observed. Working on a unit test for this too. Will complete it before the merge.