### PR TITLE
Issue 2860:  Ensure scoped name of the stream is returned by ReaderGroup#getStreamNames

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -129,7 +129,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
     Set<String> getOnlineReaders();
 
     /**
-     * Returns the set of stream names which was used to configure this group.
+     * Returns the set of scoped stream names which was used to configure this group.
      *
      * @return Set of streams for this group.
      */

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -214,11 +214,11 @@ public class ReaderGroupState implements Revisioned {
         Set<String> result = new HashSet<>();
         for (Map<Segment, Long> segments : assignedSegments.values()) {
             for (Segment segment : segments.keySet()) {
-                result.add(segment.getStreamName());
+                result.add(segment.getScopedStreamName());
             }
         }
         for (Segment segment : unassignedSegments.keySet()) {
-            result.add(segment.getStreamName());
+            result.add(segment.getScopedStreamName());
         }
         return result;
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -113,6 +115,22 @@ public class ReaderGroupStateTest {
         assertTrue(latestPosition.isPresent());
         assertEquals(3L, latestPosition.get().get(getStream("S1")).get(getSegment("S1")).longValue());
         assertEquals(3L, latestPosition.get().get(getStream("S2")).get(getSegment("S2")).longValue());
+    }
+
+    @Test
+    public void getStreamNames() {
+        // configured Streams.
+        Set<String> configuredStreams = ImmutableSet.of(getStream("S1").getScopedName(), getStream("S2").getScopedName());
+
+        // validate stream names
+        assertEquals(configuredStreams, readerState.getStreamNames());
+
+        //Simulate addition of a reader and assigning of segments to the reader.
+        new AddReader("reader1").applyTo(readerState, revision);
+        new ReaderGroupState.AcquireSegment("reader1", new Segment(SCOPE, "S1", 0)).applyTo(readerState, revision);
+
+        // validate stream names
+        assertEquals(configuredStreams, readerState.getStreamNames());
     }
 
     private Segment getSegment(String streamName) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -307,8 +307,8 @@ public class ControllerRestApiTest {
         assertEquals("Get readergroup name", readerGroupName1, readerGroupProperty.getReaderGroupName());
         assertEquals("Get readergroup scope name", testScope, readerGroupProperty.getScopeName());
         assertEquals("Get readergroup streams size", 2, readerGroupProperty.getStreamList().size());
-        assertTrue(readerGroupProperty.getStreamList().contains(testStream1));
-        assertTrue(readerGroupProperty.getStreamList().contains(testStream2));
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream1).getScopedName()));
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream2).getScopedName()));
         assertEquals("Get readergroup onlinereaders size", 2, readerGroupProperty.getOnlineReaderIds().size());
         assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader1));
         assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader2));

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -210,7 +210,7 @@ public class StreamCutsTest {
     private void validateCuts(ReaderGroup group, Map<Stream, StreamCut> cuts, Set<String> segmentNames) {
         Set<String> streamNames = group.getStreamNames();
         cuts.forEach((s, c) -> {
-                assertTrue(streamNames.contains(s.getStreamName()));
+                assertTrue(streamNames.contains(s.getScopedName()));
                 assertTrue(((StreamCutImpl) c).validate(segmentNames));
         });
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -44,11 +44,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class EndToEndReaderGroupTest {
@@ -195,6 +197,11 @@ public class EndToEndReaderGroupTest {
         writeTestEvent(scopeB, streamName, 1);
         eventRead = reader1.readNextEvent(10000);
         assertEquals("1", eventRead.getEvent());
+
+        // Verify ReaderGroup.getStreamNames().
+        Set<String> managedStreams = readerGroup.getStreamNames();
+        assertTrue(managedStreams.contains(Stream.of(scopeA, streamName).getScopedName()));
+        assertTrue(managedStreams.contains(Stream.of(scopeB, streamName).getScopedName()));
     }
 
     private StreamConfiguration getStreamConfig(String scope, String streamName) {

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -171,7 +171,7 @@ public class EndToEndReaderGroupTest {
         ClientFactory clientFactory = new ClientFactoryImpl(streamName, controller, connectionFactory);
 
         @Cleanup
-        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(streamName, controller, clientFactory,
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(defaultScope, controller, clientFactory,
                                                                      connectionFactory);
         groupManager.createReaderGroup("group", ReaderGroupConfig.builder()
                                                                  .disableAutomaticCheckpoints()

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -23,6 +23,7 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
@@ -95,11 +96,7 @@ public class EndToEndReaderGroupTest {
 
     @Test(timeout = 30000)
     public void testReaderOffline() throws Exception {
-        StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scope("test")
-                                                        .streamName("test")
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 2))
-                                                        .build();
+        StreamConfiguration config = getStreamConfig("test", "test");
         LocalController controller = (LocalController) controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
         controller.createStream(config).get();
@@ -142,5 +139,78 @@ public class EndToEndReaderGroupTest {
 
         eventRead = reader2.readNextEvent(10000);
         assertEquals("data1", eventRead.getEvent());
+    }
+
+    @Test(timeout = 30000)
+    public void testMultiScopeReaderGroup() throws Exception {
+        LocalController controller = (LocalController) controllerWrapper.getController();
+
+        // Config of two streams with same name and different scopes.
+        String defaultScope = "test";
+        String scopeA = "scopeA";
+        String scopeB = "scopeB";
+        String streamName = "test";
+
+        // Create Scopes
+        controllerWrapper.getControllerService().createScope(defaultScope).get();
+        controllerWrapper.getControllerService().createScope(scopeA).get();
+        controllerWrapper.getControllerService().createScope(scopeB).get();
+
+        // Create Streams.
+        controller.createStream(getStreamConfig(scopeA, streamName)).get();
+        controller.createStream(getStreamConfig(scopeB, streamName)).get();
+
+        // Create ReaderGroup and reader.
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                                    .controllerURI(URI.create("tcp://" + serviceHost))
+                                                                                    .build());
+        @Cleanup
+        ClientFactory clientFactory = new ClientFactoryImpl(streamName, controller, connectionFactory);
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(streamName, controller, clientFactory,
+                                                                     connectionFactory);
+        groupManager.createReaderGroup("group", ReaderGroupConfig.builder()
+                                                                 .disableAutomaticCheckpoints()
+                                                                 .stream(Stream.of(scopeA, streamName))
+                                                                 .stream(Stream.of(scopeB, streamName))
+                                                                 .build());
+
+        ReaderGroup readerGroup = groupManager.getReaderGroup("group");
+        @Cleanup
+        EventStreamReader<String> reader1 = clientFactory.createReader("reader1", "group", new JavaSerializer<>(),
+                                                                       ReaderConfig.builder().build());
+
+        // Read empty stream.
+        EventRead<String> eventRead = reader1.readNextEvent(100);
+        assertNull("Event read should be null since no events are written", eventRead.getEvent());
+
+        // Write to scopeA stream.
+        writeTestEvent(scopeA, streamName, 0);
+        eventRead = reader1.readNextEvent(10000);
+        assertEquals("0", eventRead.getEvent());
+
+        // Write to scopeB stream.
+        writeTestEvent(scopeB, streamName, 1);
+        eventRead = reader1.readNextEvent(10000);
+        assertEquals("1", eventRead.getEvent());
+    }
+
+    private StreamConfiguration getStreamConfig(String scope, String streamName) {
+        return StreamConfiguration.builder()
+                                  .scope(scope)
+                                  .streamName(streamName)
+                                  .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 2))
+                                  .build();
+    }
+
+    private void writeTestEvent(String scope, String streamName, int eventId) {
+        @Cleanup
+        ClientFactory clientFactory = ClientFactory.withScope(scope, controllerURI);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(), EventWriterConfig.builder().build());
+
+        writer.writeEvent( "0", Integer.toString(eventId)).join();
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -334,8 +334,8 @@ public class ControllerRestApiTest {
         assertEquals("Get readergroup name", readerGroupName1, readerGroupProperty.getReaderGroupName());
         assertEquals("Get readergroup scope name", testScope, readerGroupProperty.getScopeName());
         assertEquals("Get readergroup streams size", 2, readerGroupProperty.getStreamList().size());
-        assertTrue(readerGroupProperty.getStreamList().contains(testStream1));
-        assertTrue(readerGroupProperty.getStreamList().contains(testStream2));
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream1).getScopedName()));
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream2).getScopedName()));
         assertEquals("Get readergroup onlinereaders size", 2, readerGroupProperty.getOnlineReaderIds().size());
         assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader1));
         assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader2));


### PR DESCRIPTION
**Change log description**  
- Ensure scoped stream name is returned by ReaderGroup#getStreamNames.

**Purpose of the change**  
Fixes #2860 

**What the code does**  
Ensure the scoped stream name (e.g: scopeA/streamA) is returned by ReaderGroup#getStreamNames().

**How to verify it**  
All the existing tests should continue to pass.
