### PR TITLE
Issue 3055: Update Pravega version in r0.4 to 0.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ typesafeConfigVersion=1.3.1
 gradleGitPluginVersion=2.2.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.4.0-SNAPSHOT
+pravegaVersion=0.4.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Removes SNAPSHOT suffix from Pravega version as part of creating a release.

**Purpose of the change**  
Fixes #3055 

**What the code does**  
No code changes, only version in gradle.properties.

**How to verify it**  
Run `./gradlew install` and verify that it is publishing the artifacts under the right version.
