### PR TITLE
Issue 2023: Controller gRPC api for stream cut validation

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -264,6 +264,14 @@ public class ControllerService {
                 .thenApplyAsync(x -> x.stream().anyMatch(z -> z.segmentId() == segmentId), executor);
     }
 
+    public CompletableFuture<Boolean> isStreamCutValid(final String scope,
+                                                     final String stream,
+                                                     final Map<Long, Long> streamCut) {
+        Exceptions.checkNotNullOrEmpty(scope, "scope");
+        Exceptions.checkNotNullOrEmpty(stream, "stream");
+        return streamStore.isStreamCutValid(scope, stream, streamCut, null, executor);
+    }
+
     @SuppressWarnings("ReturnCount")
     public CompletableFuture<Pair<UUID, List<SegmentRange>>> createTransaction(final String scope, final String stream,
                                                                                final long lease) {

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -234,6 +234,19 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
+    public void isStreamCutValid(Controller.StreamCut request, StreamObserver<Controller.StreamCutValidityResponse> responseObserver) {
+        log.info("isStreamCutValid called for stream {}/{} streamcut {}.", request.getStreamInfo().getScope(),
+                request.getStreamInfo().getStream(), request.getCutMap());
+        authenticateExecuteAndProcessResults(v -> checkAuthorization(request.getStreamInfo().getScope() + "/" +
+                        request.getStreamInfo().getStream(), AuthHandler.Permissions.READ_UPDATE),
+                () -> controllerService.isStreamCutValid(request.getStreamInfo().getScope(),
+                        request.getStreamInfo().getStream(),
+                        request.getCutMap())
+                        .thenApply(bRes -> Controller.StreamCutValidityResponse.newBuilder().setResponse(bRes).build()),
+                responseObserver);
+    }
+
+    @Override
     public void createTransaction(CreateTxnRequest request, StreamObserver<Controller.CreateTxnResponse> responseObserver) {
         log.info("createTransaction called for stream {}/{}.", request.getStreamInfo().getScope(),
                 request.getStreamInfo().getStream());

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -398,6 +398,17 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
+    public CompletableFuture<Boolean> isStreamCutValid(final String scope,
+                                                final String streamName,
+                                                final Map<Long, Long> streamCut,
+                                                final OperationContext context,
+                                                final Executor executor) {
+        Stream stream = getStream(scope, streamName, context);
+        return withCompletion(stream.isStreamCutValid(streamCut), executor);
+    }
+
+
+    @Override
     public CompletableFuture<EpochTransitionRecord> startScale(final String scope,
                                                                final String name,
                                                                final List<Long> sealedSegments,

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -34,6 +34,7 @@ import io.pravega.controller.store.stream.tables.StreamCutRecord;
 import io.pravega.controller.store.stream.tables.StreamTruncationRecord;
 import io.pravega.controller.store.stream.tables.TableHelper;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
+import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -437,6 +438,26 @@ public abstract class PersistentStreamBase<T> implements Stream {
                                         .thenApply(segmentTable ->
                                                 TableHelper.findSegmentsBetweenStreamCuts(historyIndex.getData(), historyTable.getData(),
                                                         segmentIndex.getData(), segmentTable.getData(), from, to)))));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isStreamCutValid(Map<Long, Long> streamCut) {
+        return Futures.allOfWithResults(streamCut.keySet().stream().map(x -> getSegment(x).thenApply(segment ->
+                new SimpleEntry<>(segment.getKeyStart(), segment.getKeyEnd())))
+                .collect(Collectors.toList()))
+                .thenAccept(TableHelper::validateStreamCut)
+                .handle((r, e) -> {
+                    if (e != null) {
+                        if (Exceptions.unwrap(e) instanceof IllegalArgumentException) {
+                            return false;
+                        } else {
+                            log.warn("Exception while trying to validate a stream cut for stream {}/{}", scope, name);
+                            throw Lombok.sneakyThrow(e);
+                        }
+                    } else {
+                        return true;
+                    }
+                });
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -170,6 +170,13 @@ interface Stream {
     CompletableFuture<List<Segment>> getSegmentsBetweenStreamCuts(final Map<Long, Long> from, final Map<Long, Long> to);
 
     /**
+     * Method to validate stream cut based on its definition - disjoint sets that cover the entire range of keyspace.
+     * @param streamCut stream cut to validate.
+     * @return Future which when completed has the result of validation check (true for valid and false for illegal streamCuts).
+     */
+    CompletableFuture<Boolean> isStreamCutValid(Map<Long, Long> streamCut);
+
+    /**
      * @return currently active segments
      */
     CompletableFuture<List<Long>> getActiveSegments();

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -386,6 +386,22 @@ public interface StreamMetadataStore {
                                                            final Executor executor);
 
     /**
+     * Method to validate stream cut based on its definition - disjoint sets that cover the entire range of keyspace.
+     *
+     * @param scope scope name
+     * @param streamName stream name
+     * @param streamCut stream cut to validate
+     * @param context execution context
+     * @param executor executor
+     * @return Future which when completed has the result of validation check (true for valid and false for illegal streamCuts).
+     */
+    CompletableFuture<Boolean> isStreamCutValid(final String scope,
+                                                final String streamName,
+                                                final Map<Long, Long> streamCut,
+                                                final OperationContext context,
+                                                final Executor executor);
+
+    /**
      * Scales in or out the currently set of active segments of a stream.
      *
      * @param scope          stream scope

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -866,6 +866,30 @@ public abstract class StreamMetadataStoreTest {
     }
 
     @Test
+    public void streamCutTest() throws Exception {
+        final String scope = "ScopeStreamCut";
+        final String stream = "StreamCut";
+        final ScalingPolicy policy = ScalingPolicy.fixed(2);
+        final StreamConfiguration configuration = StreamConfiguration.builder().scope(scope).streamName(stream).scalingPolicy(policy).build();
+
+        long start = System.currentTimeMillis();
+        store.createScope(scope).get();
+
+        store.createStream(scope, stream, configuration, start, null, executor).get();
+        store.setState(scope, stream, State.ACTIVE, null, executor).get();
+
+        Map<Long, Long> invalid = new HashMap<>();
+        invalid.put(0L, 0L);
+
+        Map<Long, Long> valid = new HashMap<>();
+        valid.put(0L, 0L);
+        valid.put(1L, 0L);
+
+        assertTrue(store.isStreamCutValid(scope, stream, valid, null, executor).join());
+        assertFalse(store.isStreamCutValid(scope, stream, invalid, null, executor).join());
+    }
+
+    @Test
     public void retentionSetTest() throws Exception {
         final String scope = "ScopeRetain";
         final String stream = "StreamRetain";

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -30,6 +30,7 @@ service ControllerService {
     rpc checkScale(ScaleStatusRequest) returns (ScaleStatusResponse);
     rpc getURI(SegmentId) returns (NodeUri);
     rpc isSegmentValid(SegmentId) returns (SegmentValidityResponse);
+    rpc isStreamCutValid(StreamCut) returns (StreamCutValidityResponse);
     rpc createTransaction(CreateTxnRequest) returns (CreateTxnResponse);
     rpc commitTransaction(TxnRequest) returns (TxnStatus);
     rpc abortTransaction(TxnRequest) returns (TxnStatus);
@@ -295,6 +296,10 @@ message GetSegmentsRequest {
 }
 
 message SegmentValidityResponse {
+    bool response = 1;
+}
+
+message StreamCutValidityResponse {
     bool response = 1;
 }
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <Shivesh.Ranjan@gmail.com>

**Change log description**  
Introduced new gRPC api for stream cut validation. 

**Purpose of the change**  
Fixes #2023 

**What the code does**  
Introduces a new gRPC api for stream cut validation. This api simply passes the stream cut to the metadata store where its validation is performed. Validation checks if entire keyspace range is covered and if it does not have any overlapping segments involved in the stream cut. 
Note: The current representation of stream cut has problems that we will tackle separately.
As part of this PR we have not changed the stream cut representation and validation logic. It simply introduces a new controller gRPC api for stream cut validation. 
Note: we have exposed this api but we are deliberately not using it in reader group generated stream cuts because they may yield false negatives because of limitation of stream cut representation. 

**How to verify it**  
Unit tests added. 