### PR TITLE
Issue 2974: Update the docker-compose yml link in the documentation

### DIFF
--- a/documentation/src/docs/deployment/run-local.md
+++ b/documentation/src/docs/deployment/run-local.md
@@ -63,7 +63,7 @@ To use this you need to have Docker `1.12` or later.
 Download the [docker-compose.yml](https://github.com/pravega/pravega/tree/master/docker/compose/docker-compose.yml) from github. For example:
 
 ```
-wget https://github.com/pravega/pravega/tree/master/docker/compose/docker-compose.yml
+wget https://raw.githubusercontent.com/pravega/pravega/master/docker/compose/docker-compose.yml
 ```
 
 You need to set the IP address of your local machine as the value of HOST_IP in the following command. To run:


### PR DESCRIPTION


**Change log description**  
The current link is to the html page of the yml file. It should point to the raw file.

**Purpose of the change**  
Fixing the documentation.

**What the code does**  
No new code, just updating the documentation.

**How to verify it**  
Try the link.
