### PR TITLE
Issue 2644: Controller should send truncation offset instead of default 0

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -156,9 +156,9 @@ public class ControllerService {
         // First fetch segments active at specified timestamp from the specified stream.
         // Divide current segments in segmentFutures into at most count positions.
         return streamStore.getActiveSegments(scope, stream, timestamp, null, executor).thenApply(segments -> {
-            return segments.stream()
-                           .map(number -> ModelHelper.createSegmentId(scope, stream, number))
-                           .collect(Collectors.toMap(id -> id, id -> 0L));
+            return segments.entrySet().stream()
+                           .collect(Collectors.toMap(entry -> ModelHelper.createSegmentId(scope, stream, entry.getKey()),
+                                   Map.Entry::getValue));
             //TODO: Implement https://github.com/pravega/pravega/issues/191  (Which will supply a value besides 0)
         });
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -354,7 +354,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 
 
     @Override
-    public CompletableFuture<List<Long>> getActiveSegments(final String scope, final String name, final long timestamp, final OperationContext context, final Executor executor) {
+    public CompletableFuture<Map<Long, Long>> getActiveSegments(final String scope, final String name, final long timestamp, final OperationContext context, final Executor executor) {
         Stream stream = getStream(scope, name, context);
         return withCompletion(stream.getActiveSegments(timestamp), executor);
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -405,7 +405,7 @@ public abstract class PersistentStreamBase<T> implements Stream {
      * @return : list of active segment numbers at given time stamp
      */
     @Override
-    public CompletableFuture<List<Long>> getActiveSegments(final long timestamp) {
+    public CompletableFuture<Map<Long, Long>> getActiveSegments(final long timestamp) {
         return getTruncationRecord(false)
                 .thenCompose(truncationRecord -> getHistoryIndex()
                         .thenCompose(historyIndex -> getHistoryTable()

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -178,7 +178,7 @@ interface Stream {
      * @param timestamp point in time.
      * @return the list of segments active at timestamp.
      */
-    CompletableFuture<List<Long>> getActiveSegments(final long timestamp);
+    CompletableFuture<Map<Long, Long>> getActiveSegments(final long timestamp);
 
     /**
      * Returns the active segments in the specified epoch.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -316,7 +316,7 @@ public interface StreamMetadataStore {
      * @param executor  callers executor
      * @return the list of segments numbers active at timestamp.
      */
-    CompletableFuture<List<Long>> getActiveSegments(final String scope, final String name, final long timestamp, final OperationContext context, final Executor executor);
+    CompletableFuture<Map<Long, Long>> getActiveSegments(final String scope, final String name, final long timestamp, final OperationContext context, final Executor executor);
 
     /**
      * Returns the segments in the specified epoch of the specified stream.

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -115,7 +115,7 @@ public abstract class StreamMetadataStoreTest {
         List<Segment> segments = store.getActiveSegments(scope, stream1, null, executor).get();
         assertEquals(2, segments.size());
 
-        List<Long> historicalSegments = store.getActiveSegments(scope, stream1, 10L, null, executor).get();
+        Map<Long, Long> historicalSegments = store.getActiveSegments(scope, stream1, 10L, null, executor).get();
         assertEquals(2, historicalSegments.size());
 
         segments = store.getActiveSegments(scope, stream2, null, executor).get();

--- a/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
@@ -958,7 +958,7 @@ public class TableHelperTest {
                 activeSegmentsWithOffset.get(fourSegmentId) == 1L &&
                 activeSegmentsWithOffset.get(fiveSegmentId) == 1L);
 
-        // 2.3 epoch at time = 2 = {0, 2, 3}
+        // 2.3 epoch at time = 2 = {0, 2, 4, 5}
         // expected active segments = 0/1, 2/1, 4/1, 5/1
         activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 2, historyIndex, historyTable,
                 segmentIndex, segmentTable, truncationRecord);

--- a/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/TableHelperTest.java
@@ -16,6 +16,7 @@ import io.pravega.controller.store.stream.tables.StreamTruncationRecord;
 import io.pravega.controller.store.stream.tables.TableHelper;
 import io.pravega.test.common.AssertExtensions;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.curator.shaded.com.google.common.collect.Sets;
 import org.junit.Test;
 
 import java.util.AbstractMap;
@@ -133,14 +134,14 @@ public class TableHelperTest {
         activeSegments = TableHelper.getActiveSegments(historyIndex, historyTable);
         assertEquals(activeSegments, newSegments);
 
-        activeSegments = TableHelper.getActiveSegments(0, historyIndex, historyTable, null, null, null);
-        assertEquals(startSegments, activeSegments);
+        Map<Long, Long> activeSegmentsWithOffset = TableHelper.getActiveSegments(0, historyIndex, historyTable, null, null, null);
+        assertEquals(Sets.newHashSet(startSegments), activeSegmentsWithOffset.keySet());
 
-        activeSegments = TableHelper.getActiveSegments(timestamp - 1, historyIndex, historyTable, null, null, null);
-        assertEquals(startSegments, activeSegments);
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp - 1, historyIndex, historyTable, null, null, null);
+        assertEquals(Sets.newHashSet(startSegments), activeSegmentsWithOffset.keySet());
 
-        activeSegments = TableHelper.getActiveSegments(timestamp + 1, historyIndex, historyTable, null, null, null);
-        assertEquals(newSegments, activeSegments);
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 1, historyIndex, historyTable, null, null, null);
+        assertEquals(Sets.newHashSet(newSegments), activeSegmentsWithOffset.keySet());
     }
 
     @Test
@@ -789,7 +790,7 @@ public class TableHelperTest {
     public void truncationTest() {
         final List<Long> startSegments = Lists.newArrayList(0L, 1L);
         int epoch = 0;
-        // epoch 0
+        // epoch 0 --> 0, 1
         long timestamp = System.currentTimeMillis();
         Pair<byte[], byte[]> segmentTableAndIndex = createSegmentTableAndIndex(2, timestamp);
         byte[] segmentTable = segmentTableAndIndex.getValue();
@@ -800,7 +801,7 @@ public class TableHelperTest {
         List<Long> activeSegments = TableHelper.getActiveSegments(historyIndex, historyTable);
         assertEquals(activeSegments, startSegments);
 
-        // epoch 1
+        // epoch 1 --> 0, 2, 3 
         epoch++;
         long twoSegmentId = computeSegmentId(2, 1);
         long threeSegmentId = computeSegmentId(3, 1);
@@ -818,7 +819,7 @@ public class TableHelperTest {
         HistoryRecord partial = HistoryRecord.readLatestRecord(historyIndex, historyTable, false).get();
         historyTable = TableHelper.completePartialRecordInHistoryTable(historyIndex, historyTable, partial, timestamp + 1);
 
-        // epoch 2
+        // epoch 2 --> 0, 2, 4, 5
         epoch++;
         long fourSegmentId = computeSegmentId(4, 2);
         long fiveSegmentId = computeSegmentId(5, 2);
@@ -836,7 +837,7 @@ public class TableHelperTest {
         partial = HistoryRecord.readLatestRecord(historyIndex, historyTable, false).get();
         historyTable = TableHelper.completePartialRecordInHistoryTable(historyIndex, historyTable, partial, timestamp + 2);
 
-        // epoch 3
+        // epoch 3 --> 0, 4, 5, 6, 7
         epoch++;
         long sixSegmentId = computeSegmentId(6, 3);
         long sevenSegmentId = computeSegmentId(7, 3);
@@ -854,7 +855,7 @@ public class TableHelperTest {
         partial = HistoryRecord.readLatestRecord(historyIndex, historyTable, false).get();
         historyTable = TableHelper.completePartialRecordInHistoryTable(historyIndex, historyTable, partial, timestamp + 3);
 
-        // epoch 4
+        // epoch 4 --> 4, 5, 6, 7, 8, 9
         epoch++;
         long eightSegmentId = computeSegmentId(8, 4);
         long nineSegmentId = computeSegmentId(9, 4);
@@ -885,6 +886,32 @@ public class TableHelperTest {
                 truncationRecord.getCutEpochMap().get(1L) == 0);
         truncationRecord = StreamTruncationRecord.complete(truncationRecord);
 
+        // getActiveSegments wrt first truncation record which is on epoch 0
+        Map<Long, Long> activeSegmentsWithOffset;
+        // 1. truncationRecord = 0/1, 1/1
+        
+        // 1.1 epoch at time = 0 = {0, 1}
+        // expected active segments with offset = 0/1, 1/1
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp, historyIndex, historyTable, 
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 2 && 
+                activeSegmentsWithOffset.containsKey(0L) && 
+                activeSegmentsWithOffset.containsKey(1L) && 
+                activeSegmentsWithOffset.get(0L) == 1L && 
+                activeSegmentsWithOffset.get(1L) == 1L);
+
+        // 1.2 epoch at time = 1 = {0, 2, 3}
+        // expected active segments = 0/1, 2/0, 3/0
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 1, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 3 &&
+                activeSegmentsWithOffset.containsKey(0L) &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(threeSegmentId) &&
+                activeSegmentsWithOffset.get(0L) == 1L &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 0L &&
+                activeSegmentsWithOffset.get(threeSegmentId) == 0L);
+
         Map<Long, Long> streamCut2 = new HashMap<>();
         streamCut2.put(0L, 1L);
         streamCut2.put(twoSegmentId, 1L);
@@ -902,6 +929,49 @@ public class TableHelperTest {
                 truncationRecord.getCutEpochMap().get(fiveSegmentId) == 2);
         truncationRecord = StreamTruncationRecord.complete(truncationRecord);
 
+        // 2. truncationRecord = 0/1, 2/1, 4/1, 5/1. 
+        // 2.1 epoch at time = 0 = {0, 1}
+        // expected active segments = 0/1, 2/1, 4/1, 5/1
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 4 &&
+                activeSegmentsWithOffset.containsKey(0L) &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.get(0L) == 1L &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 1L);
+
+        // 2.2 epoch at time = 1 = {0, 2, 3}
+        // expected active segments = 0/1, 2/1, 4/1, 5/1
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 1, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 4 &&
+                activeSegmentsWithOffset.containsKey(0L) &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.get(0L) == 1L &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 1L);
+
+        // 2.3 epoch at time = 2 = {0, 2, 3}
+        // expected active segments = 0/1, 2/1, 4/1, 5/1
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 2, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 4 &&
+                activeSegmentsWithOffset.containsKey(0L) &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.get(0L) == 1L &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 1L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 1L);
+
         Map<Long, Long> streamCut3 = new HashMap<>();
         streamCut3.put(twoSegmentId, 10L);
         streamCut3.put(fourSegmentId, 10L);
@@ -918,6 +988,77 @@ public class TableHelperTest {
                 truncationRecord.getCutEpochMap().get(eightSegmentId) == 4 &&
                 truncationRecord.getCutEpochMap().get(nineSegmentId) == 4);
         truncationRecord = StreamTruncationRecord.complete(truncationRecord);
+
+        // 3. truncation record 2/10, 4/10, 5/10, 8/10, 9/10
+        // getActiveSegments wrt first truncation record which spans epoch 2 to 4
+
+        // 3.1 epoch at time 0 = 0 = {0, 1}
+        // expected active segments = 2/10, 4/10, 5/10, 8/10, 9/10
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 5 &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.containsKey(eightSegmentId) &&
+                activeSegmentsWithOffset.containsKey(nineSegmentId) &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(eightSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(nineSegmentId) == 10L);
+
+        // 3.2 epoch at time 2 = 2 = {0, 2, 4, 5}
+        // expected active segments = 2/10, 4/10, 5/10, 8/10, 9/10
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 2, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 5 &&
+                activeSegmentsWithOffset.containsKey(twoSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.containsKey(eightSegmentId) &&
+                activeSegmentsWithOffset.containsKey(nineSegmentId) &&
+                activeSegmentsWithOffset.get(twoSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(eightSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(nineSegmentId) == 10L);
+
+        // 3.3 epoch at time 3 = 3 = {0, 4, 5, 6, 7}
+        // expected active segments = 4/10, 5/10, 8/10, 9/10, 6/0, 7/0
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 3, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 6 &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.containsKey(eightSegmentId) &&
+                activeSegmentsWithOffset.containsKey(nineSegmentId) &&
+                activeSegmentsWithOffset.containsKey(sixSegmentId) &&
+                activeSegmentsWithOffset.containsKey(sevenSegmentId) &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(eightSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(nineSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(sixSegmentId) == 0L &&
+                activeSegmentsWithOffset.get(sevenSegmentId) == 0L);
+
+        // 3.4 epoch at time 4 = 4 = {4, 5, 6, 7, 8, 9}
+        // expected active segments = 4/10, 5/10, 8/10, 9/10, 6/0, 7/0
+        activeSegmentsWithOffset = TableHelper.getActiveSegments(timestamp + 4, historyIndex, historyTable,
+                segmentIndex, segmentTable, truncationRecord);
+        assertTrue(activeSegmentsWithOffset.size() == 6 &&
+                activeSegmentsWithOffset.containsKey(fourSegmentId) &&
+                activeSegmentsWithOffset.containsKey(fiveSegmentId) &&
+                activeSegmentsWithOffset.containsKey(eightSegmentId) &&
+                activeSegmentsWithOffset.containsKey(nineSegmentId) &&
+                activeSegmentsWithOffset.containsKey(sixSegmentId) &&
+                activeSegmentsWithOffset.containsKey(sevenSegmentId) &&
+                activeSegmentsWithOffset.get(fourSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(fiveSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(eightSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(nineSegmentId) == 10L &&
+                activeSegmentsWithOffset.get(sixSegmentId) == 0L &&
+                activeSegmentsWithOffset.get(sevenSegmentId) == 0L);
 
         // behind previous
         Map<Long, Long> streamCut4 = new HashMap<>();

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -365,34 +365,34 @@ public class ZkStreamTest {
         successors = store.getSuccessors(SCOPE, streamName, eleven, context, executor).get();
         assertTrue(successors.isEmpty());
         // start -1
-        List<Long> historicalSegments = store.getActiveSegments(SCOPE, streamName, start - 1, context, executor).get();
+        Map<Long, Long> historicalSegments = store.getActiveSegments(SCOPE, streamName, start - 1, context, executor).get();
         assertEquals(historicalSegments.size(), 5);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)));
 
         // start + 1
         historicalSegments = store.getActiveSegments(SCOPE, streamName, start + 1, context, executor).get();
         assertEquals(historicalSegments.size(), 5);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)));
 
         // scale1 + 1
         historicalSegments = store.getActiveSegments(SCOPE, streamName, scale1 + 1000, context, executor).get();
         assertEquals(historicalSegments.size(), 4);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, 1L, 2L, five)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, 1L, 2L, five)));
 
         // scale2 + 1
         historicalSegments = store.getActiveSegments(SCOPE, streamName, scale2 + 1000, context, executor).get();
         assertEquals(historicalSegments.size(), 4);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, six, seven, eight)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, six, seven, eight)));
 
         // scale3 + 1
         historicalSegments = store.getActiveSegments(SCOPE, streamName, scale3 + 1000, context, executor).get();
         assertEquals(historicalSegments.size(), 5);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, six, nine, ten, eleven)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, six, nine, ten, eleven)));
 
         // scale 3 + 10000
         historicalSegments = store.getActiveSegments(SCOPE, streamName, scale3 + 10000, context, executor).get();
         assertEquals(historicalSegments.size(), 5);
-        assertTrue(historicalSegments.containsAll(Lists.newArrayList(0L, six, nine, ten, eleven)));
+        assertTrue(historicalSegments.keySet().containsAll(Lists.newArrayList(0L, six, nine, ten, eleven)));
 
         assertFalse(store.isSealed(SCOPE, streamName, context, executor).get());
         assertNotEquals(0, store.getActiveSegments(SCOPE, streamName, context, executor).get().size());

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -352,8 +352,6 @@ public class EndToEndTruncationTest {
         final EventStreamReader<String> newReader = clientFactory.createReader(newReaderGroupName + "2",
                 newReaderGroupName, new JavaSerializer<>(), ReaderConfig.builder().build());
 
-        // Check that we get a TruncatedDataException after truncating the active segment and then read the expected event.
-        assertThrows(TruncatedDataException.class, () -> newReader.readNextEvent(1000).getEvent());
         assertEquals("Expected read event: ", "1", newReader.readNextEvent(1000).getEvent());
         assertNull(newReader.readNextEvent(1000).getEvent());
     }
@@ -399,10 +397,6 @@ public class EndToEndTruncationTest {
 
         // Just after the truncation, trying to read the whole stream should raise a TruncatedDataException.
         final String newGroupName = readerGroupName + "new";
-        groupManager.createReaderGroup(newGroupName, ReaderGroupConfig.builder().stream(Stream.of(scope, streamName)).build());
-        assertThrows(TruncatedDataException.class, () -> Futures.allOf(readDummyEvents(clientFactory, newGroupName, parallelism)).join());
-
-        // Read again, now expecting to read from the offset defined in truncate call onwards.
         groupManager.createReaderGroup(newGroupName, ReaderGroupConfig.builder().stream(Stream.of(scope, streamName)).build());
         futures = readDummyEvents(clientFactory, newGroupName, parallelism);
         Futures.allOf(futures).join();


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>
**Change log description**
Controller has truncation record and the correct offsets. But it used to return default offsets for getSegmentsAt api. Now it sends default offsets only for segments that are not part of truncation point.  

**Purpose of the change**
Fixes #2644 

**What the code does**
In `StreamMetadataStore`, we have the `getActiveSegments(time)` API, which takes active segments corresponding to the given time parameter, and then crosses them with the current truncation record to compute the actual active segments. Since this API call was designed before the truncation capability, it never sent the offsets, only the segment ids. Moreover, these offsets were defaulted to 0 by the `ControllerService` layer before responding to the client.

Now we have changed the signature of the store API to return both segment ids with corresponding offsets. For segments that are not part of truncation record, they are defaulted to offset 0. 

**How to verify it**
Unit test added. 