### PR TITLE
Issue 2902: Prevent NPE when truncate leaves trailing bytes in the segment (#2903)

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -131,7 +131,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
             throw new SegmentTruncatedException();
         }
         while (buffer.dataAvailable() < WireCommands.TYPE_PLUS_LENGTH_SIZE) {
-            if (buffer.dataAvailable() == 0 && receivedEndOfSegment) {
+            if (receivedEndOfSegment) {
                 throw new EndOfSegmentException();
             }
             Futures.await(outstandingRequest, timeout);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
@@ -48,11 +48,10 @@ public interface SegmentMetadataClient extends AutoCloseable {
     /**
      * Deletes all data before the offset of the provided segment.
      * This data will no longer be readable. Existing offsets are not affected by this operations. 
-     * The new startingOffset will be reflected in {@link SegmentMetadataClient#getSegmentInfo(String).startingOffset}.
-     * @param segment The segment to truncate.
+     * The new startingOffset will be reflected in {@link SegmentMetadataClient#getSegmentInfo().startingOffset}.
      * @param offset The offset the segment should be truncated at.
      */
-    abstract void truncateSegment(Segment segment, long offset);
+    abstract void truncateSegment(long offset);
     
     @Override
     abstract void close();

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -196,10 +196,10 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
     }
 
     @Override
-    public void truncateSegment(Segment segment, long offset) {
+    public void truncateSegment(long offset) {
         val future = RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class)
                                    .throwingOn(NoSuchSegmentException.class)
-                                   .runAsync(() -> truncateSegmentAsync(segment, offset, delegationToken),
+                                   .runAsync(() -> truncateSegmentAsync(segmentId, offset, delegationToken),
                                              connectionFactory.getInternalExecutor());
         future.join();
     }

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -185,7 +185,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
 
     @Override
     public void truncateToRevision(Revision newStart) {
-        meta.truncateSegment(newStart.asImpl().getSegment(), newStart.asImpl().getOffsetInSegment());
+        meta.truncateSegment(newStart.asImpl().getOffsetInSegment());
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -99,7 +99,7 @@ public class SegmentIteratorTest {
         assertEquals("1", iter.next());
         long segmentLength = metadataClient.fetchCurrentSegmentLength();
         assertEquals(0, segmentLength % 3);
-        metadataClient.truncateSegment(segment, segmentLength * 2 / 3);
+        metadataClient.truncateSegment(segmentLength * 2 / 3);
         AssertExtensions.assertThrows(TruncatedDataException.class, () -> iter.next());
         @Cleanup
         SegmentIteratorImpl<String> iter2 = new SegmentIteratorImpl<>(factory, segment, stringSerializer,

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -201,6 +201,16 @@ public class SegmentInputStreamTest {
     }
     
     @Test
+    public void testStreamTruncatedWithPartialEvent() throws EndOfSegmentException {
+        ByteBuffer trailingData = ByteBuffer.wrap(new byte[] {0, 1});
+        TestAsyncSegmentInputStream fakeNetwork = new TestAsyncSegmentInputStream(segment, 1);
+        @Cleanup
+        SegmentInputStreamImpl stream = new SegmentInputStreamImpl(fakeNetwork, 0);
+        fakeNetwork.complete(0, new WireCommands.SegmentRead(segment.getScopedName(), 0, false, true, trailingData.slice()));
+        AssertExtensions.assertThrows(EndOfSegmentException.class, () -> stream.read());
+    }
+    
+    @Test
     public void testIsSegmentReady() throws EndOfSegmentException, SegmentTruncatedException {
         byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int numEntries = SegmentInputStreamImpl.DEFAULT_BUFFER_SIZE / data.length;

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -89,7 +89,7 @@ public class SegmentMetadataClientTest {
                 return null;
             }
         }).when(connection).send(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, ""));
-        client.truncateSegment(segment, 123L);
+        client.truncateSegment(123L);
         Mockito.verify(connection).send(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, ""));
     }  
 

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -365,9 +365,9 @@ public class EventStreamReaderTest {
         assertEquals(0, length % 3);
         EventRead<byte[]> event1 = reader.readNextEvent(0);
         assertEquals(buffer1, ByteBuffer.wrap(event1.getEvent()));
-        metadataClient.truncateSegment(segment, length / 3);
+        metadataClient.truncateSegment(length / 3);
         assertEquals(buffer2, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
-        metadataClient.truncateSegment(segment, length);
+        metadataClient.truncateSegment(length);
         ByteBuffer buffer4 = writeInt(stream, 4);
         AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
         assertEquals(buffer4, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -182,7 +182,7 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
 
     @Override
     @Synchronized
-    public void truncateSegment(Segment segment, long offset) {
+    public void truncateSegment(long offset) {
         Preconditions.checkArgument(offset <= writeOffset);
         if (offset >= startingOffset) {
             startingOffset = offset;

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -43,6 +43,7 @@ import static io.pravega.client.stream.impl.ReaderGroupImpl.getEndSegmentsForStr
 public class MockStreamManager implements StreamManager, ReaderGroupManager {
 
     private final String scope;
+    @Getter
     private final ConnectionFactoryImpl connectionFactory;
     private final MockController controller;
     @Getter

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -20,6 +20,9 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentMetadataClient;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactoryImpl;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
@@ -30,6 +33,7 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
@@ -37,6 +41,9 @@ import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.client.stream.mock.MockClientFactory;
+import io.pravega.client.stream.mock.MockController;
+import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -46,6 +53,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
@@ -55,8 +63,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -115,6 +127,63 @@ public class EndToEndTruncationTest {
         server.close();
         serviceBuilder.close();
         zkTestServer.close();
+    }
+    
+    @Test(timeout = 7000)
+    public void testTruncationOffsets() throws InterruptedException, ExecutionException, TimeoutException,
+                                        TruncatedDataException, ReinitializationRequiredException {
+        String endpoint = "localhost";
+        String scope = "scope";
+        String streamName = "abc";
+        int port = TestUtils.getAvailableListenPort();
+        String testString = "Hello world\n";
+        StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();
+        @Cleanup
+        PravegaConnectionListener server = new PravegaConnectionListener(false, port, store);
+        server.startListening();
+        @Cleanup
+        MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
+        @Cleanup
+        MockClientFactory clientFactory = streamManager.getClientFactory();
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName, null);
+        Serializer<String> serializer = new JavaSerializer<>();
+        @Cleanup
+        EventStreamWriter<String> producer = clientFactory.createEventWriter(streamName, serializer,
+                                                                             EventWriterConfig.builder().build());
+        Future<Void> ack = producer.writeEvent(testString);
+        ack.get(5, TimeUnit.SECONDS);
+
+        MockController controller = new MockController(endpoint, port, streamManager.getConnectionFactory());
+        SegmentMetadataClientFactory metadataClientFactory = new SegmentMetadataClientFactoryImpl(controller,
+                                                                                                  streamManager.getConnectionFactory());
+        Segment segment = new Segment(scope, streamName, 0);
+        SegmentMetadataClient metadataClient = metadataClientFactory.createSegmentMetadataClient(segment, "");
+        assertEquals(0, metadataClient.getSegmentInfo().getStartingOffset());
+        long writeOffset = metadataClient.getSegmentInfo().getWriteOffset();
+        assertEquals(writeOffset, metadataClient.fetchCurrentSegmentLength());
+        assertTrue(metadataClient.getSegmentInfo().getWriteOffset() > testString.length());
+        metadataClient.truncateSegment(writeOffset);
+        assertEquals(writeOffset, metadataClient.getSegmentInfo().getStartingOffset());
+        assertEquals(writeOffset, metadataClient.getSegmentInfo().getWriteOffset());
+        assertEquals(writeOffset, metadataClient.fetchCurrentSegmentLength());
+
+        ack = producer.writeEvent(testString);
+        ack.get(5, TimeUnit.SECONDS);
+
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
+                                                         .disableAutomaticCheckpoints()
+                                                         .stream(new StreamImpl(scope, streamName))
+                                                         .build();
+        streamManager.createReaderGroup("ReaderGroup", groupConfig);
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader("reader", "ReaderGroup", serializer,
+                                                                      ReaderConfig.builder().build());
+        AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(2000));
+        EventRead<String> event = reader.readNextEvent(2000);
+        assertEquals(testString, event.getEvent());
+        event = reader.readNextEvent(100);
+        assertEquals(null, event.getEvent());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
Change log description

Skip over trailing bytes at the end of a segment if they are smaller than the length of an event header.
Purpose of the change
Fixes #2902. But does not actually identify why the truncate was leaving a single trailing byte.

What the code does

Removes a redundant parameter to truncateSegment().
Adds a truncation integration test.
Skips over trailing bytes at the end of the segment if they can't form a full event.
Adds a test for this case.