### PR TITLE
Issue 2891: Expose versioned metadata from store and add start and complete for each processing workflows

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
@@ -13,6 +13,7 @@ import com.google.common.base.Preconditions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.VersionedMetadata;
 import io.pravega.controller.store.stream.tables.State;
 import io.pravega.controller.store.stream.tables.StreamTruncationRecord;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
@@ -58,31 +59,33 @@ public class TruncateStreamTask implements StreamTask<TruncateStreamEvent> {
         String scope = request.getScope();
         String stream = request.getStream();
 
-        return streamMetadataStore.getTruncationRecord(scope, stream, true, context, executor)
-                .thenCompose(property -> {
-                    if (!property.isUpdating()) {
+        return streamMetadataStore.getVersionedTruncationRecord(scope, stream, true, context, executor)
+                .thenCompose(existing -> {
+                    if (!existing.getObject().isUpdating()) {
                         // if the state is TRUNCATING but the truncation record is not updating, we should reset the state to ACTIVE.
                         return streamMetadataStore.resetStateConditionally(scope, stream, State.TRUNCATING, context, executor)
                                 .thenRun(() -> {
                                     throw new TaskExceptions.StartException("Truncate Stream not started yet.");
                                 });
                     } else {
-                        return processTruncate(scope, stream, property, context,
+                        return processTruncate(scope, stream, existing, context,
                                 this.streamMetadataTasks.retrieveDelegationToken());
                     }
                 });
     }
 
-    private CompletableFuture<Void> processTruncate(String scope, String stream, StreamTruncationRecord truncationRecord,
+    private CompletableFuture<Void> processTruncate(String scope, String stream, VersionedMetadata<StreamTruncationRecord> versionedTruncationRecord,
                                                     OperationContext context, String delegationToken) {
+        StreamTruncationRecord truncationRecord = versionedTruncationRecord.getObject();
         log.info("Truncating stream {}/{} at stream cut: {}", scope, stream, truncationRecord.getStreamCut());
         return Futures.toVoid(streamMetadataStore.setState(scope, stream, State.TRUNCATING, context, executor)
                 .thenCompose(x -> notifyTruncateSegments(scope, stream, truncationRecord.getStreamCut(), delegationToken))
                 .thenCompose(x -> notifyDeleteSegments(scope, stream, truncationRecord.getToDelete(), delegationToken))
-                 .thenCompose(x -> streamMetadataStore.getSizeTillStreamCut(scope, stream, truncationRecord.getStreamCut(), context, executor))
-                 .thenAccept(truncatedSize -> DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(TRUNCATED_SIZE, scope, stream), truncatedSize))
-                 .thenCompose(deleted -> streamMetadataStore.completeTruncation(scope, stream, context, executor))
-                 .thenCompose(x -> streamMetadataStore.setState(scope, stream, State.ACTIVE, context, executor)));
+                .thenCompose(x -> streamMetadataStore.getSizeTillStreamCut(scope, stream, truncationRecord.getStreamCut(),
+                        context, executor))
+                .thenAccept(truncatedSize -> DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(TRUNCATED_SIZE, scope, stream), truncatedSize))
+                .thenCompose(deleted -> streamMetadataStore.completeTruncation(scope, stream, versionedTruncationRecord, context, executor))
+                .thenCompose(x -> streamMetadataStore.setState(scope, stream, State.ACTIVE, context, executor)));
     }
 
     private CompletableFuture<Void> notifyDeleteSegments(String scope, String stream, Set<Long> segmentsToDelete, String delegationToken) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -278,18 +278,18 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Void> completeTruncation(final String scope, final String name,
+    public CompletableFuture<Void> completeTruncation(final String scope, final String name, final VersionedMetadata<StreamTruncationRecord> record,
                                                       final OperationContext context, final Executor executor) {
-        return withCompletion(getStream(scope, name, context).completeTruncation(), executor);
+        return withCompletion(getStream(scope, name, context).completeTruncation(record), executor);
     }
 
     @Override
-    public CompletableFuture<StreamTruncationRecord> getTruncationRecord(final String scope,
-                                                                         final String name,
-                                                                         final boolean ignoreCached,
-                                                                         final OperationContext context,
-                                                                         final Executor executor) {
-        return withCompletion(getStream(scope, name, context).getTruncationRecord(ignoreCached), executor);
+    public CompletableFuture<VersionedMetadata<StreamTruncationRecord>> getVersionedTruncationRecord(final String scope,
+                                                                                  final String name,
+                                                                                  final boolean ignoreCached,
+                                                                                  final OperationContext context,
+                                                                                  final Executor executor) {
+        return withCompletion(getStream(scope, name, context).getVersionedTruncationRecord(ignoreCached), executor);
     }
 
     @Override
@@ -303,8 +303,9 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 
     @Override
     public CompletableFuture<Void> completeUpdateConfiguration(final String scope, final String name,
+                                                               final VersionedMetadata<StreamConfigurationRecord> existing,
                                                                final OperationContext context, final Executor executor) {
-        return withCompletion(getStream(scope, name, context).completeUpdateConfiguration(), executor);
+        return withCompletion(getStream(scope, name, context).completeUpdateConfiguration(existing), executor);
     }
 
     @Override
@@ -315,12 +316,11 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<StreamConfigurationRecord> getConfigurationRecord(final String scope,
-                                                                               final String name,
-                                                                               final boolean ignoreCached,
-                                                                               final OperationContext context,
-                                                                               final Executor executor) {
-        return withCompletion(getStream(scope, name, context).getConfigurationRecord(ignoreCached), executor);
+    public CompletableFuture<VersionedMetadata<StreamConfigurationRecord>> getVersionedConfigurationRecord(final String scope,
+                                                                                        final String name,
+                                                                                        final OperationContext context,
+                                                                                        final Executor executor) {
+        return withCompletion(getStream(scope, name, context).getVersionedConfigurationRecord(), executor);
     }
 
     @Override
@@ -417,7 +417,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 
 
     @Override
-    public CompletableFuture<EpochTransitionRecord> startScale(final String scope,
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> startScale(final String scope,
                                                                final String name,
                                                                final List<Long> sealedSegments,
                                                                final List<AbstractMap.SimpleEntry<Double, Double>> newRanges,
@@ -430,29 +430,38 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Void> scaleCreateNewSegments(final String scope,
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> getVersionedEpochTransition(String scope, String stream,
+                                                                             OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).getVersionedEpochTransition(), executor);
+    }
+
+    @Override
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> scaleCreateNewSegments(final String scope,
                                                           final String name,
                                                           final boolean isManualScale,
+                                                          final VersionedMetadata<EpochTransitionRecord> record,
                                                           final OperationContext context,
                                                           final Executor executor) {
-        return withCompletion(getStream(scope, name, context).scaleCreateNewSegments(isManualScale), executor);
+        return withCompletion(getStream(scope, name, context).scaleCreateNewSegments(isManualScale, record), executor);
     }
 
     @Override
-    public CompletableFuture<Void> scaleNewSegmentsCreated(final String scope,
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> scaleNewSegmentsCreated(final String scope,
                                                            final String name,
+                                                           final VersionedMetadata<EpochTransitionRecord> record,
                                                            final OperationContext context,
                                                            final Executor executor) {
-        return withCompletion(getStream(scope, name, context).scaleNewSegmentsCreated(), executor);
+        return withCompletion(getStream(scope, name, context).scaleNewSegmentsCreated(record), executor);
     }
 
     @Override
-    public CompletableFuture<Void> scaleSegmentsSealed(final String scope,
-                                                       final String name,
-                                                       final Map<Long, Long> sealedSegmentSizes,
-                                                       final OperationContext context,
-                                                       final Executor executor) {
-        CompletableFuture<Void> future = withCompletion(getStream(scope, name, context).scaleOldSegmentsSealed(sealedSegmentSizes), executor);
+    public CompletableFuture<Void> completeScale(final String scope,
+                                                 final String name,
+                                                 final Map<Long, Long> sealedSegmentSizes,
+                                                 final VersionedMetadata<EpochTransitionRecord> record,
+                                                 final OperationContext context,
+                                                 final Executor executor) {
+        CompletableFuture<Void> future = withCompletion(getStream(scope, name, context).scaleOldSegmentsSealed(sealedSegmentSizes, record), executor);
 
         future.thenCompose(result -> CompletableFuture.allOf(
                 getActiveSegments(scope, name, System.currentTimeMillis(), null, executor).thenAccept(list ->
@@ -466,15 +475,24 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Void> rollingTxnNewSegmentsCreated(String scope, String name, Map<Long, Long> sealedTxnEpochSegments,
-                                                                int txnEpoch, long time, OperationContext context, Executor executor) {
-        return withCompletion(getStream(scope, name, context).rollingTxnNewSegmentsCreated(sealedTxnEpochSegments, txnEpoch, time), executor);
+    public CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> startRollingTxn(String scope, String stream,
+                                       int txnEpoch, int activeEpoch, VersionedMetadata<CommittingTransactionsRecord> existing,
+                                       OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).startRollingTxn(txnEpoch, activeEpoch, existing), executor);
+    }
+
+
+    @Override
+    public CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> rollingTxnCreateDuplicateEpochs(String scope, String name,
+                        Map<Long, Long> sealedTxnEpochSegments, long time, VersionedMetadata<CommittingTransactionsRecord> record,
+                        OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, name, context).rollingTxnCreateDuplicateEpochs(sealedTxnEpochSegments, time, record), executor);
     }
 
     @Override
-    public CompletableFuture<Void> rollingTxnActiveEpochSealed(String scope, String name, Map<Long, Long> sealedActiveEpochSegments,
-                                                               int activeEpoch, long time, OperationContext context, Executor executor) {
-        return withCompletion(getStream(scope, name, context).rollingTxnActiveEpochSealed(sealedActiveEpochSegments, activeEpoch, time), executor);
+    public CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> completeRollingTxn(String scope, String name, Map<Long, Long> sealedActiveEpochSegments,
+                                                  long time, VersionedMetadata<CommittingTransactionsRecord> record, OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, name, context).completeRollingTxn(sealedActiveEpochSegments, time, record), executor);
     }
 
     @Override
@@ -687,20 +705,21 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Void> createCommittingTransactionsRecord(String scope, String stream, int epoch, List<UUID> txnsToCommit,
-                                                                      OperationContext context, ScheduledExecutorService executor) {
-        return withCompletion(getStream(scope, stream, context).createCommittingTransactionsRecord(epoch, txnsToCommit), executor);
+    public CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> startCommitTransactions(String scope,
+                                           String stream, int epoch, OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).startCommittingTransactions(epoch), executor);
     }
 
     @Override
-    public CompletableFuture<CommittingTransactionsRecord> getCommittingTransactionsRecord(String scope, String stream, OperationContext context,
-                                                                                           ScheduledExecutorService executor) {
-        return withCompletion(getStream(scope, stream, context).getCommittingTransactionsRecord(), executor);
+    public CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> getVersionedCommittingTransactionsRecord(String scope, String stream, OperationContext context,
+                                                                                                    ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).getVersionedCommitTransactionsRecord(), executor);
     }
 
     @Override
-    public CompletableFuture<Void> deleteCommittingTransactionsRecord(String scope, String stream, OperationContext context, ScheduledExecutorService executor) {
-        return withCompletion(getStream(scope, stream, context).deleteCommittingTransactionsRecord(), executor);
+    public CompletableFuture<Void> completeCommitTransactions(String scope, String stream, VersionedMetadata<CommittingTransactionsRecord> record,
+                                                              OperationContext context, ScheduledExecutorService executor) {
+        return withCompletion(getStream(scope, stream, context).completeCommittingTransactions(record), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -179,12 +179,14 @@ public interface StreamMetadataStore {
      *
      * @param scope         stream scope
      * @param name          stream name.
+     * @param existing      versioned StreamConfigurationRecord
      * @param context       operation context
      * @param executor      callers executor
      * @return future of opration
      */
     CompletableFuture<Void> completeUpdateConfiguration(final String scope,
                                                         final String name,
+                                                        final VersionedMetadata<StreamConfigurationRecord> existing,
                                                         final OperationContext context,
                                                         final Executor executor);
 
@@ -206,15 +208,13 @@ public interface StreamMetadataStore {
      *
      * @param scope        stream scope
      * @param name         stream name.
-     * @param ignoreCached ignore cached value.
      * @param context      operation context
      * @param executor     callers executor
      * @return current stream configuration.
      */
-    CompletableFuture<StreamConfigurationRecord> getConfigurationRecord(final String scope, final String name,
-                                                                        final boolean ignoreCached,
-                                                                        final OperationContext context,
-                                                                        final Executor executor);
+    CompletableFuture<VersionedMetadata<StreamConfigurationRecord>> getVersionedConfigurationRecord(final String scope, final String name,
+                                                                                                    final OperationContext context,
+                                                                                                    final Executor executor);
 
     /**
      * Start new stream truncation.
@@ -237,12 +237,14 @@ public interface StreamMetadataStore {
      *
      * @param scope               stream scope
      * @param name                stream name.
+     * @param record              versioned record
      * @param context             operation context
      * @param executor            callers executor
      * @return boolean indicating whether the stream was updated
      */
     CompletableFuture<Void> completeTruncation(final String scope,
                                                final String name,
+                                               final VersionedMetadata<StreamTruncationRecord> record,
                                                final OperationContext context,
                                                final Executor executor);
 
@@ -256,10 +258,10 @@ public interface StreamMetadataStore {
      * @param executor     callers executor
      * @return current truncation property.
      */
-    CompletableFuture<StreamTruncationRecord> getTruncationRecord(final String scope, final String name,
-                                                                  final boolean ignoreCached,
-                                                                  final OperationContext context,
-                                                                  final Executor executor);
+    CompletableFuture<VersionedMetadata<StreamTruncationRecord>> getVersionedTruncationRecord(final String scope, final String name,
+                                                                           final boolean ignoreCached,
+                                                                           final OperationContext context,
+                                                                           final Executor executor);
 
     /**
      * Set the stream state to sealed.
@@ -402,6 +404,20 @@ public interface StreamMetadataStore {
                                                 final Executor executor);
 
     /**
+     * Api to get Versioned epoch transition record.
+     *
+     * @param scope scope
+     * @param stream stream
+     * @param context operation context
+     * @param executor executor
+     *
+     * @return Future which when completed has the versioned epoch transition record.
+     */
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> getVersionedEpochTransition(String scope, String stream,
+                                                                                            OperationContext context,
+                                                                                            ScheduledExecutorService executor);
+
+    /**
      * Scales in or out the currently set of active segments of a stream.
      *
      * @param scope          stream scope
@@ -414,7 +430,7 @@ public interface StreamMetadataStore {
      * @param executor       callers executor
      * @return the list of newly created segments
      */
-    CompletableFuture<EpochTransitionRecord> startScale(final String scope, final String name,
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> startScale(final String scope, final String name,
                                                             final List<Long> sealedSegments,
                                                             final List<SimpleEntry<Double, Double>> newRanges,
                                                             final long scaleTimestamp,
@@ -428,13 +444,15 @@ public interface StreamMetadataStore {
      * @param scope          stream scope
      * @param name           stream name.
      * @param isManualScale  flag to indicate that the processing is being performed for manual scale
+     * @param previous       previous versioned record
      * @param context        operation context
      * @param executor       callers executor
      * @return future
      */
-    CompletableFuture<Void> scaleCreateNewSegments(final String scope,
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> scaleCreateNewSegments(final String scope,
                                                    final String name,
                                                    final boolean isManualScale,
+                                                   final VersionedMetadata<EpochTransitionRecord> previous,
                                                    final OperationContext context,
                                                    final Executor executor);
 
@@ -443,12 +461,15 @@ public interface StreamMetadataStore {
      *
      * @param scope          stream scope
      * @param name           stream name.
+     * @param previous       previous versioned record
      * @param context        operation context
      * @param executor       callers executor
-     * @return future
+     * @return Future which when completed contains the updated versioned epoch transition record and indicates that
+     * new segment created step of scale is complete.
      */
-    CompletableFuture<Void> scaleNewSegmentsCreated(final String scope,
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> scaleNewSegmentsCreated(final String scope,
                                                     final String name,
+                                                    final VersionedMetadata<EpochTransitionRecord> previous,
                                                     final OperationContext context,
                                                     final Executor executor);
 
@@ -458,14 +479,20 @@ public interface StreamMetadataStore {
      * @param scope          stream scope
      * @param name           stream name.
      * @param sealedSegmentSizes sealed segments with size at the time of sealing
+     * @param previous       previous versioned record
      * @param context        operation context
      * @param executor       callers executor
      * @return future
      */
-    CompletableFuture<Void> scaleSegmentsSealed(final String scope, final String name,
-                                                final Map<Long, Long> sealedSegmentSizes,
-                                                final OperationContext context,
-                                                final Executor executor);
+    CompletableFuture<Void> completeScale(final String scope, final String name,
+                                          final Map<Long, Long> sealedSegmentSizes,
+                                          final VersionedMetadata<EpochTransitionRecord> previous,
+                                          final OperationContext context,
+                                          final Executor executor);
+
+    CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> startRollingTxn(String scope, String stream,
+                                       int txnEpoch, int activeEpoch, VersionedMetadata<CommittingTransactionsRecord> existing,
+                                       OperationContext context, ScheduledExecutorService executor);
 
     /**
      * This method is called from Rolling transaction workflow after new transactions that are duplicate of active transactions
@@ -476,14 +503,16 @@ public interface StreamMetadataStore {
      * @param scope          stream scope
      * @param name           stream name.
      * @param sealedTxnEpochSegments sealed segments from intermediate txn epoch with size at the time of sealing
-     * @param txnEpoch       epoch for transactions that need to be rolled over
      * @param time           timestamp
+     * @param record         previous versioned record
      * @param context        operation context
      * @param executor       callers executor
      * @return CompletableFuture which upon completion will indicate that we have successfully created new epoch entries.
      */
-    CompletableFuture<Void> rollingTxnNewSegmentsCreated(final String scope, final String name, Map<Long, Long> sealedTxnEpochSegments,
-                                                         final int txnEpoch, final long time, final OperationContext context, final Executor executor);
+    CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> rollingTxnCreateDuplicateEpochs(final String scope,
+                                           final String name, Map<Long, Long> sealedTxnEpochSegments,
+                                           final long time, final VersionedMetadata<CommittingTransactionsRecord> record,
+                                           final OperationContext context, final Executor executor);
 
     /**
      * This is final step of rolling transaction and is called after old segments are sealed in segment store.
@@ -492,15 +521,16 @@ public interface StreamMetadataStore {
      * @param scope          stream scope
      * @param name           stream name.
      * @param sealedActiveEpochSegments sealed segments from active epoch with size at the time of sealing
-     * @param activeEpoch    active epoch against which rolling txn was started
-     * @param time           timestamp
+     * @param time           time
+     * @param record         previous versioned record
      * @param context        operation context
      * @param executor       callers executor
      * @return CompletableFuture which upon successful completion will indicate that rolling transaction is complete.
      */
-    CompletableFuture<Void> rollingTxnActiveEpochSealed(final String scope, final String name, final Map<Long, Long> sealedActiveEpochSegments,
-                                                        final int activeEpoch, final long time, final OperationContext context, final Executor executor);
-
+    CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> completeRollingTxn(final String scope, final String name,
+                                                                    final Map<Long, Long> sealedActiveEpochSegments, final long time,
+                                                                    final VersionedMetadata<CommittingTransactionsRecord> record,
+                                                                    final OperationContext context, final Executor executor);
 
     /**
      * If the state of the stream in the store matches supplied state, reset.
@@ -911,13 +941,14 @@ public interface StreamMetadataStore {
      * @param scope scope name
      * @param stream stream name
      * @param epoch epoch
-     * @param txnsToCommit transactions to commit within the epoch
      * @param context operation context
      * @param executor executor
      * @return A completableFuture which, when completed, mean that the record has been created successfully.
      */
-    CompletableFuture<Void> createCommittingTransactionsRecord(final String scope, final String stream, final int epoch, final List<UUID> txnsToCommit,
-                                                               final OperationContext context, final ScheduledExecutorService executor);
+    CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> startCommitTransactions(final String scope, final String stream,
+                                                                                               final int epoch,
+                                                                                               final OperationContext context,
+                                                                                               final ScheduledExecutorService executor);
 
     /**
      * Method to fetch committing transaction record from the store for a given stream.
@@ -930,20 +961,21 @@ public interface StreamMetadataStore {
      * @param executor executor
      * @return A completableFuture which, when completed, will contain committing transaction record if it exists, or null otherwise.
      */
-    CompletableFuture<CommittingTransactionsRecord> getCommittingTransactionsRecord(final String scope, final String stream,
-                                                                                    final OperationContext context, final ScheduledExecutorService executor);
+    CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> getVersionedCommittingTransactionsRecord(final String scope, final String stream,
+                                                                                             final OperationContext context, final ScheduledExecutorService executor);
 
     /**
      * Method to delete committing transaction record from the store for a given stream.
      *
      * @param scope scope name
      * @param stream stream name
+     * @param record versioned record
      * @param context operation context
      * @param executor executor
      * @return A completableFuture which, when completed, will mean that deletion of txnCommitNode is complete.
      */
-    CompletableFuture<Void> deleteCommittingTransactionsRecord(final String scope, final String stream, final OperationContext context,
-                                                               final ScheduledExecutorService executor);
+    CompletableFuture<Void> completeCommitTransactions(final String scope, final String stream, final VersionedMetadata<CommittingTransactionsRecord> record,
+                                                       final OperationContext context, final ScheduledExecutorService executor);
 
     /**
      * Method to get all transactions in a given epoch. This method returns a map of transaction id to transaction record.

--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedMetadata.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedMetadata.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import lombok.Data;
+
+@Data
+public class VersionedMetadata<OBJECT> {
+    private final OBJECT object;
+    private final Integer version;
+}

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -167,16 +167,16 @@ public class ZKStoreHelper {
         return result;
     }
 
-    CompletableFuture<Void> setData(final String path, final Data<Integer> data) {
-        final CompletableFuture<Void> result = new CompletableFuture<>();
+    CompletableFuture<Integer> setData(final String path, final Data<Integer> data) {
+        final CompletableFuture<Integer> result = new CompletableFuture<>();
         try {
             if (data.getVersion() == null) {
                 client.setData().inBackground(
-                        callback(event -> result.complete(null), result::completeExceptionally, path), executor)
+                        callback(event -> result.complete(event.getStat().getVersion()), result::completeExceptionally, path), executor)
                         .forPath(path, data.getData());
             } else {
                 client.setData().withVersion(data.getVersion()).inBackground(
-                        callback(event -> result.complete(null), result::completeExceptionally, path), executor)
+                        callback(event -> result.complete(event.getStat().getVersion()), result::completeExceptionally, path), executor)
                         .forPath(path, data.getData());
             }
         } catch (Exception e) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -54,7 +54,7 @@ import static io.pravega.controller.server.retention.BucketChangeListener.Stream
  * ZK stream metadata store.
  */
 @Slf4j
-class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
+class ZKStreamMetadataStore extends AbstractStreamMetadataStore implements AutoCloseable {
     @VisibleForTesting
     /**
      * This constant defines the size of the block of counter values that will be used by this controller instance.
@@ -407,7 +407,7 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
                     if (data == null) {
                         return storeHelper.createZNodeIfNotExist(retentionPath, serialize);
                     } else {
-                        return storeHelper.setData(retentionPath, new Data<>(serialize, data.getVersion()));
+                        return Futures.toVoid(storeHelper.setData(retentionPath, new Data<>(serialize, data.getVersion())));
                     }
                 });
     }
@@ -451,7 +451,7 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
                                   Preconditions.checkArgument(lastActiveSegment >= oldLastActiveSegment,
                                           "Old last active segment ({}) for {}/{} is higher than current one {}.",
                                           oldLastActiveSegment, scope, stream, lastActiveSegment);
-                                  return storeHelper.setData(deletePath, new Data<>(maxSegmentNumberBytes, data.getVersion()));
+                                  return Futures.toVoid(storeHelper.setData(deletePath, new Data<>(maxSegmentNumberBytes, data.getVersion())));
                               }
                           });
     }
@@ -497,6 +497,12 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore {
     @VisibleForTesting
     public void setStoreHelperForTesting(ZKStoreHelper storeHelper) {
         this.storeHelper = storeHelper;
+    }
+
+    @Override
+    public void close() throws Exception {
+        completedTxnGC.stopAsync();
+        completedTxnGC.awaitTerminated();
     }
     // endregion
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/tables/EpochTransitionRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/tables/EpochTransitionRecord.java
@@ -30,6 +30,7 @@ import java.util.AbstractMap;
 @AllArgsConstructor
 public class EpochTransitionRecord {
     public static final EpochTransitionRecordSerializer SERIALIZER = new EpochTransitionRecordSerializer();
+    public static final EpochTransitionRecord EMPTY = new EpochTransitionRecord(Integer.MIN_VALUE, Long.MIN_VALUE, ImmutableSet.of(), ImmutableMap.of());
 
     /**
      * Active epoch at the time of requested transition.

--- a/controller/src/main/java/io/pravega/controller/store/stream/tables/StateRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/tables/StateRecord.java
@@ -28,6 +28,10 @@ public class StateRecord {
 
     private final State state;
 
+    public static StateRecord create(State state) {
+        return StateRecord.builder().state(state).build();
+    }
+
     public static class StateRecordBuilder implements ObjectBuilder<StateRecord> {
 
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/tables/serializers/CommittingTransactionsRecordSerializer.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/tables/serializers/CommittingTransactionsRecordSerializer.java
@@ -26,7 +26,7 @@ public class CommittingTransactionsRecordSerializer
 
     @Override
     protected void declareVersions() {
-        version(0).revision(0, this::write00, this::read00);
+        version(0).revision(0, this::write00, this::read00).revision(1, this::write01, this::read01);
     }
 
     private void read00(RevisionDataInput revisionDataInput, CommittingTransactionsRecord.CommittingTransactionsRecordBuilder builder)
@@ -38,6 +38,19 @@ public class CommittingTransactionsRecordSerializer
     private void write00(CommittingTransactionsRecord record, RevisionDataOutput revisionDataOutput) throws IOException {
         revisionDataOutput.writeInt(record.getEpoch());
         revisionDataOutput.writeCollection(record.getTransactionsToCommit(), RevisionDataOutput::writeUUID);
+    }
+
+    private void read01(RevisionDataInput revisionDataInput, CommittingTransactionsRecord.CommittingTransactionsRecordBuilder builder)
+            throws IOException {
+        builder.epoch(revisionDataInput.readInt())
+                .transactionsToCommit(revisionDataInput.readCollection(RevisionDataInput::readUUID, ArrayList::new))
+                .activeEpoch(revisionDataInput.readInt());
+    }
+
+    private void write01(CommittingTransactionsRecord record, RevisionDataOutput revisionDataOutput) throws IOException {
+        revisionDataOutput.writeInt(record.getEpoch());
+        revisionDataOutput.writeCollection(record.getTransactionsToCommit(), RevisionDataOutput::writeUUID);
+        revisionDataOutput.writeInt(record.getActiveEpoch());
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -263,12 +263,13 @@ public class ZkStreamTest {
         long scale1 = start + 10000;
         ArrayList<Long> sealedSegments = Lists.newArrayList(3L, 4L);
         long five = computeSegmentId(5, 1);
-        EpochTransitionRecord response = store.startScale(SCOPE, streamName, sealedSegments, newRanges, scale1, false, context, executor).get();
+        VersionedMetadata<EpochTransitionRecord> versioned = store.startScale(SCOPE, streamName, sealedSegments, newRanges, scale1, false, context, executor).get();
+        EpochTransitionRecord response = versioned.getObject();
         ImmutableMap<Long, AbstractMap.SimpleEntry<Double, Double>> newSegments = response.getNewSegmentsWithRange();
         store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
-        store.scaleCreateNewSegments(SCOPE, streamName, false, context, executor).get();
-        store.scaleNewSegmentsCreated(SCOPE, streamName, context, executor).get();
-        store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments.stream().collect(Collectors.toMap(x -> x, x -> 0L)),
+        versioned = store.scaleCreateNewSegments(SCOPE, streamName, false, versioned, context, executor).get();
+        versioned = store.scaleNewSegmentsCreated(SCOPE, streamName, versioned, context, executor).get();
+        store.completeScale(SCOPE, streamName, sealedSegments.stream().collect(Collectors.toMap(x -> x, x -> 0L)), versioned,
                 context, executor).get();
         store.setState(SCOPE, streamName, State.ACTIVE, null, executor).join();
         segments = store.getActiveSegments(SCOPE, streamName, context, executor).get();
@@ -287,12 +288,13 @@ public class ZkStreamTest {
         long six = computeSegmentId(6, 2);
         long seven = computeSegmentId(7, 2);
         long eight = computeSegmentId(8, 2);
-        response = store.startScale(SCOPE, streamName, sealedSegments1, newRanges, scale2, false, context, executor).get();
+        versioned = store.startScale(SCOPE, streamName, sealedSegments1, newRanges, scale2, false, context, executor).get();
+        response = versioned.getObject();
         ImmutableMap<Long, AbstractMap.SimpleEntry<Double, Double>> segmentsCreated = response.getNewSegmentsWithRange();
         store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
-        store.scaleCreateNewSegments(SCOPE, streamName, false, context, executor).get();
-        store.scaleNewSegmentsCreated(SCOPE, streamName, context, executor).get();
-        store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments1.stream().collect(Collectors.toMap(x -> x, x -> 0L)),
+        versioned = store.scaleCreateNewSegments(SCOPE, streamName, false, versioned, context, executor).get();
+        versioned = store.scaleNewSegmentsCreated(SCOPE, streamName, versioned, context, executor).get();
+        store.completeScale(SCOPE, streamName, sealedSegments1.stream().collect(Collectors.toMap(x -> x, x -> 0L)), versioned,
                 context, executor).get();
         store.setState(SCOPE, streamName, State.ACTIVE, null, executor).join();
 
@@ -312,12 +314,13 @@ public class ZkStreamTest {
         long ten = computeSegmentId(10, 3);
         long eleven = computeSegmentId(11, 3);
         ArrayList<Long> sealedSegments2 = Lists.newArrayList(seven, eight);
-        response = store.startScale(SCOPE, streamName, sealedSegments2, newRanges, scale3, false, context, executor).get();
+        versioned = store.startScale(SCOPE, streamName, sealedSegments2, newRanges, scale3, false, context, executor).get();
+        response = versioned.getObject();
         segmentsCreated = response.getNewSegmentsWithRange();
         store.setState(SCOPE, streamName, State.SCALING, null, executor).join();
-        store.scaleCreateNewSegments(SCOPE, streamName, false, context, executor).get();
-        store.scaleNewSegmentsCreated(SCOPE, streamName, context, executor).get();
-        store.scaleSegmentsSealed(SCOPE, streamName, sealedSegments2.stream().collect(Collectors.toMap(x -> x, x -> 0L)),
+        versioned = store.scaleCreateNewSegments(SCOPE, streamName, false, versioned, context, executor).get();
+        versioned = store.scaleNewSegmentsCreated(SCOPE, streamName, versioned, context, executor).get();
+        store.completeScale(SCOPE, streamName, sealedSegments2.stream().collect(Collectors.toMap(x -> x, x -> 0L)), versioned,
                 context, executor).get();
         store.setState(SCOPE, streamName, State.ACTIVE, null, executor).join();
 


### PR DESCRIPTION
**Change log description**  
Expose versioned metadata objects from the store interface to processors. 
Model all processing as start-processing and complete-processing. 

**Purpose of the change**  
Fixes #2891 

**What the code does**  
Added a new `VersionedMetadata` class that exposes the metadata version outside of store.
All processor tasks, updateStreamTask, TruncateStreamTask, ScaleOperationTask and CommitRequesthandler initiate processing by calling start-`processing` and get the versionedMetadata.
These use this versioned metadata object to perform all subsequent steps of metadata udpates to the store. 
Another important change is that the records corresponding to processing (`scale -> EpochTransitionRecord`, `txnCommit -> CommittingTxnRecords`, `updateConfig -> StreamConfigurationRecord`, `truncateStream -> StreamTruncationRecord`) are never deleted. They are created and reset to default values when processing is not happening. Non default values indicate on going work request and acts as a write ahead log. 
Whenever processing starts, it will first update the corresponding record with the request's input and then pass the updated record to subsequent steps. Each intermediate step takes existing record and returns an updated record. 
The above primitives and changes allow us to decouple store logic from processing and store does not care if multiple processors are attempting to perform updates concurrently.  

Following is how workflows have changed:
1. Scale workflow:
All intermediate steps take epoch transition record and return an updated record back to the caller. 
 - metadatastore.startScale -> return versioned epochTransitionRecord 
 - metadatastore.scaleCreateNewSegments(versionedRecord)  -> return updated versioned epochTransitionRecord 
 - create new segments in segment store
 - metadatastore.scaleNewSegmentsCreated -> return updated versioned epochTransitionRecord 
 - seal active segments
 - metadatastore.completeScale -> return updated versioned epochTransitionRecord 

2. CommitRequestHandler.java
There are two major changes to this class. Two methods in the class are moved to streamMetadataStore a. createAndGetCommitTxnList is moved inside metadata store and implemented as `StartCommitTransactions`.
b. commitTransactions is moved to streamMetadata store and implemented as `completeCommitTransactions`.
All other intermediate steps involved in rolling transactions take and return `VersionedMetadata<CommittingTransactionsRecord>`

So commit workflow looks as follows:
- startCommitTransactions // creates commitTransactionRecord
-  if (need to roll?) 
       rollTransactions:
       - startRollingTxn --> update committingTxnRecord with active-epoch //indicates rolling txn ongoing
       - create duplicate txn segments in segment store and merge transactions to them. create duplicate active epoch segments
       - rollingTxnCreateDuplicateEpochs --> creates duplicate epochs in metadata store
       - seal active epoch segments in segment store
       - completeRollingTxn --> completes any partial metadata records in metadata store

else 
       commitTransactions
- completeCommitTransactions --> loops over txn list and marks them as committed And resets commitTransactionsRecord

3. UpdateConfiguration:
- startUpdateConfiguration // at the time of request submission
- getVersionedStreamConfigurationRecord
- completeUpdateConfiguration(versionedRecord)

3. truncate task
- startTruncate stream // at the time of request submission
- getVersionedStreamTruncationRecord
- completeTruncation(versionedRecord)

**How to verify it**  
Existing unit tests updated. New unit tests will be added. 