### PR TITLE
Issue 2523: Fix a race condition in EndToEndChannelLeakTest

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
@@ -10,6 +10,7 @@
 
 package io.pravega.client.netty.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -166,7 +167,8 @@ public class ClientConnectionInboundHandler extends ChannelInboundHandlerAdapter
         }
     }
 
-    private Channel getChannel() throws ConnectionFailedException {
+    @VisibleForTesting
+    Channel getChannel() throws ConnectionFailedException {
         Channel ch = channel.get();
         if (ch == null) {
             throw new ConnectionFailedException("Connection to " + connectionName + " is not established.");

--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionInboundHandler.java
@@ -161,6 +161,7 @@ public class ClientConnectionInboundHandler extends ChannelInboundHandlerAdapter
     public void close() {
         Channel ch = channel.get();
         if (ch != null) {
+            log.debug("Closing channel:{}", ch);
             ch.close();
         }
     }

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -46,6 +46,7 @@ import io.pravega.shared.protocol.netty.ExceptionLoggingHandler;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommands;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,7 +66,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
     private final ClientConfig clientConfig;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ScheduledExecutorService executor;
-    @Getter
+    @Getter(AccessLevel.PACKAGE)
     private final ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
     /**

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -170,7 +170,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                     if (future.isSuccess()) {
                         //since ChannelFuture is complete future.channel() is not a blocking call.
                         Channel ch = future.channel();
-                        log.debug("==> Connect operation completed for channel:{}, local address:{}, remote address:{}",
+                        log.debug("Connect operation completed for channel:{}, local address:{}, remote address:{}",
                                 ch.id(), ch.localAddress(), ch.remoteAddress());
                         allChannels.add(ch); // Once a channel is closed the channel group implementation removes it.
                         connectionComplete.complete(handler);

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.group.ChannelGroup;
@@ -47,9 +48,11 @@ import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommands;
 import java.io.File;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
@@ -59,7 +62,6 @@ import lombok.extern.slf4j.Slf4j;
 public final class ConnectionFactoryImpl implements ConnectionFactory {
 
     private EventLoopGroup group;
-    private boolean nio = false;
     private final ClientConfig clientConfig;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ScheduledExecutorService executor;
@@ -70,19 +72,29 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
      * @param clientConfig Configuration object holding details about connection to the segmentstore.
      */
     public ConnectionFactoryImpl(ClientConfig clientConfig) {
-        this(clientConfig, null);
+        this(clientConfig, (Integer) null);
     }
 
     @VisibleForTesting
     public ConnectionFactoryImpl(ClientConfig clientConfig, Integer numThreadsInPool) {
-        executor = ExecutorServiceHelpers.newScheduledThreadPool(getNumThreads(numThreadsInPool), "clientInternal");
+        this.executor = ExecutorServiceHelpers.newScheduledThreadPool(getNumThreads(numThreadsInPool), "clientInternal");
         this.clientConfig = clientConfig;
-        try {
-            this.group = new EpollEventLoopGroup();
-        } catch (ExceptionInInitializerError | UnsatisfiedLinkError | NoClassDefFoundError e) {
+        this.group = getEventLoopGroup();
+    }
+
+    @VisibleForTesting
+    public ConnectionFactoryImpl(ClientConfig clientConfig, ScheduledExecutorService executor) {
+        this.executor = executor;
+        this.clientConfig = clientConfig;
+        this.group = getEventLoopGroup();
+    }
+
+    private EventLoopGroup getEventLoopGroup() {
+        if (Epoll.isAvailable()) {
+            return new EpollEventLoopGroup();
+        } else {
             log.warn("Epoll not available. Falling back on NIO.");
-            nio = true;
-            this.group = new NioEventLoopGroup();
+            return new NioEventLoopGroup();
         }
     }
 
@@ -123,7 +135,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
         ClientConnectionInboundHandler handler = new ClientConnectionInboundHandler(location.getEndpoint(), rp, batchSizeTracker);
         Bootstrap b = new Bootstrap();
         b.group(group)
-         .channel(nio ? NioSocketChannel.class : EpollSocketChannel.class)
+         .channel(Epoll.isAvailable() ? EpollSocketChannel.class : NioSocketChannel.class)
          .option(ChannelOption.TCP_NODELAY, true)
          .handler(new ChannelInitializer<SocketChannel>() {
              @Override
@@ -158,7 +170,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                     if (future.isSuccess()) {
                         //since ChannelFuture is complete future.channel() is not a blocking call.
                         Channel ch = future.channel();
-                        log.debug("Connect operation completed for channel:{}, local address:{}, remote address:{}",
+                        log.debug("==> Connect operation completed for channel:{}, local address:{}, remote address:{}",
                                 ch.id(), ch.localAddress(), ch.remoteAddress());
                         allChannels.add(ch); // Once a channel is closed the channel group implementation removes it.
                         connectionComplete.complete(handler);
@@ -193,7 +205,9 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
     }
 
     public int getActiveChannelCount() {
-        return allChannels.size();
+        List<Channel> activeChannels = allChannels.stream().filter(Channel::isActive).collect(Collectors.toList());
+        log.debug("Channels that are active are {}", activeChannels);
+        return activeChannels.size();
     }
 
     @Override

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
@@ -32,6 +32,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.InlineExecutor;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
@@ -106,7 +107,7 @@ public class EndToEndChannelLeakTest {
         controllerWrapper.getControllerService().createScope(SCOPE).get();
         controller.createStream(config).get();
         @Cleanup
-        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build(), new InlineExecutor());
         @Cleanup
         ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, controller, connectionFactory);
 


### PR DESCRIPTION
**Change log description**  
Fix sporadic failures in EndToEndChannelLeakTest

**Purpose of the change**  
Fixes #2523 

**What the code does**  
- Ensure inline executor is used for EndToEndChannelLeakTest.
- Ensure only channels which are in Active state are returned as part of `io.pravega.client.netty.impl.ConnectionFactoryImpl#getActiveChannelCount`

**How to verify it**  
EndToEndChannelLeakTest should pass consistently.
Update: With the changes in the PR not able to simulate the issue for the last 8 hours.