### PR TITLE
Issue 2888: Remove SNAPSHOT suffix for 0.3.2 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ typesafeConfigVersion=1.3.1
 gradleGitPluginVersion=2.2.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.3.2-SNAPSHOT
+pravegaVersion=0.3.2
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Removes the SNAPSHOT fix from the Pravega version property in gradle.properties as part of the preparation to release 0.3.2. 

**Purpose of the change**  
Fixes #2888 

**What the code does**  
There is no code change, only a single change to the `gradle.properties` file.

**How to verify it**  
Build and make sure that the new version is published locally  with `./gradlew install`.