### PR TITLE
Issue 2671: Delay updating positions in Checkpoint until readNextEvent() is called

### DIFF
--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import lombok.Cleanup;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
@@ -311,8 +312,13 @@ public class EventStreamReaderTest {
         assertTrue(eventRead.isCheckpoint());
         assertNull(eventRead.getEvent());
         assertEquals("Foo", eventRead.getCheckpointName());
+        InOrder order = Mockito.inOrder(groupState);
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState, Mockito.never()).checkpoint(Mockito.anyString(), Mockito.any());
         assertEquals(buffer, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
         assertNull(reader.readNextEvent(0).getEvent());
+        order.verify(groupState).checkpoint(Mockito.eq("Foo"), Mockito.any());
+        order.verify(groupState).getCheckpoint();
         reader.close();
     }
     


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Delay updating positions in Checkpoint until readNextEvent() is called so that the future returned from initiateCheckpoint() will not complete until the application actually has performed the checkpoint.

**Purpose of the change**  
Fixes #2671. By delaying the update of the position object in the readerGroupState, the future returned from initiateCheckpoint() will not complete until the application actually has performed the checkpoint rather than merely having received it.

**What the code does**  
Instead of updating the positions in the Checkpoint object inside of the ReaderGroupState when the Checkpoint object is returned to the reader do this when the application subsequently calls read next event.