### PR TITLE
Issue 2973: Update Zookeeper Docker image dependency

### DIFF
--- a/docker/compose/docker-compose-extendeds3.yml
+++ b/docker/compose/docker-compose-extendeds3.yml
@@ -10,7 +10,7 @@
 version: '2'
 services:
   zookeeper:
-    image: jplock/zookeeper:3.5.2-alpha
+    image: zookeeper:3.5.4-beta
     ports:
       - "2181:2181"
 

--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -10,7 +10,7 @@
 version: '2'
 services:
   zookeeper:
-    image: jplock/zookeeper:3.5.2-alpha
+    image: zookeeper:3.5.4-beta
     ports:
       - "2181:2181"
 

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -17,7 +17,7 @@ volumes:
       device: ":${NFS_PATH}"
 services:
   zookeeper:
-    image: jplock/zookeeper:3.5.2-alpha
+    image: zookeeper:3.5.4-beta
     ports:
       - "2181:2181"
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -10,7 +10,7 @@
 version: '2'
 services:
   zookeeper:
-    image: jplock/zookeeper:3.5.2-alpha
+    image: zookeeper:3.5.4-beta
     ports:
       - "2181:2181"
 

--- a/docker/compose/swarm/zookeeper.yml
+++ b/docker/compose/swarm/zookeeper.yml
@@ -10,4 +10,4 @@
 version: '3'
 services:
   zookeeper:
-    image: jplock/zookeeper:3.5.2-alpha
+    image: zookeeper:3.5.4-beta

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/ZookeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/ZookeeperService.java
@@ -28,7 +28,7 @@ import static io.pravega.test.system.framework.TestFrameworkException.Type.Inter
 @Slf4j
 public class ZookeeperService extends MarathonBasedService {
 
-    private static final String ZK_IMAGE = "jplock/zookeeper:3.5.2-alpha";
+    private static final String ZK_IMAGE = "zookeeper:3.5.4-beta";
     private int instances = 1;
     private double cpu = 1.0;
     private double mem = 1024.0;


### PR DESCRIPTION
**Change log description**  
Update Zookeeper Docker image dependency from `jplock/zookeeper:3.5.2-alpha` to official `zookeeper:3.5.4-beta`. Newer versions of Zookeeper contain a significant number of bug fixes. Check the following link for a detailed change log: https://zookeeper.apache.org/releases.html

**Purpose of the change**  
Fixes #2973

**What the code does**  
Update Zookeeper Docker image in compose files.

**How to verify it**  
All tests must pass.

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>