### PR TITLE
Issue 2776: Wrong TruncatedDataException assertions

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -27,7 +27,6 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
@@ -55,7 +54,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -174,12 +174,8 @@ public class OffsetTruncationTest {
         StreamCut streamCut = cp.asImpl().getPositions().values().iterator().next();
         assertTrue(streamManager.truncateStream(SCOPE, STREAM, streamCut));
 
-        // Just after the truncation, trying to read the whole stream should raise a TruncatedDataException.
+        // Just after the truncation, read events from the offset defined in truncate call onwards.
         final String newGroupName = READER_GROUP + "new";
-        groupManager.createReaderGroup(newGroupName, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM)).build());
-        assertThrows(TruncatedDataException.class, () -> Futures.allOf(readDummyEvents(clientFactory, newGroupName, PARALLELISM)).join());
-
-        // Read again, now expecting to read events from the offset defined in truncate call onwards.
         groupManager.createReaderGroup(newGroupName, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM)).build());
         futures = readDummyEvents(clientFactory, newGroupName, PARALLELISM);
         Futures.allOf(futures).join();

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -162,10 +162,6 @@ public class RetentionTest {
                 new JavaSerializer<>(),
                 ReaderConfig.builder().build());
 
-        //try reading the event that was written earlier.
-        //expectation is it should have been truncated and we should find stream to be empty
-        assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(6000));
-
         //verify reader functionality is unaffected post truncation
         String event = "newEvent";
         writer.writeEvent(event);

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -20,7 +20,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.RetentionPolicy;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
@@ -49,7 +48,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j


### PR DESCRIPTION
**Change log description**
Removed assertions expecting `TruncatedDataException` from `OffsetTruncationTest.java` and `RetentionTest.java`

**Purpose of the change**
Fixes #2776.

**What the code does**
PR #2757 changes the way a reader interacts with the system after a truncation operation. Before, upon a stream truncation, a reader expected a `TruncatedDataException` on the first read attempt and got the correct truncation offsets on the second read attempt to continue reading data from the stream. Conversely, now the controller automatically sets the correct truncation offsets for the reader on the first read attempt without getting a `TruncatedDataException`. For this reason, assertions expecting `TruncatedDataException` need to be removed.

**How to verify it**
The involved system tests should pass.