### PR TITLE
 Issue 2986, Issue 2968: Updates to metrics doc and names

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -47,7 +47,7 @@ public final class MetricsNames {
 
     // Cache (RocksDB) stats
     public static final String CACHE_INSERT_LATENCY = "segmentstore.cache.insert_latency_ms";
-    public static final String CACHE_GET_LATENCY = "segment.store.cache.get_latency_ms";
+    public static final String CACHE_GET_LATENCY = "segmentstore.cache.get_latency_ms";
     public static final String CACHE_TOTAL_SIZE_BYTES = "segmentstore.cache.size_bytes";
     public static final String CACHE_GENERATION_SPREAD = "segmentstore.cache.gen";
 


### PR DESCRIPTION
Issue-2986: update metrics.md to reflect the changes of metrics related PR 2921, PR 2676
Issue-2968: fixed Metrics typo of "Cache Get Latency"

Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description** 
For issue-2968: correction of the typo inside MetricsNames.java;
For issue-2986: updated metrics.md to reflect the recent metrics changes.

**Purpose of the change**  
Fixes #2968, Fixes #2986.

**What the code does**  
Inside MetricsNames.java, the typo of "segment.store.cache.get_latency_ms" changed to "segmentstore.cache.get_latency_ms"
Inside metrics.md: many changes to reflect the changes made by PR 2921 and PR 2676.

**How to verify it**  
For issue-2968: metric "segmentstore.cache.get_latency_ms" starts showing up
For issue-2986: metrics.md reflects the latest metrics changes
