### PR TITLE
Issue 2746: PravegaRequestProcessor should send an empty Read result before cancelling Read request.

### DIFF
--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -101,21 +101,6 @@ public class SegmentInputStreamTest {
     }
 
     @Test
-    public void testReadEmpty() {
-        byte[] data = new byte[0];
-        ByteBuffer wireData = createEventFromData(data);
-        TestAsyncSegmentInputStream fakeNetwork = new TestAsyncSegmentInputStream(segment, 3);
-        @Cleanup
-        SegmentInputStreamImpl stream = new SegmentInputStreamImpl(fakeNetwork, 0);
-        ByteBuffer read = assertBlocks(() -> stream.read(),
-                () -> fakeNetwork.complete(0, new WireCommands.SegmentRead(segment.getScopedName(), 0, false, false, wireData.slice())));
-        assertEquals(ByteBuffer.wrap(data), read);
-        read = assertBlocks(() -> stream
-                .read(), () -> fakeNetwork.complete(1, new WireCommands.SegmentRead(segment.getScopedName(), wireData.capacity(), false, false, wireData.slice())));
-        assertEquals(ByteBuffer.wrap(data), read);
-    }
-
-    @Test
     public void testSmallerThanNeededRead() throws EndOfSegmentException, SegmentTruncatedException {
         byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         ByteBuffer wireData = createEventFromData(data);

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -114,6 +114,7 @@ public interface StreamSegmentStore {
      * consume the read data. If the operation failed, the future will be failed with the causing exception.
      * @throws NullPointerException     If any of the arguments are null.
      * @throws IllegalArgumentException If any of the arguments are invalid.
+     * @throws java.util.concurrent.CancellationException If the segment container is shutting down or the segment is evicted from memory.
      */
     CompletableFuture<ReadResult> read(String streamSegmentName, long offset, int maxLength, Duration timeout);
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -111,10 +111,11 @@ public interface StreamSegmentStore {
      * @param maxLength         The maximum number of bytes to read.
      * @param timeout           Timeout for the operation.
      * @return A CompletableFuture that, when completed normally, will contain a ReadResult instance that can be used to
-     * consume the read data. If the operation failed, the future will be failed with the causing exception.
+     * consume the read data. If the operation failed, the future will be failed with the causing exception. The future
+     * will be failed with a {@link java.util.concurrent.CancellationException} if the segment container is shutting down
+     * or the segment is evicted from memory.
      * @throws NullPointerException     If any of the arguments are null.
      * @throws IllegalArgumentException If any of the arguments are invalid.
-     * @throws java.util.concurrent.CancellationException If the segment container is shutting down or the segment is evicted from memory.
      */
     CompletableFuture<ReadResult> read(String streamSegmentName, long offset, int maxLength, Duration timeout);
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -439,7 +439,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         } else if ( u instanceof ReadCancellationException) {
             log.info("Closing connection {} while reading segment {} due to CancellationException.", connection, segment);
             connection.send(new SegmentRead(segment, requestId, true, false, EMPTY_BYTE_BUFFER));
-            connection.close();
         } else if (u instanceof CancellationException) {
             log.info("Closing connection {} while performing {} due to {}.", connection, operation, u.getMessage());
             connection.close();
@@ -617,7 +616,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     /**
      * Custom exception to indicate a {@link CancellationException} during a Read segment operation.
      */
-    private class ReadCancellationException extends IllegalStateException {
+    private class ReadCancellationException extends RuntimeException {
         ReadCancellationException(Throwable wrapppedException) {
             super("CancellationException during operation Read segment", wrapppedException);
         }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -176,7 +176,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                     handleReadResult(readSegment, readResult);
                     readStreamSegment.reportSuccessEvent(timer.getElapsed());
                 })
-                .exceptionally(ex -> handleException(readSegment.getOffset(), segment, "Read segment", ex));
+                .exceptionally(ex -> handleReadException(readSegment.getOffset(), segment, ex));
     }
 
     private boolean verifyToken(String segment, long requestId, String delegationToken, AuthHandler.Permissions read, String operation) {
@@ -217,7 +217,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             segmentStore.getStreamSegmentInfo(segment, false, TIMEOUT)
                     .thenAccept(info ->
                             connection.send(new SegmentIsTruncated(nonCachedEntry.getStreamSegmentOffset(), segment, info.getStartOffset())))
-                    .exceptionally(e -> handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e));
+                    .exceptionally(e -> handleReadException(nonCachedEntry.getStreamSegmentOffset(), segment, e));
         } else {
             Preconditions.checkState(nonCachedEntry != null, "No ReadResultEntries returned from read!?");
             nonCachedEntry.requestContent(TIMEOUT);
@@ -234,11 +234,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                             // to make a read. In that case, send the appropriate error back.
                             connection.send(new SegmentIsTruncated(nonCachedEntry.getStreamSegmentOffset(), segment, nonCachedEntry.getStreamSegmentOffset()));
                         } else {
-                            handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e);
+                            handleReadException(nonCachedEntry.getStreamSegmentOffset(), segment, e);
                         }
                         return null;
                     })
-                    .exceptionally(e -> handleException(nonCachedEntry.getStreamSegmentOffset(), segment, "Read segment", e));
+                    .exceptionally(e -> handleReadException(nonCachedEntry.getStreamSegmentOffset(), segment, e));
         }
     }
 
@@ -400,6 +400,17 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 });
     }
 
+    private Void handleReadException(long readOffset, String segment, Throwable u) {
+        if (u != null && Exceptions.unwrap(u) instanceof CancellationException) {
+            log.info("Closing connection {} while reading on segment {} due to CancellationException.", connection, segment);
+            connection.send(new SegmentRead(segment, readOffset, true, false, EMPTY_BYTE_BUFFER));
+            connection.close();
+            return null;
+        } else {
+            return handleException(readOffset, segment, "Read segment", u);
+        }
+    }
+
     private Void handleException(long requestId, String segment, String operation, Throwable u) {
         if (u == null) {
             IllegalStateException exception = new IllegalStateException("No exception to handle.");
@@ -424,7 +435,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             connection.send(new WrongHost(requestId, segment, ""));
         } else if (u instanceof CancellationException) {
             log.info("Closing connection {} while performing {} on segment {} due to {}.", connection, operation, segment, u.getMessage());
-            connection.send(new SegmentRead(segment, requestId, true, false, EMPTY_BYTE_BUFFER));
             connection.close();
         } else if (u instanceof AuthenticationException) {
             log.warn("Authentication error during '{}'.", operation);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -202,8 +202,6 @@ public class PravegaRequestProcessorTest {
         verify(store).read(streamSegmentName, 0, readLength, PravegaRequestProcessor.TIMEOUT);
         // Since the underlying store cancels the read request verify if an empty SegmentRead Wirecommand is sent as a response.
         verify(connection).send(new WireCommands.SegmentRead(streamSegmentName, 0, true, false, ByteBuffer.wrap(new byte[0])));
-        // Verify if the connection is closed after sending an empty SegmentRead response.
-        verify(connection).close();
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
@@ -177,6 +178,32 @@ public class PravegaRequestProcessorTest {
         processor.readSegment(new WireCommands.ReadSegment(streamSegmentName, 0, readLength, ""));
         verify(store).read(streamSegmentName, 0, readLength, PravegaRequestProcessor.TIMEOUT);
         verify(connection).send(new WireCommands.SegmentRead(streamSegmentName, 0, false, true, ByteBuffer.wrap(new byte[0])));
+        verifyNoMoreInteractions(connection);
+        verifyNoMoreInteractions(store);
+    }
+
+    @Test(timeout = 20000)
+    public void testReadSegmentEmpty() {
+        // Set up PravegaRequestProcessor instance to execute read segment request against
+        String streamSegmentName = "testReadSegment";
+        int readLength = 1000;
+
+        StreamSegmentStore store = mock(StreamSegmentStore.class);
+        ServerConnection connection = mock(ServerConnection.class);
+        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection);
+
+        CompletableFuture<ReadResult> readResult = new CompletableFuture<>();
+        readResult.completeExceptionally(new CancellationException("cancel read"));
+        // Simulate a CancellationException for a Read Segment.
+        when(store.read(streamSegmentName, 0, readLength, PravegaRequestProcessor.TIMEOUT)).thenReturn(readResult);
+
+        // Execute and Verify readSegment is calling stack in connection and store is executed as design.
+        processor.readSegment(new WireCommands.ReadSegment(streamSegmentName, 0, readLength, ""));
+        verify(store).read(streamSegmentName, 0, readLength, PravegaRequestProcessor.TIMEOUT);
+        // Since the underlying store cancels the read request verify if an empty SegmentRead Wirecommand is sent as a response.
+        verify(connection).send(new WireCommands.SegmentRead(streamSegmentName, 0, true, false, ByteBuffer.wrap(new byte[0])));
+        // Verify if the connection is closed after sending an empty SegmentRead response.
+        verify(connection).close();
         verifyNoMoreInteractions(connection);
         verifyNoMoreInteractions(store);
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -183,7 +183,7 @@ public class PravegaRequestProcessorTest {
     }
 
     @Test(timeout = 20000)
-    public void testReadSegmentEmpty() {
+    public void testReadSegmentWithCancellationException() {
         // Set up PravegaRequestProcessor instance to execute read segment request against
         String streamSegmentName = "testReadSegment";
         int readLength = 1000;


### PR DESCRIPTION
**Change log description**

Ensure an empty `WireCommands.SegmentRead` is sent while cancelling pending read requests.

**Purpose of the change**
Fixes #2746

**What the code does**
On receiving a `CancellationException` for a read request ensure PravegaRequestProcessor sends and empty SegmentRead message.

**How to verify it**
All the existing tests and newly added tests should pass.