### PR TITLE
Issue 2987: Update Pravega base Docker images to Alpine

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -8,11 +8,13 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 MAINTAINER Arvind Kandhare [arvind.kandhare@emc.com]
 
-RUN apt-get update \
-&&  apt-get install -y wget unzip \
+RUN apk add --update \
+    wget \
+    unzip \
+&&  rm -rf /var/cache/apk/* \
 &&  mkdir -p /opt \
 &&  cd /opt
 

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -12,6 +12,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER Arvind Kandhare [arvind.kandhare@emc.com]
 
 RUN apk add --update \
+    bash \
     wget \
     unzip \
 &&  rm -rf /var/cache/apk/* \

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -9,7 +9,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-set -e
+set -eo pipefail
 
 ZK_HOME=/opt/zookeeper
 BK_HOME=/opt/bookkeeper
@@ -63,14 +63,14 @@ echo "wait for zookeeper"
 until ${ZK_HOME}/bin/zkCli.sh -server $ZK_URL ls /; do sleep 2; done
 
 echo "create the zk root"
-${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}
-${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}
-${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}
+# Silence exit codes with "|| :" as the commands can safely fail with a "Node already exists" error
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH} || :
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME} || :
+${ZK_HOME}/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME} || :
 
 echo "format the bookie"
-# format bookie
-BOOKIE_CONF=${BK_HOME}/conf/bk_server.conf ${BK_HOME}/bin/bookkeeper shell metaformat -nonInteractive
+# Silence exit codes with "|| :" as the command can safely fail if another instance has already formatted the bookie
+BOOKIE_CONF=${BK_HOME}/conf/bk_server.conf ${BK_HOME}/bin/bookkeeper shell metaformat -nonInteractive || :
 
 echo "start a new bookie"
-# start bookie,
 SERVICE_PORT=$PORT0 ${BK_HOME}/bin/bookkeeper bookie --conf ${BK_HOME}/conf/bk_server.conf

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -9,6 +9,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+set -e
+
 ZK_HOME=/opt/zookeeper
 BK_HOME=/opt/bookkeeper
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     command: segmentstore
     environment:
       WAIT_FOR: bookie1:3181,bookie2:3182,bookie3:3183,hdfs:8020
+      TIER2_STORAGE: "HDFS"
       HDFS_REPLICATION: 1
       HDFS_URL: ${HOST_IP}:8020
       ZK_URL: zookeeper:2181

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -12,6 +12,7 @@ FROM openjdk:8-jre-alpine
 RUN apk add --update \
     rpcbind \
     nfs-utils \
+    python \
   && rm -rf /var/cache/apk/*
 
 EXPOSE 9090 9091 10000 12345

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -7,10 +7,12 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
-RUN apt-get update && apt-get install -y -q rpcbind nfs-common \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --update \
+    rpcbind \
+    nfs-utils \
+  && rm -rf /var/cache/apk/*
 
 EXPOSE 9090 9091 10000 12345
 WORKDIR /opt/pravega
@@ -19,5 +21,3 @@ COPY entrypoint.sh /opt/pravega/scripts/
 COPY wait_for /opt/pravega/scripts/
 
 ENTRYPOINT [ "/opt/pravega/scripts/entrypoint.sh" ]
-
-

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -12,6 +12,7 @@ FROM openjdk:8-jre-alpine
 RUN apk add --update \
     rpcbind \
     nfs-utils \
+    libc6-compat \
     python \
   && rm -rf /var/cache/apk/*
 

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -9,7 +9,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-set -e
+set -eo pipefail
 
 dir=$( cd "$( dirname "$0" )" && pwd )
 # Adds a system property if the value is not empty

--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -9,6 +9,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+set -e
+
 dir=$( cd "$( dirname "$0" )" && pwd )
 # Adds a system property if the value is not empty
 add_system_property() {
@@ -138,4 +140,3 @@ standalone)
     exit 1
     ;;
 esac
-


### PR DESCRIPTION
**Change log description**  
- Replace base Docker images for Pravega and BookKeeper from `openjdk:8-jre` to `openjdk:8-jre:alpine` to use Alpine-based images. 
- Use `apk` instead of `apt-get` to install system packages.
- Reduce Pravega Docker image size from 758MB to 241MB (-68%)
- Reduce BookKeeper Docker image size from 777MB to 206MB (-73%)
- Add bash flag `set -eo pipefail` to Docker entrypoints to immediately fail if a command fails. 
- Append `|| :` to entrypoint commands that are allowed to fail.

**Purpose of the change**  
- Fixes #2987
- Fixes #3008

**What the code does**  
Changes the Docker base image in:
- `docker/pravega/Dockerfile`
- `docker/bookkeeper/Dockerfile`

**How to verify it**  
Build, deploy Docker images, and run all tests based on the new images.

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>