### PR TITLE
Issue 2823: Updated StreamCuts in ReaderGroup

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -828,15 +828,9 @@ public class ReaderGroupState implements Revisioned {
         void update(ReaderGroupState state) {
             state.checkpointState.readerCheckpointed(checkpointId, readerId, positions);
 
-            // Update the offsets of segments with the current positions for this checkpoint.
+            // Each reader updates the offsets of its assigned segments with the current positions for this checkpoint.
             for (Entry<Segment, Long> entry : positions.entrySet()) {
-                state.unassignedSegments.computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
-            }
-
-            for (String reader : state.assignedSegments.keySet()) {
-                for (Entry<Segment, Long> entry : positions.entrySet()) {
-                    state.assignedSegments.get(reader).computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
-                }
+                state.assignedSegments.get(readerId).computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
             }
         }
         

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -827,6 +827,17 @@ public class ReaderGroupState implements Revisioned {
         @Override
         void update(ReaderGroupState state) {
             state.checkpointState.readerCheckpointed(checkpointId, readerId, positions);
+
+            // Update the offsets of segments with the current positions for this checkpoint.
+            for (Entry<Segment, Long> entry : positions.entrySet()) {
+                state.unassignedSegments.computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
+            }
+
+            for (String reader : state.assignedSegments.keySet()) {
+                for (Entry<Segment, Long> entry : positions.entrySet()) {
+                    state.assignedSegments.get(reader).computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
+                }
+            }
         }
         
         private static class CheckpointReaderBuilder implements ObjectBuilder<CheckpointReader> {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -831,7 +831,7 @@ public class ReaderGroupState implements Revisioned {
             // Each reader updates the offsets of its assigned segments with the current positions for this checkpoint.
             final Map<Segment, Long> readerPositions = state.assignedSegments.get(readerId);
             for (Entry<Segment, Long> entry : positions.entrySet()) {
-                readerPositions.computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
+                readerPositions.replace(entry.getKey(), entry.getValue());
             }
         }
         

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -829,8 +829,9 @@ public class ReaderGroupState implements Revisioned {
             state.checkpointState.readerCheckpointed(checkpointId, readerId, positions);
 
             // Each reader updates the offsets of its assigned segments with the current positions for this checkpoint.
+            final Map<Segment, Long> readerPositions = state.assignedSegments.get(readerId);
             for (Entry<Segment, Long> entry : positions.entrySet()) {
-                state.assignedSegments.get(readerId).computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
+                readerPositions.computeIfPresent(entry.getKey(), (k, v) -> positions.get(entry.getKey()));
             }
         }
         

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@Slf4j
+public class ReaderGroupStreamCutUpdateTest {
+
+    private final int controllerPort = TestUtils.getAvailableListenPort();
+    private final String serviceHost = "localhost";
+    private final URI controllerURI = URI.create("tcp://" + serviceHost + ":" + controllerPort);
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final int containerCount = 4;
+    private TestingServer zkTestServer;
+    private PravegaConnectionListener server;
+    private ControllerWrapper controllerWrapper;
+    private ServiceBuilder serviceBuilder;
+    private ScheduledExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+
+        server = new PravegaConnectionListener(false, servicePort, store);
+        server.startListening();
+
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                containerCount);
+        controllerWrapper.awaitRunning();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ExecutorServiceHelpers.shutdown(executor);
+        controllerWrapper.close();
+        server.close();
+        serviceBuilder.close();
+        zkTestServer.close();
+    }
+
+    @Test
+    public void testStreamcutsUpdateInReaderGroup() throws Exception {
+        final String scope = "testStreamcutsUpdateInReaderGroup";
+        final String stream = "myStream2";
+        final String readerGroupName = "testStreamcutsUpdateInReaderGroupRG";
+        final int checkpointingIntervalMs = 2000;
+        final int readerSleepInterval = 250;
+        final int numEvents = 200;
+
+        // First, create the stream.
+        StreamManager streamManager = StreamManager.create(controllerURI);
+        Assert.assertTrue(streamManager.createScope(scope));
+        StreamConfiguration streamConfiguration = StreamConfiguration.builder()
+                                                                     .scope(scope)
+                                                                     .streamName(stream)
+                                                                     .scalingPolicy(ScalingPolicy.fixed(2))
+                                                                     .build();
+        streamManager.createStream(scope, stream, streamConfiguration);
+
+        // Write some events in the stream.
+        @Cleanup
+        ClientFactory clientFactory = ClientFactory.withScope(scope, controllerURI);
+        writeEvents(clientFactory, stream, numEvents);
+
+        // Read the events and test that positions are getting updated.
+        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
+                                                               .stream(Stream.of(scope, stream))
+                                                               .automaticCheckpointIntervalMillis(checkpointingIntervalMs)
+                                                               .build();
+
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
+        ReaderGroup readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
+        @Cleanup
+        EventStreamReader<Double> reader = clientFactory.createReader("myReader", readerGroupName,
+                new JavaSerializer<>(), ReaderConfig.builder().build());
+
+        Map<Stream, StreamCut> currentStreamcuts = readerGroup.getStreamCuts();
+        EventRead eventRead;
+        int lastIteration = 0, iteration = 0;
+        int assertionFrequency = checkpointingIntervalMs / readerSleepInterval;
+        do {
+            eventRead = reader.readNextEvent(5000);
+            if (iteration != lastIteration && iteration % assertionFrequency == 0) {
+                log.info("Comparing streamcuts: {} / {} in iteration {}.", currentStreamcuts, readerGroup.getStreamCuts(), iteration);
+                Assert.assertNotEquals(currentStreamcuts, readerGroup.getStreamCuts());
+                currentStreamcuts = readerGroup.getStreamCuts();
+                lastIteration = iteration;
+            }
+
+            Thread.sleep(readerSleepInterval);
+            if (!eventRead.isCheckpoint()) {
+                iteration++;
+            }
+        } while ((eventRead.isCheckpoint() || eventRead.getEvent() != null) && iteration < numEvents);
+    }
+
+    private void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents, int offset) {
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        for (int i = offset; i < totalEvents; i++) {
+            writer.writeEvent(String.valueOf(i)).join();
+            log.info("Writing event: {} to stream {}", i, streamName);
+        }
+    }
+
+    private void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
+        writeEvents(clientFactory, streamName, totalEvents, 0);
+    }
+}

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
@@ -88,14 +88,14 @@ public class ReaderGroupStreamCutUpdateTest {
         zkTestServer.close();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testStreamcutsUpdateInReaderGroup() throws Exception {
         final String scope = "testStreamcutsUpdateInReaderGroup";
-        final String stream = "myStream2";
+        final String stream = "myStream";
         final String readerGroupName = "testStreamcutsUpdateInReaderGroupRG";
         final int checkpointingIntervalMs = 2000;
         final int readerSleepInterval = 250;
-        final int numEvents = 200;
+        final int numEvents = 100;
 
         // First, create the stream.
         StreamManager streamManager = StreamManager.create(controllerURI);
@@ -132,6 +132,8 @@ public class ReaderGroupStreamCutUpdateTest {
         int assertionFrequency = checkpointingIntervalMs / readerSleepInterval;
         do {
             eventRead = reader.readNextEvent(5000);
+
+            // Check that the streamcuts are being updated periodically via automatic reader group checkpoints.
             if (iteration != lastIteration && iteration % assertionFrequency == 0) {
                 log.info("Comparing streamcuts: {} / {} in iteration {}.", currentStreamcuts, readerGroup.getStreamCuts(), iteration);
                 Assert.assertNotEquals(currentStreamcuts, readerGroup.getStreamCuts());


### PR DESCRIPTION
**Change log description**
- This PR allows `ReaderGroup.getStreamCuts()` to get updated values according to the checkpoints being processed in the reader group.
- Added unit test/integration test to verify the fix.

**Purpose of the change**
Fixes #2823.

**What the code does**
This PR modifies `CheckpointReader.update()` method in `ReaderGroupState` to update `assignedSegments` offsets upon a checkpoint state update. This change allows `ReaderGroupState.getPositions()` to retrieve updated values, which are in turn used by `ReaderGroup.getStreamCuts()` to provide users with updated stream cuts.

**How to verify it**
- All test should be passing as before (unit, integration, system).
- Added a new unit test to check that `assignedSegments` are updated upon a checkpoint.
- Added a new integration test to check that a client application gets updated streamcuts from  `ReaderGroup.getStreamCuts()` according to the automatic checkpoints defined in the `ReaderGroup`.
