### PR TITLE
Issue 2995: Remove netty from common.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,6 @@ project('common') {
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         compile group: 'com.google.code.findbugs', name: 'annotations', version: findbugsVersion
         compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        compile group: 'io.netty', name: 'netty-all', version: nettyVersion
     }
 
     javadoc {


### PR DESCRIPTION
**Change log description**  
Remove dependency on netty from common.

**Purpose of the change**  
Fix #2995

**What the code does**  
Removes an unneeded dependency

