### PR TITLE
Issue 2784: Change version in r0.3 branch in preparation for release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ typesafeConfigVersion=1.3.1
 gradleGitPluginVersion=2.2.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.3.1-SNAPSHOT
+pravegaVersion=0.3.1
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**
* Updates the Pravega version in gradle.properties in preparation for release 0.3.1.

**Purpose of the change**
Fixes #2784 

**What the code does**
No code change, only a configuration change. It changes the Pravega version number.

**How to verify it**
Build should yield artifacts for 0.3.1.