### PR TITLE
Issue 2798: Add precondition checks on splits and merges from the controller.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -693,6 +693,7 @@ public class ControllerImpl implements Controller {
             log.debug("Received the following data from the controller {}", ranges.getSegmentRangesList());
             NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
             for (SegmentRange r : ranges.getSegmentRangesList()) {
+                Preconditions.checkState(r.getMinKey() <= r.getMaxKey());
                 rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
             }
             return new StreamSegments(rangeMap, ranges.getDelegationToken());
@@ -779,6 +780,7 @@ public class ControllerImpl implements Controller {
         NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
 
         for (SegmentRange r : response.getActiveSegmentsList()) {
+            Preconditions.checkState(r.getMinKey() <= r.getMaxKey());
             rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
         }
         StreamSegments segments = new StreamSegments(rangeMap, response.getDelegationToken());

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -693,7 +693,9 @@ public class ControllerImpl implements Controller {
             log.debug("Received the following data from the controller {}", ranges.getSegmentRangesList());
             NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
             for (SegmentRange r : ranges.getSegmentRangesList()) {
-                Preconditions.checkState(r.getMinKey() <= r.getMaxKey());
+                Preconditions.checkState(r.getMinKey() <= r.getMaxKey(),
+                                         "Min keyrange %s was not less than maximum keyRange %s for segment %s",
+                                         r.getMinKey(), r.getMaxKey(), r.getSegmentId());
                 rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
             }
             return new StreamSegments(rangeMap, ranges.getDelegationToken());

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentWithRange.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentWithRange.java
@@ -30,6 +30,7 @@ public class SegmentWithRange implements Serializable {
         Preconditions.checkNotNull(segment);
         Preconditions.checkArgument(rangeLow >= 0.0 && rangeLow <= 1.0);
         Preconditions.checkArgument(rangeHigh >= 0.0 && rangeHigh <= 1.0);
+        Preconditions.checkArgument(rangeLow <= rangeHigh);
         this.segment = segment;
         this.low = rangeLow;
         this.high = rangeHigh;

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -68,6 +68,7 @@ public class StreamSegments {
     }
     
     public StreamSegments withReplacementRange(StreamSegmentsWithPredecessors replacementRanges) {
+        verifyReplacementRange(replacementRanges);
         NavigableMap<Double, Segment> result = new TreeMap<>();
         Map<Long, List<SegmentWithRange>> replacedRanges = replacementRanges.getReplacementRanges();
         for (Entry<Double, Segment> exitingSegment : segments.entrySet()) {
@@ -83,6 +84,15 @@ public class StreamSegments {
         return new StreamSegments(result, delegationToken);
     }
     
+    private void verifyReplacementRange(StreamSegmentsWithPredecessors replacementRanges) {
+        for (Entry<Long, List<SegmentWithRange>> entry : replacementRanges.getReplacementRanges().entrySet()) {
+            double upperRange = entry.getValue().stream().mapToDouble(range -> range.getHigh()).max().orElseThrow(IllegalStateException::new);
+            Segment segment = segments.get(upperRange);
+            Preconditions.checkState(segment != null && segment.getSegmentId() == entry.getKey(),
+                                     "Incorrect upper range {} for segment being replaced {}", upperRange, segment);
+        }
+    }
+
     @Override
     public String toString() {
         return "StreamSegments:" + segments.toString();


### PR DESCRIPTION
**Change log description**
Add some precondition checks on StreamSegments returned from the controller.

**Purpose of the change**
Fixes #2798 

**What the code does**
Adds some sanity checks for the data coming from the controller after a segment sealed.

**How to verify it**
Existing tests actually cover this fairly well.