### PR TITLE
Issue 2801: Remove redundant invocation of fetch successors during Abort transaction.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactory.java
@@ -23,12 +23,11 @@ public interface SegmentOutputStreamFactory {
      *
      * @param segment The segment the transaction belongs to.
      * @param txId    The transaction id.
-     * @param segmentSealedCallback Method to be executed on receiving SegmentSealed from SSS.
      * @param config  The configuration for the writer
      * @param delegationToken token to pass on to segmentstore to authenticate access to the segment.
      * @return New instance of SegmentOutputStream with an open transaction.
      */
-    SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, Consumer<Segment> segmentSealedCallback, EventWriterConfig config, String delegationToken);
+    SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, EventWriterConfig config, String delegationToken);
 
     /**
      * Creates a stream for an existing segment. This operation will fail if the segment does not

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -29,12 +29,13 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
 
     private final Controller controller;
     private final ConnectionFactory cf;
+    private final Consumer<Segment> nopSegmentSealedCallback = s -> log.error("Transaction segment: {} cannot be sealed", s);
 
     @Override
-    public SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, Consumer<Segment> segmentSealedCallback,
-                                                                EventWriterConfig config, String delegationToken) {
+    public SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, EventWriterConfig config,
+                                                                String delegationToken) {
         return new SegmentOutputStreamImpl(StreamSegmentNameUtils.getTransactionNameFromId(segment.getScopedName(), txId), controller, cf,
-                UUID.randomUUID(), segmentSealedCallback, getRetryFromConfig(config), delegationToken);
+                UUID.randomUUID(), nopSegmentSealedCallback, getRetryFromConfig(config), delegationToken);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -498,6 +498,10 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
             state.waitForInflight();
             Exceptions.checkNotClosed(state.isClosed(), this);
+            /* SegmentSealedException is thrown if either of the below conditions are true
+                 - resendToSuccessorsCallback has been invoked.
+                 - the segment corresponds to an aborted Transaction.
+             */
             if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
                 throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
             }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -422,7 +422,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      */
     @Override
     public void write(PendingEvent event) {
-        checkState(!state.isAlreadySealed(), "Segment: %s is already sealed", segmentName);
+        //State is set to sealed during a Transaction abort and the segment writer should not throw an {@link IllegalStateException} in such a case.
+        checkState(StreamSegmentNameUtils.isTransactionSegment(segmentName) || !state.isAlreadySealed(), "Segment: %s is already sealed", segmentName);
         synchronized (writeOrderLock) {
             ClientConnection connection;
             try {

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -50,6 +50,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
+
+import io.pravega.shared.segment.StreamSegmentNameUtils;
 import lombok.Getter;
 import lombok.Lombok;
 import lombok.RequiredArgsConstructor;
@@ -309,10 +311,17 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
 
         @Override
         public void noSuchSegment(NoSuchSegment noSuchSegment) {
-            state.failConnection(new NoSuchSegmentException(noSuchSegment.getSegment()));
-            log.info("Segment being written to {} by writer {} no longer exists due to Stream Truncation, resending to the newer segment.",
-                    noSuchSegment.getSegment(), writerId);
-            invokeResendCallBack(noSuchSegment);
+            final String segment = noSuchSegment.getSegment();
+            if (StreamSegmentNameUtils.isTransactionSegment(segment)) {
+                log.info("Transaction Segment: {} no longer exists since the txn is aborted", noSuchSegment.getSegment());
+                //close the connection and update the exception to SegmentSealed.
+                state.failConnection(new SegmentSealedException(segment));
+            } else {
+                state.failConnection(new NoSuchSegmentException(segment));
+                log.info("Segment being written to {} by writer {} no longer exists due to Stream Truncation, resending to the newer segment.",
+                        noSuchSegment.getSegment(), writerId);
+                invokeResendCallBack(noSuchSegment);
+            }
         }
 
         @Override
@@ -489,7 +498,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
             state.waitForInflight();
             Exceptions.checkNotClosed(state.isClosed(), this);
-            if (state.needSuccessors.get()) {
+            if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
                 throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
             }
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -297,12 +297,12 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     @Override
     public Transaction<Type> beginTxn() {
         TxnSegments txnSegments = getAndHandleExceptions(controller.createTransaction(stream, config.getTransactionTimeoutTime()),
-                                                         RuntimeException::new);
+                RuntimeException::new);
         UUID txnId = txnSegments.getTxnId();
         Map<Segment, SegmentTransaction<Type>> transactions = new HashMap<>();
         for (Segment s : txnSegments.getSteamSegments().getSegments()) {
             SegmentOutputStream out = outputStreamFactory.createOutputStreamForTransaction(s, txnId,
-                    segmentSealedCallBack, config, txnSegments.getSteamSegments().getDelegationToken());
+                    config, txnSegments.getSteamSegments().getDelegationToken());
             SegmentTransactionImpl<Type> impl = new SegmentTransactionImpl<>(txnId, out, serializer);
             transactions.put(s, impl);
         }
@@ -321,7 +321,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
         
         Map<Segment, SegmentTransaction<Type>> transactions = new HashMap<>();
         for (Segment s : segments.getSegments()) {
-            SegmentOutputStream out = outputStreamFactory.createOutputStreamForTransaction(s, txId, segmentSealedCallBack, config, segments.getDelegationToken());
+            SegmentOutputStream out = outputStreamFactory.createOutputStreamForTransaction(s, txId, config, segments.getDelegationToken());
             SegmentTransactionImpl<Type> impl = new SegmentTransactionImpl<>(txId, out, serializer);
             transactions.put(s, impl);
         }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -341,7 +341,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         FakeSegmentOutputStream bad = new FakeSegmentOutputStream(segment);
         Mockito.when(controller.createTransaction(stream, 0))
                .thenReturn(CompletableFuture.completedFuture(new TxnSegments(getSegments(segment), txid)));
-        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any(), any()))
+        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any()))
                 .thenReturn(outputStream);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(bad);
 
@@ -375,7 +375,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         FakeSegmentOutputStream bad = new FakeSegmentOutputStream(segment);
         Mockito.when(controller.createTransaction(stream, 0))
                .thenReturn(CompletableFuture.completedFuture(new TxnSegments(getSegments(segment), txid)));
-        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any(), any()))
+        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any()))
                 .thenReturn(outputStream);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(bad);
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
@@ -30,7 +30,6 @@ public class MockSegmentStreamFactory implements SegmentInputStreamFactory, Segm
 
     @Override
     public SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId,
-                                                                Consumer<Segment> segmentSealedCallback,
                                                                 EventWriterConfig config, String delegationToken) {
         throw new UnsupportedOperationException();
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
+import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
@@ -38,10 +39,13 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import io.pravega.test.integration.demo.ControllerWrapper;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
@@ -55,6 +59,9 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
+
+    private static final String STREAM = "stream";
+    private static final String SCOPE = "scope";
 
     private final int controllerPort = TestUtils.getAvailableListenPort();
     private final String serviceHost = "localhost";
@@ -145,6 +152,35 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
         assertNotNull(event);
         assertEquals("txntest2", event.getEvent());
     }
+
+    @Test//(timeout = 10000)
+    public void testTxnWithErrors() throws Exception {
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scope(SCOPE)
+                                                        .streamName(STREAM)
+                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .build();
+        Controller controller = controllerWrapper.getController();
+        controllerWrapper.getControllerService().createScope(SCOPE).get();
+        controller.createStream(config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> test = clientFactory.createEventWriter(STREAM, new JavaSerializer<>(),
+                EventWriterConfig.builder().transactionTimeoutTime(10000).build());
+        Transaction<String> transaction = test.beginTxn();
+        transaction.writeEvent("0", "txntest1");
+        controller.abortTransaction(Stream.of(SCOPE, STREAM), transaction.getTxnId()).join();
+        TimeUnit.SECONDS.sleep(10);
+        Transaction.Status status = controller.checkTransactionStatus(Stream.of(SCOPE, STREAM), transaction.getTxnId()).join();
+        assertEquals(Transaction.Status.ABORTED, status);
+        transaction.writeEvent("0", "txntest2");
+        AssertExtensions.assertThrows("TxnFailedException should be thrown", () -> transaction.commit(), t -> t instanceof TxnFailedException);
+    }
+
+
 
     @Test(timeout = 10000)
     public void testTxnConfig() throws Exception {


### PR DESCRIPTION
**Change log description**
- Remove redundant invocation of fetch successors during Abort Transaction.
- Fix incorrect logs on EventWriterClient for abort transaction.

**Purpose of the change**
Fixes #2801 

**What the code does**
Currently in case of an abort transaction  due to a missing `io.pravega.client.stream.impl.Controller#pingTransaction` the transaction segment writer can receive a `WireCommandType.NO_SUCH_SEGMENT`. 
In such a scenario the current segmentwriter would trigger a fetch successor callback, which is redundant, as receiving a `WireCommandType.NO_SUCH_SEGMENT` implies that the transaction has been aborted.

This PR removes this redundant callback invocation.

**How to verify it**
There are no changes to the functionality/behavior. All the existing and newly added tests should continue to pass.
