### PR TITLE
Issue 2920: Normalize format for metrics names

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -12,67 +12,67 @@ package io.pravega.shared;
 public final class MetricsNames {
     // Metrics in Segment Store Service
     // Segment-related stats
-    public static final String SEGMENT_CREATE_LATENCY = "segment_create_latency_ms"; // Timer
-    public static final String SEGMENT_READ_LATENCY = "segment_read_latency_ms";     // Timer
-    public static final String SEGMENT_WRITE_LATENCY = "segment_write_latency_ms";   // Timer
+    public static final String SEGMENT_CREATE_LATENCY = "segmentstore.segment_create_latency_ms"; // Timer
+    public static final String SEGMENT_READ_LATENCY = "segmentstore.segment_read_latency_ms";     // Timer
+    public static final String SEGMENT_WRITE_LATENCY = "segmentstore.segment_write_latency_ms";   // Timer
     public static final String SEGMENT_READ_BYTES = "segmentstore.segment_read_bytes";            // Dynamic Counter
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
     public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment_write_events";        // Dynamic Counter
 
     //storage stats
-    public static final String STORAGE_READ_LATENCY = "tier2_read_latency_ms";   // Timer
-    public static final String STORAGE_WRITE_LATENCY = "tier2_write_latency_ms"; // Timer
-    public static final String STORAGE_READ_BYTES = "tier2_read_bytes";          // Counter
-    public static final String STORAGE_WRITE_BYTES = "tier2_write_bytes";        // Counter
+    public static final String STORAGE_READ_LATENCY = "segmentstore.storage.read_latency_ms";   // Timer
+    public static final String STORAGE_WRITE_LATENCY = "segmentstore.storage.write_latency_ms"; // Timer
+    public static final String STORAGE_READ_BYTES = "segmentstore.storage.read_bytes";          // Counter
+    public static final String STORAGE_WRITE_BYTES = "segmentstore.storage.write_bytes";        // Counter
 
     //Cache (RocksDB) stats
-    public static final String CACHE_INSERT_LATENCY = "cache_insert_latency";
-    public static final String CACHE_GET_LATENCY = "cache_get_latency";
+    public static final String CACHE_INSERT_LATENCY = "segmentstore.cache_insert_latency";
+    public static final String CACHE_GET_LATENCY = "segment.store.cache_get_latency";
 
     //DurableDataLog (Tier1) stats
-    public static final String BK_TOTAL_WRITE_LATENCY = "bookkeeper_total_write_latency"; // Including Queue
-    public static final String BK_WRITE_LATENCY = "bookkeeper_write_latency";  // Exclusively the write to BK.
-    public static final String BK_WRITE_BYTES = "bookkeeper_write_bytes";
-    public static final String BK_WRITE_QUEUE_SIZE = "bookkeeper_write_queue_size";
-    public static final String BK_WRITE_QUEUE_FILL_RATE = "bookkeeper_write_queue_fill";
-    public static final String BK_LEDGER_COUNT = "bookkeeper_ledger_count";
+    public static final String BK_TOTAL_WRITE_LATENCY = "segmentstore.bookkeeper.total_write_latency"; // Including Queue
+    public static final String BK_WRITE_LATENCY = "segmentstore.bookkeeper.write_latency";  // Exclusively the write to BK.
+    public static final String BK_WRITE_BYTES = "segmentstore.bookkeeper.write_bytes";
+    public static final String BK_WRITE_QUEUE_SIZE = "segmentstore.bookkeeper.write_queue_size";
+    public static final String BK_WRITE_QUEUE_FILL_RATE = "segmentstore.bookkeeper.write_queue_fill";
+    public static final String BK_LEDGER_COUNT = "segmentstore.bookkeeper.bookkeeper_ledger_count";
 
     //Container-specific metrics
-    public static final String CONTAINER_APPEND_COUNT = "container_append_count";
-    public static final String CONTAINER_APPEND_OFFSET_COUNT = "container_append_offset_count";
-    public static final String CONTAINER_UPDATE_ATTRIBUTES_COUNT = "container_update_attributes_count";
-    public static final String CONTAINER_GET_ATTRIBUTES_COUNT = "container_get_attributes_count";
-    public static final String CONTAINER_READ_COUNT = "container_read_count";
-    public static final String CONTAINER_GET_INFO_COUNT = "container_get_info_count";
-    public static final String CONTAINER_CREATE_SEGMENT_COUNT = "container_create_segment_count";
-    public static final String CONTAINER_DELETE_SEGMENT_COUNT = "container_delete_segment_count";
-    public static final String CONTAINER_MERGE_SEGMENT_COUNT = "container_merge_segment_count";
-    public static final String CONTAINER_SEAL_COUNT = "container_seal_count";
-    public static final String CONTAINER_TRUNCATE_COUNT = "container_truncate_count";
-    public static final String PROCESS_OPERATIONS_LATENCY = "process_operations_latency";
-    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "process_operations_batch_size";
-    public static final String OPERATION_QUEUE_SIZE = "operation_queue_size";
-    public static final String OPERATION_PROCESSOR_IN_FLIGHT = "operation_processor_in_flight";
-    public static final String OPERATION_QUEUE_WAIT_TIME = "operation_queue_wait_time";
-    public static final String OPERATION_PROCESSOR_DELAY_MILLIS = "operation_processor_delay_ms";
-    public static final String OPERATION_COMMIT_LATENCY = "operation_commit_latency_ms";
-    public static final String OPERATION_LATENCY = "operation_latency_ms";
-    public static final String OPERATION_COMMIT_METADATA_TXN_COUNT = "operation_commit_metadata_txn_count";
-    public static final String OPERATION_COMMIT_MEMORY_LATENCY = "operation_commit_memory_latency_ms";
-    public static final String OPERATION_LOG_SIZE = "operation_log_size";
-    public static final String ACTIVE_SEGMENT_COUNT = "active_segments";
+    public static final String CONTAINER_APPEND_COUNT = "segmentstore.container.append_count";
+    public static final String CONTAINER_APPEND_OFFSET_COUNT = "segmentstore.container.append_offset_count";
+    public static final String CONTAINER_UPDATE_ATTRIBUTES_COUNT = "segmentstore.container.update_attributes_count";
+    public static final String CONTAINER_GET_ATTRIBUTES_COUNT = "segmentstore.container.get_attributes_count";
+    public static final String CONTAINER_READ_COUNT = "segmentstore.container.read_count";
+    public static final String CONTAINER_GET_INFO_COUNT = "segmentstore.container.get_info_count";
+    public static final String CONTAINER_CREATE_SEGMENT_COUNT = "segmentstore.container.create_segment_count";
+    public static final String CONTAINER_DELETE_SEGMENT_COUNT = "segmentstore.container.delete_segment_count";
+    public static final String CONTAINER_MERGE_SEGMENT_COUNT = "segmentstore.container.merge_segment_count";
+    public static final String CONTAINER_SEAL_COUNT = "segmentstore.container.seal_count";
+    public static final String CONTAINER_TRUNCATE_COUNT = "segmentstore.container.truncate_count";
+    public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.process.operations_latency";
+    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.process.operations_batch_size";
+    public static final String OPERATION_QUEUE_SIZE = "segmentstore.operation.queue_size";
+    public static final String OPERATION_PROCESSOR_IN_FLIGHT = "segmentstore.operation.processor_in_flight";
+    public static final String OPERATION_QUEUE_WAIT_TIME = "segmentstore.operation.queue_wait_time";
+    public static final String OPERATION_PROCESSOR_DELAY_MILLIS = "segmentstore.operation.processor_delay_ms";
+    public static final String OPERATION_COMMIT_LATENCY = "segmentstore.operation.commit_latency_ms";
+    public static final String OPERATION_LATENCY = "segmentstore.operation.latency_ms";
+    public static final String OPERATION_COMMIT_METADATA_TXN_COUNT = "segmentstore.operation.commit_metadata_txn_count";
+    public static final String OPERATION_COMMIT_MEMORY_LATENCY = "segmentstore.operation.commit_memory_latency_ms";
+    public static final String OPERATION_LOG_SIZE = "segmentstore.operation.log_size";
+    public static final String ACTIVE_SEGMENT_COUNT = "segmentstore.active_segments";
 
     // General metrics
-    public static final String CACHE_TOTAL_SIZE_BYTES = "cache_size_bytes";
-    public static final String CACHE_GENERATION_SPREAD = "cache_gen";
-    public static final String THREAD_POOL_QUEUE_SIZE = "thread_pool_queue_size";
-    public static final String THREAD_POOL_ACTIVE_THREADS = "thread_pool_active_threads";
+    public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache_size_bytes";
+    public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache_gen";
+    public static final String THREAD_POOL_QUEUE_SIZE = "segmentstore.thread_pool_queue_size";
+    public static final String THREAD_POOL_ACTIVE_THREADS = "segmentstore.thread_pool_active_threads";
 
     // Metrics in Controller
     // Stream request counts (Static)
-    public static final String CREATE_STREAM = "stream_created";    // Histogram
-    public static final String SEAL_STREAM = "stream_sealed";       // Histogram
-    public static final String DELETE_STREAM = "stream_deleted";    // Histogram
+    public static final String CREATE_STREAM = "controller.stream_created";    // Histogram
+    public static final String SEAL_STREAM = "controller.stream_sealed";       // Histogram
+    public static final String DELETE_STREAM = "controller.stream_deleted";    // Histogram
 
     // Transaction request Operations (Dynamic)
     public static final String CREATE_TRANSACTION = "controller.transactions_created";   // Dynamic Counter

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -39,19 +39,19 @@ public final class MetricsNames {
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment.write_bytes";          // Dynamic Counter
     public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment.write_events";        // Dynamic Counter
 
-    //storage stats
+    // Storage stats
     public static final String STORAGE_READ_LATENCY = "segmentstore.storage.read_latency_ms";   // Timer
     public static final String STORAGE_WRITE_LATENCY = "segmentstore.storage.write_latency_ms"; // Timer
     public static final String STORAGE_READ_BYTES = "segmentstore.storage.read_bytes";          // Counter
     public static final String STORAGE_WRITE_BYTES = "segmentstore.storage.write_bytes";        // Counter
 
-    //Cache (RocksDB) stats
+    // Cache (RocksDB) stats
     public static final String CACHE_INSERT_LATENCY = "segmentstore.cache.insert_latency_ms";
     public static final String CACHE_GET_LATENCY = "segment.store.cache.get_latency_ms";
     public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache.size_bytes";
     public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache.gen";
 
-    //DurableDataLog (Tier1) stats
+    // DurableDataLog (Tier1) stats
     public static final String BK_TOTAL_WRITE_LATENCY = "segmentstore.bookkeeper.total_write_latency_ms"; // Including Queue
     public static final String BK_WRITE_LATENCY = "segmentstore.bookkeeper.write_latency_ms";  // Exclusively the write to BK.
     public static final String BK_WRITE_BYTES = "segmentstore.bookkeeper.write_bytes";
@@ -59,7 +59,7 @@ public final class MetricsNames {
     public static final String BK_WRITE_QUEUE_FILL_RATE = "segmentstore.bookkeeper.write_queue_fill";
     public static final String BK_LEDGER_COUNT = "segmentstore.bookkeeper.bookkeeper_ledger_count";
 
-    //Segment container metrics
+    // Segment container metrics
     public static final String CONTAINER_APPEND_COUNT = "segmentstore.container.append_count";
     public static final String CONTAINER_APPEND_OFFSET_COUNT = "segmentstore.container.append_offset_count";
     public static final String CONTAINER_UPDATE_ATTRIBUTES_COUNT = "segmentstore.container.update_attributes_count";
@@ -72,7 +72,7 @@ public final class MetricsNames {
     public static final String CONTAINER_SEAL_COUNT = "segmentstore.container.seal_count";
     public static final String CONTAINER_TRUNCATE_COUNT = "segmentstore.container.truncate_count";
 
-    //Operation processor metrics
+    // Operation processor metrics
     public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.container.process_operations.latency_ms";
     public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.container.process_operations.batch_size";
     public static final String OPERATION_QUEUE_SIZE = "segmentstore.container.operation_queue.size";

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -46,14 +46,14 @@ public final class MetricsNames {
     public static final String STORAGE_WRITE_BYTES = "segmentstore.storage.write_bytes";        // Counter
 
     //Cache (RocksDB) stats
-    public static final String CACHE_INSERT_LATENCY = "segmentstore.cache.insert_latency";
-    public static final String CACHE_GET_LATENCY = "segment.store.cache.get_latency";
+    public static final String CACHE_INSERT_LATENCY = "segmentstore.cache.insert_latency_ms";
+    public static final String CACHE_GET_LATENCY = "segment.store.cache.get_latency_ms";
     public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache.size_bytes";
     public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache.gen";
 
     //DurableDataLog (Tier1) stats
-    public static final String BK_TOTAL_WRITE_LATENCY = "segmentstore.bookkeeper.total_write_latency"; // Including Queue
-    public static final String BK_WRITE_LATENCY = "segmentstore.bookkeeper.write_latency";  // Exclusively the write to BK.
+    public static final String BK_TOTAL_WRITE_LATENCY = "segmentstore.bookkeeper.total_write_latency_ms"; // Including Queue
+    public static final String BK_WRITE_LATENCY = "segmentstore.bookkeeper.write_latency_ms";  // Exclusively the write to BK.
     public static final String BK_WRITE_BYTES = "segmentstore.bookkeeper.write_bytes";
     public static final String BK_WRITE_QUEUE_SIZE = "segmentstore.bookkeeper.write_queue_size";
     public static final String BK_WRITE_QUEUE_FILL_RATE = "segmentstore.bookkeeper.write_queue_fill";
@@ -71,8 +71,8 @@ public final class MetricsNames {
     public static final String CONTAINER_MERGE_SEGMENT_COUNT = "segmentstore.container.merge_segment_count";
     public static final String CONTAINER_SEAL_COUNT = "segmentstore.container.seal_count";
     public static final String CONTAINER_TRUNCATE_COUNT = "segmentstore.container.truncate_count";
-    public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.process.operations_latency";
-    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.process.operations_batch_size";
+    public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.process_operations.latency_ms";
+    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.process_operations.batch_size";
     public static final String OPERATION_QUEUE_SIZE = "segmentstore.operation.queue_size";
     public static final String OPERATION_PROCESSOR_IN_FLIGHT = "segmentstore.operation.processor_in_flight";
     public static final String OPERATION_QUEUE_WAIT_TIME = "segmentstore.operation.queue_wait_time";

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -59,7 +59,7 @@ public final class MetricsNames {
     public static final String BK_WRITE_QUEUE_FILL_RATE = "segmentstore.bookkeeper.write_queue_fill";
     public static final String BK_LEDGER_COUNT = "segmentstore.bookkeeper.bookkeeper_ledger_count";
 
-    //Container-specific metrics
+    //Segment container metrics
     public static final String CONTAINER_APPEND_COUNT = "segmentstore.container.append_count";
     public static final String CONTAINER_APPEND_OFFSET_COUNT = "segmentstore.container.append_offset_count";
     public static final String CONTAINER_UPDATE_ATTRIBUTES_COUNT = "segmentstore.container.update_attributes_count";
@@ -71,17 +71,21 @@ public final class MetricsNames {
     public static final String CONTAINER_MERGE_SEGMENT_COUNT = "segmentstore.container.merge_segment_count";
     public static final String CONTAINER_SEAL_COUNT = "segmentstore.container.seal_count";
     public static final String CONTAINER_TRUNCATE_COUNT = "segmentstore.container.truncate_count";
-    public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.process_operations.latency_ms";
-    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.process_operations.batch_size";
-    public static final String OPERATION_QUEUE_SIZE = "segmentstore.operation.queue_size";
-    public static final String OPERATION_PROCESSOR_IN_FLIGHT = "segmentstore.operation.processor_in_flight";
-    public static final String OPERATION_QUEUE_WAIT_TIME = "segmentstore.operation.queue_wait_time";
-    public static final String OPERATION_PROCESSOR_DELAY_MILLIS = "segmentstore.operation.processor_delay_ms";
-    public static final String OPERATION_COMMIT_LATENCY = "segmentstore.operation.commit_latency_ms";
-    public static final String OPERATION_LATENCY = "segmentstore.operation.latency_ms";
-    public static final String OPERATION_COMMIT_METADATA_TXN_COUNT = "segmentstore.operation.commit_metadata_txn_count";
-    public static final String OPERATION_COMMIT_MEMORY_LATENCY = "segmentstore.operation.commit_memory_latency_ms";
-    public static final String OPERATION_LOG_SIZE = "segmentstore.operation.log_size";
+
+    //Operation processor metrics
+    public static final String PROCESS_OPERATIONS_LATENCY = "segmentstore.container.process_operations.latency_ms";
+    public static final String PROCESS_OPERATIONS_BATCH_SIZE = "segmentstore.container.process_operations.batch_size";
+    public static final String OPERATION_QUEUE_SIZE = "segmentstore.container.operation_queue.size";
+    public static final String OPERATION_PROCESSOR_IN_FLIGHT = "segmentstore.container.operation_processor.in_flight";
+    public static final String OPERATION_QUEUE_WAIT_TIME = "segmentstore.container.operation_queue.wait_time";
+    public static final String OPERATION_PROCESSOR_DELAY_MILLIS = "segmentstore.container.operation_processor.delay_ms";
+    public static final String OPERATION_COMMIT_LATENCY = "segmentstore.container.operation_commit.latency_ms";
+    public static final String OPERATION_LATENCY = "segmentstore.container.operation.latency_ms";
+    public static final String OPERATION_COMMIT_METADATA_TXN_COUNT = "segmentstore.container.operation_commit.metadata_txn_count";
+    public static final String OPERATION_COMMIT_MEMORY_LATENCY = "segmentstore.container.operation_commit.memory_latency_ms";
+    public static final String OPERATION_LOG_SIZE = "segmentstore.container.operation.log_size";
+
+    // Segment container metadata
     public static final String ACTIVE_SEGMENT_COUNT = "segmentstore.active_segments";
 
     // Thread pool metrics

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -9,15 +9,35 @@
  */
 package io.pravega.shared;
 
+
+
+/*
+ * Class that defines all names used for metrics that Pravega exports. All metrics have a prefix that indicates
+ * the component that is exporting it. We use a second level to indicate the sub-component (e.g., storage) or
+ * abstraction (e.g., transactions) the metric is related to.
+ *
+ * The current prefix being used are:
+ * - segmentstore.segment: metrics for individual segments
+ * - segmentstore.storage: metrics related to our long-term storage (Tier 2)
+ * - segmentstore.bookkeeper: metrics related to bookkeeper (Tier 1)
+ * - segmentstore.container: metrics for segment containers
+ * - segmentstore.cache: cache-related metrics (RocksDB)
+ * - controller.stream: metrics for operations on streams (e.g., number of streams created)
+ * - controller.segments: metrics about segments, per stream (e.g., count, splits, merges)
+ * - controller.transactions: metrics related to transactions (e.g., created, committed, aborted)
+ * - controller.retention: metrics related to data retention, per stream (e.g., frequency, size of truncated data)
+ */
+
+
 public final class MetricsNames {
     // Metrics in Segment Store Service
     // Segment-related stats
-    public static final String SEGMENT_CREATE_LATENCY = "segmentstore.segment_create_latency_ms"; // Timer
-    public static final String SEGMENT_READ_LATENCY = "segmentstore.segment_read_latency_ms";     // Timer
-    public static final String SEGMENT_WRITE_LATENCY = "segmentstore.segment_write_latency_ms";   // Timer
-    public static final String SEGMENT_READ_BYTES = "segmentstore.segment_read_bytes";            // Dynamic Counter
-    public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment_write_bytes";          // Dynamic Counter
-    public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment_write_events";        // Dynamic Counter
+    public static final String SEGMENT_CREATE_LATENCY = "segmentstore.segment.create_latency_ms"; // Timer
+    public static final String SEGMENT_READ_LATENCY = "segmentstore.segment.read_latency_ms";     // Timer
+    public static final String SEGMENT_WRITE_LATENCY = "segmentstore.segment.write_latency_ms";   // Timer
+    public static final String SEGMENT_READ_BYTES = "segmentstore.segment.read_bytes";            // Dynamic Counter
+    public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment.write_bytes";          // Dynamic Counter
+    public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment.write_events";        // Dynamic Counter
 
     //storage stats
     public static final String STORAGE_READ_LATENCY = "segmentstore.storage.read_latency_ms";   // Timer
@@ -26,8 +46,10 @@ public final class MetricsNames {
     public static final String STORAGE_WRITE_BYTES = "segmentstore.storage.write_bytes";        // Counter
 
     //Cache (RocksDB) stats
-    public static final String CACHE_INSERT_LATENCY = "segmentstore.cache_insert_latency";
-    public static final String CACHE_GET_LATENCY = "segment.store.cache_get_latency";
+    public static final String CACHE_INSERT_LATENCY = "segmentstore.cache.insert_latency";
+    public static final String CACHE_GET_LATENCY = "segment.store.cache.get_latency";
+    public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache.size_bytes";
+    public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache.gen";
 
     //DurableDataLog (Tier1) stats
     public static final String BK_TOTAL_WRITE_LATENCY = "segmentstore.bookkeeper.total_write_latency"; // Including Queue
@@ -62,33 +84,31 @@ public final class MetricsNames {
     public static final String OPERATION_LOG_SIZE = "segmentstore.operation.log_size";
     public static final String ACTIVE_SEGMENT_COUNT = "segmentstore.active_segments";
 
-    // General metrics
-    public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache_size_bytes";
-    public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache_gen";
-    public static final String THREAD_POOL_QUEUE_SIZE = "segmentstore.thread_pool_queue_size";
-    public static final String THREAD_POOL_ACTIVE_THREADS = "segmentstore.thread_pool_active_threads";
+    // Thread pool metrics
+    public static final String THREAD_POOL_QUEUE_SIZE = "segmentstore.thread_pool.queue_size";
+    public static final String THREAD_POOL_ACTIVE_THREADS = "segmentstore.thread_pool.active_threads";
 
     // Metrics in Controller
     // Stream request counts (Static)
-    public static final String CREATE_STREAM = "controller.stream_created";    // Histogram
-    public static final String SEAL_STREAM = "controller.stream_sealed";       // Histogram
-    public static final String DELETE_STREAM = "controller.stream_deleted";    // Histogram
+    public static final String CREATE_STREAM = "controller.stream.created";    // Histogram
+    public static final String SEAL_STREAM = "controller.stream.sealed";       // Histogram
+    public static final String DELETE_STREAM = "controller.stream.deleted";    // Histogram
 
     // Transaction request Operations (Dynamic)
-    public static final String CREATE_TRANSACTION = "controller.transactions_created";   // Dynamic Counter
-    public static final String COMMIT_TRANSACTION = "controller.transactions_committed"; // Dynamic Counter
-    public static final String ABORT_TRANSACTION = "controller.transactions_aborted";    // Dynamic Counter
-    public static final String OPEN_TRANSACTIONS = "controller.transactions_opened";     // Dynamic Gauge
-    public static final String TIMEDOUT_TRANSACTIONS = "controller.transactions_timedout";     // Dynamic Counter
+    public static final String CREATE_TRANSACTION = "controller.transactions.created";   // Dynamic Counter
+    public static final String COMMIT_TRANSACTION = "controller.transactions.committed"; // Dynamic Counter
+    public static final String ABORT_TRANSACTION = "controller.transactions.aborted";    // Dynamic Counter
+    public static final String OPEN_TRANSACTIONS = "controller.transactions.opened";     // Dynamic Gauge
+    public static final String TIMEDOUT_TRANSACTIONS = "controller.transactions.timedout";     // Dynamic Counter
 
     // Stream segment counts (Dynamic)
-    public static final String SEGMENTS_COUNT = "controller.segments_count";   // Dynamic Gauge
-    public static final String SEGMENTS_SPLITS = "controller.segment_splits"; // Dynamic Counter
-    public static final String SEGMENTS_MERGES = "controller.segment_merges"; // Dynamic Counter
+    public static final String SEGMENTS_COUNT = "controller.segments.count";   // Dynamic Gauge
+    public static final String SEGMENTS_SPLITS = "controller.segment.splits"; // Dynamic Counter
+    public static final String SEGMENTS_MERGES = "controller.segment.merges"; // Dynamic Counter
 
     // Stream retention operations (Dynamic)
-    public static final String RETENTION_FREQUENCY = "controller.retention_frequency";   // Dynamic Counter
-    public static final String TRUNCATED_SIZE = "controller.truncated_size"; // Dynamic Counter
+    public static final String RETENTION_FREQUENCY = "controller.retention.frequency";   // Dynamic Counter
+    public static final String TRUNCATED_SIZE = "controller.retention.truncated_size"; // Dynamic Counter
 
     private static String escapeSpecialChar(String name) {
         return name.replace('/', '.').replace(':', '.').replace('|', '.').replaceAll("\\s+", "_");

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -188,7 +188,7 @@ public class MetricsTest {
                 }
             }
 
-            long initialCount = MetricRegistryUtils.getCounter("pravega.segmentstore.segment_read_bytes." + scope + "." + STREAM_NAME + ".0.#epoch.0.Counter").getCount();
+            long initialCount = MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes." + scope + "." + STREAM_NAME + ".0.#epoch.0.Counter").getCount();
             Assert.assertEquals(bytesWritten, initialCount);
 
             Exceptions.handleInterrupted(() -> Thread.sleep(10 * 1000));
@@ -212,7 +212,7 @@ public class MetricsTest {
                 }
             }
 
-            long countAfterCacheEvicted = MetricRegistryUtils.getCounter("pravega.segmentstore.segment_read_bytes." + scope + "." + STREAM_NAME + ".0.#epoch.0.Counter").getCount();
+            long countAfterCacheEvicted = MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes." + scope + "." + STREAM_NAME + ".0.#epoch.0.Counter").getCount();
 
             //Metric is evicted from Cache, after cache eviction duration
             //Count starts from 0, rather than adding up to previously ready bytes, as cache is evicted.
@@ -254,7 +254,7 @@ public class MetricsTest {
                 }
             }
 
-            long countFromSecondSegment = MetricRegistryUtils.getCounter("pravega.segmentstore.segment_read_bytes." + scope + "." + STREAM_NAME + ".1.#epoch.1.Counter").getCount();
+            long countFromSecondSegment = MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes." + scope + "." + STREAM_NAME + ".1.#epoch.1.Counter").getCount();
 
             Assert.assertEquals(bytesWritten, countFromSecondSegment);
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Adds a common prefix to every metric to enable users to easily spot the component exporting the metric.

* Adds a second level to the segment store to identify the specific sub-component that a specific metric is being exported by.

**Purpose of the change**  
Fixes #2920 

**What the code does**  
In `io.pravega.shared.MetricsNames`, make sure that all metrics have a prefix that identifies the the component that is exporting the metrics.

**How to verify it**  
It should not break the build.
