### PR TITLE
Issue 2944: Sporadic failure HDFSIntegration.testendtoend

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
@@ -130,7 +130,7 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     public CompletableFuture<ReadResult> read(String streamSegmentName, long offset, int maxLength, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         TimeoutTimer timer = new TimeoutTimer(timeout);
-        return Retry.withExpBackoff(1, 10, 5)
+        return Retry.withExpBackoff(30, 10, 4)
                     .retryingOn(StreamSegmentNotExistsException.class)
                     .throwingOn(RuntimeException.class)
                     .run(() -> getStreamSegmentInfo(streamSegmentName, false, timer.getRemaining())
@@ -140,7 +140,7 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     @Override
     public CompletableFuture<SegmentProperties> getStreamSegmentInfo(String streamSegmentName, boolean waitForPendingOps, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
-        return Retry.withExpBackoff(1, 10, 5)
+        return Retry.withExpBackoff(30, 10, 4)
                     .retryingOn(StreamSegmentNotExistsException.class)
                     .throwingOn(RuntimeException.class)
                     .run(() -> this.segmentStateMapper.getSegmentInfoFromStorage(streamSegmentName, timeout));

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -738,7 +738,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             // 1. Deletion status
             SegmentProperties sp = null;
             try {
-                sp = baseStore.getStreamSegmentInfo(segmentName, false, TIMEOUT).join();
+                sp = baseStore.getStreamSegmentInfo(segmentName, true, TIMEOUT).join();
             } catch (Exception ex) {
                 if (!(Exceptions.unwrap(ex) instanceof StreamSegmentNotExistsException)) {
                     throw ex;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -738,7 +738,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             // 1. Deletion status
             SegmentProperties sp = null;
             try {
-                sp = baseStore.getStreamSegmentInfo(segmentName, true, TIMEOUT).join();
+                sp = baseStore.getStreamSegmentInfo(segmentName, false, TIMEOUT).join();
             } catch (Exception ex) {
                 if (!(Exceptions.unwrap(ex) instanceof StreamSegmentNotExistsException)) {
                     throw ex;


### PR DESCRIPTION
**Change log description**  
This PR adds retries to `ReadOnlySegmentContainer` read operations for tolerating failures in reads addressed to segments being concurrently truncated.

**Purpose of the change**  
Fixes #2944, #3030.

**What the code does**  
`ReadOnlySegmentContainer` is special as it can only perform reads from Tier 2 storage. However, it may be the case that while one of those containers is reading a given segment, another ongoing operation deletes or truncates that segment, which may cause unexpected failures (e.g., `StreamSegmentNotExistsException`). This PR just adds retries to read operations in `ReadOnlySegmentContainer` with a twofold objective: i) handle concurrent Segment truncations/deletions while `ReadOnlySegmentContainer` is reading, and ii) handle reads related to Segments in Tier 1 but not yet existing in Tier 2. 

**How to verify it**  
`HDFSIntegration` tests should pass consistently. We have executed +70 times all tests under `:segmentstore:server:host:test` without observing any failure. Before that, with 20 runs we could reproduce issue #2944.