### PR TITLE
Issue 2754: RocksDB off-heap memory consumption in segment store process (longevity runs)

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -67,7 +67,9 @@ class RocksDBCache implements Cache {
      * RocksDB stores data in memory related to internal indexes (e.g., it may range between 5% to 30% of the total
      * memory consumption depending on the configuration and data at hand). The size of the internal indexes in RocksDB
      * mainly depend on the size of cached data blocks (cacheBlockSizeKB). If you increase cacheBlockSizeKB, the number
-     * of blocks will decrease, so the index size will also reduce linearly (but increasing read amplification).
+     * of blocks will decrease, so the index size will also reduce linearly (but increasing read amplification). For an
+     * in depth description of RocksDB's memory settings and their potential implications, we refer to:
+     * https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
      */
     private static final int CACHE_BLOCK_SIZE_KB = 32;
 


### PR DESCRIPTION
**Change log description**
This PR proposes a set of default configuration settings for RocksDB to preserve memory in the segment store process and allow longevity experiments to run for a longer period of time. All the default settings are in `RocksDBCache.java`, thus avoiding changes in `config.properties`. This has been done in purpose as this PR is intended to be cherry-picked for release `0.3.1`, so no major changes from a user perspective are expected.

**Purpose of the change**
Fixes #2754.

**What the code does**
The code sets several RocksDB default parameters with conservative values to preserve memory:
- Cache block size has been set to 32KB (default 4KB) to reduce the memory usage of internal indexes of RocksDB. 
- Total space for memtables has been set to 64MB to reduce memory usage absorbing writes (by default is 64MB per memtable).

The block cache size for reads by default is `8`MB, which has been considered small enough and has not been further reduced in this PR.

Other flags have been also found helpful to reduce memory footprint in RocksDB:
- `setCacheIndexAndFilterBlocks(true)` indicates that we want to store index/filter blocks to the block cache (instead of loading them in separate memory spaces).
- `setOptimizeFiltersForHits(true)` reduces the amount of index data structures (last level of LSM).
- `setUseDirectReads(true)` uses direct reads from storage device to user memory space bypassing system page cache.

Note that the objective of these default values has been to reduce memory consumption. In terms of performance, a new PR will be created (see issue #2289) to expose these parameters in the configuration as "turning knobs" that will allow us to find interesting memory efficiency/performance trade-offs.

**How to verify it**
With these default values, a longevity experiment running on a small cluster (3 nodes) and a moderate workload (`mediumScale`) finishes due to lack of storage space after `1.3h`. We did not observe `cgroups` messages related to the restart of the segment store process by excessive memory usage in the container (`2GB` limit). Note that without the changes of this PR, the process gets killed after 30 mins of supporting this workload due to excessive memory usage. The evolution of the memory consumption in the segment store process can be seen in the attached figure (red line).   
![longevity_1087_segment_store_per_process_memory](https://user-images.githubusercontent.com/717112/42754809-3787100e-88f6-11e8-827e-24c081b34a23.png)
We can observe how the process seems to stabilize its consumption of memory in the last part of the experiment between `1.7`GB and `1.8`GB. From this point onward, we need to execute longer runs with larger clusters to verify the extend of this improvement.

All system tests should be working as before.  

