### PR TITLE
Issue 2715: Refactor system tests

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -18,17 +18,19 @@ import io.pravega.client.stream.impl.StreamSegments;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
-import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+
 import static org.junit.Assert.assertTrue;
 
+/**
+ * This class provides useful methods for classes that aim at implementing system tests in which service instance
+ * failures are involved during read and write workloads.
+ */
 @Slf4j
 abstract class AbstractFailoverTests extends AbstractReadWriteTest {
 
@@ -43,54 +45,6 @@ abstract class AbstractFailoverTests extends AbstractReadWriteTest {
     URI controllerURIDirect = null;
     Controller controller;
     ScheduledExecutorService controllerExecutorService;
-
-    static URI startZookeeperInstance() {
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        return zkUris.get(0);
-    }
-
-    static void startBookkeeperInstances(final URI zkUri) {
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-    }
-
-    static URI startPravegaControllerInstances(final URI zkUri) throws ExecutionException {
-        Service controllerService = Utils.createPravegaControllerService(zkUri);
-        if (!controllerService.isRunning()) {
-            controllerService.start(true);
-        }
-        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
-        List<URI> conUris = controllerService.getServiceDetails();
-        log.info("conuris {} {}", conUris.get(0), conUris.get(1));
-        log.debug("Pravega Controller service  details: {}", conUris);
-        // Fetch all the RPC endpoints and construct the client URIs.
-        final List<String> uris = conUris.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT
-                : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
-                                         .collect(Collectors.toList());
-
-        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
-        log.info("Controller Service direct URI: {}", controllerURI);
-        return controllerURI;
-    }
-
-    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI) throws ExecutionException {
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-        Futures.getAndHandleExceptions(segService.scaleService(3), ExecutionException::new);
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega Segmentstore service  details: {}", segUris);
-    }
 
     void performFailoverTest() throws ExecutionException {
         log.info("Test with 3 controller, segment store instances running and without a failover scenario");

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -9,163 +9,87 @@
  */
 package io.pravega.test.system;
 
-import com.google.common.base.Preconditions;
-import io.netty.util.internal.ConcurrentSet;
-import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.Controller;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamSegments;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
-import java.util.HashMap;
-import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import static java.util.Collections.synchronizedList;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import lombok.extern.slf4j.Slf4j;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-abstract class AbstractFailoverTests {
+abstract class AbstractFailoverTests extends AbstractReadWriteTest {
 
     static final String AUTO_SCALE_STREAM = "testReadWriteAndAutoScaleStream";
     static final String SCALE_STREAM = "testReadWriteAndScaleStream";
-    static final String RK_VALUE_SEPARATOR = ":";
     //Duration for which the system test waits for writes/reads to happen post failover.
     //10s (SessionTimeout) + 10s (RebalanceContainers) + 20s (For Container recovery + start) + NetworkDelays
     static final int WAIT_AFTER_FAILOVER_MILLIS = 40 * 1000;
-    static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
-    static final int WRITER_MAX_RETRY_ATTEMPTS = 20;
-    static final int NUM_EVENTS_PER_TRANSACTION = 50;
-    static final int RK_RENEWAL_RATE_TRANSACTION = NUM_EVENTS_PER_TRANSACTION / 2;
-    static final int RK_RENEWAL_RATE_WRITER = 500;
-    static final int SCALE_WAIT_ITERATIONS = 12;
 
-    final String readerName = "reader";
     Service controllerInstance;
     Service segmentStoreInstance;
     URI controllerURIDirect = null;
-    ScheduledExecutorService executorService;
-    ScheduledExecutorService controllerExecutorService;
     Controller controller;
-    TestState testState;
+    ScheduledExecutorService controllerExecutorService;
 
-    static class TestState {
-        //read and write count variables
-        final AtomicBoolean stopReadFlag = new AtomicBoolean(false);
-        final AtomicBoolean stopWriteFlag = new AtomicBoolean(false);
-        final AtomicReference<Throwable> getWriteException = new AtomicReference<>();
-        final AtomicReference<Throwable> getTxnWriteException = new AtomicReference<>();
-        final AtomicReference<Throwable> getReadException =  new AtomicReference<>();
-        //list of all writer's futures
-        final List<CompletableFuture<Void>> writers = synchronizedList(new ArrayList<>());
-        //list of all reader's futures
-        final List<CompletableFuture<Void>> readers = synchronizedList(new ArrayList<>());
-        final List<CompletableFuture<Void>> writersListComplete = synchronizedList(new ArrayList<>());
-        final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
-        final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
-        final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
-        final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
-        final ConcurrentSet<UUID> committingTxn = new ConcurrentSet<>();
-        final ConcurrentSet<UUID> abortedTxn = new ConcurrentSet<>();
-        final boolean txnWrite;
-
-        final AtomicLong writtenEvents = new AtomicLong();
-        final AtomicLong readEvents = new AtomicLong();
-
-        TestState(boolean txnWrite) {
-            this.txnWrite = txnWrite;
+    static URI startZookeeperInstance() {
+        Service zkService = Utils.createZookeeperService();
+        if (!zkService.isRunning()) {
+            zkService.start(true);
         }
+        List<URI> zkUris = zkService.getServiceDetails();
+        log.debug("Zookeeper service details: {}", zkUris);
+        return zkUris.get(0);
+    }
 
-        long incrementTotalWrittenEvents() {
-            return writtenEvents.incrementAndGet();
+    static void startBookkeeperInstances(final URI zkUri) {
+        Service bkService = Utils.createBookkeeperService(zkUri);
+        if (!bkService.isRunning()) {
+            bkService.start(true);
         }
+        List<URI> bkUris = bkService.getServiceDetails();
+        log.debug("Bookkeeper service details: {}", bkUris);
+    }
 
-        long incrementTotalWrittenEvents(int increment) {
-            return writtenEvents.addAndGet(increment);
+    static URI startPravegaControllerInstances(final URI zkUri) throws ExecutionException {
+        Service controllerService = Utils.createPravegaControllerService(zkUri);
+        if (!controllerService.isRunning()) {
+            controllerService.start(true);
         }
+        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
+        List<URI> conUris = controllerService.getServiceDetails();
+        log.info("conuris {} {}", conUris.get(0), conUris.get(1));
+        log.debug("Pravega Controller service  details: {}", conUris);
+        // Fetch all the RPC endpoints and construct the client URIs.
+        final List<String> uris = conUris.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT
+                : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
+                                         .collect(Collectors.toList());
 
-        long incrementTotalReadEvents() {
-            return readEvents.incrementAndGet();
+        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
+        log.info("Controller Service direct URI: {}", controllerURI);
+        return controllerURI;
+    }
+
+    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI) throws ExecutionException {
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
+        if (!segService.isRunning()) {
+            segService.start(true);
         }
-
-        long getEventWrittenCount() {
-            return writtenEvents.get();
-        }
-
-        long getEventReadCount() {
-            return readEvents.get();
-        }
-
-        void checkForAnomalies() {
-            boolean failed = false;
-            long eventReadCount = getEventReadCount();
-            long eventWrittenCount = getEventWrittenCount();
-            if (eventReadCount != eventWrittenCount) {
-                failed = true;
-                log.error("Read write count mismatch => readCount = {}, writeCount = {}", eventReadCount, eventWrittenCount);
-            }
-
-            if (committingTxn.size() > 0) {
-                failed = true;
-                log.error("Txn left committing: {}", committingTxn);
-            }
-
-            if (abortedTxn.size() > 0) {
-                failed = true;
-                log.error("Txn aborted: {}", abortedTxn);
-            }
-            assertFalse("Test Failed", failed);
-        }
-
-        public void cancelAllPendingWork() {
-            synchronized (readers) {
-                readers.forEach(future -> {
-                    try {
-                        future.cancel(true);
-                    } catch (Exception e) {
-                        log.error("exception thrown while cancelling reader thread", e);
-                    }
-                });
-            }
-
-            synchronized (writers) {
-                writers.forEach(future -> {
-                    try {
-                        future.cancel(true);
-                    } catch (Exception e) {
-                        log.error("exception thrown while cancelling writer thread", e);
-                    }
-                });
-            }
-        }
+        Futures.getAndHandleExceptions(segService.scaleService(3), ExecutionException::new);
+        List<URI> segUris = segService.getServiceDetails();
+        log.debug("Pravega Segmentstore service  details: {}", segUris);
     }
 
     void performFailoverTest() throws ExecutionException {
@@ -236,7 +160,7 @@ abstract class AbstractFailoverTests {
         log.info("Sleeping for {} ", WAIT_AFTER_FAILOVER_MILLIS);
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
         log.info("Read count: {}, write count: {} without any failover after sleep before scaling",
-                testState.getEventReadCount(),  testState.getEventWrittenCount());
+                testState.getEventReadCount(), testState.getEventWrittenCount());
 
         //Scale down segment store instances to 2
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(2), ExecutionException::new);
@@ -244,7 +168,7 @@ abstract class AbstractFailoverTests {
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
         log.info("Scaling down Segment Store instances from 3 to 2");
         log.info("Read count: {}, write count: {} after Segment Store  failover after sleep",
-                testState.getEventReadCount(),  testState.getEventWrittenCount());
+                testState.getEventReadCount(), testState.getEventWrittenCount());
 
         //Scale down controller instances to 2
         Futures.getAndHandleExceptions(controllerInstance.scaleService(2), ExecutionException::new);
@@ -252,7 +176,7 @@ abstract class AbstractFailoverTests {
         Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
         log.info("Scaling down controller instances from 3 to 2");
         log.info("Read count: {}, write count: {} after controller failover after sleep",
-                testState.getEventReadCount(),  testState.getEventWrittenCount());
+                testState.getEventReadCount(), testState.getEventWrittenCount());
 
         //Scale down segment store, controller to 1 instance each.
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
@@ -263,196 +187,7 @@ abstract class AbstractFailoverTests {
         log.info("Stop write flag status: {}, stop read flag status: {} ",
                 testState.stopWriteFlag.get(), testState.stopReadFlag.get());
         log.info("Read count: {}, write count: {} with Segment Store  and controller failover after sleep",
-                testState.getEventReadCount(),  testState.getEventWrittenCount());
-    }
-
-    CompletableFuture<Void> startWriting(final EventStreamWriter<String> writer) {
-        return CompletableFuture.runAsync(() -> {
-            String uniqueRoutingKey = UUID.randomUUID().toString();
-            long seqNumber = 0;
-            while (!testState.stopWriteFlag.get()) {
-                try {
-                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
-
-                    // The content of events is generated following the pattern routingKey:seq_number, where
-                    // seq_number is monotonically increasing for every routing key, being the expected delta between
-                    // consecutive seq_number values always 1.
-                    final String eventContent = uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber;
-                    log.debug("Event write count before write call {}", testState.getEventWrittenCount());
-                    writer.writeEvent(uniqueRoutingKey, eventContent);
-                    log.debug("Event write count before flush {}", testState.getEventWrittenCount());
-                    writer.flush();
-                    testState.incrementTotalWrittenEvents();
-                    log.debug("Writing event {}", eventContent);
-                    log.debug("Event write count {}", testState.getEventWrittenCount());
-                    seqNumber++;
-
-                    // Renewal of routing key to test writing in multiple segments for the same writer.
-                    if (seqNumber == RK_RENEWAL_RATE_WRITER) {
-                        log.info("Renew writer routing key and reinitialize seqNumber at event {}.", seqNumber);
-                        uniqueRoutingKey = UUID.randomUUID().toString();
-                        seqNumber = 0;
-                    }
-                } catch (Throwable e) {
-                    log.error("Test exception in writing events: ", e);
-                    testState.getWriteException.set(e);
-                }
-            }
-            closeWriter(writer);
-        }, executorService);
-    }
-
-    private void closeWriter(EventStreamWriter<String> writer) {
-        try {
-            log.info("Closing writer");
-            writer.close();
-        } catch (Throwable e) {
-            log.error("Error while closing writer", e);
-            testState.getWriteException.compareAndSet(null, e);
-        }
-    }
-
-    void waitForTxnsToComplete() {
-        log.info("Wait for txns to complete");
-        if (!Futures.await(Futures.allOf(testState.txnStatusFutureList))) {
-            log.error("Transaction futures did not complete with exceptions");
-        }
-        // check for exceptions during transaction commits
-        if (testState.getTxnWriteException.get() != null) {
-            log.info("Unable to commit transaction:", testState.getTxnWriteException.get());
-            Assert.fail("Unable to commit transaction. Test failure");
-        }
-    }
-
-    CompletableFuture<Void> startWritingIntoTxn(final EventStreamWriter<String> writer) {
-        return CompletableFuture.runAsync(() -> {
-            while (!testState.stopWriteFlag.get()) {
-                Transaction<String> transaction = null;
-                AtomicBoolean txnIsDone = new AtomicBoolean(false);
-
-                try {
-                    transaction = writer.beginTxn();
-                    String uniqueRoutingKey = transaction.getTxnId().toString();
-                    long seqNumber = 0;
-                    for (int j = 1; j <= NUM_EVENTS_PER_TRANSACTION; j++) {
-                        // The content of events is generated following the pattern routingKey:seq_number. In this case,
-                        // the context of the routing key is the transaction.
-                        transaction.writeEvent(uniqueRoutingKey, uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber);
-                        log.debug("Writing event: {} into transaction: {}", uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber,
-                                transaction.getTxnId());
-                        seqNumber++;
-
-                        // Renewal of routing key to test writing in multiple segments for the same transaction.
-                        if (j % RK_RENEWAL_RATE_TRANSACTION == 0) {
-                            log.info("Renew transaction writer routing key and reinitialize seqNumber at event {}.", j);
-                            uniqueRoutingKey = UUID.randomUUID().toString();
-                            seqNumber = 0;
-                        }
-                    }
-                    //commit Txn
-                    transaction.commit();
-                    txnIsDone.set(true);
-
-                    //wait for transaction to get committed
-                    testState.txnStatusFutureList.add(checkTxnStatus(transaction, NUM_EVENTS_PER_TRANSACTION));
-                } catch (Throwable e) {
-                    // Given that we have retry logic both in the interaction with controller and
-                    // segment store, we should fail the test case in the presence of any exception
-                    // caught here.
-                    txnIsDone.set(true);
-                    log.warn("Exception while writing events in the transaction: ", e);
-                    if (transaction != null) {
-                        log.debug("Transaction with id: {}  failed", transaction.getTxnId());
-                    }
-                    testState.getTxnWriteException.set(e);
-                    return;
-                }
-            }
-            closeWriter(writer);
-        }, executorService);
-    }
-
-    private CompletableFuture<Void> checkTxnStatus(Transaction<String> txn, int eventsWritten) {
-        testState.committingTxn.add(txn.getTxnId());
-        return Retry.indefinitelyWithExpBackoff("Txn did not get committed").runAsync(() -> {
-            Transaction.Status status = txn.checkStatus();
-            log.debug("Txn id {} status is {}", txn.getTxnId(), status);
-            if (status.equals(Transaction.Status.COMMITTED)) {
-                testState.incrementTotalWrittenEvents(eventsWritten);
-                testState.committingTxn.remove(txn.getTxnId());
-                log.info("Event write count: {}", testState.getEventWrittenCount());
-            } else if (status.equals(Transaction.Status.ABORTED)) {
-                log.debug("Transaction with id: {} aborted", txn.getTxnId());
-                testState.abortedTxn.add(txn.getTxnId());
-            } else {
-                throw new TxnNotCompleteException();
-            }
-
-            return CompletableFuture.completedFuture(null);
-        }, executorService);
-    }
-
-    CompletableFuture<Void> startReading(final EventStreamReader<String> reader) {
-        return CompletableFuture.runAsync(() -> {
-            log.info("Exit flag status: {}, Read count: {}, Write count: {}", testState.stopReadFlag.get(),
-                    testState.getEventReadCount(), testState.getEventWrittenCount());
-            final Map<String, Long> routingKeySeqNumber = new HashMap<>();
-            while (!(testState.stopReadFlag.get() && testState.getEventReadCount() == testState.getEventWrittenCount())) {
-                log.info("Entering read loop");
-                // Exit only if exitFlag is true  and read Count equals write count.
-                try {
-                    final String event = reader.readNextEvent(SECONDS.toMillis(5)).getEvent();
-                    log.debug("Reading event {}", event);
-                    if (event != null) {
-                        // For every new event read, the reader asserts that its value is equal to the existing
-                        // seq_number + 1. This ensures that readers receive events in the same order that writers
-                        // produced them and that there are no duplicate or missing events.
-                        final String[] keyAndSeqNum = event.split(RK_VALUE_SEPARATOR);
-                        final long seqNumber = Long.valueOf(keyAndSeqNum[1]);
-                        routingKeySeqNumber.compute(keyAndSeqNum[0], (rk, currentSeqNum) -> {
-                            if (currentSeqNum != null && currentSeqNum + 1 != seqNumber) {
-                                throw new AssertionError("Event order violated at " + currentSeqNum + " by " + seqNumber);
-                            }
-                            return seqNumber;
-                        });
-                        testState.incrementTotalReadEvents();
-                        log.debug("Event read count {}", testState.getEventReadCount());
-                    } else {
-                        log.debug("Read timeout");
-                    }
-                } catch (Throwable e) {
-                    log.error("Test exception in reading events: ", e);
-                    testState.getReadException.set(e);
-                }
-            }
-            log.info("Completed reading");
-            closeReader(reader);
-        }, executorService);
-    }
-
-    private void closeReader(EventStreamReader<String> reader) {
-        try {
-            log.info("Closing reader");
-            reader.close();
-        } catch (Throwable e) {
-            log.error("Error while closing reader", e);
-            testState.getReadException.compareAndSet(null, e);
-        }
-    }
-
-    void cleanUp(String scope, String stream, ReaderGroupManager readerGroupManager, String readerGroupName) throws InterruptedException, ExecutionException {
-        CompletableFuture<Boolean> sealStreamStatus = Retry.indefinitelyWithExpBackoff("Failed to seal stream. retrying ...")
-                .runAsync(() -> controller.sealStream(scope, stream), executorService);
-        log.info("Sealing stream {}", stream);
-        assertTrue(sealStreamStatus.get());
-        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, stream);
-        log.info("Deleting stream {}", stream);
-        assertTrue(deleteStreamStatus.get());
-        log.info("Deleting readergroup {}", readerGroupName);
-        readerGroupManager.deleteReaderGroup(readerGroupName);
-        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
-        log.info("Deleting scope {}", scope);
-        assertTrue(deleteScopeStatus.get());
+                testState.getEventReadCount(), testState.getEventWrittenCount());
     }
 
     void createScopeAndStream(String scope, String stream, StreamConfiguration config, StreamManager streamManager) {
@@ -463,157 +198,19 @@ abstract class AbstractFailoverTests {
         log.debug("Create stream status {}", createStreamStatus);
     }
 
-    void createWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
-        Preconditions.checkNotNull(testState.writersListComplete.get(0));
-        log.info("Client factory details {}", clientFactory.toString());
-        log.info("Creating {} writers", writers);
-        List<EventStreamWriter<String>> writerList = new ArrayList<>(writers);
-        List<CompletableFuture<Void>> writerFutureList = new ArrayList<>();
-        log.info("Writers writing in the scope {}", scope);
-        CompletableFuture.runAsync(() -> {
-            for (int i = 0; i < writers; i++) {
-                log.info("Starting writer{}", i);
-
-                if (!testState.txnWrite) {
-                    final EventStreamWriter<String> tmpWriter = clientFactory.createEventWriter(stream,
-                            new JavaSerializer<>(),
-                            EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                    .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
-                    writerList.add(tmpWriter);
-                    final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
-                    Futures.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
-                    writerFutureList.add(writerFuture);
-                } else  {
-                    final EventStreamWriter<String> tmpWriter = clientFactory.createEventWriter(stream,
-                            new JavaSerializer<>(),
-                            EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                    .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS)
-                                    .transactionTimeoutTime(59000).build());
-                    writerList.add(tmpWriter);
-                    final CompletableFuture<Void> txnWriteFuture = startWritingIntoTxn(tmpWriter);
-                    Futures.exceptionListener(txnWriteFuture, t -> log.error("Error while writing events into transaction:", t));
-                    writerFutureList.add(txnWriteFuture);
-                }
-
-            }
-        }).thenRun(() -> {
-            testState.writers.addAll(writerFutureList);
-            Futures.completeAfter(() -> Futures.allOf(writerFutureList),
-                    testState.writersListComplete.get(0));
-            Futures.exceptionListener(testState.writersListComplete.get(0),
-                    t -> log.error("Exception while waiting for writers to complete", t));
-        });
-    }
-
-    void createReaders(ClientFactory clientFactory, String readerGroupName, String scope,
-                                 ReaderGroupManager readerGroupManager, String stream, final int readers) {
-        log.info("Creating Reader group: {}, with readergroup manager using scope: {}", readerGroupName, scope);
-        readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().stream(Stream.of(scope, stream)).build());
-        log.info("Reader group name: {}, Reader group scope: {}, Online readers: {}",
-                readerGroupManager.getReaderGroup(readerGroupName).getGroupName(), readerGroupManager
-                        .getReaderGroup(readerGroupName).getScope(), readerGroupManager
-                        .getReaderGroup(readerGroupName).getOnlineReaders());
-        log.info("Creating {} readers", readers);
-        List<EventStreamReader<String>> readerList = new ArrayList<>(readers);
-        List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
-        log.info("Scope that is seen by readers {}", scope);
-
-        CompletableFuture.runAsync(() -> {
-            for (int i = 0; i < readers; i++) {
-                log.info("Starting reader: {}, with id: {}", i, readerName + i);
-                final EventStreamReader<String> reader = clientFactory.createReader(readerName + i,
-                        readerGroupName,
-                        new JavaSerializer<>(),
-                        ReaderConfig.builder().build());
-                readerList.add(reader);
-                final CompletableFuture<Void> readerFuture = startReading(reader);
-                Futures.exceptionListener(readerFuture, t -> log.error("Error while reading events:", t));
-                readerFutureList.add(readerFuture);
-            }
-        }).thenRun(() -> {
-            testState.readers.addAll(readerFutureList);
-            Futures.completeAfter(() -> Futures.allOf(readerFutureList), testState.readersComplete);
-            Futures.exceptionListener(testState.readersComplete,
-                    t -> log.error("Exception while waiting for all readers to complete", t));
-        });
-    }
-
-    void addNewWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
-        Preconditions.checkNotNull(testState.writersListComplete.get(1));
-        log.info("Client factory details {}", clientFactory.toString());
-        log.info("Creating {} writers", writers);
-        List<EventStreamWriter<String>> newlyAddedWriterList = new ArrayList<>();
-        List<CompletableFuture<Void>> newWritersFutureList = new ArrayList<>();
-        log.info("Writers writing in the scope {}", scope);
-        CompletableFuture.runAsync(() -> {
-            for (int i = 0; i < writers; i++) {
-                log.info("Starting writer{}", i);
-                if (!testState.txnWrite) {
-                    final EventStreamWriter<String> tmpWriter = clientFactory.createEventWriter(stream,
-                            new JavaSerializer<>(),
-                            EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                    .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS).build());
-                    newlyAddedWriterList.add(tmpWriter);
-                    final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
-                    Futures.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
-                    newWritersFutureList.add(writerFuture);
-                } else  {
-                    final EventStreamWriter<String> tmpWriter = clientFactory.createEventWriter(stream,
-                            new JavaSerializer<>(),
-                            EventWriterConfig.builder().maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
-                                    .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS)
-                                    .transactionTimeoutTime(59000).build());
-                    newlyAddedWriterList.add(tmpWriter);
-                    final CompletableFuture<Void> txnWriteFuture = startWritingIntoTxn(tmpWriter);
-                    Futures.exceptionListener(txnWriteFuture, t -> log.error("Error while writing events into transaction:", t));
-                    newWritersFutureList.add(txnWriteFuture);
-                }
-            }
-        }).thenRun(() -> {
-            testState.writers.addAll(newWritersFutureList);
-            Futures.completeAfter(() -> Futures.allOf(newWritersFutureList), testState.writersListComplete.get(1));
-            Futures.exceptionListener(testState.writersListComplete.get(1),
-                    t -> log.error("Exception while waiting for writers to complete", t));
-        });
-    }
-
-    void stopWriters() {
-        //Stop Writers
-        log.info("Stop write flag status {}", testState.stopWriteFlag);
-        testState.stopWriteFlag.set(true);
-
-        log.info("Wait for writers execution to complete");
-        if (!Futures.await(Futures.allOf(testState.writersListComplete))) {
-            log.error("Writers stopped with exceptions");
-        }
-
-        // check for exceptions during writes
-        if (testState.getWriteException.get() != null) {
-            log.info("Unable to write events:", testState.getWriteException.get());
-            Assert.fail("Unable to write events. Test failure");
-        }
-    }
-
-    void stopReaders() {
-        //Stop Readers
-        log.info("Stop read flag status {}", testState.stopReadFlag);
-        testState.stopReadFlag.set(true);
-
-        log.info("Wait for readers execution to complete");
-        if (!Futures.await(testState.readersComplete)) {
-            log.error("Readers stopped with exceptions");
-        }
-        //check for exceptions during read
-        if (testState.getReadException.get() != null) {
-            log.info("Unable to read events:", testState.getReadException.get());
-            Assert.fail("Unable to read events. Test failure");
-        }
-    }
-
-    void validateResults() {
-        log.info("All writers and readers have stopped. Event Written Count:{}, Event Read " +
-                "Count: {}", testState.getEventWrittenCount(), testState.getEventReadCount());
-        assertEquals(testState.getEventWrittenCount(), testState.getEventReadCount());
+    void cleanUp(String scope, String stream, ReaderGroupManager readerGroupManager, String readerGroupName) throws InterruptedException, ExecutionException {
+        CompletableFuture<Boolean> sealStreamStatus = Retry.indefinitelyWithExpBackoff("Failed to seal stream. retrying ...")
+                                                           .runAsync(() -> controller.sealStream(scope, stream), executorService);
+        log.info("Sealing stream {}", stream);
+        assertTrue(sealStreamStatus.get());
+        CompletableFuture<Boolean> deleteStreamStatus = controller.deleteStream(scope, stream);
+        log.info("Deleting stream {}", stream);
+        assertTrue(deleteStreamStatus.get());
+        log.info("Deleting readergroup {}", readerGroupName);
+        readerGroupManager.deleteReaderGroup(readerGroupName);
+        CompletableFuture<Boolean> deleteScopeStatus = controller.deleteScope(scope);
+        log.info("Deleting scope {}", scope);
+        assertTrue(deleteScopeStatus.get());
     }
 
     void waitForScaling(String scope, String stream, StreamConfiguration initialConfig) {
@@ -631,57 +228,4 @@ abstract class AbstractFailoverTests {
 
         assertTrue("Scaling did not happen within desired time", scaled);
     }
-
-    static URI startZookeeperInstance() {
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        return zkUris.get(0);
-    }
-
-    static void startBookkeeperInstances(final URI zkUri) {
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-    }
-
-    static URI startPravegaControllerInstances(final URI zkUri) throws ExecutionException {
-        Service controllerService = Utils.createPravegaControllerService(zkUri);
-        if (!controllerService.isRunning()) {
-            controllerService.start(true);
-        }
-        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
-        List<URI> conUris = controllerService.getServiceDetails();
-        log.info("conuris {} {}", conUris.get(0), conUris.get(1));
-        log.debug("Pravega Controller service  details: {}", conUris);
-        // Fetch all the RPC endpoints and construct the client URIs.
-        final List<String> uris = conUris.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT
-                : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
-                .collect(Collectors.toList());
-
-        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
-        log.info("Controller Service direct URI: {}", controllerURI);
-        return controllerURI;
-    }
-
-    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI) throws ExecutionException {
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-        Futures.getAndHandleExceptions(segService.scaleService(3), ExecutionException::new);
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega Segmentstore service  details: {}", segUris);
-    }
-
-    static class TxnNotCompleteException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
-    }
-
 }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -73,6 +73,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
      * validation logic on the events processed.
      */
     static class TestState {
+
         //read and write count variables
         final AtomicBoolean stopReadFlag = new AtomicBoolean(false);
         final AtomicBoolean stopWriteFlag = new AtomicBoolean(false);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.fail;
  * Abstract class that provides convenient event read/write methods for testing purposes.
  */
 @Slf4j
-abstract class AbstractReadWriteTest {
+abstract class AbstractReadWriteTest extends AbstractSystemTest {
 
     static final String RK_VALUE_SEPARATOR = ":";
     static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
@@ -489,7 +489,7 @@ abstract class AbstractReadWriteTest {
     }
 
     private <T> int readEvents(EventStreamReader<T> reader, int limit) {
-        return readEvents(reader,limit,false);
+        return readEvents(reader, limit, false);
     }
 
     private <T> int readEvents(EventStreamReader<T> reader, int limit, boolean reinitializationExpected) {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -9,20 +9,42 @@
  */
 package io.pravega.test.system;
 
+import com.google.common.base.Preconditions;
+import io.netty.util.internal.ConcurrentSet;
 import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.common.util.Retry;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import static java.util.Collections.synchronizedList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 /**
  * Abstract class that provides convenient event read/write methods for testing purposes.
@@ -30,46 +52,476 @@ import static java.util.stream.Collectors.toList;
 @Slf4j
 abstract class AbstractReadWriteTest {
 
+    static final String RK_VALUE_SEPARATOR = ":";
+    static final int WRITER_MAX_BACKOFF_MILLIS = 5 * 1000;
+    static final int WRITER_MAX_RETRY_ATTEMPTS = 20;
+    static final int NUM_EVENTS_PER_TRANSACTION = 50;
+    static final int RK_RENEWAL_RATE_TRANSACTION = NUM_EVENTS_PER_TRANSACTION / 2;
+    static final int TRANSACTION_TIMEOUT = 59 * 1000;
+    static final int RK_RENEWAL_RATE_WRITER = 500;
+    static final int SCALE_WAIT_ITERATIONS = 12;
     private static final int READ_TIMEOUT = 1000;
 
+    final String readerName = "reader";
+    ScheduledExecutorService executorService;
+    TestState testState;
+
+    /**
+     * This class encapsulates the information regarding the execution of a system test. This includes the references to
+     * readers and writers, the number of events read/written, the exceptions occurred on readers/writers through the
+     * test's execution, and the flags to stop the execution of readers/writers. It also contains logic to perform some
+     * validation logic on the events processed.
+     */
+    static class TestState {
+        //read and write count variables
+        final AtomicBoolean stopReadFlag = new AtomicBoolean(false);
+        final AtomicBoolean stopWriteFlag = new AtomicBoolean(false);
+        final AtomicReference<Throwable> getWriteException = new AtomicReference<>();
+        final AtomicReference<Throwable> getTxnWriteException = new AtomicReference<>();
+        final AtomicReference<Throwable> getReadException =  new AtomicReference<>();
+        //list of all writer's futures
+        final List<CompletableFuture<Void>> writers = synchronizedList(new ArrayList<>());
+        //list of all reader's futures
+        final List<CompletableFuture<Void>> readers = synchronizedList(new ArrayList<>());
+        final List<CompletableFuture<Void>> writersListComplete = synchronizedList(new ArrayList<>());
+        final CompletableFuture<Void> writersComplete = new CompletableFuture<>();
+        final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
+        final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
+        final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
+        final ConcurrentSet<UUID> committingTxn = new ConcurrentSet<>();
+        final ConcurrentSet<UUID> abortedTxn = new ConcurrentSet<>();
+        final boolean txnWrite;
+
+        final AtomicLong writtenEvents = new AtomicLong();
+        final AtomicLong readEvents = new AtomicLong();
+
+        TestState(boolean txnWrite) {
+            this.txnWrite = txnWrite;
+        }
+
+        long incrementTotalWrittenEvents() {
+            return writtenEvents.incrementAndGet();
+        }
+
+        long incrementTotalWrittenEvents(int increment) {
+            return writtenEvents.addAndGet(increment);
+        }
+
+        long incrementTotalReadEvents() {
+            return readEvents.incrementAndGet();
+        }
+
+        long getEventWrittenCount() {
+            return writtenEvents.get();
+        }
+
+        long getEventReadCount() {
+            return readEvents.get();
+        }
+
+        void checkForAnomalies() {
+            boolean failed = false;
+            long eventReadCount = getEventReadCount();
+            long eventWrittenCount = getEventWrittenCount();
+            if (eventReadCount != eventWrittenCount) {
+                failed = true;
+                log.error("Read write count mismatch => readCount = {}, writeCount = {}", eventReadCount, eventWrittenCount);
+            }
+
+            if (committingTxn.size() > 0) {
+                failed = true;
+                log.error("Txn left committing: {}", committingTxn);
+            }
+
+            if (abortedTxn.size() > 0) {
+                failed = true;
+                log.error("Txn aborted: {}", abortedTxn);
+            }
+            assertFalse("Test Failed", failed);
+        }
+
+        public void cancelAllPendingWork() {
+            synchronized (readers) {
+                readers.forEach(future -> {
+                    try {
+                        future.cancel(true);
+                    } catch (Exception e) {
+                        log.error("exception thrown while cancelling reader thread", e);
+                    }
+                });
+            }
+
+            synchronized (writers) {
+                writers.forEach(future -> {
+                    try {
+                        future.cancel(true);
+                    } catch (Exception e) {
+                        log.error("exception thrown while cancelling writer thread", e);
+                    }
+                });
+            }
+        }
+    }
+
+    CompletableFuture<Void> startWriting(final EventStreamWriter<String> writer) {
+        return startWriting(writer, testState.stopWriteFlag);
+    }
+
+    CompletableFuture<Void> startWriting(final EventStreamWriter<String> writer, AtomicBoolean stopFlag) {
+        return CompletableFuture.runAsync(() -> {
+            String uniqueRoutingKey = UUID.randomUUID().toString();
+            long seqNumber = 0;
+            while (!stopFlag.get()) {
+                try {
+                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
+
+                    // The content of events is generated following the pattern routingKey:seq_number, where
+                    // seq_number is monotonically increasing for every routing key, being the expected delta between
+                    // consecutive seq_number values always 1.
+                    final String eventContent = uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber;
+                    log.debug("Event write count before write call {}", testState.getEventWrittenCount());
+                    writer.writeEvent(uniqueRoutingKey, eventContent);
+                    log.debug("Event write count before flush {}", testState.getEventWrittenCount());
+                    writer.flush();
+                    testState.incrementTotalWrittenEvents();
+                    log.debug("Writing event {}", eventContent);
+                    log.debug("Event write count {}", testState.getEventWrittenCount());
+                    seqNumber++;
+
+                    // Renewal of routing key to test writing in multiple segments for the same writer.
+                    if (seqNumber == RK_RENEWAL_RATE_WRITER) {
+                        log.info("Renew writer routing key and reinitialize seqNumber at event {}.", seqNumber);
+                        uniqueRoutingKey = UUID.randomUUID().toString();
+                        seqNumber = 0;
+                    }
+                } catch (Throwable e) {
+                    log.error("Test exception in writing events: ", e);
+                    testState.getWriteException.set(e);
+                }
+            }
+            log.info("Completed writing");
+            closeWriter(writer);
+        }, executorService);
+    }
+
+    CompletableFuture<Void> startWritingIntoTxn(final EventStreamWriter<String> writer, AtomicBoolean stopFlag) {
+        return CompletableFuture.runAsync(() -> {
+            while (!stopFlag.get()) {
+                Transaction<String> transaction = null;
+                AtomicBoolean txnIsDone = new AtomicBoolean(false);
+
+                try {
+                    transaction = writer.beginTxn();
+                    String uniqueRoutingKey = transaction.getTxnId().toString();
+                    long seqNumber = 0;
+                    for (int j = 1; j <= NUM_EVENTS_PER_TRANSACTION; j++) {
+                        // The content of events is generated following the pattern routingKey:seq_number. In this case,
+                        // the context of the routing key is the transaction.
+                        transaction.writeEvent(uniqueRoutingKey, uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber);
+                        log.debug("Writing event: {} into transaction: {}", uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber,
+                                transaction.getTxnId());
+                        seqNumber++;
+
+                        // Renewal of routing key to test writing in multiple segments for the same transaction.
+                        if (j % RK_RENEWAL_RATE_TRANSACTION == 0) {
+                            log.info("Renew transaction writer routing key and reinitialize seqNumber at event {}.", j);
+                            uniqueRoutingKey = UUID.randomUUID().toString();
+                            seqNumber = 0;
+                        }
+                    }
+                    //commit Txn
+                    transaction.commit();
+                    txnIsDone.set(true);
+
+                    //wait for transaction to get committed
+                    testState.txnStatusFutureList.add(checkTxnStatus(transaction, NUM_EVENTS_PER_TRANSACTION));
+                } catch (Throwable e) {
+                    // Given that we have retry logic both in the interaction with controller and
+                    // segment store, we should fail the test case in the presence of any exception
+                    // caught here.
+                    txnIsDone.set(true);
+                    log.warn("Exception while writing events in the transaction: ", e);
+                    if (transaction != null) {
+                        log.debug("Transaction with id: {}  failed", transaction.getTxnId());
+                    }
+                    testState.getTxnWriteException.set(e);
+                    return;
+                }
+            }
+            log.info("Completed writing into txn");
+            closeWriter(writer);
+        }, executorService);
+    }
+
+    CompletableFuture<Void> startReading(final EventStreamReader<String> reader) {
+        return startReading(reader, testState.stopReadFlag);
+    }
+
+    CompletableFuture<Void> startReading(final EventStreamReader<String> reader, AtomicBoolean stopFlag) {
+        return CompletableFuture.runAsync(() -> {
+            log.info("Exit flag status: {}, Read count: {}, Write count: {}", testState.stopReadFlag.get(),
+                    testState.getEventReadCount(), testState.getEventWrittenCount());
+            final Map<String, Long> routingKeySeqNumber = new HashMap<>();
+            while (!(stopFlag.get() && testState.getEventReadCount() == testState.getEventWrittenCount())) {
+                log.info("Entering read loop");
+                // Exit only if exitFlag is true  and read Count equals write count.
+                try {
+                    final String event = reader.readNextEvent(SECONDS.toMillis(5)).getEvent();
+                    log.debug("Reading event {}", event);
+                    if (event != null) {
+                        // For every new event read, the reader asserts that its value is equal to the existing
+                        // seq_number + 1. This ensures that readers receive events in the same order that writers
+                        // produced them and that there are no duplicate or missing events.
+                        final String[] keyAndSeqNum = event.split(RK_VALUE_SEPARATOR);
+                        final long seqNumber = Long.valueOf(keyAndSeqNum[1]);
+                        routingKeySeqNumber.compute(keyAndSeqNum[0], (rk, currentSeqNum) -> {
+                            if (currentSeqNum != null && currentSeqNum + 1 != seqNumber) {
+                                throw new AssertionError("Event order violated at " + currentSeqNum + " by " + seqNumber);
+                            }
+                            return seqNumber;
+                        });
+                        testState.incrementTotalReadEvents();
+                        log.debug("Event read count {}", testState.getEventReadCount());
+                    } else {
+                        log.debug("Read timeout");
+                    }
+                } catch (Throwable e) {
+                    log.error("Test exception in reading events: ", e);
+                    testState.getReadException.set(e);
+                }
+            }
+            log.info("Completed reading");
+            closeReader(reader);
+        }, executorService);
+    }
+
+    void createReaders(ClientFactory clientFactory, String readerGroupName, String scope,
+                       ReaderGroupManager readerGroupManager, String stream, final int readers) {
+        log.info("Creating Reader group: {}, with readergroup manager using scope: {}", readerGroupName, scope);
+        readerGroupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().stream(Stream.of(scope, stream)).build());
+        log.info("Reader group name: {}, Reader group scope: {}, Online readers: {}",
+                readerGroupManager.getReaderGroup(readerGroupName).getGroupName(), readerGroupManager
+                        .getReaderGroup(readerGroupName).getScope(), readerGroupManager
+                        .getReaderGroup(readerGroupName).getOnlineReaders());
+        log.info("Creating {} readers", readers);
+        List<EventStreamReader<String>> readerList = new ArrayList<>(readers);
+        List<CompletableFuture<Void>> readerFutureList = new ArrayList<>();
+        log.info("Scope that is seen by readers {}", scope);
+
+        CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < readers; i++) {
+                log.info("Starting reader: {}, with id: {}", i, readerName + i);
+                final EventStreamReader<String> reader = clientFactory.createReader(readerName + i,
+                        readerGroupName,
+                        new JavaSerializer<>(),
+                        ReaderConfig.builder().build());
+                readerList.add(reader);
+                final CompletableFuture<Void> readerFuture = startReading(reader);
+                Futures.exceptionListener(readerFuture, t -> log.error("Error while reading events:", t));
+                readerFutureList.add(readerFuture);
+            }
+        }, executorService).thenRun(() -> {
+            testState.readers.addAll(readerFutureList);
+            Futures.completeAfter(() -> Futures.allOf(readerFutureList), testState.readersComplete);
+            Futures.exceptionListener(testState.readersComplete,
+                    t -> log.error("Exception while waiting for all readers to complete", t));
+        });
+    }
+
+    void createWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
+        createWritersInternal(clientFactory, writers, scope, stream, testState.writersComplete);
+    }
+
+    void addNewWriters(ClientFactory clientFactory, final int writers, String scope, String stream) {
+        Preconditions.checkNotNull(testState.writersListComplete.get(0));
+        createWritersInternal(clientFactory, writers, scope, stream, testState.newWritersComplete);
+    }
+
+    void waitForTxnsToComplete() {
+        log.info("Wait for txns to complete");
+        if (!Futures.await(Futures.allOf(testState.txnStatusFutureList))) {
+            log.error("Transaction futures did not complete with exceptions");
+        }
+        // check for exceptions during transaction commits
+        if (testState.getTxnWriteException.get() != null) {
+            log.info("Unable to commit transaction:", testState.getTxnWriteException.get());
+            fail("Unable to commit transaction. Test failure");
+        }
+    }
+
+    void stopWriters() {
+        //Stop Writers
+        log.info("Stop write flag status {}", testState.stopWriteFlag);
+        testState.stopWriteFlag.set(true);
+
+        log.info("Wait for writers execution to complete");
+        if (!Futures.await(Futures.allOf(testState.writersListComplete))) {
+            log.error("Writers stopped with exceptions");
+        }
+
+        // check for exceptions during writes
+        if (testState.getWriteException.get() != null) {
+            log.info("Unable to write events:", testState.getWriteException.get());
+            fail("Unable to write events. Test failure");
+        }
+    }
+
+    void stopReaders() {
+        //Stop Readers
+        log.info("Stop read flag status {}", testState.stopReadFlag);
+        testState.stopReadFlag.set(true);
+
+        log.info("Wait for readers execution to complete");
+        if (!Futures.await(testState.readersComplete)) {
+            log.error("Readers stopped with exceptions");
+        }
+        //check for exceptions during read
+        if (testState.getReadException.get() != null) {
+            log.info("Unable to read events:", testState.getReadException.get());
+            fail("Unable to read events. Test failure");
+        }
+    }
+
+    void validateResults() {
+        log.info("All writers and readers have stopped. Event Written Count:{}, Event Read " +
+                "Count: {}", testState.getEventWrittenCount(), testState.getEventReadCount());
+        assertEquals(testState.getEventWrittenCount(), testState.getEventReadCount());
+    }
+
     void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
+        writeEvents(clientFactory, streamName, totalEvents, 0);
+    }
+
+    void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents, int initialPoint) {
         @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
-        for (int i = 0; i < totalEvents; i++) {
-            writer.writeEvent(streamName + String.valueOf(i)).join();
+        for (int i = initialPoint; i < totalEvents + initialPoint; i++) {
+            writer.writeEvent(String.valueOf(i)).join();
             log.debug("Writing event: {} to stream {}.", streamName + String.valueOf(i), streamName);
         }
     }
 
-    List<CompletableFuture<Integer>> readEventFutures(ClientFactory client, String rGroup, int numReaders) {
-        List<EventStreamReader<String>> readers = new ArrayList<>();
+    <T extends Serializable> List<CompletableFuture<Integer>> readEventFutures(ClientFactory client, String rGroup, int numReaders, int limit) {
+        List<EventStreamReader<T>> readers = new ArrayList<>();
         for (int i = 0; i < numReaders; i++) {
-            readers.add(client.createReader(String.valueOf(i), rGroup, new JavaSerializer<>(), ReaderConfig.builder().build()));
+            readers.add(client.createReader(rGroup + "-" + String.valueOf(i), rGroup,
+                    new JavaSerializer<>(), ReaderConfig.builder().build()));
         }
 
-        return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r))).collect(toList());
+        return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r, limit / numReaders))).collect(toList());
     }
 
-    private <T> int readEvents(EventStreamReader<T> reader) {
+    List<CompletableFuture<Integer>> readEventFutures(ClientFactory clientFactory, String readerGroup, int numReaders) {
+        return readEventFutures(clientFactory, readerGroup, numReaders, Integer.MAX_VALUE);
+    }
+
+    // Private methods region
+
+    private void createWritersInternal(ClientFactory clientFactory, final int writers, String scope, String stream, CompletableFuture<Void> writersComplete) {
+        testState.writersListComplete.add(writersComplete);
+        log.info("Client factory details {}", clientFactory.toString());
+        log.info("Creating {} writers", writers);
+        List<CompletableFuture<Void>> writerFutureList = new ArrayList<>();
+        log.info("Writers writing in the scope {}", scope);
+        CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < writers; i++) {
+                log.info("Starting writer{}", i);
+                final EventStreamWriter<String> tmpWriter = instantiateWriter(clientFactory, stream);
+                final CompletableFuture<Void> writerFuture = startWriting(tmpWriter);
+                Futures.exceptionListener(writerFuture, t -> log.error("Error while writing events:", t));
+                writerFutureList.add(writerFuture);
+            }
+        }, executorService).thenRun(() -> {
+            testState.writers.addAll(writerFutureList);
+            Futures.completeAfter(() -> Futures.allOf(writerFutureList), writersComplete);
+            Futures.exceptionListener(writersComplete, t -> log.error("Exception while waiting for writers to complete", t));
+        });
+    }
+
+    private <T extends Serializable> EventStreamWriter<T> instantiateWriter(ClientFactory clientFactory, String stream) {
+        EventWriterConfig writerConfig = EventWriterConfig.builder()
+                                                          .maxBackoffMillis(WRITER_MAX_BACKOFF_MILLIS)
+                                                          .retryAttempts(WRITER_MAX_RETRY_ATTEMPTS)
+                                                          .transactionTimeoutTime(TRANSACTION_TIMEOUT)
+                                                          .build();
+        return clientFactory.createEventWriter(stream, new JavaSerializer<>(), writerConfig);
+    }
+
+    private <T> void closeWriter(EventStreamWriter<T> writer) {
+        try {
+            log.info("Closing writer");
+            writer.close();
+        } catch (Throwable e) {
+            log.error("Error while closing writer", e);
+            testState.getWriteException.compareAndSet(null, e);
+        }
+    }
+
+    private <T> void closeReader(EventStreamReader<T> reader) {
+        try {
+            log.info("Closing reader");
+            reader.close();
+        } catch (Throwable e) {
+            log.error("Error while closing reader", e);
+            testState.getReadException.compareAndSet(null, e);
+        }
+    }
+
+    private CompletableFuture<Void> checkTxnStatus(Transaction<String> txn, int eventsWritten) {
+        testState.committingTxn.add(txn.getTxnId());
+        return Retry.indefinitelyWithExpBackoff("Txn did not get committed").runAsync(() -> {
+            Transaction.Status status = txn.checkStatus();
+            log.debug("Txn id {} status is {}", txn.getTxnId(), status);
+            if (status.equals(Transaction.Status.COMMITTED)) {
+                testState.incrementTotalWrittenEvents(eventsWritten);
+                testState.committingTxn.remove(txn.getTxnId());
+                log.info("Event write count: {}", testState.getEventWrittenCount());
+            } else if (status.equals(Transaction.Status.ABORTED)) {
+                log.debug("Transaction with id: {} aborted", txn.getTxnId());
+                testState.abortedTxn.add(txn.getTxnId());
+            } else {
+                throw new TxnNotCompleteException();
+            }
+
+            return CompletableFuture.completedFuture(null);
+        }, executorService);
+    }
+
+    private <T> int readEvents(EventStreamReader<T> reader, int limit) {
+        return readEvents(reader,limit,false);
+    }
+
+    private <T> int readEvents(EventStreamReader<T> reader, int limit, boolean reinitializationExpected) {
         EventRead<T> event = null;
         int validEvents = 0;
-        boolean reinitializationRequired;
-        do {
-            try {
-                event = reader.readNextEvent(READ_TIMEOUT);
-                log.debug("Read event result in readEvents: {}.", event.getEvent());
-                if (event.getEvent() != null) {
-                    validEvents++;
+        boolean reinitializationRequired = false;
+        try {
+            do {
+                try {
+                    event = reader.readNextEvent(READ_TIMEOUT);
+                    log.debug("Read event result in readEvents: {}.", event.getEvent());
+                    if (event.getEvent() != null) {
+                        validEvents++;
+                    }
+                    reinitializationRequired = false;
+                } catch (ReinitializationRequiredException e) {
+                    log.error("Exception while reading event using readerId: {}", reader, e);
+                    if (reinitializationExpected) {
+                        reinitializationRequired = true;
+                    } else {
+                        fail("Reinitialization Exception is not expected");
+                    }
                 }
-                reinitializationRequired = false;
-            } catch (ReinitializationRequiredException e) {
-                log.warn("Reinitialization of readers required: {}.", e);
-                reinitializationRequired = true;
-            }
-        } while (reinitializationRequired || event.getEvent() != null || event.isCheckpoint());
+            } while (reinitializationRequired || ((event.getEvent() != null || event.isCheckpoint()) && validEvents < limit));
+        } finally {
+            closeReader(reader);
+        }
 
-        reader.close();
         return validEvents;
+    }
+
+    static class TxnNotCompleteException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
  * Abstract scale tests. This contains all the common methods used for auto scale related tests.
  */
 @Slf4j
-abstract class AbstractScaleTests {
+abstract class AbstractScaleTests extends AbstractReadWriteTest {
     protected final static String SCOPE = "testAutoScale" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     @Getter(lazy = true)
     private final URI controllerURI = createControllerURI();
@@ -69,5 +69,4 @@ abstract class AbstractScaleTests {
     class ScaleOperationNotDoneException extends RuntimeException {
         private static final long serialVersionUID = 1L;
     }
-
 }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -31,7 +31,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 abstract class AbstractScaleTests extends AbstractReadWriteTest {
-    protected final static String SCOPE = "testAutoScale" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+
+    final static String SCOPE = "testAutoScale" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     @Getter(lazy = true)
     private final URI controllerURI = createControllerURI();
     @Getter(lazy = true)

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -43,6 +43,28 @@ abstract class AbstractSystemTest {
         log.debug("Bookkeeper service details: {}", bkUris);
     }
 
+    static URI ensureControllerRunning(final URI zkUri) {
+        Service conService = Utils.createPravegaControllerService(zkUri);
+        if (!conService.isRunning()) {
+            conService.start(true);
+        }
+
+        List<URI> conUris = conService.getServiceDetails();
+        log.debug("Pravega Controller service details: {}", conUris);
+        return conUris.get(0);
+    }
+
+    static List<URI> ensureSegmentStoreRunning(final URI zkUri, final URI controllerURI) {
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
+        if (!segService.isRunning()) {
+            segService.start(true);
+        }
+
+        List<URI> segUris = segService.getServiceDetails();
+        log.debug("Pravega segmentstore service details: {}", segUris);
+        return segUris;
+    }
+
     static URI startPravegaControllerInstances(final URI zkUri, final int instanceCount) throws ExecutionException {
         Service controllerService = Utils.createPravegaControllerService(zkUri);
         if (!controllerService.isRunning()) {

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -43,15 +43,15 @@ abstract class AbstractSystemTest {
         log.debug("Bookkeeper service details: {}", bkUris);
     }
 
-    static URI startPravegaControllerInstances(final URI zkUri) throws ExecutionException {
+    static URI startPravegaControllerInstances(final URI zkUri, final int instanceCount) throws ExecutionException {
         Service controllerService = Utils.createPravegaControllerService(zkUri);
         if (!controllerService.isRunning()) {
             controllerService.start(true);
         }
-        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(controllerService.scaleService(instanceCount), ExecutionException::new);
         List<URI> conUris = controllerService.getServiceDetails();
-        log.info("conuris {} {}", conUris.get(0), conUris.get(1));
-        log.debug("Pravega Controller service  details: {}", conUris);
+        log.info("Pravega Controller service  details: {}", conUris);
+
         // Fetch all the RPC endpoints and construct the client URIs.
         final List<String> uris = conUris.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT
                 : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
@@ -62,13 +62,13 @@ abstract class AbstractSystemTest {
         return controllerURI;
     }
 
-    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI) throws ExecutionException {
+    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI, final int instanceCount) throws ExecutionException {
         Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
         if (!segService.isRunning()) {
             segService.start(true);
         }
-        Futures.getAndHandleExceptions(segService.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segService.scaleService(instanceCount), ExecutionException::new);
         List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega Segmentstore service details: {}", segUris);
+        log.info("Pravega Segmentstore service details: {}", segUris);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.common.concurrent.Futures;
+import io.pravega.test.system.framework.Utils;
+import io.pravega.test.system.framework.services.Service;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Abstract class containing utilities to initialize Pravega services that are necessary in most system tests.
+ */
+@Slf4j
+public class AbstractSystemTest {
+
+    static URI startZookeeperInstance() {
+        Service zkService = Utils.createZookeeperService();
+        if (!zkService.isRunning()) {
+            zkService.start(true);
+        }
+        List<URI> zkUris = zkService.getServiceDetails();
+        log.debug("Zookeeper service details: {}", zkUris);
+        return zkUris.get(0);
+    }
+
+    static void startBookkeeperInstances(final URI zkUri) {
+        Service bkService = Utils.createBookkeeperService(zkUri);
+        if (!bkService.isRunning()) {
+            bkService.start(true);
+        }
+        List<URI> bkUris = bkService.getServiceDetails();
+        log.debug("Bookkeeper service details: {}", bkUris);
+    }
+
+    static URI startPravegaControllerInstances(final URI zkUri) throws ExecutionException {
+        Service controllerService = Utils.createPravegaControllerService(zkUri);
+        if (!controllerService.isRunning()) {
+            controllerService.start(true);
+        }
+        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
+        List<URI> conUris = controllerService.getServiceDetails();
+        log.info("conuris {} {}", conUris.get(0), conUris.get(1));
+        log.debug("Pravega Controller service  details: {}", conUris);
+        // Fetch all the RPC endpoints and construct the client URIs.
+        final List<String> uris = conUris.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT
+                : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
+                                         .collect(Collectors.toList());
+
+        URI controllerURI = URI.create("tcp://" + String.join(",", uris));
+        log.info("Controller Service direct URI: {}", controllerURI);
+        return controllerURI;
+    }
+
+    static void startPravegaSegmentStoreInstances(final URI zkUri, final URI controllerURI) throws ExecutionException {
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
+        if (!segService.isRunning()) {
+            segService.start(true);
+        }
+        Futures.getAndHandleExceptions(segService.scaleService(3), ExecutionException::new);
+        List<URI> segUris = segService.getServiceDetails();
+        log.debug("Pravega Segmentstore service details: {}", segUris);
+    }
+}

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
  * Abstract class containing utilities to initialize Pravega services that are necessary in most system tests.
  */
 @Slf4j
-public class AbstractSystemTest {
+abstract class AbstractSystemTest {
 
     static URI startZookeeperInstance() {
         Service zkService = Utils.createZookeeperService();

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -70,45 +70,11 @@ public class AutoScaleTest extends AbstractScaleTests {
     private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Environment
-    public static void initialize() {
-
-        //1. check if zk is running, if not start it
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-        //2, check if bk is running, otherwise start, get the zk ip
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("bookkeeper service details: {}", bkUris);
-
-        //3. start controller
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega Controller service details: {}", conUris);
-
-        //4.start host
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("pravega host service details: {}", segUris);
-        URI segUri = segUris.get(0);
+    public static void initialize() throws ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     /**

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -63,11 +63,11 @@ public class AutoScaleTest extends AbstractScaleTests {
     private static final StreamConfiguration CONFIG_DOWN = StreamConfiguration.builder().scope(SCOPE)
             .streamName(SCALE_DOWN_STREAM_NAME).scalingPolicy(SCALING_POLICY).build();
 
-    private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
-
     //The execution time for @Before + @After + @Test methods should be less than 10 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10 * 60);
+
+    private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Environment
     public static void initialize() {

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -9,18 +9,15 @@
  */
 package io.pravega.test.system;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientFactory;
-import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
@@ -34,14 +31,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,14 +62,15 @@ public class AutoScaleTest extends AbstractScaleTests {
 
     private static final StreamConfiguration CONFIG_DOWN = StreamConfiguration.builder().scope(SCOPE)
             .streamName(SCALE_DOWN_STREAM_NAME).scalingPolicy(SCALING_POLICY).build();
-    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(5);
+
+    private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     //The execution time for @Before + @After + @Test methods should be less than 10 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10 * 60);
 
     @Environment
-    public static void setup() {
+    public static void initialize() {
 
         //1. check if zk is running, if not start it
         Service zkService = Utils.createZookeeperService();
@@ -122,11 +119,11 @@ public class AutoScaleTest extends AbstractScaleTests {
      * @throws ExecutionException   if error in create stream
      */
     @Before
-    public void createStream() throws InterruptedException, ExecutionException {
+    public void setup() throws InterruptedException, ExecutionException {
 
         //create a scope
         Controller controller = getController();
-
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(5, "AutoScaleTest-main");
         Boolean createScopeStatus = controller.createScope(SCOPE).get();
         log.debug("create scope status {}", createScopeStatus);
 
@@ -146,15 +143,24 @@ public class AutoScaleTest extends AbstractScaleTests {
         Boolean status = controller.scaleStream(new StreamImpl(SCOPE, SCALE_DOWN_STREAM_NAME),
                 Collections.singletonList(0L),
                 keyRanges,
-                EXECUTOR_SERVICE).getFuture().get();
+                executorService).getFuture().get();
         assertTrue(status);
 
         createStreamStatus = controller.createStream(CONFIG_TXN).get();
         log.debug("create stream status for txn stream {}", createStreamStatus);
     }
 
+    @After
+    public void tearDown() {
+        getClientFactory().close();
+        getConnectionFactory().close();
+        getController().close();
+        ExecutorServiceHelpers.shutdown(executorService, scaleExecutorService);
+    }
+
     @Test
     public void scaleTests() {
+        testState = new TestState(false);
         CompletableFuture<Void> scaleup = scaleUpTest();
         CompletableFuture<Void> scaleDown = scaleDownTest();
         CompletableFuture<Void> scalewithTxn = scaleUpTxnTest();
@@ -169,25 +175,17 @@ public class AutoScaleTest extends AbstractScaleTests {
 
     /**
      * Invoke the simple scale up Test, produce traffic from multiple writers in parallel.
-     * The test will periodically check if a scale event has occured by talking to controller via
+     * The test will periodically check if a scale event has occurred by talking to controller via
      * controller client.
      *
      * @throws InterruptedException if interrupted
      * @throws URISyntaxException   If URI is invalid
      */
     private CompletableFuture<Void> scaleUpTest() {
-
         ClientFactory clientFactory = getClientFactory();
         ControllerImpl controller = getController();
-
         final AtomicBoolean exit = new AtomicBoolean(false);
-
-        startNewWriter(clientFactory, exit);
-        startNewWriter(clientFactory, exit);
-        startNewWriter(clientFactory, exit);
-        startNewWriter(clientFactory, exit);
-        startNewWriter(clientFactory, exit);
-        startNewWriter(clientFactory, exit);
+        createWriters(clientFactory, 6, SCOPE, SCALE_UP_STREAM_NAME);
 
         // overall wait for test to complete in 260 seconds (4.2 minutes) or scale up, whichever happens first.
         return Retry.withExpBackoff(10, 10, 30, Duration.ofSeconds(10).toMillis())
@@ -200,25 +198,21 @@ public class AutoScaleTest extends AbstractScaleTests {
                                 throw new ScaleOperationNotDoneException();
                             } else {
                                 log.info("scale up done successfully");
-
                                 exit.set(true);
                             }
-                        }), EXECUTOR_SERVICE);
+                        }), scaleExecutorService);
     }
 
     /**
      * Invoke the simple scale down Test, produce no into a stream.
-     * The test will periodically check if a scale event has occured by talking to controller via
+     * The test will periodically check if a scale event has occurred by talking to controller via
      * controller client.
      *
      * @throws InterruptedException if interrupted
      * @throws URISyntaxException   If URI is invalid
      */
     private CompletableFuture<Void> scaleDownTest() {
-
         final ControllerImpl controller = getController();
-
-        final AtomicBoolean exit = new AtomicBoolean(false);
 
         // overall wait for test to complete in 260 seconds (4.2 minutes) or scale down, whichever happens first.
         return Retry.withExpBackoff(10, 10, 30, Duration.ofSeconds(10).toMillis())
@@ -230,30 +224,24 @@ public class AutoScaleTest extends AbstractScaleTests {
                                 throw new ScaleOperationNotDoneException();
                             } else {
                                 log.info("scale down done successfully");
-
-                                exit.set(true);
                             }
-                        }), EXECUTOR_SERVICE);
+                        }), scaleExecutorService);
     }
 
     /**
-     * Invoke the scale up Test with transactional writes. Produce traffic from multiple writers in parallel.
-     * Each writer writes using transactions.
-     * Transactions are committed quickly to give
-     * The test will periodically check if a scale event has occured by talking to controller via
-     * controller client.
+     * Invoke the scale up Test with transactional writes. Produce traffic from multiple writers in parallel. Each
+     * writer writes using transactions. The test will periodically check if a scale event has occurred by talking to
+     * controller via controller client.
      *
      * @throws InterruptedException if interrupted
      * @throws URISyntaxException   If URI is invalid
      */
     private CompletableFuture<Void> scaleUpTxnTest() {
-
         ControllerImpl controller = getController();
-
         final AtomicBoolean exit = new AtomicBoolean(false);
-
         ClientFactory clientFactory = getClientFactory();
-        startNewTxnWriter(clientFactory, exit);
+        startWritingIntoTxn(clientFactory.createEventWriter(SCALE_UP_TXN_STREAM_NAME, new JavaSerializer<>(),
+                EventWriterConfig.builder().build()), exit);
 
         // overall wait for test to complete in 260 seconds (4.2 minutes) or scale up, whichever happens first.
         return Retry.withExpBackoff(10, 10, 30, Duration.ofSeconds(10).toMillis())
@@ -267,54 +255,6 @@ public class AutoScaleTest extends AbstractScaleTests {
                                 log.info("txn test scale up done successfully");
                                 exit.set(true);
                             }
-                        }), EXECUTOR_SERVICE);
-    }
-
-    private void startNewWriter(ClientFactory clientFactory, AtomicBoolean exit) {
-        CompletableFuture.runAsync(() -> {
-            @Cleanup
-            EventStreamWriter<String> writer = clientFactory.createEventWriter(SCALE_UP_STREAM_NAME,
-                    new JavaSerializer<>(),
-                    EventWriterConfig.builder().build());
-
-            while (!exit.get()) {
-                try {
-                    writer.writeEvent("0", "test").get();
-                } catch (Throwable e) {
-                    log.warn("test exception writing events: {}", e);
-                    break;
-                }
-            }
-        });
-    }
-
-    private void startNewTxnWriter(ClientFactory clientFactory, AtomicBoolean exit) {
-        CompletableFuture.runAsync(() -> {
-            @Cleanup
-            EventStreamWriter<String> writer = clientFactory.createEventWriter(SCALE_UP_TXN_STREAM_NAME,
-                    new JavaSerializer<>(),
-                    EventWriterConfig.builder().transactionTimeoutTime(25000).build());
-
-            while (!exit.get()) {
-                try {
-                    Transaction<String> transaction = writer.beginTxn();
-
-                    for (int i = 0; i < 100; i++) {
-                        transaction.writeEvent("0", "txntest");
-                    }
-
-                    transaction.commit();
-                } catch (Throwable e) {
-                    if (!(e instanceof RuntimeException && e.getCause() != null &&
-                            e.getCause() instanceof io.grpc.StatusRuntimeException &&
-                            ((io.grpc.StatusRuntimeException) e.getCause()).getStatus().getCode().equals(Status.Code.INTERNAL) &&
-                            Objects.equals(((StatusRuntimeException) e.getCause()).getStatus().getDescription(),
-                                    "io.pravega.controller.task.Stream.StreamTransactionMetadataTasks not yet ready"))) {
-                        log.warn("test exception writing events in a transaction : {}", e);
-                        break;
-                    }
-                }
-            }
-        });
+                        }), scaleExecutorService);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -22,14 +22,11 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
-import io.pravega.test.system.framework.Utils;
-import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -70,11 +67,11 @@ public class AutoScaleTest extends AbstractScaleTests {
     private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Environment
-    public static void initialize() throws ExecutionException {
+    public static void initialize() {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     /**

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -73,8 +73,8 @@ public class AutoScaleTest extends AbstractScaleTests {
     public static void initialize() throws ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     /**

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -83,8 +83,8 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -40,7 +40,6 @@ import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -80,11 +79,11 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
      * @throws MarathonException When error in setup.
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -133,7 +133,6 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
         readerGroupManager = ReaderGroupManager.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURIDirect).build());
     }
 
-
     @After
     public void tearDown() {
         testState.stopReadFlag.set(true);
@@ -146,8 +145,6 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
     }
-
-
 
     @Test
     public void bookieFailoverTest() throws ExecutionException, InterruptedException {

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -75,8 +75,8 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -72,11 +72,11 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
      * @throws MarathonException    when error in setup
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -137,7 +137,6 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
     public void tearDown() {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -72,44 +72,11 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
      * @throws MarathonException    when error in setup
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        //1. check if zk is running, if not start it
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-        //2, check if bk is running, otherwise start, get the zk ip
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        //3. start controller
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega controller service details: {}", conUris);
-
-        //4.start segmentstore
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega segmentstore service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class BookkeeperTest {
+
     /**
      * This is used to setup the various services required by the system test framework.
      *

--- a/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
@@ -15,7 +15,9 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.util.List;
@@ -24,6 +26,9 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class BookkeeperTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -44,10 +49,10 @@ public class BookkeeperTest {
 
     /**
      * Invoke the bookkeeper test.
-     * The test fails incase bookkeeper is not running on given port.
+     * The test fails in case bookkeeper is not running on given port.
      */
 
-    @Test(timeout = 5 * 60 * 1000)
+    @Test
     public void bkTest() {
         log.debug("Start execution of bkTest");
         Service bk = Utils.createBookkeeperService(null);

--- a/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
@@ -30,7 +30,7 @@ public class BookkeeperTest {
      * @throws MarathonException if error in setup
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
         Service zk = Utils.createZookeeperService();
         if (!zk.isRunning()) {
             zk.start(true);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -48,6 +48,7 @@ import org.junit.runner.RunWith;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ControllerFailoverTest extends AbstractSystemTest {
+
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(5);
     private Service controllerService1 = null;
     private URI controllerURIDirect = null;

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -57,8 +57,8 @@ public class ControllerFailoverTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 2);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -39,7 +39,9 @@ import mesosphere.marathon.client.MarathonException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 /**
@@ -48,6 +50,9 @@ import org.junit.runner.RunWith;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ControllerFailoverTest extends AbstractSystemTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(3 * 60);
 
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(5);
     private Service controllerService1 = null;
@@ -85,7 +90,7 @@ public class ControllerFailoverTest extends AbstractSystemTest {
         log.info("Controller Service direct URI: {}", controllerURIDirect);
     }
 
-    @Test(timeout = 180000)
+    @Test
     public void failoverTest() throws InterruptedException, ExecutionException {
         String scope = "testFailoverScope" + RandomStringUtils.randomAlphabetic(5);
         String stream = "testFailoverStream" + RandomStringUtils.randomAlphabetic(5);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -48,12 +48,12 @@ import org.junit.runner.RunWith;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ControllerFailoverTest {
-    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(5);
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(5);
     private Service controllerService1 = null;
     private URI controllerURIDirect = null;
 
     @Environment
-    public static void setup() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException, ExecutionException {
 
         //1. check if zk is running, if not start it
         Service zkService = Utils.createZookeeperService();
@@ -101,7 +101,6 @@ public class ControllerFailoverTest {
         log.debug("pravega host service details: {}", segUris);
     }
 
-
     @Before
     public void getControllerInfo() {
         Service zkService = Utils.createZookeeperService();
@@ -136,13 +135,12 @@ public class ControllerFailoverTest {
         newRangesToCreate.put(0.0, 0.25);
         newRangesToCreate.put(0.25, 0.5);
         long lease = 29000;
-        long maxExecutionTime = 60000;
 
         // Connect with first controller instance.
         final Controller controller1 = new ControllerImpl(
                 ControllerImplConfig.builder()
                                     .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
-                                    .build(), EXECUTOR_SERVICE);
+                                    .build(), executorService);
 
         // Create scope, stream, and a transaction with high timeout value.
         controller1.createScope(scope).join();
@@ -183,7 +181,7 @@ public class ControllerFailoverTest {
         final Controller controller2 = new ControllerImpl(
                 ControllerImplConfig.builder()
                                     .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
-                                    .build(), EXECUTOR_SERVICE);
+                                    .build(), executorService);
 
         // Fetch status of transaction.
         log.info("Fetching status of transaction {}, time elapsed since its creation={}",

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -57,8 +57,8 @@ public class ControllerFailoverTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -91,7 +91,7 @@ public class ControllerRestApiTest {
      * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
 
         //1. check if zk is running, if not start it
         Service zkService = Utils.createZookeeperService();

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -95,8 +95,8 @@ public class ControllerRestApiTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Test(timeout = 300000)

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -45,7 +45,6 @@ import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -92,11 +91,11 @@ public class ControllerRestApiTest extends AbstractSystemTest {
      * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Test(timeout = 300000)

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -57,7 +57,9 @@ import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
@@ -70,6 +72,9 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ControllerRestApiTest extends AbstractSystemTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
 
     private final Client client;
     private WebTarget webTarget;
@@ -98,7 +103,7 @@ public class ControllerRestApiTest extends AbstractSystemTest {
         ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
-    @Test(timeout = 300000)
+    @Test
     public void restApiTests() {
 
         Service conService = Utils.createPravegaControllerService(null);

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -39,10 +39,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static io.pravega.test.system.framework.Utils.DOCKER_BASED;
+import static io.pravega.test.system.framework.Utils.createZookeeperService;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MultiControllerTest {
+public class MultiControllerTest extends AbstractSystemTest {
 
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private Service controllerService = null;
@@ -51,21 +52,8 @@ public class MultiControllerTest {
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.info("Zookeeper service details: {}", zkUris);
-
-        Service controllerService = Utils.createPravegaControllerService(zkUris.get(0), "multicontroller");
-        if (!controllerService.isRunning()) {
-            controllerService.start(true);
-        }
-        Futures.getAndHandleExceptions(controllerService.scaleService(2), ExecutionException::new);
-
-        List<URI> conUris = controllerService.getServiceDetails();
-        log.debug("Pravega Controller service  details: {}", conUris);
+        URI zkUris = startZookeeperInstance();
+        startPravegaControllerInstances(zkUris, 2);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -36,18 +36,13 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import static io.pravega.test.system.framework.Utils.DOCKER_BASED;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class MultiControllerTest extends AbstractSystemTest {
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(8 * 60);
 
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private Service controllerService = null;

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -57,7 +57,14 @@ public class MultiControllerTest extends AbstractSystemTest {
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUris = startZookeeperInstance();
-        startPravegaControllerInstances(zkUris, 2);
+        Service controllerService = Utils.createPravegaControllerService(zkUris, "multicontroller");
+        if (!controllerService.isRunning()) {
+            controllerService.start(true);
+        }
+        Futures.getAndHandleExceptions(controllerService.scaleService(2), ExecutionException::new);
+
+        List<URI> conUris = controllerService.getServiceDetails();
+        log.debug("Pravega Controller service  details: {}", conUris);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -36,14 +36,18 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import static io.pravega.test.system.framework.Utils.DOCKER_BASED;
-import static io.pravega.test.system.framework.Utils.createZookeeperService;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class MultiControllerTest extends AbstractSystemTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(8 * 60);
 
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private Service controllerService = null;
@@ -63,7 +67,7 @@ public class MultiControllerTest extends AbstractSystemTest {
         List<URI> zkUris = zkService.getServiceDetails();
         log.info("zookeeper service details: {}", zkUris);
 
-        controllerService = Utils.createPravegaControllerService(zkUris.get(0), "multicontroller");
+        controllerService = Utils.createPravegaControllerService(zkUris.get(0));
         if (!controllerService.isRunning()) {
             controllerService.start(true);
         }

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -74,7 +74,7 @@ public class MultiControllerTest extends AbstractSystemTest {
         List<URI> zkUris = zkService.getServiceDetails();
         log.info("zookeeper service details: {}", zkUris);
 
-        controllerService = Utils.createPravegaControllerService(zkUris.get(0));
+        controllerService = Utils.createPravegaControllerService(zkUris.get(0), "multicontroller");
         if (!controllerService.isRunning()) {
             controllerService.start(true);
         }

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -43,6 +43,7 @@ import static io.pravega.test.system.framework.Utils.DOCKER_BASED;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class MultiControllerTest {
+
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private Service controllerService = null;
     private AtomicReference<URI> controllerURIDirect = new AtomicReference<>();

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -66,8 +66,8 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -108,7 +108,6 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
                                         controllerExecutorService);
         testState = new TestState(true);
         //read and write count variables
-        testState.writersListComplete.add(0, testState.writersComplete);
         streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
@@ -120,7 +119,6 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
     public void tearDown() throws ExecutionException {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -134,7 +134,7 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
 }
 
-    @Test(timeout = 15 * 60 * 1000)
+    @Test
     public void multiReaderTxnWriterWithFailOverTest() throws Exception {
         try {
             createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -48,9 +48,11 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
     private static final String STREAM_NAME = "testMultiReaderWriterTxnStream";
+
     //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
+
     private final String scope = "testMultiReaderWriterTxnScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testMultiReaderWriterTxnReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private ScalingPolicy scalingPolicy = ScalingPolicy.fixed(NUM_READERS);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -85,7 +85,8 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         log.info("Pravega Controller service instance details: {}", conURIs);
 
         // Fetch all the RPC endpoints and construct the client URIs.
-        final List<String> uris = conURIs.stream().filter(uri -> Utils.DOCKER_BASED ? uri.getPort() == Utils.DOCKER_CONTROLLER_PORT : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
+        final List<String> uris = conURIs.stream().filter(uri -> Utils.DOCKER_BASED ?
+                uri.getPort() == Utils.DOCKER_CONTROLLER_PORT : uri.getPort() == Utils.MARATHON_CONTROLLER_PORT).map(URI::getAuthority)
                 .collect(Collectors.toList());
 
         controllerURIDirect = URI.create("tcp://" + String.join(",", uris));

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -66,8 +66,8 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -121,7 +121,6 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
     public void tearDown() throws ExecutionException {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -65,8 +65,8 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -132,7 +132,7 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 15 * 60 * 1000)
+    @Test
     public void multiReaderWriterWithFailOverTest() throws Exception {
         try {
             createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -48,6 +48,7 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
     private static final String STREAM_NAME = "testMultiReaderWriterStream";
     private static final int NUM_WRITERS = 5;
     private static final int NUM_READERS = 5;
+
     //The execution time for @Before + @After + @Test methods should be less than 15 mins. Else the test will timeout.
     @Rule
     public Timeout globalTimeout = Timeout.seconds(15 * 60);
@@ -114,7 +115,6 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         readerGroupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerURIDirect).build());
-
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
+public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
 
     private static final String STREAM_NAME = "testMultiReaderWriterStream";
     private static final int NUM_WRITERS = 5;
@@ -109,7 +109,6 @@ public class MultiReaderWriterWithFailOverTest extends  AbstractFailoverTests {
 
         testState = new TestState(false);
         //read and write count variables
-        testState.writersListComplete.add(0, testState.writersComplete);
         streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -65,8 +65,8 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -54,11 +54,27 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
     private Service controllerInstance = null;
 
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+
+        // Start controller.
+        Service controllerService = Utils.createPravegaControllerService(zkUri);
+        if (!controllerService.isRunning()) {
+            controllerService.start(true);
+        }
+
+        List<URI> conUris = controllerService.getServiceDetails();
+        log.info("Pravega Controller service instance details: {}", conUris);
+
+        // Start segment store.
+        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
+        if (!segService.isRunning()) {
+            segService.start(true);
+        }
+
+        List<URI> segUris = segService.getServiceDetails();
+        log.info("pravega host service details: {}", segUris);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -40,7 +40,9 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 /**
@@ -49,6 +51,9 @@ import org.junit.runner.RunWith;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class MultiSegmentStoreTest extends AbstractSystemTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10 * 60);
 
     private Service segmentServiceInstance = null;
     private Service controllerInstance = null;
@@ -87,7 +92,7 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
         Futures.getAndHandleExceptions(this.segmentServiceInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 600000)
+    @Test
     public void testMultiSegmentStores() throws InterruptedException, ExecutionException {
         // Test Sanity.
         log.info("Test with 1 segment store running");

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -48,49 +48,17 @@ import org.junit.runner.RunWith;
  */
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MultiSegmentStoreTest {
+public class MultiSegmentStoreTest extends AbstractSystemTest {
 
     private Service segmentServiceInstance = null;
     private Service controllerInstance = null;
 
     @Environment
-    public static void initialize() throws MarathonException {
-
-        // 1. Check if zk is running, if not start it.
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.info("zookeeper service details: {}", zkUris);
-        URI zkUri = zkUris.get(0);
-        // 2. Check if bk is running, otherwise start it.
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.info("bookkeeper service details: {}", bkUris);
-
-        // 3. Start controller.
-        Service controllerService = Utils.createPravegaControllerService(zkUri);
-        if (!controllerService.isRunning()) {
-            controllerService.start(true);
-        }
-
-        List<URI> conUris = controllerService.getServiceDetails();
-        log.info("Pravega Controller service instance details: {}", conUris);
-
-        // 4. Start segment store.
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.info("pravega host service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -57,24 +57,8 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-
-        // Start controller.
-        Service controllerService = Utils.createPravegaControllerService(zkUri);
-        if (!controllerService.isRunning()) {
-            controllerService.start(true);
-        }
-
-        List<URI> conUris = controllerService.getServiceDetails();
-        log.info("Pravega Controller service instance details: {}", conUris);
-
-        // Start segment store.
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.info("pravega host service details: {}", segUris);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -77,8 +77,8 @@ public class OffsetTruncationTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -35,7 +35,6 @@ import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -74,11 +73,11 @@ public class OffsetTruncationTest extends AbstractReadWriteTest {
      * @throws MarathonException When error in setup.
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -35,6 +35,7 @@ import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -73,45 +74,11 @@ public class OffsetTruncationTest extends AbstractReadWriteTest {
      * @throws MarathonException When error in setup.
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        // 1. Check if zk is running, if not start it.
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        // Get the zk ip details and pass it to bk, host, controller.
-        URI zkUri = zkUris.get(0);
-
-        // 2. Check if bk is running, otherwise start, get the zk ip.
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        // 3. Start controller.
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega controller service details: {}", conUris);
-
-        // 4.Start segmentstore.
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega segmentstore service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -16,11 +16,6 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.Checkpoint;
-import io.pravega.client.stream.EventRead;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
@@ -30,7 +25,6 @@ import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.hash.RandomFactory;
@@ -39,12 +33,10 @@ import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
@@ -53,14 +45,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class OffsetTruncationTest {
+public class OffsetTruncationTest extends AbstractReadWriteTest {
 
     private static final String STREAM = "testOffsetTruncationStream";
     private static final String SCOPE = "testOffsetTruncationScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
@@ -134,6 +124,12 @@ public class OffsetTruncationTest {
         assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, config));
     }
 
+    @After
+    public void tearDown() {
+        streamManager.close();
+        ExecutorServiceHelpers.shutdown(executor);
+    }
+
     /**
      * This test verifies that truncation works specifying an offset that applies to multiple segments. To this end,
      * the test first writes a set of events on a Stream (with multiple segments) and truncates it at a specified offset
@@ -161,10 +157,10 @@ public class OffsetTruncationTest {
         ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);
 
         // Write events to the Stream.
-        writeDummyEvents(clientFactory, STREAM, totalEvents);
+        writeEvents(clientFactory, STREAM, totalEvents);
 
         // Instantiate readers to consume from Stream up to truncatedEvents.
-        List<CompletableFuture<Integer>> futures = readDummyEvents(clientFactory, READER_GROUP, PARALLELISM, truncatedEvents);
+        List<CompletableFuture<Integer>> futures = readEventFutures(clientFactory, READER_GROUP, PARALLELISM, truncatedEvents);
         Futures.allOf(futures).join();
 
         // Perform truncation on stream segment.
@@ -175,58 +171,10 @@ public class OffsetTruncationTest {
         // Just after the truncation, read events from the offset defined in truncate call onwards.
         final String newGroupName = READER_GROUP + "new";
         groupManager.createReaderGroup(newGroupName, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM)).build());
-        futures = readDummyEvents(clientFactory, newGroupName, PARALLELISM);
+        futures = readEventFutures(clientFactory, newGroupName, PARALLELISM);
         Futures.allOf(futures).join();
-        assertEquals("Expected read events: ", totalEvents - (truncatedEvents * PARALLELISM),
+        assertEquals("Expected read events: ", totalEvents - truncatedEvents,
                 (int) futures.stream().map(CompletableFuture::join).reduce((a, b) -> a + b).get());
-        log.debug("The stream has been successfully truncated at event {}. Offset truncation test passed.",
-                truncatedEvents * PARALLELISM);
-    }
-
-    @After
-    public void tearDown() {
-        streamManager.close();
-        ExecutorServiceHelpers.shutdown(executor);
-    }
-
-    private void writeDummyEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
-        @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
-        for (int i = 0; i < totalEvents; i++) {
-            writer.writeEvent(String.valueOf(i)).join();
-            log.debug("Writing event: {} to stream {}", i, streamName);
-        }
-    }
-
-    private List<CompletableFuture<Integer>> readDummyEvents(ClientFactory client, String rGroup, int numReaders, int limit) {
-        List<EventStreamReader<String>> readers = new ArrayList<>();
-        for (int i = 0; i < numReaders; i++) {
-            readers.add(client.createReader(String.valueOf(i), rGroup, new JavaSerializer<>(), ReaderConfig.builder().build()));
-        }
-
-        return readers.stream().map(r -> CompletableFuture.supplyAsync(() -> readEvents(r, limit))).collect(toList());
-    }
-
-    private List<CompletableFuture<Integer>> readDummyEvents(ClientFactory clientFactory, String readerGroup, int numReaders) {
-        return readDummyEvents(clientFactory, readerGroup, numReaders, Integer.MAX_VALUE);
-    }
-
-    @SneakyThrows
-    private <T> int readEvents(EventStreamReader<T> reader, int limit) {
-        EventRead<T> event;
-        int validEvents = 0;
-        try {
-            do {
-                event = reader.readNextEvent(1000);
-                if (event.getEvent() != null) {
-                    validEvents++;
-                }
-            } while ((event.getEvent() != null || event.isCheckpoint()) && validEvents < limit);
-        } finally {
-            reader.close();
-        }
-
-        return validEvents;
+        log.debug("The stream has been successfully truncated at event {}. Offset truncation test passed.", truncatedEvents);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
@@ -31,7 +31,7 @@ public class PravegaControllerTest {
      * @throws MarathonException if error in setup
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
         Service zk = Utils.createZookeeperService();
         if (!zk.isRunning()) {
             zk.start(true);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
@@ -15,7 +15,9 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.util.List;
@@ -24,6 +26,9 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class PravegaControllerTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -44,9 +49,9 @@ public class PravegaControllerTest {
 
     /**
      * Invoke the controller test.
-     * The test fails incase controller is not running on given ports
+     * The test fails in case controller is not running on given ports.
      */
-    @Test(timeout = 5 * 60 * 1000)
+    @Test
     public void controllerTest() {
         log.debug("Start execution of controllerTest");
         Service con = Utils.createPravegaControllerService(null);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
@@ -46,7 +46,6 @@ public class PravegaControllerTest {
      * Invoke the controller test.
      * The test fails incase controller is not running on given ports
      */
-
     @Test(timeout = 5 * 60 * 1000)
     public void controllerTest() {
         log.debug("Start execution of controllerTest");

--- a/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
@@ -55,7 +55,6 @@ public class PravegaSegmentStoreTest {
      * Invoke the segmentstore test.
      * The test fails incase segmentstore is not running on given port.
      */
-
     @Test(timeout = 5 * 60 * 1000)
     public void segmentStoreTest() {
         log.debug("Start execution of segmentStoreTest");

--- a/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
@@ -31,7 +31,7 @@ public class PravegaSegmentStoreTest {
      * @throws MarathonException if error in setup
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
         Service zk = Utils.createZookeeperService();
         if (!zk.isRunning()) {
             zk.start(true);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
@@ -15,7 +15,9 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import java.util.List;
@@ -24,6 +26,9 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class PravegaSegmentStoreTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -55,7 +60,7 @@ public class PravegaSegmentStoreTest {
      * Invoke the segmentstore test.
      * The test fails incase segmentstore is not running on given port.
      */
-    @Test(timeout = 5 * 60 * 1000)
+    @Test
     public void segmentStoreTest() {
         log.debug("Start execution of segmentStoreTest");
         Service seg = Utils.createPravegaSegmentStoreService(null, null);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -78,8 +78,8 @@ public class PravegaTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @BeforeClass

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -75,11 +75,11 @@ public class PravegaTest extends AbstractSystemTest {
      * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @BeforeClass

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -71,7 +71,7 @@ public class PravegaTest {
      * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
 
         //1. check if zk is running, if not start it
         Service zkService = Utils.createZookeeperService();

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class PravegaTest {
+public class PravegaTest extends AbstractSystemTest {
 
     private final static String STREAM_NAME = "testStreamSampleY";
     private final static String STREAM_SCOPE = "testScopeSampleY";
@@ -61,7 +61,11 @@ public class PravegaTest {
     public Timeout globalTimeout = Timeout.seconds(12 * 60);
 
     private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(4);
-    private final StreamConfiguration config = StreamConfiguration.builder().scope(STREAM_SCOPE).streamName(STREAM_NAME).scalingPolicy(scalingPolicy).build();
+    private final StreamConfiguration config = StreamConfiguration.builder()
+                                                                  .scope(STREAM_SCOPE)
+                                                                  .streamName(STREAM_NAME)
+                                                                  .scalingPolicy(scalingPolicy)
+                                                                  .build();
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -71,44 +75,11 @@ public class PravegaTest {
      * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        //1. check if zk is running, if not start it
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-        //2, check if bk is running, otherwise start, get the zk ip
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("bookkeeper service details: {}", bkUris);
-
-        //3. start controller
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega Controller service details: {}", conUris);
-
-        //4.start host
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("pravega host service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @BeforeClass
@@ -192,5 +163,4 @@ public class PravegaTest {
         reader.close();
         groupManager.deleteReaderGroup(READER_GROUP);
     }
-
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -120,6 +120,10 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @After
     public void tearDown() throws ExecutionException {
+        testState.stopReadFlag.set(true);
+        testState.stopWriteFlag.set(true);
+        //interrupt writers and readers threads if they are still running.
+        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
         readerGroupManager.close();
@@ -167,10 +171,6 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
             log.info("Test ReadTxnWriteAutoScaleWithFailover succeeds");
         } finally {
             testState.checkForAnomalies();
-            testState.stopReadFlag.set(true);
-            testState.stopWriteFlag.set(true);
-            //interrupt writers and readers threads if they are still running.
-            testState.cancelAllPendingWork();
         }
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -72,7 +72,6 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
-
     @Before
     public void setup() {
         // Get zk details to verify if controller, segmentstore are running
@@ -112,8 +111,6 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
                                          .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(true);
-        testState.writersListComplete.add(0, testState.writersComplete);
-        testState.writersListComplete.add(1, testState.newWritersComplete);
         streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
@@ -123,11 +120,6 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @After
     public void tearDown() throws ExecutionException {
-        testState.stopReadFlag.set(true);
-        testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
-        //interrupt writers and readers threads if they are still running.
-        testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
         readerGroupManager.close();
@@ -175,6 +167,10 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
             log.info("Test ReadTxnWriteAutoScaleWithFailover succeeds");
         } finally {
             testState.checkForAnomalies();
+            testState.stopReadFlag.set(true);
+            testState.stopWriteFlag.set(true);
+            //interrupt writers and readers threads if they are still running.
+            testState.cancelAllPendingWork();
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -133,7 +133,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 25 * 60 * 1000)
+    @Test
     public void readTxnWriteAutoScaleWithFailoverTest() throws Exception {
         try {
             createWriters(clientFactory, INIT_NUM_WRITERS, scope, stream);

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -68,8 +68,8 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -68,8 +68,8 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -173,5 +173,4 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
             testState.cancelAllPendingWork();
         }
     }
-
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -73,8 +73,8 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -73,8 +73,8 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -77,7 +77,6 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
-
     @Before
     public void setup() {
         // Get zk details to verify if controller, segmentstore are running

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -117,7 +117,6 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
                                     .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(true);
-        testState.writersListComplete.add(0, testState.writersComplete);
         streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
@@ -130,7 +129,6 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
     public void tearDown() throws ExecutionException {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -66,8 +66,8 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
     public static void initialize() throws ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     /**

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -126,9 +126,9 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
 
         //2.2 Create readers.
         CompletableFuture<Void> reader1 = startReading(clientFactory.createReader("reader1", READER_GROUP_NAME,
-                new JavaSerializer(), ReaderConfig.builder().build()), stopReadFlag);
+                new JavaSerializer<>(), ReaderConfig.builder().build()), stopReadFlag);
         CompletableFuture<Void> reader2 = startReading(clientFactory.createReader("reader2", READER_GROUP_NAME,
-                new JavaSerializer(), ReaderConfig.builder().build()), stopReadFlag);
+                new JavaSerializer<>(), ReaderConfig.builder().build()), stopReadFlag);
 
         //3 Now increase the number of TxnWriters to trigger scale operation.
         log.info("Increasing the number of writers to 6");

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -11,19 +11,15 @@ package io.pravega.test.system;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.Controller;
-import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.common.util.Retry;
@@ -33,29 +29,23 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-
 import static java.time.Duration.ofSeconds;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
@@ -69,13 +59,13 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
     private static final StreamConfiguration CONFIG = StreamConfiguration.builder().scope(SCOPE)
             .streamName(STREAM_NAME).scalingPolicy(SCALING_POLICY).build();
 
-    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(12 * 60);
 
     @Environment
-    public static void setup() {
+    public static void initialize() {
 
         //1. check if zk is running, if not start it
         Service zkService = Utils.createZookeeperService();
@@ -108,7 +98,6 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
             segService.start(true);
         }
         log.debug("Pravega host service details: {}", segService.getServiceDetails());
-
     }
 
     /**
@@ -119,9 +108,9 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
      * @throws ExecutionException   if error in create stream
      */
     @Before
-    public void createStream() throws InterruptedException, ExecutionException {
-
+    public void setup() throws InterruptedException, ExecutionException {
         Controller controller = getController();
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(4, "ReadWithAutoScaleTest-main");
 
         //create a scope
         Boolean createScopeStatus = controller.createScope(SCOPE).get();
@@ -132,23 +121,30 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         log.debug("Create stream status {}", createStreamStatus);
     }
 
+    @After
+    public void tearDown() {
+        getClientFactory().close();
+        getConnectionFactory().close();
+        getController().close();
+        ExecutorServiceHelpers.shutdown(executorService, scaleExecutorService);
+    }
+
     @Test
     public void scaleTestsWithReader() {
-
         URI controllerUri = getControllerURI();
-        ControllerImpl controller = getController();
-        ConcurrentLinkedQueue<Long> eventsReadFromPravega = new ConcurrentLinkedQueue<>();
+        Controller controller = getController();
+        testState = new TestState(true);
 
         final AtomicBoolean stopWriteFlag = new AtomicBoolean(false);
         final AtomicBoolean stopReadFlag = new AtomicBoolean(false);
-        final AtomicLong eventData = new AtomicLong(); //data used by each of the writers.
-        final AtomicLong eventReadCount = new AtomicLong(); // used by readers to maintain a count of events.
 
         @Cleanup
         ClientFactory clientFactory = getClientFactory();
 
         //1. Start writing events to the Stream.
-        CompletableFuture<Void> writer1 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
+        List<CompletableFuture<Void>> writers = new ArrayList<>();
+        writers.add(startWritingIntoTxn(clientFactory.createEventWriter(STREAM_NAME, new JavaSerializer<>(),
+                EventWriterConfig.builder().transactionTimeoutTime(25000).build()), stopWriteFlag));
 
         //2. Start a reader group with 2 readers (The stream is configured with 2 segments.)
 
@@ -159,18 +155,17 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         readerGroupManager.createReaderGroup(READER_GROUP_NAME, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         //2.2 Create readers.
-        CompletableFuture<Void> reader1 = startReader("reader1", clientFactory, READER_GROUP_NAME,
-                eventsReadFromPravega, eventData, eventReadCount, stopReadFlag );
-        CompletableFuture<Void> reader2 = startReader("reader2", clientFactory, READER_GROUP_NAME,
-                eventsReadFromPravega, eventData, eventReadCount, stopReadFlag);
+        CompletableFuture<Void> reader1 = startReading(clientFactory.createReader("reader1", READER_GROUP_NAME,
+                new JavaSerializer(), ReaderConfig.builder().build()), stopReadFlag);
+        CompletableFuture<Void> reader2 = startReading(clientFactory.createReader("reader2", READER_GROUP_NAME,
+                new JavaSerializer(), ReaderConfig.builder().build()), stopReadFlag);
 
         //3 Now increase the number of TxnWriters to trigger scale operation.
         log.info("Increasing the number of writers to 6");
-        CompletableFuture<Void> writer2 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
-        CompletableFuture<Void> writer3 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
-        CompletableFuture<Void> writer4 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
-        CompletableFuture<Void> writer5 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
-        CompletableFuture<Void> writer6 = startNewTxnWriter(eventData, clientFactory, stopWriteFlag);
+        for (int i = 0; i < 5; i++) {
+            writers.add(startWritingIntoTxn(clientFactory.createEventWriter(STREAM_NAME, new JavaSerializer<>(),
+                    EventWriterConfig.builder().transactionTimeoutTime(25000).build()), stopWriteFlag));
+        }
 
         //4 Wait until the scale operation is triggered (else time out)
         //    validate the data read by the readers ensuring all the events are read and there are no duplicates.
@@ -191,112 +186,20 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                             } else {
                                 Assert.fail("Current number of Segments reduced to less than 2. Failure of test");
                             }
-                        }), EXECUTOR_SERVICE)
-                .thenCompose(v -> CompletableFuture.allOf(writer1, writer2, writer3, writer4, writer5, writer6))
+                        }), scaleExecutorService)
+                .thenCompose(v -> Futures.allOf(writers))
                 .thenCompose(v -> {
                     stopReadFlag.set(true);
                     log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +
-                            "Count: {}", eventData.get(), eventsReadFromPravega.size());
+                            "Count: {}", testState.writtenEvents, testState.readEvents);
                     return CompletableFuture.allOf(reader1, reader2);
                 })
-                .thenRun(() -> validateResults(eventData.get(), eventsReadFromPravega));
+                .thenRun(this::validateResults);
 
         Futures.getAndHandleExceptions(testResult
                 .whenComplete((r, e) -> {
                     recordResult(testResult, "ScaleUpWithTxnWithReaderGroup");
                 }), RuntimeException::new);
         readerGroupManager.deleteReaderGroup(READER_GROUP_NAME);
-    }
-
-    //Helper methods
-    private void validateResults(final long lastEventCount, final Collection<Long> readEvents) {
-        log.info("Last Event Count is {}", lastEventCount);
-        assertTrue("Overflow in the number of events published ", lastEventCount > 0);
-        // Number of event read should be equal to number of events published.
-        assertEquals(lastEventCount, readEvents.size());
-        assertEquals(lastEventCount, new TreeSet<>(readEvents).size()); //check unique events.
-    }
-
-    private CompletableFuture<Void> startReader(final String id, final ClientFactory clientFactory, final String
-            readerGroupName, final ConcurrentLinkedQueue<Long> readResult, final AtomicLong writeCount, final
-    AtomicLong readCount, final AtomicBoolean exitFlag) {
-
-        return CompletableFuture.runAsync(() -> {
-            @Cleanup
-            final EventStreamReader<Long> reader = clientFactory.createReader(id,
-                    readerGroupName,
-                    new JavaSerializer<Long>(),
-                    ReaderConfig.builder().build());
-            long count;
-            while (!(exitFlag.get() && readCount.get() == writeCount.get())) {
-                // exit only if exitFlag is true  and read Count equals write count.
-                try {
-                    final Long longEvent = reader.readNextEvent(SECONDS.toMillis(60)).getEvent();
-                    if (longEvent != null) {
-                        //update if event read is not null.
-                        readResult.add(longEvent);
-                        count = readCount.incrementAndGet();
-                        log.debug("Reader {}, read count {}", id, count);
-                    } else {
-                        log.debug("Null event, reader {}, read count {}", id, readCount.get());
-                    }
-                } catch (ReinitializationRequiredException e) {
-                    log.warn("Test Exception while reading from the stream", e);
-                    break;
-                }
-            }
-        });
-    }
-
-    private CompletableFuture<Void> startNewTxnWriter(final AtomicLong data, final ClientFactory clientFactory,
-                                                      final AtomicBoolean exitFlag) {
-        return CompletableFuture.runAsync(() -> {
-            @Cleanup
-            EventStreamWriter<Long> writer = clientFactory.createEventWriter(STREAM_NAME,
-                    new JavaSerializer<Long>(),
-                    EventWriterConfig.builder().transactionTimeoutTime(25000).build());
-            while (!exitFlag.get()) {
-                try {
-                    //create a transaction with 10 events.
-                    Transaction<Long> transaction = Retry.withExpBackoff(10, 10, 20, ofSeconds(1).toMillis())
-                            .retryingOn(TxnCreationFailedException.class)
-                            .throwingOn(RuntimeException.class)
-                            .run(() -> createTransaction(writer, exitFlag));
-
-                    for (int i = 0; i < 100; i++) {
-                        long value = data.incrementAndGet();
-                        transaction.writeEvent(String.valueOf(value), value);
-                    }
-                    transaction.commit();
-
-                } catch (Throwable e) {
-                    log.warn("test exception writing events in a transaction.", e);
-                    break;
-                }
-            }
-        });
-    }
-
-    private Transaction<Long> createTransaction(EventStreamWriter<Long> writer, final AtomicBoolean exitFlag) {
-        Transaction<Long> txn = null;
-        try {
-            txn = writer.beginTxn();
-            log.info("Transaction created with id:{} ", txn.getTxnId());
-        } catch (RuntimeException ex) {
-            log.info("Exception encountered while trying to begin Transaction ", ex.getCause());
-            final Class<? extends Throwable> exceptionClass = ex.getCause().getClass();
-            if (exceptionClass.equals(io.grpc.StatusRuntimeException.class) && !exitFlag.get())  {
-                //Exit flag is true no need to retry.
-                log.warn("Cause for failure is {} and we need to retry", exceptionClass.getName());
-                throw new TxnCreationFailedException(); // we can retry on this exception.
-            } else {
-                throw ex;
-            }
-        }
-        return txn;
-    }
-
-    private class TxnCreationFailedException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -63,11 +63,11 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
     private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Environment
-    public static void initialize() throws ExecutionException {
+    public static void initialize() {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     /**

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -135,7 +135,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 25 * 60 * 1000)
+    @Test
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
         try {
             createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -68,8 +68,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -109,11 +109,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         controller = new ControllerImpl(ControllerImplConfig.builder()
                                                             .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
                                                             .maxBackoffMillis(5000).build(),
-
                                         controllerExecutorService);
         testState = new TestState(false);
-        testState.writersListComplete.add(0, testState.writersComplete);
-        testState.writersListComplete.add(1, testState.newWritersComplete);
         streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, AUTO_SCALE_STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
@@ -127,7 +124,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     public void tearDown() throws ExecutionException {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -68,8 +68,8 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -135,7 +135,6 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-
     @Test(timeout = 25 * 60 * 1000)
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
         try {

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -138,7 +138,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
     }
 
-    @Test(timeout = 25 * 60 * 1000)
+    @Test
     public void readWriteAndScaleWithFailoverTest() throws Exception {
         try {
             createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -72,8 +72,8 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -72,8 +72,8 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 3);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 3);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -115,7 +115,6 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
                                     .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(false);
-        testState.writersListComplete.add(0, testState.writersComplete);
         streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
         createScopeAndStream(scope, SCALE_STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
@@ -128,7 +127,6 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     public void tearDown() throws ExecutionException {
         testState.stopReadFlag.set(true);
         testState.stopWriteFlag.set(true);
-        testState.checkForAnomalies();
         //interrupt writers and readers threads if they are still running.
         testState.cancelAllPendingWork();
         streamManager.close();

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -81,11 +80,11 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     private URI controllerURI;
 
     @Environment
-    public static void initialize() throws ExecutionException {
+    public static void initialize() {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -45,6 +45,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,8 +84,8 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     public static void initialize() throws ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before
@@ -93,6 +94,11 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         StreamManager streamManager = StreamManager.create(controllerURI);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, streamConfig));
+    }
+
+    @After
+    public void tearDown() {
+        ExecutorServiceHelpers.shutdown(readerExecutor);
     }
 
     @Test

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -139,6 +139,7 @@ public class RetentionTest {
         log.info("Invoking Writer test with Controller URI: {}", controllerURI);
 
         //create a writer
+        @Cleanup
         EventStreamWriter<Serializable> writer = clientFactory.createEventWriter(STREAM,
                 new JavaSerializer<>(),
                 EventWriterConfig.builder().build());

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -29,6 +29,7 @@ import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
@@ -43,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -78,8 +80,8 @@ public class RetentionTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before
@@ -90,6 +92,11 @@ public class RetentionTest extends AbstractSystemTest {
         streamManager = StreamManager.create(controllerURI);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, config));
+    }
+
+    @After
+    public void tearDown() {
+        streamManager.close();
     }
 
     @Test

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -39,6 +39,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
@@ -52,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class RetentionTest {
+public class RetentionTest extends AbstractSystemTest {
 
     private static final String STREAM = "testRetentionStream";
     private static final String SCOPE = "testRetentionScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
@@ -68,52 +69,17 @@ public class RetentionTest {
     private URI controllerURI;
     private StreamManager streamManager;
 
-
-
     /**
      * This is used to setup the various services required by the system test framework.
      *
      * @throws MarathonException    when error in setup
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        //1. check if zk is running, if not start it
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        //get the zk ip details and pass it to bk, host, controller
-        URI zkUri = zkUris.get(0);
-        //2, check if bk is running, otherwise start, get the zk ip
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        //3. start controller
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega controller service details: {}", conUris);
-
-        //4.start segmentstore
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega segmentstore service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -29,7 +29,6 @@ import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.Exceptions;
-import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
@@ -40,7 +39,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
@@ -77,11 +75,11 @@ public class RetentionTest extends AbstractSystemTest {
      * @throws MarathonException    when error in setup
      */
     @Environment
-    public static void initialize() throws MarathonException, ExecutionException {
+    public static void initialize() throws MarathonException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -91,8 +91,8 @@ public class StreamCutsTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -91,8 +91,8 @@ public class StreamCutsTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -87,45 +88,11 @@ public class StreamCutsTest extends AbstractReadWriteTest {
      * @throws MarathonException When error in setup.
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        // 1. Check if zk is running, if not start it.
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        // Get the zk ip details and pass it to bk, host, controller.
-        URI zkUri = zkUris.get(0);
-
-        // 2. Check if bk is running, otherwise start, get the zk ip.
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        // 3. Start controller.
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega controller service details: {}", conUris);
-
-        // 4.Start segmentstore.
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega segmentstore service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -70,8 +70,8 @@ public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -70,8 +70,8 @@ public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri);
-        startPravegaSegmentStoreInstances(zkUri, controllerUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri, 1);
     }
 
     @Before

--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -12,14 +12,11 @@ package io.pravega.test.system;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
@@ -30,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class StreamsAndScopesManagementTest {
+public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
 
     private static final int NUM_SCOPES = 3;
     private static final int NUM_STREAMS = 5;
@@ -69,45 +67,11 @@ public class StreamsAndScopesManagementTest {
      * @throws MarathonException When error in setup.
      */
     @Environment
-    public static void initialize() throws MarathonException {
-
-        // 1. Check if zk is running, if not start it.
-        Service zkService = Utils.createZookeeperService();
-        if (!zkService.isRunning()) {
-            zkService.start(true);
-        }
-
-        List<URI> zkUris = zkService.getServiceDetails();
-        log.debug("Zookeeper service details: {}", zkUris);
-        // Get the zk ip details and pass it to bk, host, controller.
-        URI zkUri = zkUris.get(0);
-
-        // 2. Check if bk is running, otherwise start, get the zk ip.
-        Service bkService = Utils.createBookkeeperService(zkUri);
-        if (!bkService.isRunning()) {
-            bkService.start(true);
-        }
-
-        List<URI> bkUris = bkService.getServiceDetails();
-        log.debug("Bookkeeper service details: {}", bkUris);
-
-        // 3. Start controller.
-        Service conService = Utils.createPravegaControllerService(zkUri);
-        if (!conService.isRunning()) {
-            conService.start(true);
-        }
-
-        List<URI> conUris = conService.getServiceDetails();
-        log.debug("Pravega controller service details: {}", conUris);
-
-        // 4.Start segmentstore.
-        Service segService = Utils.createPravegaSegmentStoreService(zkUri, conUris.get(0));
-        if (!segService.isRunning()) {
-            segService.start(true);
-        }
-
-        List<URI> segUris = segService.getServiceDetails();
-        log.debug("Pravega segmentstore service details: {}", segUris);
+    public static void initialize() throws MarathonException, ExecutionException {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = startPravegaControllerInstances(zkUri);
+        startPravegaSegmentStoreInstances(zkUri, controllerUri);
     }
 
     @Before
@@ -231,16 +195,6 @@ public class StreamsAndScopesManagementTest {
             log.info("Sealing and deleting an already deleted stream {}/{}.", scope, stream);
             assertThrows(RuntimeException.class, () -> streamManager.sealStream(scope, stream));
             assertFalse(streamManager.deleteStream(scope, stream));
-        }
-    }
-
-    private void writeEvents(ClientFactory clientFactory, String streamName, int totalEvents) {
-        @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
-        for (int i = 0; i < totalEvents; i++) {
-            writer.writeEvent(String.valueOf(i)).join();
-            log.debug("Writing event: {} to stream {}", i, streamName);
         }
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
@@ -18,7 +18,9 @@ import mesosphere.marathon.client.MarathonException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import java.net.URI;
 import static org.apache.curator.framework.imps.CuratorFrameworkState.STARTED;
@@ -27,6 +29,9 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SystemTestRunner.class)
 public class ZookeeperTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -42,10 +47,10 @@ public class ZookeeperTest {
 
     /**
      * Invoke the zookeeper test, ensure zookeeper can be accessed.
-     * The test fails incase zookeeper cannot be accessed
+     * The test fails in case zookeeper cannot be accessed.
      *
      */
-    @Test(timeout = 5 * 60 * 1000)
+    @Test
     public void zkTest() {
         log.info("Start execution of ZkTest");
         Service zk = Utils.createZookeeperService();

--- a/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
@@ -33,7 +33,7 @@ public class ZookeeperTest {
      * @throws MarathonException if error in setup
      */
     @Environment
-    public static void setup() throws MarathonException {
+    public static void initialize() throws MarathonException {
         Service zk = Utils.createZookeeperService();
         if (!zk.isRunning()) {
             zk.start(true);


### PR DESCRIPTION
**Change log description**
Code refactor of system tests:
- Better encapsulation of functionality in specific abstract classes.
- Removed redundant IO methods for writing/reading events.
- Removed redundant service initialization code.
- Added comments and minor style improvements in various tests.

**Purpose of the change**
Fixes #2715.

**What the code does**
First of all, this PR attempts to clearly define the functionality that each `Abstract*` test class should contain. In this sense, now we find 4 abstract system test classes:
- `AbstractSystemTest` contains the functionalities to start service instances (e.g., controller, segment store, bookkeeper, zookeeper). This allows us to remove most of the duplicate code existing in most `initialize()` methods.

- `AbstractReadWriteTest` (extends `AbstractSystemTest`) contains all the common methods related to reading and writing events. Before, the read/write utility methods was contained in `AbstractFailoverTests` and duplicated across several tests.

- `AbstractFailoverTests` and `AbstractScaleTests` (extend `AbstractReadWriteTest`): now these classes contain the functionality related to failover and autoscale testing testing, respectively.

Apart from better encapsulating functionality, these changes allowed us to reduce a significant number of code lines related to initialization of tests (`initialize()` method) and duplicate read/write methods.

Second, for the sake of clarity, this PR sets a standard for initialization test method naming: the `@Environment` method is named `initialize` and the `@Before` method `setup` in all tests. Before, these names were mixed, which did not facilitate reading. Moreover, all tests define `@Environment`, `@Before`, `@After` methods before the actual test methods.

Finally, this PR adds some comments in abstract classes and contains several minor style improvements (e.g., blank lines, log messages).

**How to verify it**
System tests should be passing as before this PR.