### PR TITLE
Issue 2935: Fix failing outstanding checkpoint validation test

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -292,15 +292,21 @@ public class CheckpointTest {
                     .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit"));
         }
 
-        EventRead<String> read = reader1.readNextEvent(60000);
+        EventRead<String> read = reader1.readNextEvent(100);
         assertTrue(read.isCheckpoint());
         assertEquals("Checkpoint1", read.getCheckpointName());
         assertNull(read.getEvent());
 
-        read = reader2.readNextEvent(60000);
+        read = reader2.readNextEvent(100);
         assertTrue(read.isCheckpoint());
         assertEquals("Checkpoint1", read.getCheckpointName());
         assertNull(read.getEvent());
+
+        read = reader1.readNextEvent(100);
+        assertFalse(read.isCheckpoint());
+
+        read = reader2.readNextEvent(100);
+        assertFalse(read.isCheckpoint());
 
         Checkpoint cpResult = checkpoint1.get(5, TimeUnit.SECONDS);
         assertTrue(checkpoint1.isDone());


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**  
- Fixed failing test case that times out while waiting for the future to return a result 

**Purpose of the change**  
Fixes #2935

**What the code does**  
- It makes an attempt to read the event (`readNextEvent()`) from both the readers before trying to get the result from the `future` instance. 

**How to verify it**  
./gradlew :test:integration:test --tests io.pravega.test.integration.CheckpointTest should pass
