### PR TITLE
Issue 2759: Sporadic timeout error in StreamsAndScopesManagementTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -55,7 +55,7 @@ public class StreamsAndScopesManagementTest {
     // TODO: Re-creation of Streams cannot be tested (Issue https://github.com/pravega/pravega/issues/2641).
     private static final int TEST_ITERATIONS = 1;
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(8 * 60);
+    public Timeout globalTimeout = Timeout.seconds(12 * 60);
 
     private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(4,
             "StreamsAndScopesManagementTest-controller");


### PR DESCRIPTION
**Change log description**
Increased timeout in `StreamsAndScopesManagementTest.java`, as it was too close to the actual duration of the experiment.

**Purpose of the change**
Fixes #2759. 

**What the code does**
The timeout in `StreamsAndScopesManagementTest.java` was too close to the actual experiment duration. Therefore, minor fluctuations in the performance of the platform/system caused the test to time out. For instance, in the last successful system test build the experiment finished just `7s` before the timeout. This PR increases the test timeout to avoid sporadic failures due to system/platform performance fluctuations. 

**How to verify it**
The `StreamsAndScopesManagementTest` test should pass consistently.