### PR TITLE
Issue 2963: Update docker images to use OpenJDK image

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -8,7 +8,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM java:8
+FROM openjdk:8-alpine
 MAINTAINER Arvind Kandhare [arvind.kandhare@emc.com]
 
 RUN apt-get update \

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -8,7 +8,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM openjdk:8-alpine
+FROM openjdk:8-jre
 MAINTAINER Arvind Kandhare [arvind.kandhare@emc.com]
 
 RUN apt-get update \

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -7,7 +7,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-FROM java:8
+FROM openjdk:8-alpine
 
 RUN apt-get update && apt-get install -y -q rpcbind nfs-common \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -7,7 +7,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-FROM openjdk:8-alpine
+FROM openjdk:8-jre
 
 RUN apt-get update && apt-get install -y -q rpcbind nfs-common \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Updates base docker image according to the suggestion in issue #2963 .

**Purpose of the change**  
Fixes #2963 

**What the code does**  
Changes the docker base image in two places:
* `docker/pravega/Dockerfile`
* `docker/bookkeeper/Dockerfile`

**How to verify it**  
Build and deploy docker images.