### PR TITLE
Issue 2773: Do not check for data availability in the stream locally

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
@@ -13,6 +13,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import java.io.EOFException;
 import java.io.FileNotFoundException;
 import lombok.Lombok;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -41,6 +42,8 @@ final class HDFSExceptionHelpers {
             return new StreamSegmentNotExistsException(segmentName, e);
         } else if (e instanceof FileAlreadyExistsException) {
             return new StreamSegmentExistsException(segmentName, e);
+        } else if (e instanceof EOFException) {
+            throw new ArrayIndexOutOfBoundsException(segmentName);
         } else if (e instanceof AclException) {
             return new StreamSegmentSealedException(segmentName, e);
         } else {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
@@ -13,7 +13,6 @@ import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
-import java.io.EOFException;
 import java.io.FileNotFoundException;
 import lombok.Lombok;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -42,8 +41,6 @@ final class HDFSExceptionHelpers {
             return new StreamSegmentNotExistsException(segmentName, e);
         } else if (e instanceof FileAlreadyExistsException) {
             return new StreamSegmentExistsException(segmentName, e);
-        } else if (e instanceof EOFException) {
-            throw new ArrayIndexOutOfBoundsException(segmentName);
         } else if (e instanceof AclException) {
             return new StreamSegmentSealedException(segmentName, e);
         } else {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -642,8 +642,7 @@ class HDFSStorage implements SyncStorage {
         try (FSDataInputStream stream = this.fileSystem.open(currentFile.getPath())) {
             stream.readFully(offset, buffer, bufferOffset, length);
         } catch (EOFException e) {
-            log.warn("End of file reached before reading the data.", e);
-            return 0;
+            throw new IllegalArgumentException(String.format("Reading at offset (%d) which is beyond the current size of segment.", offset));
         }
         return length;
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.SyncStorage;
+import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -640,6 +641,9 @@ class HDFSStorage implements SyncStorage {
         FileStatus currentFile = findStatusForSegment(handle.getSegmentName(), true);
         try (FSDataInputStream stream = this.fileSystem.open(currentFile.getPath())) {
             stream.readFully(offset, buffer, bufferOffset, length);
+        } catch (EOFException e) {
+            log.warn("End of file reached before reading the data.", e);
+            return 0;
         }
         return length;
     }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSStorage.java
@@ -639,9 +639,6 @@ class HDFSStorage implements SyncStorage {
         //There is only one file per segment.
         FileStatus currentFile = findStatusForSegment(handle.getSegmentName(), true);
         try (FSDataInputStream stream = this.fileSystem.open(currentFile.getPath())) {
-            if (offset + length > stream.available()) {
-                throw new ArrayIndexOutOfBoundsException();
-            }
             stream.readFully(offset, buffer, bufferOffset, length);
         }
         return length;


### PR DESCRIPTION
**Change log description**
HDFS implementation checks for data availability locally in the read stream. This ensures that there is enough data available to read without blocking.
The idea is that in case multiple reads are in process the threads are not blocked. This fails in case of longevity runs where data may not be cached ever after multiple calls. At that point it makes sense to block for the read to happen.

**Purpose of the change**
Fixes #2773.

**What the code does**
Removes the availability check on the run.

**How to verify it**
ArrayOutOfBoundsException is not observed.