### PR TITLE
Issue 2828: Limit outstanding checkpoint request to ReaderGroup

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -52,6 +52,7 @@ public class ReaderGroupConfig implements Serializable {
    public static class ReaderGroupConfigBuilder implements ObjectBuilder<ReaderGroupConfig> {
        private long groupRefreshTimeMillis = 3000; //default value
        private long automaticCheckpointIntervalMillis = 120000; //default value
+       // maximum outstanding checkpoint request that is allowed at any given time.
        private int maxOutstandingCheckpointRequest = 3; //default value
 
        /**
@@ -173,16 +174,6 @@ public class ReaderGroupConfig implements Serializable {
         */
        public ReaderGroupConfigBuilder startFromCheckpoint(final Checkpoint checkpoint) {
            this.startingStreamCuts(checkpoint.asImpl().getPositions());
-           return this;
-       }
-
-       /**
-        * Ensure not more than maximum outstanding checkpoint requests are allowed at any given time.
-        * @param maxOutstandingCheckpointRequest Max allowed outstanding checkpoint request.
-        * @return Reader group config builder.
-        */
-       public ReaderGroupConfigBuilder maxPendingCheckpoints(final int maxOutstandingCheckpointRequest) {
-           this.maxOutstandingCheckpointRequest = maxOutstandingCheckpointRequest;
            return this;
        }
 

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -203,6 +203,10 @@ public class ReaderGroupConfig implements Serializable {
            //basic check to verify if endStreamCut > startStreamCut.
            validateStartAndEndStreamCuts(startingStreamCuts, endingStreamCuts);
 
+           //basic check to verify if maxOutstandingCheckpointRequest value > 0
+           Preconditions.checkArgument(maxOutstandingCheckpointRequest > 0,
+                   "Outstanding checkpoint request should be greater than zero");
+
            return new ReaderGroupConfig(groupRefreshTimeMillis, automaticCheckpointIntervalMillis,
                    startingStreamCuts, endingStreamCuts, maxOutstandingCheckpointRequest);
        }

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -137,8 +137,8 @@ public class CheckpointState {
         return !uncheckpointedHosts.isEmpty();
     }
 
-    int getUnCheckpointedHostsSize() {
-        return uncheckpointedHosts.size();
+    int getOutstandingCheckpoints() {
+        return checkpoints.size();
     }
     
     void clearCheckpointsBefore(String checkpointId) {

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -136,6 +136,10 @@ public class CheckpointState {
     boolean hasOngoingCheckpoint() {
         return !uncheckpointedHosts.isEmpty();
     }
+
+    int getUnCheckpointedHostsSize() {
+        return uncheckpointedHosts.size();
+    }
     
     void clearCheckpointsBefore(String checkpointId) {
         if (checkpointPositions.containsKey(checkpointId)) {

--- a/client/src/main/java/io/pravega/client/stream/impl/MaxNumberOfCheckpointsExceededException.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/MaxNumberOfCheckpointsExceededException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.stream.impl;
+
+public class MaxNumberOfCheckpointsExceededException extends CheckpointFailedException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MaxNumberOfCheckpointsExceededException(String message) {
+        super(message);
+    }
+
+    public MaxNumberOfCheckpointsExceededException(Throwable e) {
+        super(e);
+    }
+
+    public MaxNumberOfCheckpointsExceededException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -117,9 +117,8 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
             int maxOutstandingCheckpointRequest = config.getMaxOutstandingCheckpointRequest();
             int currentOutstandingCheckpointRequest = checkpointState.getOutstandingCheckpoints();
             if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
-                String errorMessage = rejectMessage + maxOutstandingCheckpointRequest;
-                log.warn("maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {}",
-                        maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, errorMessage);
+                log.warn("maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}",
+                        maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage, maxOutstandingCheckpointRequest);
                 return false;
             } else {
                 updates.add(new CreateCheckpoint(checkpointName));

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -111,8 +111,8 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
 
         synchronizer.fetchUpdates();
         int maxOutstandingCheckpointRequest = this.synchronizer.getState().getConfig().getMaxOutstandingCheckpointRequest();
-        int currentOutstandingCheckpointRequest = synchronizer.getState().getCheckpointState().getUnCheckpointedHostsSize();
-        if (currentOutstandingCheckpointRequest == maxOutstandingCheckpointRequest) {
+        int currentOutstandingCheckpointRequest = synchronizer.getState().getCheckpointState().getOutstandingCheckpoints();
+        if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
             String errorMessage = "rejecting checkpoint request since pending checkpoint reaches max allowed limit: " + maxOutstandingCheckpointRequest;
             log.warn("maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {}",
                     maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, errorMessage);

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -128,7 +128,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         });
 
         if (!canPerformCheckpoint) {
-            return Futures.failedFuture(new CheckpointFailedException(rejectMessage));
+            return Futures.failedFuture(new MaxNumberOfCheckpointsExceededException(rejectMessage));
         }
 
         AtomicBoolean checkpointPending = new AtomicBoolean(true);

--- a/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
@@ -176,6 +176,36 @@ public class ReaderGroupConfigTest {
                          .build();
     }
 
+    @Test
+    public void testOutstandingCheckpointRequestConfig() {
+        //test if the supplied pending checkpoint value is configured
+        ReaderGroupConfig cfg = ReaderGroupConfig.builder()
+                .disableAutomaticCheckpoints()
+                .stream("scope/s1", getStreamCut("s1"))
+                .maxPendingCheckpoints(5)
+                .build();
+        assertEquals(cfg.getMaxOutstandingCheckpointRequest(), 5);
+
+        //test if the default checkpoint value is configured
+        cfg = ReaderGroupConfig.builder()
+                .disableAutomaticCheckpoints()
+                .stream("scope/s1", getStreamCut("s1"))
+                .build();
+        assertEquals(cfg.getMaxOutstandingCheckpointRequest(), 3);
+
+        //test if the minimum checkpoint value is being validated
+        try {
+            cfg = ReaderGroupConfig.builder()
+                    .disableAutomaticCheckpoints()
+                    .stream("scope/s1", getStreamCut("s1"))
+                    .maxPendingCheckpoints(-1)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Outstanding checkpoint request should be greater than zero");
+        }
+
+    }
+
     private StreamCut getStreamCut(String streamName) {
         return getStreamCut(streamName, 10L);
     }

--- a/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
@@ -182,7 +182,7 @@ public class ReaderGroupConfigTest {
         ReaderGroupConfig cfg = ReaderGroupConfig.builder()
                 .disableAutomaticCheckpoints()
                 .stream("scope/s1", getStreamCut("s1"))
-                .maxPendingCheckpoints(5)
+                .maxOutstandingCheckpointRequest(5)
                 .build();
         assertEquals(cfg.getMaxOutstandingCheckpointRequest(), 5);
 
@@ -198,7 +198,7 @@ public class ReaderGroupConfigTest {
             cfg = ReaderGroupConfig.builder()
                     .disableAutomaticCheckpoints()
                     .stream("scope/s1", getStreamCut("s1"))
-                    .maxPendingCheckpoints(-1)
+                    .maxOutstandingCheckpointRequest(-1)
                     .build();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Outstanding checkpoint request should be greater than zero");

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -154,7 +154,7 @@ public class ReaderGroupImplTest {
     }
 
     @Test
-    public void initiateCheckpointFailue() {
+    public void initiateCheckpointFailure() {
         when(synchronizer.updateState(any(StateSynchronizer.UpdateGeneratorFunction.class))).thenReturn(false);
         CompletableFuture<Checkpoint> result = readerGroup.initiateCheckpoint("test", scheduledThreadPoolExecutor);
         assertTrue("expecting a checkpoint failure", result.isCompletedExceptionally());

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +40,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -62,6 +66,8 @@ public class ReaderGroupImplTest {
     private StateSynchronizer<ReaderGroupState> synchronizer;
     @Mock
     private ReaderGroupState state;
+    @Mock
+    private ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
 
     private Serializer<InitialUpdate<ReaderGroupState>> initSerializer = new ReaderGroupStateInitSerializer();
     private Serializer<Update<ReaderGroupState>> updateSerializer = new ReaderGroupStateUpdatesSerializer();
@@ -145,6 +151,25 @@ public class ReaderGroupImplTest {
                 .thenReturn(CompletableFuture.completedFuture(new StreamSegmentSuccessors(r, "")));
 
         assertEquals(40L, readerGroup.unreadBytes());
+    }
+
+    @Test
+    public void initiateCheckpointFailue() {
+        when(synchronizer.updateState(any(StateSynchronizer.UpdateGeneratorFunction.class))).thenReturn(false);
+        CompletableFuture<Checkpoint> result = readerGroup.initiateCheckpoint("test", scheduledThreadPoolExecutor);
+        assertTrue("expecting a checkpoint failure", result.isCompletedExceptionally());
+        try {
+            result.get();
+        } catch (InterruptedException | ExecutionException e) {
+            assertTrue("expecting checkpoint failed exception", e.getCause() instanceof CheckpointFailedException);
+        }
+    }
+
+    @Test
+    public void initiateCheckpointSuccess() {
+        when(synchronizer.updateState(any(StateSynchronizer.UpdateGeneratorFunction.class))).thenReturn(true);
+        CompletableFuture<Checkpoint> result = readerGroup.initiateCheckpoint("test", scheduledThreadPoolExecutor);
+        assertFalse("not expecting a checkpoint failure", result.isCompletedExceptionally());
     }
 
     private StreamCut createStreamCut(String streamName, int numberOfSegments) {

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -161,7 +161,7 @@ public class ReaderGroupImplTest {
         try {
             result.get();
         } catch (InterruptedException | ExecutionException e) {
-            assertTrue("expecting checkpoint failed exception", e.getCause() instanceof CheckpointFailedException);
+            assertTrue("expecting MaxNumberOfCheckpointsExceededException", e.getCause() instanceof MaxNumberOfCheckpointsExceededException);
         }
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -10,7 +10,7 @@
 package io.pravega.test.integration;
 
 import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.impl.CheckpointFailedException;
+import io.pravega.client.stream.impl.MaxNumberOfCheckpointsExceededException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
@@ -280,7 +280,7 @@ public class CheckpointTest {
         try {
             checkpoint2.get();
         } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof CheckpointFailedException);
+            assertTrue(e.getCause() instanceof MaxNumberOfCheckpointsExceededException);
             assertTrue(e.getCause().getMessage()
                     .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit"));
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -282,7 +282,7 @@ public class CheckpointTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof CheckpointFailedException);
             assertTrue(e.getCause().getMessage()
-                    .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit: " + maxOutstandingCheckpointRequest));
+                    .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit"));
         }
 
         EventRead<String> read = reader1.readNextEvent(60000);

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -236,7 +236,7 @@ public class CheckpointTest {
         int maxOutstandingCheckpointRequest = 1;
         ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
                 .stream(Stream.of(scope, streamName))
-                .maxPendingCheckpoints(maxOutstandingCheckpointRequest)
+                .maxOutstandingCheckpointRequest(maxOutstandingCheckpointRequest)
                 .build();
         streamManager.createScope(scope);
         streamManager.createStream(scope, streamName, StreamConfiguration.builder()

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -10,6 +10,7 @@
 package io.pravega.test.integration;
 
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.CheckpointFailedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
@@ -214,5 +215,88 @@ public class CheckpointTest {
         Checkpoint cpResult = checkpoint.get(5, TimeUnit.SECONDS);
         assertTrue(checkpoint.isDone());
         assertEquals("Checkpoint", cpResult.getName());
+    }
+
+    @Test(timeout = 20000)
+    public void testMaxPendingCheckpoint() throws ReinitializationRequiredException, InterruptedException,
+            ExecutionException, TimeoutException {
+        String endpoint = "localhost";
+        String streamName = "abcd";
+        String readerGroupName = "group1";
+        int port = TestUtils.getAvailableListenPort();
+        String testString = "Hello world\n";
+        String scope = "Scope12";
+        StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();
+        @Cleanup
+        PravegaConnectionListener server = new PravegaConnectionListener(false, port, store);
+        server.startListening();
+        @Cleanup
+        MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
+        MockClientFactory clientFactory = streamManager.getClientFactory();
+        int maxOutstandingCheckpointRequest = 1;
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
+                .stream(Stream.of(scope, streamName))
+                .maxPendingCheckpoints(maxOutstandingCheckpointRequest)
+                .build();
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                .scope(scope)
+                .streamName(streamName)
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build());
+        streamManager.createReaderGroup(readerGroupName, groupConfig);
+
+        @Cleanup
+        ReaderGroup readerGroup = streamManager.getReaderGroup(readerGroupName);
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        EventStreamWriter<String> producer = clientFactory.createEventWriter(streamName, serializer,
+                EventWriterConfig.builder().build());
+        producer.writeEvent(testString);
+        producer.writeEvent(testString);
+        producer.writeEvent(testString);
+        producer.flush();
+
+        AtomicLong clock = new AtomicLong();
+        @Cleanup
+        EventStreamReader<String> reader1 = clientFactory.createReader("reader1", readerGroupName, serializer,
+                ReaderConfig.builder().build(), clock::get,
+                clock::get);
+        @Cleanup
+        EventStreamReader<String> reader2 = clientFactory.createReader("reader2", readerGroupName, serializer,
+                ReaderConfig.builder().build(), clock::get,
+                clock::get);
+        clock.addAndGet(CLOCK_ADVANCE_INTERVAL);
+
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor1 = new InlineExecutor();
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor2 = new InlineExecutor();
+
+        CompletableFuture<Checkpoint> checkpoint1 = readerGroup.initiateCheckpoint("Checkpoint1", backgroundExecutor1);
+        assertFalse(checkpoint1.isDone());
+
+        CompletableFuture<Checkpoint> checkpoint2 = readerGroup.initiateCheckpoint("Checkpoint2", backgroundExecutor2);
+        assertTrue(checkpoint2.isCompletedExceptionally());
+        try {
+            checkpoint2.get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof CheckpointFailedException);
+            assertTrue(e.getCause().getMessage()
+                    .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit: " + maxOutstandingCheckpointRequest));
+        }
+
+        EventRead<String> read = reader1.readNextEvent(60000);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint1", read.getCheckpointName());
+        assertNull(read.getEvent());
+
+        read = reader2.readNextEvent(60000);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint1", read.getCheckpointName());
+        assertNull(read.getEvent());
+
+        Checkpoint cpResult = checkpoint1.get(5, TimeUnit.SECONDS);
+        assertTrue(checkpoint1.isDone());
+        assertEquals("Checkpoint1", cpResult.getName());
     }
 }


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**  
 - added configurable option to `readergroup` to limit outstanding checkpoint request

**Purpose of the change**  
Fixes #2828

**What the code does**  
Upon initiating checkpoint request, it validates if the current outstanding checkpoint request has reached the maximum allowed limit and throws an exception.

**How to verify it**  
Added test case to validate the configurable limits 
