### PR TITLE
Issue 2779: BookieFailoverTest timeout error

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -212,6 +212,8 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
             // Bring back the bookie which was killed.
             Futures.getAndHandleExceptions(bookkeeperService.scaleService(3), ExecutionException::new);
 
+            // Give some more time to writers to write more events.
+            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
             stopWriters();
 
             // Also, verify writes happened after bookie is brought back.

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -198,18 +198,18 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
             Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
             long writeCountBeforeSleep  = testState.getEventWrittenCount();
-            log.info("Write count after bookie failover after {} seconds sleep {}.", WAIT_AFTER_FAILOVER_MILLIS / 1000, writeCountBeforeSleep);
+            log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountBeforeSleep, WAIT_AFTER_FAILOVER_MILLIS / 1000);
 
             log.info("Sleeping for {} seconds.", WAIT_AFTER_FAILOVER_MILLIS / 1000);
             Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
             long writeCountAfterSleep  = testState.getEventWrittenCount();
-            log.info("Write count after bookie failover after {} seconds sleep {}.", WAIT_AFTER_FAILOVER_MILLIS / 1000, writeCountAfterSleep);
+            log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountAfterSleep, WAIT_AFTER_FAILOVER_MILLIS / 1000);
 
             Assert.assertEquals("Unexpected writes performed during Bookie failover.", writeCountAfterSleep, writeCountBeforeSleep);
             log.info("Writes failed when bookie is scaled down.");
 
-            // Bring back the bookie which was killed.
+            // Bring up a new bookie instance.
             Futures.getAndHandleExceptions(bookkeeperService.scaleService(3), ExecutionException::new);
 
             // Give some more time to writers to write more events.

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -217,7 +217,7 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
             // Also, verify writes happened after bookie is brought back.
             long finalWriteCount = testState.getEventWrittenCount();
             log.info("Final write count {}.", finalWriteCount);
-            Assert.assertTrue( finalWriteCount > writeCountAfterSleep);
+            Assert.assertTrue(finalWriteCount > writeCountAfterSleep);
 
             stopReaders();
 


### PR DESCRIPTION
**Change log description**
This PR fixes the timeout error in `BookieFailoverTest` as follows: 
- Added a sleep in `BookieFailoverTest` to allow readers to get properly created. 
- Sleep intervals during failover have been set to match with other failovers in `AbstractFailoverTests`. 

**Purpose of the change**
Fixes #2779.

**What the code does**
The code adds one sleep interval between the creation of readers and the bookie failover event. Without this sleep interval, not all the readers were created and, what is worse, some of them were assumed to be created by the test but never started due to the Bookie failure. Now, all the readers get properly created and consume events. 
Moreover, the sleep intervals during failover have been set in the same way than `AbstractFailoverTests` (shorter intervals). The reason for this change is that extend the failover period for a too long period of time makes readers to get a `RetriesExhaustedException`. While having this exception does not prevent the test to write/read all the events, `AbstractFailoverTests` is instructed to fail the test if any reader gets an unexpected exception as this one.

**How to verify it**
`BookieFailoverTest` should pass consistently in system test builds.