### PR TITLE
Issue 2644: Remove duplicate logic of fetching offsets for a Stream Head in BatchClient.

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientImpl.java
@@ -113,12 +113,7 @@ public class BatchClientImpl implements BatchClient {
     private CompletableFuture<StreamCut> fetchHeadStreamCut(final Stream stream) {
         //Fetch segments pointing to the current HEAD of the stream.
         return controller.getSegmentsAtTime(new StreamImpl(stream.getScope(), stream.getStreamName()), 0L)
-                .thenApply( s -> {
-                    //fetch the correct start offset from Segment store.
-                    Map<Segment, Long> pos = s.keySet().stream().map(this::segmentToInfo)
-                            .collect(Collectors.toMap(SegmentInfo::getSegment, SegmentInfo::getStartingOffset));
-                    return new StreamCutImpl(stream, pos);
-                });
+                .thenApply( s -> new StreamCutImpl(stream, s));
     }
 
     private CompletableFuture<StreamCut> fetchTailStreamCut(final Stream stream) {


### PR DESCRIPTION
**Change log description**  
Remove duplicate logic of fetching offsets for a Stream Head.

**Purpose of the change**  
Fixes #2644 

**What the code does**  
With PR  #2757 Controller api `controller.getSegmentsAtTime(..)` now returns the updated offsets after truncation. Hence the duplicate logic of fetching offsets in the BatchClient is not required now.

**How to verify it**  
All the existing tests should continue to pass.