### PR TITLE
Issue 2796: Health check for services deployed using docker system test framework

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -83,7 +83,6 @@ public class BookkeeperDockerService extends DockerBasedService {
 
         String cmd1 = "CMD-SHELL";
         String cmd2 = "ss -l | grep "+BK_PORT;
-
         List<String> cmdList = new ArrayList<>();
         cmdList.add(cmd1);
         cmdList.add(cmd2);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -80,19 +80,13 @@ public class BookkeeperDockerService extends DockerBasedService {
         stringList.add(env3);
         stringList.add(env4);
 
-        String cmd1 = "CMD-SHELL";
-        String cmd2 = "ss -l | grep "+BK_PORT;
-        List<String> cmdList = new ArrayList<>();
-        cmdList.add(cmd1);
-        cmdList.add(cmd2);
-
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(0).condition("none").build())
                 .containerSpec(ContainerSpec.builder()
                         .hostname(serviceName)
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+BK_PORT+" || exit 1")).build())
                         .mounts(Arrays.asList(mount1, mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -80,13 +80,21 @@ public class BookkeeperDockerService extends DockerBasedService {
         stringList.add(env2);
         stringList.add(env3);
         stringList.add(env4);
+
+        String cmd1 = "CMD-SHELL";
+        String cmd2 = "ss -l | grep "+BK_PORT;
+
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(cmd1);
+        cmdList.add(cmd2);
+
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(0).condition("none").build())
                 .containerSpec(ContainerSpec.builder()
                         .hostname(serviceName)
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
-                        .healthcheck(ContainerConfig.Healthcheck.create(null, Duration.ofSeconds(10).toNanos(), Duration.ofSeconds(10).toNanos(), 3))
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
                         .mounts(Arrays.asList(mount1, mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -22,7 +22,6 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -86,7 +86,7 @@ public class BookkeeperDockerService extends DockerBasedService {
                         .hostname(serviceName)
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+BK_PORT+" || exit 1")).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())
                         .mounts(Arrays.asList(mount1, mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -49,6 +49,7 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
     final DockerClient dockerClient;
     final String serviceName;
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(3);
+    private List<String> commandList = new ArrayList<>();
 
     DockerBasedService(final String serviceName) {
         this.dockerClient = DefaultDockerClient.builder().uri("http://" + MASTER_IP + ":" + DOCKER_CLIENT_PORT).build();
@@ -187,6 +188,26 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
         } catch (Exception e) {
             throw new TestFrameworkException(TestFrameworkException.Type.RequestFailed, "Unable to create service", e);
         }
+    }
+
+    void commonHealthCheck() {
+        String command1 = "CMD-SHELL";
+        String command2 = "hostname | grep "+serviceName+" || exit 1";
+        commandList.add(command1);
+        commandList.add(command2);
+    }
+
+    List<String> healthCheck(String cmd1) {
+        commonHealthCheck();
+        commandList.add(cmd1);
+        return commandList;
+    }
+
+    List<String> healthCheck(String cmd1, String cmd2) {
+        commonHealthCheck();
+        healthCheck(cmd1);
+        healthCheck(cmd2);
+        return commandList;
     }
 
     long setNanoCpus(final double cpu) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -204,9 +204,8 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
     }
 
     List<String> healthCheck(String cmd1, String cmd2) {
-        commonHealthCheck();
         healthCheck(cmd1);
-        healthCheck(cmd2);
+        commandList.add(cmd2);
         return commandList;
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -21,8 +21,6 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -62,7 +60,6 @@ public class HDFSDockerService extends DockerBasedService {
         Mount mount = Mount.builder().type("volume").source("hadoop-logs-volume").target("/opt/hadoop/logs").build();
         String env1 = "SSH_PORT=2222";
         String env2 = "HDFS_HOST=" + serviceName;
-
 
         String cmd1 = "CMD-SHELL";
         String cmd2 = "ss -l | grep 8020";

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -66,7 +66,6 @@ public class HDFSDockerService extends DockerBasedService {
 
         String cmd1 = "CMD-SHELL";
         String cmd2 = "ss -l | grep 8020";
-
         List<String> cmdList = new ArrayList<>();
         cmdList.add(cmd1);
         cmdList.add(cmd2);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -61,17 +61,11 @@ public class HDFSDockerService extends DockerBasedService {
         String env1 = "SSH_PORT=2222";
         String env2 = "HDFS_HOST=" + serviceName;
 
-        String cmd1 = "CMD-SHELL";
-        String cmd2 = "ss -l | grep 8020";
-        List<String> cmdList = new ArrayList<>();
-        cmdList.add(cmd1);
-        cmdList.add(cmd2);
-
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(hdfsimage).env(Arrays.asList(env1, env2))
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep 8020 || exit 1")).build())
                         .mounts(mount)
                         .labels(labels)
                         .hostname(serviceName)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -65,7 +65,7 @@ public class HDFSDockerService extends DockerBasedService {
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(hdfsimage).env(Arrays.asList(env1, env2))
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep 8020 || exit 1")).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(8020)).build())
                         .mounts(mount)
                         .labels(labels)
                         .hostname(serviceName)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -62,11 +62,20 @@ public class HDFSDockerService extends DockerBasedService {
         Mount mount = Mount.builder().type("volume").source("hadoop-logs-volume").target("/opt/hadoop/logs").build();
         String env1 = "SSH_PORT=2222";
         String env2 = "HDFS_HOST=" + serviceName;
+
+
+        String cmd1 = "CMD-SHELL";
+        String cmd2 = "ss -l | grep 8020";
+
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(cmd1);
+        cmdList.add(cmd2);
+
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(hdfsimage).env(Arrays.asList(env1, env2))
-                        .healthcheck(ContainerConfig.Healthcheck.create(null, Duration.ofSeconds(10).toNanos(), Duration.ofSeconds(10).toNanos(), 3))
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
                         .mounts(mount)
                         .labels(labels)
                         .hostname(serviceName)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -95,7 +95,6 @@ public class PravegaControllerDockerService extends DockerBasedService {
         String cmd1 = "CMD-SHELL";
         String cmd2 = "ss -l | grep "+controllerPort;
         String cmd3 = "ss -l | grep "+restPort;
-
         List<String> cmdList = new ArrayList<>();
         cmdList.add(cmd1);
         cmdList.add(cmd2);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -21,10 +21,8 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import static io.pravega.test.system.framework.Utils.ALTERNATIVE_CONTROLLER_PORT;
@@ -92,19 +90,11 @@ public class PravegaControllerDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.task.name", serviceName);
 
-        String cmd1 = "CMD-SHELL";
-        String cmd2 = "ss -l | grep "+controllerPort;
-        String cmd3 = "ss -l | grep "+restPort;
-        List<String> cmdList = new ArrayList<>();
-        cmdList.add(cmd1);
-        cmdList.add(cmd2);
-        cmdList.add(cmd3);
-
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(IMAGE_PATH + "nautilus/pravega:" + PRAVEGA_VERSION)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+controllerPort+" || exit 1", "ss -l | grep "+restPort+" || exit 1")).build())
                         .mounts(Arrays.asList(mount))
                         .hostname(serviceName)
                         .labels(labels)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -94,7 +94,7 @@ public class PravegaControllerDockerService extends DockerBasedService {
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(IMAGE_PATH + "nautilus/pravega:" + PRAVEGA_VERSION)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+controllerPort+" || exit 1", "ss -l | grep "+restPort+" || exit 1")).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(controllerPort)).build())
                         .mounts(Arrays.asList(mount))
                         .hostname(serviceName)
                         .labels(labels)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -106,7 +106,6 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
 
         String cmd1 = "CMD-SHELL";
         String cmd2 = "ss -l | grep "+SEGMENTSTORE_PORT;
-
         List<String> cmdList = new ArrayList<>();
         cmdList.add(cmd1);
         cmdList.add(cmd2);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -109,7 +109,7 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
                 .containerSpec(ContainerSpec.builder().image(IMAGE_PATH + "nautilus/pravega:" + PRAVEGA_VERSION)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+SEGMENTSTORE_PORT+" || exit 1")).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(SEGMENTSTORE_PORT)).build())
                         .mounts(Arrays.asList(mount))
                         .env(envList).args("segmentstore").build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -103,19 +103,13 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
         envList.add(env4);
         envList.add(env5);
 
-        String cmd1 = "CMD-SHELL";
-        String cmd2 = "ss -l | grep "+SEGMENTSTORE_PORT;
-        List<String> cmdList = new ArrayList<>();
-        cmdList.add(cmd1);
-        cmdList.add(cmd2);
-
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).build())
                 .containerSpec(ContainerSpec.builder().image(IMAGE_PATH + "nautilus/pravega:" + PRAVEGA_VERSION)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("ss -l | grep "+SEGMENTSTORE_PORT+" || exit 1")).build())
                         .mounts(Arrays.asList(mount))
                         .env(envList).args("segmentstore").build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -104,13 +104,20 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
         envList.add(env4);
         envList.add(env5);
 
+        String cmd1 = "CMD-SHELL";
+        String cmd2 = "ss -l | grep "+SEGMENTSTORE_PORT;
+
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(cmd1);
+        cmdList.add(cmd2);
+
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).build())
                 .containerSpec(ContainerSpec.builder().image(IMAGE_PATH + "nautilus/pravega:" + PRAVEGA_VERSION)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.create(null, Duration.ofSeconds(10).toNanos(), Duration.ofSeconds(10).toNanos(), 3))
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build())
                         .mounts(Arrays.asList(mount))
                         .env(envList).args("segmentstore").build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -23,7 +23,6 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -20,9 +20,7 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import lombok.extern.slf4j.Slf4j;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 
@@ -58,18 +56,12 @@ public class ZookeeperDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.service.name", serviceName);
 
-        String cmd1 = "CMD-SHELL";
-        String cmd2 = "netstat -plnt | grep "+ ZKSERVICE_ZKPORT;
-        List<String> cmdList = new ArrayList<>();
-        cmdList.add(cmd1);
-        cmdList.add(cmd2);
-
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .containerSpec(ContainerSpec.builder().image(ZK_IMAGE)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build()).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("netstat -plnt | grep "+ ZKSERVICE_ZKPORT+" || exit 1")).build()).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()
                         .limits(Resources.builder().memoryBytes(mem).nanoCpus((long) cpu).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -22,7 +22,9 @@ import com.spotify.docker.client.messages.swarm.TaskSpec;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 
@@ -58,13 +60,19 @@ public class ZookeeperDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.service.name", serviceName);
 
+        String cmd1 = "CMD-SHELL";
+        String cmd2 = "netstat -plnt | grep "+ ZKSERVICE_ZKPORT;
+
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(cmd1);
+        cmdList.add(cmd2);
+
         final TaskSpec taskSpec = TaskSpec
                 .builder()
                 .containerSpec(ContainerSpec.builder().image(ZK_IMAGE)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.create(null,
-                                Duration.ofSeconds(10).toNanos(), Duration.ofSeconds(10).toNanos(), 3)).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(cmdList).build()).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()
                         .limits(Resources.builder().memoryBytes(mem).nanoCpus((long) cpu).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -20,8 +20,6 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -61,7 +61,7 @@ public class ZookeeperDockerService extends DockerBasedService {
                 .containerSpec(ContainerSpec.builder().image(ZK_IMAGE)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(healthCheck("netstat -plnt | grep "+ ZKSERVICE_ZKPORT+" || exit 1")).build()).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(customHealthCheck("netstat -plnt | grep "+ ZKSERVICE_ZKPORT+" || exit 1")).build()).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()
                         .limits(Resources.builder().memoryBytes(mem).nanoCpus((long) cpu).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -62,7 +62,6 @@ public class ZookeeperDockerService extends DockerBasedService {
 
         String cmd1 = "CMD-SHELL";
         String cmd2 = "netstat -plnt | grep "+ ZKSERVICE_ZKPORT;
-
         List<String> cmdList = new ArrayList<>();
         cmdList.add(cmd1);
         cmdList.add(cmd2);


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>

**Change log description**
 *  Adds health checks to docker swarm services.
 *  Listens for the traffic on the port, by running a command inside the container

**Purpose of the change**
Fixes #2796 

**What the code does**
Ensures that the services deployed are healthy, before starting the execution of system tests.

**How to verify it**
When system tests are run using docker swarm based system test framework, the containers of the swarm services deployed should be healthy.