### PR TITLE
Issue 2958: (SegmentStore) Extracted Concurrent Dependent Processor into its own class.

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/ConcurrentDependentProcessor.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ConcurrentDependentProcessor.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.concurrent;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import io.pravega.common.ObjectClosedException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+/**
+ * Concurrent async processor that allows parallel execution of tasks with different keys, but serializes the execution
+ * of tasks with the same key.
+ *
+ * @param <KeyType> Type of the Key.
+ */
+@ThreadSafe
+@RequiredArgsConstructor
+public class ConcurrentDependentProcessor<KeyType> implements AutoCloseable {
+    private final Executor executor;
+    @GuardedBy("queue")
+    private final Map<KeyType, CompletableFuture<?>> queue = new HashMap<>();
+    @GuardedBy("queue")
+    private boolean closed = false;
+
+    @Override
+    public void close() {
+        ArrayList<CompletableFuture<?>> toCancel = new ArrayList<>();
+        synchronized (this.queue) {
+            if (!this.closed) {
+                toCancel = new ArrayList<>(this.queue.values());
+                this.queue.clear();
+                this.closed = true;
+            }
+        }
+        if (toCancel.size() > 0) {
+            toCancel.forEach(f -> f.completeExceptionally(new ObjectClosedException(this)));
+        }
+    }
+
+    /**
+     * Gets the number of concurrent tasks currently executing.
+     */
+    public int getKeyCount() {
+        synchronized (this.queue) {
+            return this.queue.size();
+        }
+    }
+
+    /**
+     * Queues up a new task to execute, subject to the given dependency Keys.
+     *
+     * This task will not begin execution until all previous tasks for the given dependency Keys have finished.
+     * In addition, no subsequent task for any of the given dependency Keys will begin executing until this task has
+     * finished executing.
+     *
+     * @param keys         A Collection of {@link KeyType} objects representing the Keys that this task is dependent on.
+     * @param toRun        A Supplier that will be invoked when it is this task's turn to run. It will return a
+     *                     CompletableFuture that will complete when this task completes.
+     * @param <ReturnType> Return type.
+     * @return A CompletableFuture that will complete with the result from the CompletableFuture returned by toRun,
+     * when toRun completes executing.
+     */
+    public <ReturnType> CompletableFuture<ReturnType> add(Collection<KeyType> keys, Supplier<CompletableFuture<? extends ReturnType>> toRun) {
+        Preconditions.checkArgument(!keys.isEmpty(), "keys cannot be empty.");
+        CompletableFuture<ReturnType> result = new CompletableFuture<>();
+        Map<KeyType, CompletableFuture<?>> existingTasks = new HashMap<>();
+        synchronized (this.queue) {
+            Exceptions.checkNotClosed(this.closed, this);
+            // Collect all currently executing tasks for the given keys.
+            for (KeyType key : keys) {
+                CompletableFuture<?> existingTask = this.queue.get(key);
+                if (existingTask != null) {
+                    existingTasks.put(key, existingTask);
+                }
+            }
+
+            if (!existingTasks.isEmpty()) {
+                // Another task is in progress for at least one key. Queue up behind them, and make sure to only start the
+                // execution once all of those tasks are done.
+                val tasks = existingTasks.values();
+                CompletableFuture.allOf(tasks.toArray(new CompletableFuture[tasks.size()]))
+                                 .whenCompleteAsync((r, ex) -> Futures.completeAfter(toRun, result), this.executor);
+            }
+
+            // Update the queues for each key to point to the latest task.
+            keys.forEach(key -> this.queue.put(key, result));
+        }
+        if (existingTasks.isEmpty()) {
+            // There were no previously running tasks for any of the given keys. Need to trigger its execution now,
+            // outside of the synchronized block.
+            Futures.completeAfter(toRun, result);
+        }
+        // Cleanup: if this was the last task in the queue, then clean up the queue.
+        result.whenComplete((r, ex) -> cleanup(keys));
+        return result;
+    }
+
+    private void cleanup(Collection<KeyType> keys) {
+        synchronized (this.queue) {
+            for (KeyType key : keys) {
+                val last = this.queue.getOrDefault(key, null);
+                if (last != null && last.isDone()) {
+                    this.queue.remove(key);
+                }
+            }
+        }
+    }
+}

--- a/common/src/test/java/io/pravega/common/concurrent/ConcurrentDependentProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ConcurrentDependentProcessorTests.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.concurrent;
+
+import io.pravega.common.ObjectClosedException;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.Cleanup;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the ConcurrentDependentProcessor class.
+ */
+public class ConcurrentDependentProcessorTests extends ThreadPooledTestSuite {
+    private static final int SHORT_TIMEOUT_MILLIS = 50;
+    private static final int TIMEOUT_MILLIS = 10000;
+
+    @Override
+    protected int getThreadPoolSize() {
+        return 3;
+    }
+
+    /**
+     * Tests the processor using two keys and verifies the tasks are executed in parallel.
+     */
+    @Test
+    public void testParallelism() throws Exception {
+        final int key1 = 1;
+        final int key2 = 2;
+        @Cleanup
+        val proc = new ConcurrentDependentProcessor<Integer>(executorService());
+        val toRun1 = new CompletableFuture<Integer>();
+        val result1 = proc.add(Collections.singleton(key1), () -> toRun1);
+
+        val toRun2 = new CompletableFuture<Integer>();
+        val result2 = proc.add(Collections.singleton(key2), () -> toRun2);
+        Assert.assertFalse("Not expecting anything to be done yet.", result1.isDone() || result2.isDone());
+
+        // Complete second run. If it completes, we have verified that it hasn't been blocked on the first one.
+        toRun2.complete(10);
+        result2.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from second key run.", result2.join(), toRun2.join());
+        Assert.assertFalse("Not expecting first task to be done yet.", result1.isDone());
+
+        // Complete the first run.
+        toRun1.complete(20);
+        result1.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from first key run.", result1.join(), toRun1.join());
+    }
+
+    /**
+     * Tests the processor using a single dependency key for each task. This means that tasks with different keys
+     * can execute in parallel while tasks with the same key may not.
+     */
+    @Test
+    public void testSingleDependencyKey() throws Exception {
+        final int key = 1;
+        final int count = 10000;
+        @Cleanup
+        val proc = new ConcurrentDependentProcessor<Integer>(executorService());
+        val running = new AtomicBoolean(false);
+        val previousRun = new AtomicReference<CompletableFuture<Integer>>();
+        val results = new ArrayList<CompletableFuture<Integer>>();
+        for (int i = 0; i < count; i++) {
+            val thisRun = new CompletableFuture<Integer>();
+            val pr = previousRun.getAndSet(thisRun);
+            results.add(proc.add(Collections.singleton(key), () -> {
+                if (!running.compareAndSet(false, true)) {
+                    Assert.fail("Concurrent execution detected.");
+                }
+
+                return thisRun.thenApply(r -> {
+                    running.set(false);
+                    return r;
+                });
+            }));
+
+            if (pr != null) {
+                pr.complete(i - 1);
+            }
+        }
+
+        // Complete the last one.
+        previousRun.get().complete(count - 1);
+
+        for (int i = 0; i < results.size(); i++) {
+            val value = results.get(i).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            Assert.assertEquals("Unexpected value.", i, (int) value);
+        }
+    }
+
+    /**
+     * Tests the processor using multiple dependency keys for each task. This means that tasks with disjoint dependency
+     * keys may execute in parallel, while the others may not.
+     */
+    @Test
+    public void testMultiDependencyKey() throws Exception {
+        final int key1 = 1;
+        final int key2 = 2;
+        final int key3 = 3;
+        @Cleanup
+        val proc = new ConcurrentDependentProcessor<Integer>(executorService());
+
+        // We setup two individual tasks to begin with.
+        val toRun1 = new CompletableFuture<Integer>();
+        val result1 = proc.add(Collections.singleton(key1), () -> toRun1);
+
+        val toRun2 = new CompletableFuture<Integer>();
+        val result2 = proc.add(Collections.singleton(key2), () -> toRun2);
+        Assert.assertFalse("Not expecting anything to be done yet.", result1.isDone() || result2.isDone());
+
+        // We setup the third task, which depends on both of the original tasks.
+        val result3 = proc.add(Arrays.asList(key1, key2, key3), () -> {
+            Assert.assertTrue("Not expecting third task to execute yet.", result1.isDone() && result2.isDone());
+            return CompletableFuture.completedFuture(3);
+        });
+
+        // Task 4 depends on Key1, which was last used during Task 3.
+        val result4 = proc.add(Collections.singleton(key1), () -> {
+            Assert.assertTrue("Not expecting fourth task to execute yet.", result3.isDone());
+            return CompletableFuture.completedFuture(4);
+        });
+
+        // Task 5 depends on Key3, which was only introduced as a group with Task 3.
+        val result5 = proc.add(Collections.singleton(key3), () -> {
+            Assert.assertTrue("Not expecting fifth task to execute yet.", result3.isDone());
+            return CompletableFuture.completedFuture(5);
+        });
+
+        // Complete the first task. Verify it did complete, but it didn't unblock the third one.
+        toRun1.complete(1);
+        result1.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from first key run.", result1.join(), toRun1.join());
+
+        AssertExtensions.assertThrows(
+                "Third task unexpectedly completed.",
+                () -> result3.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+                ex -> ex instanceof TimeoutException);
+
+        // Complete the second task. Verify both it and the third task completed.
+        toRun2.complete(2);
+        result2.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from second key run.", result2.join(), toRun2.join());
+
+        result3.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from third key run.", (int) result3.join(), 3);
+
+        result4.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from task 4.", (int) result4.join(), 4);
+
+        result5.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result from task 5.", (int) result5.join(), 5);
+    }
+
+    /**
+     * Tests the ability to cancel ongoing tasks when the processor is closed.
+     */
+    @Test
+    public void testClose() {
+        final int key = 1;
+        @Cleanup
+        val proc = new ConcurrentDependentProcessor<Integer>(executorService());
+        val toRun = new CompletableFuture<Integer>();
+        val result = proc.add(Collections.singleton(key), () -> toRun);
+
+        proc.close();
+        AssertExtensions.assertThrows(
+                "Task not cancelled.",
+                result::join,
+                ex -> ex instanceof ObjectClosedException);
+
+        Assert.assertFalse("Not expecting inner blocker task to be done.", toRun.isDone());
+    }
+}

--- a/common/src/test/java/io/pravega/common/concurrent/ConcurrentDependentProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ConcurrentDependentProcessorTests.java
@@ -23,7 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Unit tests for the ConcurrentDependentProcessor class.
@@ -31,6 +33,9 @@ import org.junit.Test;
 public class ConcurrentDependentProcessorTests extends ThreadPooledTestSuite {
     private static final int SHORT_TIMEOUT_MILLIS = 50;
     private static final int TIMEOUT_MILLIS = 10000;
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -12,22 +12,18 @@ package io.pravega.segmentstore.storage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.ConcurrentDependentProcessor;
 import io.pravega.common.function.RunnableWithException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.val;
 
 /**
  * Wrapper for a SyncStorage implementation that executes all operations asynchronously in a Thread Pool.
@@ -42,10 +38,7 @@ public class AsyncStorageWrapper implements Storage {
 
     private final SyncStorage syncStorage;
     private final Executor executor;
-    @GuardedBy("lastTasks")
-    private final HashMap<String, RunningTask> lastTasks;
-    @GuardedBy("lastTasks")
-    private int currentTaskId;
+    private final ConcurrentDependentProcessor<String> taskProcessor;
     private final AtomicBoolean closed;
 
     //endregion
@@ -61,7 +54,7 @@ public class AsyncStorageWrapper implements Storage {
     public AsyncStorageWrapper(SyncStorage syncStorage, Executor executor) {
         this.syncStorage = Preconditions.checkNotNull(syncStorage, "syncStorage");
         this.executor = Preconditions.checkNotNull(executor, "executor");
-        this.lastTasks = new HashMap<>();
+        this.taskProcessor = new ConcurrentDependentProcessor<>(this.executor);
         this.closed = new AtomicBoolean();
     }
 
@@ -154,9 +147,7 @@ public class AsyncStorageWrapper implements Storage {
      */
     @VisibleForTesting
     int getSegmentWithOngoingOperationsCount() {
-        synchronized (this.lastTasks) {
-            return this.lastTasks.size();
-        }
+        return this.taskProcessor.getKeyCount();
     }
 
     /**
@@ -166,33 +157,7 @@ public class AsyncStorageWrapper implements Storage {
      */
     private <R> CompletableFuture<R> supplyAsync(Callable<R> operation, String... segmentNames) {
         Exceptions.checkNotClosed(this.closed.get(), this);
-        CompletableFuture<R> result;
-        synchronized (this.lastTasks) {
-            // Collect all futures this is dependent on.
-            val futures = Arrays.stream(segmentNames)
-                    .map(this.lastTasks::get)
-                    .filter(Objects::nonNull)
-                    .map(t -> t.task)
-                    .toArray(CompletableFuture[]::new);
-
-            int taskId = this.currentTaskId++;
-            if (futures.length == 0) {
-                // Nothing to depend on - free to execute now.
-                result = CompletableFuture.supplyAsync(() -> execute(operation, taskId, segmentNames), this.executor);
-            } else {
-                // We need to wait on these futures to complete before executing ours.
-                result = CompletableFuture.allOf(futures)
-                        .handleAsync((r, ex) -> execute(operation, taskId, segmentNames), this.executor);
-            }
-
-            // Update the last task for each involved segment to be this so that future tasks can be properly sequenced.
-            RunningTask t = new RunningTask(taskId, result);
-            for (String s : segmentNames) {
-                this.lastTasks.put(s, t);
-            }
-        }
-
-        return result;
+        return this.taskProcessor.add(Arrays.asList(segmentNames), () -> execute(operation));
     }
 
     /**
@@ -212,39 +177,15 @@ public class AsyncStorageWrapper implements Storage {
      * Executes the given Callable synchronously and invokes cleanup when done.
      *
      * @param operation    The Callable to execute.
-     * @param taskId       The id of the current task to be used for cleanup purposes.
-     * @param segmentNames The names of the Segments involved in this operation (for sequencing purposes).
      */
-    @SneakyThrows(Exception.class)
-    private <R> R execute(Callable<R> operation, int taskId, String[] segmentNames) {
-        try {
-            return operation.call();
-        } finally {
-            cleanupIfNeeded(taskId, segmentNames);
-        }
-    }
-
-    private void cleanupIfNeeded(int taskId, String[] segmentNames) {
-        synchronized (this.lastTasks) {
-            for (String s : segmentNames) {
-                // A segment entry can be safely cleaned up if the last registered task has the same id as the one
-                // we got in this method (that means no more tasks have been added).
-                val task = this.lastTasks.get(s);
-                if (task != null && task.taskId == taskId) {
-                    this.lastTasks.remove(s);
-                }
+    private <R> CompletableFuture<R> execute(Callable<R> operation) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return operation.call();
+            } catch (Exception ex) {
+                throw new CompletionException(ex);
             }
-        }
-    }
-
-    //endregion
-
-    //region RunningTask
-
-    @RequiredArgsConstructor
-    private static final class RunningTask {
-        private final int taskId;
-        private final CompletableFuture<?> task;
+        }, this.executor);
     }
 
     //endregion

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -147,7 +147,7 @@ public class AsyncStorageWrapper implements Storage {
      */
     @VisibleForTesting
     int getSegmentWithOngoingOperationsCount() {
-        return this.taskProcessor.getKeyCount();
+        return this.taskProcessor.getCurrentTaskCount();
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
- Extracted the logic in `AsyncStorageWrapper` where it would only let one instance of a task with a particular key run at any given time (and queue tasks with same keys) into its own class.

**Purpose of the change**  
Fixes #2958.

**What the code does**  
- Created `ConcurrentDependentProcessor`
    - This generalizes the task processor in `AsyncStorageWrapper` so that it can be reused in other parts of the code (coming up in #2878).

**How to verify it**  
New unit tests added. Existing tests must pass.
