### PR TITLE
Issue 2933: Sporadic Failure in HDFSIntegrationTest.testEndToEndWithFencing

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/hdfs/HDFSExceptionHelpers.java
@@ -18,6 +18,7 @@ import lombok.Lombok;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.hdfs.protocol.AclException;
+import org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException;
 import org.apache.hadoop.ipc.RemoteException;
 
 /**
@@ -39,7 +40,7 @@ final class HDFSExceptionHelpers {
 
         if (e instanceof PathNotFoundException || e instanceof FileNotFoundException) {
             return new StreamSegmentNotExistsException(segmentName, e);
-        } else if (e instanceof FileAlreadyExistsException) {
+        } else if (e instanceof FileAlreadyExistsException || e instanceof AlreadyBeingCreatedException) {
             return new StreamSegmentExistsException(segmentName, e);
         } else if (e instanceof AclException) {
             return new StreamSegmentSealedException(segmentName, e);


### PR DESCRIPTION
**Change log description**  
Translate HDFS `AlreadyBeingCreatedException` as an equivalent for `StreamSegmentExistsException` so the fencing logic acts upon such exceptions too.

**Purpose of the change**  
Fixes #2933.

**What the code does**  
The code translates HDFS `AlreadyBeingCreatedException` as an equivalent for `StreamSegmentExistsException` so that a segment store instance can react to concurrent attempts to operate on the same file that result in that exception. The rationale is that `AlreadyBeingCreatedException` is conceptually close to the existing `FileAlreadyExistsException`, which is translated into a Pravega exception called `StreamSegmentExistsException` and handled appropriately by the fencing logic. With the change of this PR, we attempt to handle `AlreadyBeingCreatedException` in the same way, thus avoiding the root cause for the error. The analysis that led to this conclusion can be found in #2933.

**How to verify it**  
All tests should work as before and `HDFSIntegrationTest.testEndToEndWithFencing` should pass consistently.
