### PR TITLE
Issue 2810: Move MetricRegistryUtils to prevent circular dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,6 @@ project('shared:authplugin') {
 project ('shared') {
     dependencies {
         compile project(':common')
-        compile project(':shared:metrics')
         compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         compile group: 'com.google.code.findbugs', name: 'annotations', version: findbugsVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
@@ -154,7 +153,6 @@ project ('shared:metrics') {
         // https://mvnrepository.com/artifact/info.ganglia.gmetric4j/gmetric4j
         compile group: 'info.ganglia.gmetric4j', name: 'gmetric4j', version: metricsGangliaVersion
         compile project(':common')
-        testCompile project(path:':shared', configuration:'testRuntime')
     }
 
     javadoc {
@@ -350,7 +348,7 @@ project('test:integration') {
         testCompile project(path:':shared:protocol', configuration:'testRuntime')
         testCompile project(path:':segmentstore:server', configuration:'testRuntime')
         testCompile project(path:':segmentstore:server:host', configuration:'testRuntime')
-        testCompile project(path:':shared', configuration:'testRuntime')
+        testCompile project(path:':shared:metrics', configuration:'testRuntime')
 
         // Workaround for intellij issue, since we cannot add both the compile dependency and the testRuntime
         // dependency of the client project into the compile scope of the integration tests

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricRegistryUtils.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricRegistryUtils.java
@@ -7,13 +7,12 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.pravega.shared;
+package io.pravega.shared.metrics;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
-import io.pravega.shared.metrics.MetricsProvider;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -11,11 +11,11 @@ package io.pravega.shared.metrics;
 
 import io.pravega.common.Timer;
 import java.util.concurrent.atomic.AtomicInteger;
-import io.pravega.shared.MetricRegistryUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -35,19 +35,13 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
-import io.pravega.shared.MetricRegistryUtils;
+import io.pravega.shared.metrics.MetricRegistryUtils;
 import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.StatsProvider;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,6 +50,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
@@ -275,4 +276,5 @@ public class MetricsTest {
 
         log.info("Metrics Time based Cache Eviction test succeeds");
     }
+       
 }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Move MetricRegistryUtils into shared:metrics to avoid a circular dependency.

**Purpose of the change**  
Fixes #2810

**What the code does**  
Prevents `shared` from depending on `shared:metrics` and vice versa. By relocating 
MetricRegistryUtils into metrics, and changes the added dependencies to point to the new location.