### PR TITLE
Issue 3058: Additional unit tests for Controller Metadata Scalability work

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -50,10 +50,6 @@ public class InMemoryStream extends PersistentStreamBase {
     @GuardedBy("lock")
     private Map<Integer, Data> epochRecords = new HashMap<>();
     @GuardedBy("lock")
-    private Data historyIndexRoot;
-    @GuardedBy("lock")
-    private Map<Integer, Data> historyIndexLeaves = new HashMap<>();
-    @GuardedBy("lock")
     private Map<Integer, Data> historyTimeSeries = new HashMap<>();
     @GuardedBy("lock")
     private Data retentionSet;;

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -16,6 +16,8 @@ import com.google.common.cache.CacheBuilder;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.BitConverter;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StateRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.util.Config;
@@ -87,8 +89,18 @@ public class InMemoryStream extends PersistentStreamBase {
     }
 
     @VisibleForTesting
+    InMemoryStream(String scope, String name, int chunkSize, int shardSize) {
+        this(scope, name, Duration.ofHours(Config.COMPLETED_TRANSACTION_TTL_IN_HOURS).toMillis(), chunkSize, shardSize);
+    }
+
+    @VisibleForTesting
     InMemoryStream(String scope, String name, long completedTxnTTL) {
-        super(scope, name);
+        this(scope, name, completedTxnTTL, HistoryTimeSeries.HISTORY_CHUNK_SIZE, SealedSegmentsMapShard.SHARD_SIZE);
+    }
+
+    @VisibleForTesting
+    InMemoryStream(String scope, String name, long completedTxnTTL, int chunkSize, int shardSize) {
+        super(scope, name, chunkSize, shardSize);
         completedTxns = CacheBuilder.newBuilder()
                                     .expireAfterWrite(completedTxnTTL, TimeUnit.MILLISECONDS).build();
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -62,7 +62,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.pravega.controller.store.stream.records.SealedSegmentsMapShard.SHARD_SIZE;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static java.util.stream.Collectors.toMap;

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -74,18 +74,13 @@ public abstract class PersistentStreamBase implements Stream {
     private final AtomicInteger historyChunkSize;
     private final AtomicInteger shardSize;
 
-    PersistentStreamBase(final String scope, final String name) {
-        this(scope, name, HistoryTimeSeries.HISTORY_CHUNK_SIZE, SHARD_SIZE);
-    }
-    
-    @VisibleForTesting
     PersistentStreamBase(final String scope, final String name, int historyChunkSize, int shardSize) {
         this.scope = scope;
         this.name = name;
         this.historyChunkSize = new AtomicInteger(historyChunkSize);
         this.shardSize = new AtomicInteger(shardSize);
     }
-    
+
     @Override
     public String getScope() {
         return this.scope;

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -9,8 +9,8 @@
  */
 package io.pravega.controller.store.stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;
@@ -55,26 +55,35 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.pravega.controller.store.stream.records.HistoryTimeSeries.HISTORY_CHUNK_SIZE;
-import static io.pravega.controller.store.stream.records.SealedSegmentsMapShard.SHARD_SIZE;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static java.util.stream.Collectors.toMap;
 
 @Slf4j
 public abstract class PersistentStreamBase implements Stream {
-
     private final String scope;
     private final String name;
+    private final AtomicInteger historyChunkSize;
+    private final AtomicInteger shardSize;
 
     PersistentStreamBase(final String scope, final String name) {
         this.scope = scope;
         this.name = name;
+        historyChunkSize = new AtomicInteger(HistoryTimeSeries.HISTORY_CHUNK_SIZE);
+        shardSize = new AtomicInteger(SealedSegmentsMapShard.SHARD_SIZE);
+    }
+
+    @VisibleForTesting
+    void setHistoryChunkAndSealedSizeMapShardSizes(int historyChunkSize, int shardSize) {
+        this.historyChunkSize.set(historyChunkSize);
+        this.shardSize.set(shardSize);
     }
 
     @Override
@@ -338,14 +347,14 @@ public abstract class PersistentStreamBase implements Stream {
         // fetch history index and find epochs corresponding to "from" and "to"
         // fetch "from epoch" from epoch record
         // fetch epochs from history timeseries.
-        CompletableFuture<Integer> fromEpoch = findEpochAtTime(from);
-        CompletableFuture<Integer> toEpoch = findEpochAtTime(to);
+        CompletableFuture<Integer> fromEpoch = findEpochAtTime(from, false);
+        CompletableFuture<Integer> toEpoch = findEpochAtTime(to, false);
         CompletableFuture<List<EpochRecord>> records =
                 CompletableFuture.allOf(fromEpoch, toEpoch)
                                  .thenCompose(x -> {
                                      // fetch epochs will fetch it from history time series. 
                                      // this will be efficient if fromEpoch and toEpoch are near each other.
-                                     return fetchEpochs(fromEpoch.join(), toEpoch.join());
+                                     return fetchEpochs(fromEpoch.join(), toEpoch.join(), false);
                                  });
         return records.thenApply(this::mapToScaleMetadata);
     }
@@ -518,7 +527,8 @@ public abstract class PersistentStreamBase implements Stream {
                                 });
     }
 
-    private CompletableFuture<Set<StreamSegmentRecord>> segmentsBetweenStreamCutSpans(Map<StreamSegmentRecord, Integer> spanFrom,
+    @VisibleForTesting
+    CompletableFuture<Set<StreamSegmentRecord>> segmentsBetweenStreamCutSpans(Map<StreamSegmentRecord, Integer> spanFrom,
                                                                                       Map<StreamSegmentRecord, Integer> spanTo) {
         int toLow = Collections.min(spanTo.values());
         int toHigh = Collections.max(spanTo.values());
@@ -526,7 +536,7 @@ public abstract class PersistentStreamBase implements Stream {
         int fromHigh = Collections.max(spanFrom.values());
         Set<StreamSegmentRecord> segments = new HashSet<>();
 
-        return fetchEpochs(fromLow, toHigh)
+        return fetchEpochs(fromLow, toHigh, true)
                 .thenAccept(epochs -> {
                     epochs.forEach(epoch -> {
                         // for epochs that cleanly lie between from.high and to.low epochs we can include all segments present in them
@@ -550,10 +560,11 @@ public abstract class PersistentStreamBase implements Stream {
                 }).thenApply(x -> segments);
     }
 
-    private CompletableFuture<Long> sizeBetweenStreamCuts(Map<Long, Long> streamCutFrom, Map<Long, Long> streamCutTo,
+    @VisibleForTesting
+    CompletableFuture<Long> sizeBetweenStreamCuts(Map<Long, Long> streamCutFrom, Map<Long, Long> streamCutTo,
                                                           Set<StreamSegmentRecord> segmentsInBetween) {
         Map<Integer, List<StreamSegmentRecord>> shards =
-                segmentsInBetween.stream().collect(Collectors.groupingBy(x -> x.getSegmentNumber() / SHARD_SIZE));
+                segmentsInBetween.stream().collect(Collectors.groupingBy(x -> getShardNumber(x.segmentId())));
         return Futures.allOfWithResults(
                 shards.entrySet().stream()
                       .map(entry -> getSealedSegmentSizeMapShard(entry.getKey())
@@ -594,13 +605,14 @@ public abstract class PersistentStreamBase implements Stream {
                       });
     }
 
-    private CompletableFuture<Map<StreamSegmentRecord, Integer>> computeStreamCutSpan(Map<Long, Long> streamCut) {
+    @VisibleForTesting
+    CompletableFuture<Map<StreamSegmentRecord, Integer>> computeStreamCutSpan(Map<Long, Long> streamCut) {
         long mostRecent = streamCut.keySet().stream().max(Comparator.naturalOrder()).get();
         long oldest = streamCut.keySet().stream().min(Comparator.naturalOrder()).get();
         int epochLow = StreamSegmentNameUtils.getEpoch(oldest);
         int epochHigh = StreamSegmentNameUtils.getEpoch(mostRecent);
 
-        return fetchEpochs(epochLow, epochHigh).thenApply(epochs ->  {
+        return fetchEpochs(epochLow, epochHigh, true).thenApply(epochs ->  {
             List<Long> toFind = new ArrayList<>(streamCut.keySet());
             Map<StreamSegmentRecord, Integer> resultSet = new HashMap<>();
             for (int i = epochHigh - epochLow; i >= 0; i--) {
@@ -750,11 +762,11 @@ public abstract class PersistentStreamBase implements Stream {
                     if (currentEpoch.getEpoch() < versionedMetadata.getObject().getNewEpoch()) {
                         EpochTransitionRecord epochTransition = versionedMetadata.getObject();
                         // time
-                        Long time = Math.max(epochTransition.getTime(), currentEpoch.getCreationTime() + 1);
+                        long time = Math.max(epochTransition.getTime(), currentEpoch.getCreationTime() + 1);
                         // new segments
                         List<StreamSegmentRecord> newSegments =
                                 epochTransition.getNewSegmentsWithRange().entrySet().stream()
-                                               .map(x -> newSegmentRecord(x.getKey(), epochTransition.getTime(), x.getValue().getKey(), x.getValue().getValue()))
+                                               .map(x -> newSegmentRecord(x.getKey(), time, x.getValue().getKey(), x.getValue().getValue()))
                                                .collect(Collectors.toList());
                         // sealed segments
                         List<StreamSegmentRecord> sealedSegments =
@@ -791,8 +803,8 @@ public abstract class PersistentStreamBase implements Stream {
     }
 
     private CompletableFuture<Void> updateHistoryTimeSeries(HistoryTimeSeriesRecord record) {
-        int historyChunk = record.getEpoch() / HISTORY_CHUNK_SIZE;
-        boolean isFirst = record.getEpoch() % HISTORY_CHUNK_SIZE == 0;
+        int historyChunk = record.getEpoch() / historyChunkSize.get();
+        boolean isFirst = record.getEpoch() % historyChunkSize.get() == 0;
 
         if (isFirst) {
             return createHistoryTimeSeriesChunk(historyChunk, record);
@@ -907,7 +919,7 @@ public abstract class PersistentStreamBase implements Stream {
                                     activeEpochRecord.getSegments().stream()
                                                           .map(x -> newSegmentRecord(computeSegmentId(getSegmentNumber(x.segmentId()),
                                                                   committingTxnRecord.getNewActiveEpoch()),
-                                                                  timeStamp, x.getKeyStart(), x.getKeyEnd()))
+                                                                  timeStamp + 1, x.getKeyStart(), x.getKeyEnd()))
                                                           .collect(Collectors.toList());
 
                             EpochRecord duplicateTxnEpoch = EpochRecord.builder().epoch(committingTxnRecord.getNewTxnEpoch())
@@ -918,7 +930,7 @@ public abstract class PersistentStreamBase implements Stream {
                             EpochRecord duplicateActiveEpoch = EpochRecord.builder().epoch(committingTxnRecord.getNewActiveEpoch())
                                                                           .referenceEpoch(activeEpochRecord.getReferenceEpoch())
                                                                           .segments(duplicateActiveSegments)
-                                                                          .creationTime(timeStamp).build();
+                                                                          .creationTime(timeStamp + 1).build();
 
                             HistoryTimeSeriesRecord timeSeriesRecordTxnEpoch =
                                     HistoryTimeSeriesRecord.builder().epoch(duplicateTxnEpoch.getEpoch())
@@ -928,7 +940,7 @@ public abstract class PersistentStreamBase implements Stream {
                             HistoryTimeSeriesRecord timeSeriesRecordActiveEpoch =
                                     HistoryTimeSeriesRecord.builder().epoch(duplicateActiveEpoch.getEpoch())
                                                            .referenceEpoch(duplicateActiveEpoch.getReferenceEpoch())
-                                                           .creationTime(timeStamp).build();
+                                                           .creationTime(timeStamp + 1).build();
                             return createEpochRecord(duplicateTxnEpoch)
                                     .thenCompose(x -> updateHistoryTimeSeries(timeSeriesRecordTxnEpoch))
                                     .thenCompose(x -> createEpochRecord(duplicateActiveEpoch))
@@ -1422,13 +1434,24 @@ public abstract class PersistentStreamBase implements Stream {
         return createSealedSegmentSizesMapShardDataIfAbsent(shardNumber, shard.toBytes());
     }
 
-    private CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(int shard) {
-        return getSealedSegmentSizesMapShardData(shard).thenApply(x -> SealedSegmentsMapShard.fromBytes(x.getData()));
+    @VisibleForTesting
+    CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(int shard) {
+        return getSealedSegmentSizesMapShardData(shard)
+                .handle((r, e) -> {
+                    if (e != null) {
+                        if (Exceptions.unwrap(e) instanceof DataNotFoundException) {
+                            return SealedSegmentsMapShard.builder().shardNumber(shard).sealedSegmentsSizeMap(Collections.emptyMap()).build();
+                        } 
+                        throw new CompletionException(e);
+                    } else {
+                        return SealedSegmentsMapShard.fromBytes(r.getData());
+                    }
+                });
     }
 
     private CompletableFuture<Void> updateSealedSegmentSizes(Map<Long, Long> sealedSegmentSizes) {
         Map<Integer, List<Long>> shards = sealedSegmentSizes.keySet().stream()
-                                                            .collect(Collectors.groupingBy(x -> StreamSegmentNameUtils.getSegmentNumber(x) / SHARD_SIZE));
+                                                            .collect(Collectors.groupingBy(this::getShardNumber));
         return Futures.allOf(shards.entrySet().stream().map(x -> {
             int shard = x.getKey();
             List<Long> segments = x.getValue();
@@ -1440,6 +1463,10 @@ public abstract class PersistentStreamBase implements Stream {
                         return updateSealedSegmentSizesMapShardData(shard, new Data(mapShard.toBytes(), y.getVersion()));
                     }));
         }).collect(Collectors.toList()));
+    }
+
+    private int getShardNumber(long segmentId) {
+        return StreamSegmentNameUtils.getEpoch(segmentId) / shardSize.get();
     }
 
     private Map<StreamSegmentRecord, Integer> convertToSpan(EpochRecord epochRecord) {
@@ -1460,32 +1487,34 @@ public abstract class PersistentStreamBase implements Stream {
         return segmentRecords.stream().map(this::transform).collect(Collectors.toSet());
     }
     
-    private CompletableFuture<List<EpochRecord>> fetchEpochs(int fromEpoch, int toEpoch) {
+    @VisibleForTesting
+    CompletableFuture<List<EpochRecord>> fetchEpochs(int fromEpoch, int toEpoch, boolean ignoreCache) {
         // fetch history time series chunk corresponding to from.
         // read entries till either last entry or till to
         // if to is not in this chunk fetch the next chunk and read till to
         // keep doing this until all records till to have been read.
         // keep computing history record from history time series by applying delta on previous.
-        return getActiveEpochRecord(false)
-                .thenApply(currentEpoch -> currentEpoch.getEpoch() / HISTORY_CHUNK_SIZE)
+        return getActiveEpochRecord(ignoreCache)
+                .thenApply(currentEpoch -> currentEpoch.getEpoch() / historyChunkSize.get())
                 .thenCompose(latestChunkNumber -> Futures.allOfWithResults(
-                        IntStream.range(fromEpoch / HISTORY_CHUNK_SIZE, toEpoch / HISTORY_CHUNK_SIZE + 1)
+                        IntStream.range(fromEpoch / historyChunkSize.get(), toEpoch / historyChunkSize.get() + 1)
                                  .mapToObj(i -> {
-                                     int firstEpoch = i * HISTORY_CHUNK_SIZE > fromEpoch ? i * HISTORY_CHUNK_SIZE : fromEpoch;
+                                     int firstEpoch = i * historyChunkSize.get() > fromEpoch ? i * historyChunkSize.get() : fromEpoch;
+
                                      boolean ignoreCached = i >= latestChunkNumber;
-                                     return getEpochsFromHistoryChunk(i, fromEpoch, toEpoch, firstEpoch, ignoreCached);
+                                     return getEpochsFromHistoryChunk(i, firstEpoch, toEpoch, ignoreCached);
                                  }).collect(Collectors.toList())))
                 .thenApply(c -> c.stream().flatMap(Collection::stream).collect(Collectors.toList()));
     }
 
-    private CompletableFuture<List<EpochRecord>> getEpochsFromHistoryChunk(int chunk, int fromEpoch, int toEpoch, int firstEpoch, boolean ignoreCached) {
+    private CompletableFuture<List<EpochRecord>> getEpochsFromHistoryChunk(int chunk, int firstEpoch, int toEpoch, boolean ignoreCached) {
         return getEpochRecord(firstEpoch)
                 .thenCompose(first -> getHistoryTimeSeriesChunk(chunk, ignoreCached)
                         .thenCompose(x -> {
                             List<CompletableFuture<EpochRecord>> identity = new ArrayList<>();
                             identity.add(CompletableFuture.completedFuture(first));
                             return Futures.allOfWithResults(x.getHistoryRecords().stream()
-                                                             .filter(r -> r.getEpoch() > fromEpoch && r.getEpoch() <= toEpoch)
+                                                             .filter(r -> r.getEpoch() > firstEpoch && r.getEpoch() <= toEpoch)
                                                              .reduce(identity, (r, s) -> {
                                                                  CompletableFuture<EpochRecord> next = newEpochRecord(r.get(r.size() - 1),
                                                                          s.getEpoch(), s.getReferenceEpoch(), s.getSegmentsCreated(),
@@ -1508,6 +1537,7 @@ public abstract class PersistentStreamBase implements Stream {
                                                           final Collection<Long> sealedSegments, final long time) {
         if (epoch == referenceEpoch) {
             return lastRecordFuture.thenApply(lastRecord -> {
+                assert lastRecord.getEpoch() == epoch - 1;
                 List<StreamSegmentRecord> segments = new LinkedList<>(lastRecord.getSegments());
                 segments.removeIf(x -> sealedSegments.contains(x.segmentId()));
                 segments.addAll(createdSegments);
@@ -1528,10 +1558,11 @@ public abstract class PersistentStreamBase implements Stream {
                                   .keyStart(low).keyEnd(high).build();
     }
 
-    private CompletableFuture<Integer> findEpochAtTime(long timestamp) {
-        return getActiveEpoch(false)
-                .thenCompose(activeEpoch -> searchEpochAtTime(0, activeEpoch.getEpoch() / HISTORY_CHUNK_SIZE,
-                        x -> x == activeEpoch.getEpoch() / HISTORY_CHUNK_SIZE, timestamp)
+    @VisibleForTesting
+    CompletableFuture<Integer> findEpochAtTime(long timestamp, boolean ignoreCached) {
+        return getActiveEpoch(ignoreCached)
+                .thenCompose(activeEpoch -> searchEpochAtTime(0, activeEpoch.getEpoch() / historyChunkSize.get(),
+                        x -> x == activeEpoch.getEpoch() / historyChunkSize.get(), timestamp)
                         .thenApply(epoch -> {
                             if (epoch == -1) {
                                 if (timestamp > activeEpoch.getCreationTime()) {
@@ -1554,14 +1585,14 @@ public abstract class PersistentStreamBase implements Stream {
             return CompletableFuture.completedFuture(-1);
         }
 
-        return getHistoryTimeSeriesChunk(middle, ignoreCached.apply(middle))
+        return getHistoryTimeSeriesChunk(middle, ignoreCached.test(middle))
                 .thenCompose(chunk -> {
                     List<HistoryTimeSeriesRecord> historyRecords = chunk.getHistoryRecords();
                     long rangeLow = historyRecords.get(0).getScaleTime();
                     long rangeHigh = historyRecords.get(historyRecords.size() - 1).getScaleTime();
                     if (timestamp >= rangeLow && timestamp <= rangeHigh) {
                         // found
-                        int index = CollectionHelpers.findGreatestLowerBound(historyRecords, x -> Long.compare(x.getScaleTime(), timestamp));
+                        int index = CollectionHelpers.findGreatestLowerBound(historyRecords, x -> Long.compare(timestamp, x.getScaleTime()));
                         assert index >= 0;
                         return CompletableFuture.completedFuture(historyRecords.get(index).getEpoch());
                     } else if (timestamp < rangeLow) {
@@ -1574,7 +1605,14 @@ public abstract class PersistentStreamBase implements Stream {
 
     private CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(int chunkNumber, boolean ignoreCached) {
         return getHistoryTimeSeriesChunkData(chunkNumber, ignoreCached)
-                .thenApply(x -> HistoryTimeSeries.fromBytes(x.getData()));
+                .thenCompose(x -> {
+                    HistoryTimeSeries timeSeries = HistoryTimeSeries.fromBytes(x.getData());
+                    // we should only retrieve the chunk from cache once the chunk is full to capacity and hence immutable. 
+                    if (!ignoreCached && timeSeries.getHistoryRecords().size() < historyChunkSize.get()) {
+                        return getHistoryTimeSeriesChunk(chunkNumber, true);
+                    }
+                    return CompletableFuture.completedFuture(timeSeries);
+                });
     }
 
     // region abstract methods

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -62,6 +62,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.pravega.controller.store.stream.records.SealedSegmentsMapShard.SHARD_SIZE;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static java.util.stream.Collectors.toMap;
@@ -74,18 +75,17 @@ public abstract class PersistentStreamBase implements Stream {
     private final AtomicInteger shardSize;
 
     PersistentStreamBase(final String scope, final String name) {
+        this(scope, name, HistoryTimeSeries.HISTORY_CHUNK_SIZE, SHARD_SIZE);
+    }
+    
+    @VisibleForTesting
+    PersistentStreamBase(final String scope, final String name, int historyChunkSize, int shardSize) {
         this.scope = scope;
         this.name = name;
-        historyChunkSize = new AtomicInteger(HistoryTimeSeries.HISTORY_CHUNK_SIZE);
-        shardSize = new AtomicInteger(SealedSegmentsMapShard.SHARD_SIZE);
+        this.historyChunkSize = new AtomicInteger(historyChunkSize);
+        this.shardSize = new AtomicInteger(shardSize);
     }
-
-    @VisibleForTesting
-    void setHistoryChunkAndSealedSizeMapShardSizes(int historyChunkSize, int shardSize) {
-        this.historyChunkSize.set(historyChunkSize);
-        this.shardSize.set(shardSize);
-    }
-
+    
     @Override
     public String getScope() {
         return this.scope;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -14,6 +14,8 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.BitConverter;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -92,8 +94,20 @@ class ZKStream extends PersistentStreamBase {
         this(scopeName, streamName, storeHelper, () -> 0);
     }
 
+    @VisibleForTesting
+    ZKStream(final String scopeName, final String streamName, ZKStoreHelper storeHelper, int chunkSize, int shardSize) {
+        this(scopeName, streamName, storeHelper, () -> 0, chunkSize, shardSize);
+    }
+
+    @VisibleForTesting
     ZKStream(final String scopeName, final String streamName, ZKStoreHelper storeHelper, Supplier<Integer> currentBatchSupplier) {
-        super(scopeName, streamName);
+        this(scopeName, streamName, storeHelper, currentBatchSupplier, HistoryTimeSeries.HISTORY_CHUNK_SIZE, SealedSegmentsMapShard.SHARD_SIZE);
+    }
+    
+    @VisibleForTesting
+    ZKStream(final String scopeName, final String streamName, ZKStoreHelper storeHelper, Supplier<Integer> currentBatchSupplier,
+             int chunkSize, int shardSize) {
+        super(scopeName, streamName, chunkSize, shardSize);
         store = storeHelper;
         scopePath = String.format(SCOPE_PATH, scopeName);
         streamPath = String.format(STREAM_PATH, scopeName, streamName);

--- a/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamTest.java
@@ -26,7 +26,7 @@ public class InMemoryStreamTest extends StreamTestBase {
     }
 
     @Override
-    PersistentStreamBase getStream(String scope, String stream) {
-        return new InMemoryStream(scope, stream);
+    PersistentStreamBase getStream(String scope, String stream, int chunkSize, int shardSize) {
+        return new InMemoryStream(scope, stream, chunkSize, shardSize);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -53,11 +53,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class StreamTestBase {
-    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
-
     @Rule
     public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
-
+    
+    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
+    
     @Before
     public abstract void setup() throws Exception;
 
@@ -877,19 +877,20 @@ public abstract class StreamTestBase {
     }
 
     /**
-     *         epoch0 = 0, 1, 2, 3, 4
-     *         epoch1 = 5, 1, 2, 3, 4
-     *         epoch2 = 5, 6, 2, 3, 4
-     *         epoch3 = 5, 6, 7, 3, 4
-     *         epoch4 = 5, 6, 7, 8, 4
-     *         epoch5 = 5, 6, 7, 8, 9
-     *         epoch6 = 0`, 1`, 2`, 3`, 4`
-     *         epoch7 = 5`, 6`, 7`, 8`, 9`
-     *         epoch8 = 10, 6`, 7`, 8`, 9`
-     *         epoch9 = 10, 11, 7`, 8`, 9`
-     *         epoch10 = 10, 11, 12, 8`, 9`
-     *         epoch11 = 10, 11, 12, 13, 9` 
-     *         epoch12 = 10, 11, 12, 13, 14
+     * Stream history.
+     * epoch0 = 0, 1, 2, 3, 4
+     * epoch1 = 5, 1, 2, 3, 4
+     * epoch2 = 5, 6, 2, 3, 4
+     * epoch3 = 5, 6, 7, 3, 4
+     * epoch4 = 5, 6, 7, 8, 4
+     * epoch5 = 5, 6, 7, 8, 9
+     * epoch6 = 0`, 1`, 2`, 3`, 4`
+     * epoch7 = 5`, 6`, 7`, 8`, 9`
+     * epoch8 = 10, 6`, 7`, 8`, 9`
+     * epoch9 = 10, 11, 7`, 8`, 9`
+     * epoch10 = 10, 11, 12, 8`, 9`
+     * epoch11 = 10, 11, 12, 13, 9` 
+     * epoch12 = 10, 11, 12, 13, 14
      */
     @Test
     public void testFetchEpochs() {
@@ -922,19 +923,20 @@ public abstract class StreamTestBase {
     }
 
     /**
-     *         epoch0 = 0, 1, 2, 3, 4
-     *         epoch1 = 5, 1, 2, 3, 4
-     *         epoch2 = 5, 6, 2, 3, 4
-     *         epoch3 = 5, 6, 7, 3, 4
-     *         epoch4 = 5, 6, 7, 8, 4
-     *         epoch5 = 5, 6, 7, 8, 9
-     *         epoch6 = 0`, 1`, 2`, 3`, 4`
-     *         epoch7 = 5`, 6`, 7`, 8`, 9`
-     *         epoch8 = 10, 6`, 7`, 8`, 9`
-     *         epoch9 = 10, 11, 7`, 8`, 9`
-     *         epoch10 = 10, 11, 12, 8`, 9`
-     *         epoch11 = 10, 11, 12, 13, 9` 
-     *         epoch12 = 10, 11, 12, 13, 14
+     * Stream history.
+     * epoch0 = 0, 1, 2, 3, 4
+     * epoch1 = 5, 1, 2, 3, 4
+     * epoch2 = 5, 6, 2, 3, 4
+     * epoch3 = 5, 6, 7, 3, 4
+     * epoch4 = 5, 6, 7, 8, 4
+     * epoch5 = 5, 6, 7, 8, 9
+     * epoch6 = 0`, 1`, 2`, 3`, 4`
+     * epoch7 = 5`, 6`, 7`, 8`, 9`
+     * epoch8 = 10, 6`, 7`, 8`, 9`
+     * epoch9 = 10, 11, 7`, 8`, 9`
+     * epoch10 = 10, 11, 12, 8`, 9`
+     * epoch11 = 10, 11, 12, 13, 9` 
+     * epoch12 = 10, 11, 12, 13, 14
      */
     @Test
     public void testFindEpochAtTime() {
@@ -978,19 +980,20 @@ public abstract class StreamTestBase {
     }
 
     /**
-     *         epoch0 = 0, 1, 2, 3, 4
-     *         epoch1 = 5, 1, 2, 3, 4
-     *         epoch2 = 5, 6, 2, 3, 4
-     *         epoch3 = 5, 6, 7, 3, 4
-     *         epoch4 = 5, 6, 7, 8, 4
-     *         epoch5 = 5, 6, 7, 8, 9
-     *         epoch6 = 0`, 1`, 2`, 3`, 4`
-     *         epoch7 = 5`, 6`, 7`, 8`, 9`
-     *         epoch8 = 10, 6`, 7`, 8`, 9`
-     *         epoch9 = 10, 11, 7`, 8`, 9`
-     *         epoch10 = 10, 11, 12, 8`, 9`
-     *         epoch11 = 10, 11, 12, 13, 9` 
-     *         epoch12 = 10, 11, 12, 13, 14
+     * Stream history.
+     * epoch0 = 0, 1, 2, 3, 4
+     * epoch1 = 5, 1, 2, 3, 4
+     * epoch2 = 5, 6, 2, 3, 4
+     * epoch3 = 5, 6, 7, 3, 4
+     * epoch4 = 5, 6, 7, 8, 4
+     * epoch5 = 5, 6, 7, 8, 9
+     * epoch6 = 0`, 1`, 2`, 3`, 4`
+     * epoch7 = 5`, 6`, 7`, 8`, 9`
+     * epoch8 = 10, 6`, 7`, 8`, 9`
+     * epoch9 = 10, 11, 7`, 8`, 9`
+     * epoch10 = 10, 11, 12, 8`, 9`
+     * epoch11 = 10, 11, 12, 13, 9` 
+     * epoch12 = 10, 11, 12, 13, 14
      */
     @Test
     public void testSealedSegmentSizesMapShards() {
@@ -1060,7 +1063,23 @@ public abstract class StreamTestBase {
         assertEquals(1, shard6.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 12).collect(Collectors.toList()).size());
 
     }
-    
+
+    /**
+     * Stream history.
+     * epoch0 = 0, 1, 2, 3, 4
+     * epoch1 = 5, 1, 2, 3, 4
+     * epoch2 = 5, 6, 2, 3, 4
+     * epoch3 = 5, 6, 7, 3, 4
+     * epoch4 = 5, 6, 7, 8, 4
+     * epoch5 = 5, 6, 7, 8, 9
+     * epoch6 = 0`, 1`, 2`, 3`, 4`
+     * epoch7 = 5`, 6`, 7`, 8`, 9`
+     * epoch8 = 10, 6`, 7`, 8`, 9`
+     * epoch9 = 10, 11, 7`, 8`, 9`
+     * epoch10 = 10, 11, 12, 8`, 9`
+     * epoch11 = 10, 11, 12, 13, 9` 
+     * epoch12 = 10, 11, 12, 13, 14
+     */
     @Test
     public void testStreamCutsWithMultipleChunks() {
         String scope = "streamCutTest";
@@ -1145,7 +1164,6 @@ public abstract class StreamTestBase {
         assertEquals(12, span2.entrySet().stream()
                             .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 14)
                             .findAny().get().getValue().intValue());
-
 
         Set<StreamSegmentRecord> segmentsBetween = stream.segmentsBetweenStreamCutSpans(span1, span2).join();
         Set<Long> segmentIdsBetween = segmentsBetween.stream().map(x -> x.segmentId()).collect(Collectors.toSet());

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class StreamTestBase {
-    
     protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
 
     @Before

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -114,7 +114,6 @@ public abstract class StreamTestBase {
               .thenCompose(x -> stream.updateState(State.ACTIVE)).join();
     }
 
-
     @Test(timeout = 30000L)
     public void testCreateStream() {
         PersistentStreamBase stream = createStream("scope", "stream", System.currentTimeMillis(), 2, 0);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -23,9 +23,7 @@ import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.common.AssertExtensions;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -41,7 +39,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -53,8 +50,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class StreamTestBase {
-    @Rule
-    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
     
     protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
     
@@ -114,7 +109,7 @@ public abstract class StreamTestBase {
     }
 
 
-    @Test
+    @Test(timeout = 30000L)
     public void testCreateStream() {
         PersistentStreamBase stream = createStream("scope", "stream", System.currentTimeMillis(), 2, 0);
 
@@ -136,7 +131,7 @@ public abstract class StreamTestBase {
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void testSegmentQueriesDuringScale() {
         // start scale and perform `getSegment`, `getActiveEpoch` and `getEpoch` during different phases of scale
         int startingSegmentNumber = new Random().nextInt(20);
@@ -210,7 +205,7 @@ public abstract class StreamTestBase {
         assertEquals(segment.getKeyEnd(), 1.0, 0);
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void predecessorAndSuccessorTest() {
         // multiple rows in history table, find predecessor
         // - more than one predecessor
@@ -415,7 +410,7 @@ public abstract class StreamTestBase {
         assertTrue(successorsWithPredecessors.isEmpty());
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void scaleInputValidityTest() {
         int startingSegmentNumber = new Random().nextInt(2000);
         String name = "stream" + startingSegmentNumber;
@@ -596,7 +591,7 @@ public abstract class StreamTestBase {
         return stream.getEpochTransition().join();
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void segmentQueriesDuringRollingTxn() {
         // start scale and perform `getSegment`, `getActiveEpoch` and `getEpoch` during different phases of scale
         int startingSegmentNumber = new Random().nextInt(2000);
@@ -659,7 +654,7 @@ public abstract class StreamTestBase {
         stream.completeCommittingTransactions(ctr).join();
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void truncationTest() {
         int startingSegmentNumber = new Random().nextInt(2000);
         // epoch 0 --> 0, 1
@@ -892,7 +887,7 @@ public abstract class StreamTestBase {
      * epoch11 = 10, 11, 12, 13, 9` 
      * epoch12 = 10, 11, 12, 13, 14
      */
-    @Test
+    @Test(timeout = 30000L)
     public void testFetchEpochs() {
         String scope = "fetchEpoch";
         String name = "fetchEpoch";
@@ -938,7 +933,7 @@ public abstract class StreamTestBase {
      * epoch11 = 10, 11, 12, 13, 9` 
      * epoch12 = 10, 11, 12, 13, 14
      */
-    @Test
+    @Test(timeout = 30000L)
     public void testFindEpochAtTime() {
         String scope = "findEpochsAtTime";
         String name = "findEpochsAtTime";
@@ -995,7 +990,7 @@ public abstract class StreamTestBase {
      * epoch11 = 10, 11, 12, 13, 9` 
      * epoch12 = 10, 11, 12, 13, 14
      */
-    @Test
+    @Test(timeout = 30000L)
     public void testSealedSegmentSizesMapShards() {
         String scope = "sealedSizeTest";
         String name = "sealedSizeTest";
@@ -1080,7 +1075,7 @@ public abstract class StreamTestBase {
      * epoch11 = 10, 11, 12, 13, 9` 
      * epoch12 = 10, 11, 12, 13, 14
      */
-    @Test
+    @Test(timeout = 30000L)
     public void testStreamCutsWithMultipleChunks() {
         String scope = "streamCutTest";
         String name = "streamCutTest";
@@ -1212,7 +1207,7 @@ public abstract class StreamTestBase {
      |       |   3  |       |       |
      +-------+------+----------------
      */
-    @Test
+    @Test(timeout = 30000L)
     public void testStreamCutSegmentsBetween() {
         int startingSegmentNumber = new Random().nextInt(2000);
         List<AbstractMap.SimpleEntry<Double, Double>> newRanges;

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -16,12 +16,16 @@ import io.pravega.common.Exceptions;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.common.AssertExtensions;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -37,15 +41,22 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
+import static io.pravega.shared.segment.StreamSegmentNameUtils.getEpoch;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class StreamTestBase {
     protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Before
     public abstract void setup() throws Exception;
@@ -88,6 +99,20 @@ public abstract class StreamTestBase {
                      .thenCompose(y -> stream.sealTransaction(y.getId(), true, Optional.empty())
                                              .thenApply(z -> y.getId())).join();
     }
+
+    private void rollTransactions(Stream stream, long time, int epoch, int activeEpoch, Map<Long, Long> txnSizeMap, Map<Long, Long> activeSizeMap) {
+        stream.startCommittingTransactions(epoch)
+                                        .thenCompose(ctr ->
+                                                stream.getVersionedState()
+                                                      .thenCompose(state -> stream.updateVersionedState(state, State.COMMITTING_TXN))
+                                                .thenCompose(state -> stream.startRollingTxn(activeEpoch, ctr)
+                                                        .thenCompose(ctr2 -> stream.rollingTxnCreateDuplicateEpochs(txnSizeMap, time, ctr2)
+                                                        .thenCompose(v -> stream.completeRollingTxn(activeSizeMap, ctr2))
+                                                                .thenCompose(v -> stream.completeCommittingTransactions(ctr2))
+                                        )))
+              .thenCompose(x -> stream.updateState(State.ACTIVE)).join();
+    }
+
 
     @Test
     public void testCreateStream() {
@@ -811,6 +836,347 @@ public abstract class StreamTestBase {
         return span.entrySet().stream().collect(Collectors.toMap(x -> x.getKey().segmentId(), x -> x.getValue()));
     }
 
+    // region multiple chunks test
+    private PersistentStreamBase createScaleAndRollStreamForMultiChunkTests(String name, String scope, int startingSegmentNumber, Supplier<Long> time) {
+        createScope(scope);
+        PersistentStreamBase stream = createStream(scope, name, time.get(), 5, startingSegmentNumber);
+        stream.setHistoryChunkAndSealedSizeMapShardSizes(2, 2);
+        UUID txnId = createAndCommitTransaction(stream, 0, 0L);
+        // scale the stream 5 times so that over all we have 6 epochs and hence 3 chunks.  
+        for (int i = 0; i < 5; i++) {
+            Segment first = stream.getActiveSegments().join().get(0);
+            ArrayList<Long> sealedSegments = Lists.newArrayList(first.segmentId());
+            List<Map.Entry<Double, Double>> newRanges = new LinkedList<>();
+            newRanges.add(new AbstractMap.SimpleEntry<>(first.getKeyStart(), first.getKeyEnd()));
+            Map<Long, Long> sealedSizeMap = new HashMap<>();
+            sealedSizeMap.put(first.segmentId(), 100L);
+            scaleStream(stream, time.get(), sealedSegments, newRanges, sealedSizeMap);
+        }
+
+        EpochRecord activeEpoch = stream.getActiveEpoch(true).join();
+        // now roll transaction so that we have 2 more epochs added for overall 8 epochs and 4 chunks 
+        Map<Long, Long> map1 = stream.getEpochRecord(0).join().getSegmentIds().stream()
+                                     .collect(Collectors.toMap(x -> computeSegmentId(StreamSegmentNameUtils.getSegmentNumber(x),
+                                             activeEpoch.getEpoch() + 1), x -> 100L));
+        Map<Long, Long> map2 = activeEpoch.getSegmentIds().stream()
+                                     .collect(Collectors.toMap(x -> x, x -> 100L));
+
+        rollTransactions(stream, time.get(), 0, activeEpoch.getEpoch(), map1, map2);
+
+        // scale the stream 5 times so that over all we have 13 epochs and hence 7 chunks.  
+        for (int i = 0; i < 5; i++) {
+            Segment first = stream.getActiveSegments().join().get(0);
+            ArrayList<Long> sealedSegments = Lists.newArrayList(first.segmentId());
+            List<Map.Entry<Double, Double>> newRanges = new LinkedList<>();
+            newRanges.add(new AbstractMap.SimpleEntry<>(first.getKeyStart(), first.getKeyEnd()));
+            Map<Long, Long> sealedSizeMap = new HashMap<>();
+            sealedSizeMap.put(first.segmentId(), 100L);
+            scaleStream(stream, time.get(), sealedSegments, newRanges, sealedSizeMap);
+        }
+        return stream;
+    }
+
+    /**
+     *         epoch0 = 0, 1, 2, 3, 4
+     *         epoch1 = 5, 1, 2, 3, 4
+     *         epoch2 = 5, 6, 2, 3, 4
+     *         epoch3 = 5, 6, 7, 3, 4
+     *         epoch4 = 5, 6, 7, 8, 4
+     *         epoch5 = 5, 6, 7, 8, 9
+     *         epoch6 = 0`, 1`, 2`, 3`, 4`
+     *         epoch7 = 5`, 6`, 7`, 8`, 9`
+     *         epoch8 = 10, 6`, 7`, 8`, 9`
+     *         epoch9 = 10, 11, 7`, 8`, 9`
+     *         epoch10 = 10, 11, 12, 8`, 9`
+     *         epoch11 = 10, 11, 12, 13, 9` 
+     *         epoch12 = 10, 11, 12, 13, 14
+     */
+    @Test
+    public void testFetchEpochs() {
+        String scope = "fetchEpoch";
+        String name = "fetchEpoch";
+        PersistentStreamBase stream = createScaleAndRollStreamForMultiChunkTests(name, scope, new Random().nextInt(2000), System::currentTimeMillis);
+
+        List<EpochRecord> epochs = stream.fetchEpochs(0, 12, true).join();
+        assertEquals(13, epochs.size());
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 0));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 1));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 2));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 3));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 4));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 5));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 6));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 7));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 8));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 9));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 10));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 11));
+        assertTrue(epochs.stream().anyMatch(x -> x.getEpoch() == 12));
+        
+        epochs = stream.fetchEpochs(12, 13, true).join();
+        assertEquals(1, epochs.size());
+        assertEquals(stream.getEpochRecord(12).join(), epochs.get(0));
+
+        // now try to fetch an epoch that will fall in a chunk that does not exist
+        AssertExtensions.assertThrows("", stream.fetchEpochs(12, 14, true), e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
+    }
+
+    /**
+     *         epoch0 = 0, 1, 2, 3, 4
+     *         epoch1 = 5, 1, 2, 3, 4
+     *         epoch2 = 5, 6, 2, 3, 4
+     *         epoch3 = 5, 6, 7, 3, 4
+     *         epoch4 = 5, 6, 7, 8, 4
+     *         epoch5 = 5, 6, 7, 8, 9
+     *         epoch6 = 0`, 1`, 2`, 3`, 4`
+     *         epoch7 = 5`, 6`, 7`, 8`, 9`
+     *         epoch8 = 10, 6`, 7`, 8`, 9`
+     *         epoch9 = 10, 11, 7`, 8`, 9`
+     *         epoch10 = 10, 11, 12, 8`, 9`
+     *         epoch11 = 10, 11, 12, 13, 9` 
+     *         epoch12 = 10, 11, 12, 13, 14
+     */
+    @Test
+    public void testFindEpochAtTime() {
+        String scope = "findEpochsAtTime";
+        String name = "findEpochsAtTime";
+        AtomicLong timeFunc = new AtomicLong(100L);
+        PersistentStreamBase stream = createScaleAndRollStreamForMultiChunkTests(name, scope, new Random().nextInt(2000), timeFunc::incrementAndGet);
+        List<EpochRecord> epochs = stream.fetchEpochs(0, 12, true).join();
+        int epoch = stream.findEpochAtTime(0L, true).join();
+        assertEquals(0, epoch);
+        epoch = stream.findEpochAtTime(101L, true).join();
+        assertEquals(0, epoch);
+        epoch = stream.findEpochAtTime(102L, true).join();
+        assertEquals(1, epoch);
+        epoch = stream.findEpochAtTime(103L, true).join();
+        assertEquals(2, epoch);
+        epoch = stream.findEpochAtTime(104L, true).join();
+        assertEquals(3, epoch);
+        epoch = stream.findEpochAtTime(105L, true).join();
+        assertEquals(4, epoch);
+        epoch = stream.findEpochAtTime(106L, true).join();
+        assertEquals(5, epoch);
+        epoch = stream.findEpochAtTime(107L, true).join();
+        assertEquals(6, epoch);
+        epoch = stream.findEpochAtTime(108L, true).join();
+        assertEquals(7, epoch);
+        epoch = stream.findEpochAtTime(109L, true).join();
+        assertEquals(8, epoch);
+        epoch = stream.findEpochAtTime(110L, true).join();
+        assertEquals(9, epoch);
+        epoch = stream.findEpochAtTime(111L, true).join();
+        assertEquals(10, epoch);
+        epoch = stream.findEpochAtTime(112L, true).join();
+        assertEquals(11, epoch);
+        epoch = stream.findEpochAtTime(113L, true).join();
+        assertEquals(12, epoch);
+        epoch = stream.findEpochAtTime(114L, true).join();
+        assertEquals(12, epoch);
+        epoch = stream.findEpochAtTime(1000L, true).join();
+        assertEquals(12, epoch);
+    }
+
+    /**
+     *         epoch0 = 0, 1, 2, 3, 4
+     *         epoch1 = 5, 1, 2, 3, 4
+     *         epoch2 = 5, 6, 2, 3, 4
+     *         epoch3 = 5, 6, 7, 3, 4
+     *         epoch4 = 5, 6, 7, 8, 4
+     *         epoch5 = 5, 6, 7, 8, 9
+     *         epoch6 = 0`, 1`, 2`, 3`, 4`
+     *         epoch7 = 5`, 6`, 7`, 8`, 9`
+     *         epoch8 = 10, 6`, 7`, 8`, 9`
+     *         epoch9 = 10, 11, 7`, 8`, 9`
+     *         epoch10 = 10, 11, 12, 8`, 9`
+     *         epoch11 = 10, 11, 12, 13, 9` 
+     *         epoch12 = 10, 11, 12, 13, 14
+     */
+    @Test
+    public void testSealedSegmentSizesMapShards() {
+        String scope = "sealedSizeTest";
+        String name = "sealedSizeTest";
+        int startingSegmentNumber = new Random().nextInt(2000);
+        PersistentStreamBase stream = createScaleAndRollStreamForMultiChunkTests(name, scope, startingSegmentNumber, System::currentTimeMillis);
+        SealedSegmentsMapShard shard0 = stream.getSealedSegmentSizeMapShard(0).join();
+        // 5 segments created in epoch 0 and 1 segment in epoch 1
+        assertTrue(shard0.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 0 || getEpoch(x) == 1));
+        assertEquals(5, shard0.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 0).collect(Collectors.toList()).size());
+        assertEquals(1, shard0.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 1).collect(Collectors.toList()).size());
+
+        // 1 segment created in epoch 2 and 1 segment in epoch 3
+        SealedSegmentsMapShard shard1 = stream.getSealedSegmentSizeMapShard(1).join();
+        assertTrue(shard1.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 2 || getEpoch(x) == 3));
+        assertEquals(1, shard1.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 2).collect(Collectors.toList()).size());
+        assertEquals(1, shard1.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 3).collect(Collectors.toList()).size());
+
+        // 1 segment created in epoch 3 and 1 segment in epoch 4
+        SealedSegmentsMapShard shard2 = stream.getSealedSegmentSizeMapShard(2).join();
+        assertTrue(shard2.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 4 || getEpoch(x) == 5));
+        assertEquals(1, shard2.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 4).collect(Collectors.toList()).size());
+        assertEquals(1, shard2.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 5).collect(Collectors.toList()).size());
+
+        // rolling transaction, 10 segments created across two epochs mapped to the shard
+        SealedSegmentsMapShard shard3 = stream.getSealedSegmentSizeMapShard(3).join();
+        assertTrue(shard3.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 6 || getEpoch(x) == 7));
+        assertEquals(5, shard3.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 6).collect(Collectors.toList()).size());
+        assertEquals(5, shard3.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 7).collect(Collectors.toList()).size());
+
+        // 1 segment created in epoch 8 and 1 segment in epoch 9 but they are not sealed yet
+        SealedSegmentsMapShard shard4 = stream.getSealedSegmentSizeMapShard(4).join();
+        assertTrue(shard4.getSealedSegmentsSizeMap().isEmpty());
+
+        // 1 segment created in epoch 10 and 1 segment in epoch 11 but they are not sealed yet
+        SealedSegmentsMapShard shard5 = stream.getSealedSegmentSizeMapShard(5).join();
+        assertTrue(shard5.getSealedSegmentsSizeMap().isEmpty());
+
+        // 1 segment created in epoch 12 but nothing is sealed yet
+        SealedSegmentsMapShard shard6 = stream.getSealedSegmentSizeMapShard(6).join();
+        assertTrue(shard6.getSealedSegmentsSizeMap().isEmpty());
+
+        // now seal all of them again
+        EpochRecord activeEpoch = stream.getActiveEpoch(true).join();
+        List<Map.Entry<Double, Double>> newRanges = new LinkedList<>();
+        newRanges.add(new AbstractMap.SimpleEntry<>(0.0, 1.0));
+        Map<Long, Long> sealedSizeMap = new HashMap<>();
+        activeEpoch.getSegments().forEach(x -> sealedSizeMap.put(x.segmentId(), 100L));
+        scaleStream(stream, System.currentTimeMillis(), Lists.newArrayList(activeEpoch.getSegmentIds()), newRanges, sealedSizeMap);
+
+        // 1 segment created in epoch 8 and 1 segment in epoch 9 
+        shard4 = stream.getSealedSegmentSizeMapShard(4).join();
+        assertTrue(shard4.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 8 || getEpoch(x) == 9));
+        assertEquals(1, shard4.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 8).collect(Collectors.toList()).size());
+        assertEquals(1, shard4.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 9).collect(Collectors.toList()).size());
+
+        // 1 segment created in epoch 10 and 1 segment in epoch 11 
+        shard5 = stream.getSealedSegmentSizeMapShard(5).join();
+        assertTrue(shard5.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 10 || getEpoch(x) == 11));
+        assertEquals(1, shard5.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 10).collect(Collectors.toList()).size());
+        assertEquals(1, shard5.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 11).collect(Collectors.toList()).size());
+
+        // 1 segment created in epoch 12 
+        shard6 = stream.getSealedSegmentSizeMapShard(6).join();
+        assertTrue(shard6.getSealedSegmentsSizeMap().keySet().stream().allMatch(x -> getEpoch(x) == 12));
+        assertEquals(1, shard6.getSealedSegmentsSizeMap().keySet().stream().filter(x -> getEpoch(x) == 12).collect(Collectors.toList()).size());
+
+    }
+    
+    @Test
+    public void testStreamCutsWithMultipleChunks() {
+        String scope = "streamCutTest";
+        String name = "streamCutTest";
+        int startingSegmentNumber = new Random().nextInt(2000);
+        PersistentStreamBase stream = createScaleAndRollStreamForMultiChunkTests(name, scope, startingSegmentNumber, System::currentTimeMillis);
+
+        EpochRecord epoch0 = stream.getEpochRecord(0).join(); // 0, 1, 2, 3, 4
+        EpochRecord epoch1 = stream.getEpochRecord(1).join(); // 5, 1, 2, 3, 4
+        EpochRecord epoch2 = stream.getEpochRecord(2).join(); // 5, 6, 2, 3, 4
+        EpochRecord epoch3 = stream.getEpochRecord(3).join(); // 5, 6, 7, 3, 4
+        EpochRecord epoch4 = stream.getEpochRecord(4).join(); // 5, 6, 7, 8, 4
+        EpochRecord epoch5 = stream.getEpochRecord(5).join(); // 5, 6, 7, 8, 9
+        EpochRecord epoch6 = stream.getEpochRecord(6).join(); // 0`, 1`, 2`, 3`, 4`
+        EpochRecord epoch7 = stream.getEpochRecord(7).join(); // 5`, 6`, 7`, 8`, 9`
+        EpochRecord epoch8 = stream.getEpochRecord(8).join(); // 10, 6`, 7`, 8`, 9`
+        EpochRecord epoch9 = stream.getEpochRecord(9).join(); // 10, 11, 7`, 8`, 9`
+        EpochRecord epoch10 = stream.getEpochRecord(10).join(); // 10, 11, 12, 8`, 9`
+        EpochRecord epoch11 = stream.getEpochRecord(11).join(); // 10, 11, 12, 13, 9` 
+        EpochRecord epoch12 = stream.getEpochRecord(12).join(); // 10, 11, 12, 13, 14
+                
+        List<Map.Entry<Double, Double>> keyRanges = epoch0.getSegments().stream()
+                                                          .map(x -> new AbstractMap.SimpleEntry<>(x.getKeyStart(), x.getKeyEnd()))
+                                                          .collect(Collectors.toList());
+        
+        // create a streamCut1 using 0, 6, 7, 8, 9`
+        HashMap<Long, Long> streamCut1 = new HashMap<>();
+        // segment 0 from epoch 0 // sealed in epoch 1
+        streamCut1.put(epoch0.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(0).getKey(), keyRanges.get(0).getValue())).findAny().get().segmentId(), 10L);
+        // segment 6 from epoch 2 // sealed in epoch 6
+        streamCut1.put(epoch2.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(1).getKey(), keyRanges.get(1).getValue())).findAny().get().segmentId(), 10L);
+        // segment 7 from epoch 3 // sealed in epoch 6
+        streamCut1.put(epoch3.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(2).getKey(), keyRanges.get(2).getValue())).findAny().get().segmentId(), 10L);
+        // segment 8 from epoch 5 // sealed in epoch 6
+        streamCut1.put(epoch5.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(3).getKey(), keyRanges.get(3).getValue())).findAny().get().segmentId(), 10L);
+        // segment 9` from epoch 7 // created in epoch 7
+        streamCut1.put(epoch7.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(4).getKey(), keyRanges.get(4).getValue())).findAny().get().segmentId(), 10L);
+        Map<StreamSegmentRecord, Integer> span1 = stream.computeStreamCutSpan(streamCut1).join();
+        
+        assertEquals(0, span1.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 0)
+                            .findAny().get().getValue().intValue());
+        assertEquals(5, span1.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 6)
+                            .findAny().get().getValue().intValue());
+        assertEquals(5, span1.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 7)
+                            .findAny().get().getValue().intValue());
+        assertEquals(5, span1.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 8)
+                            .findAny().get().getValue().intValue());
+        assertEquals(7, span1.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 9)
+                            .findAny().get().getValue().intValue());
+
+        // create a streamCut2 5, 6`, 12, 8`, 14
+        HashMap<Long, Long> streamCut2 = new HashMap<>();
+        // segment 5 from epoch 1 // sealed in epoch 6 
+        streamCut2.put(epoch1.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(0).getKey(), keyRanges.get(0).getValue())).findAny().get().segmentId(), 10L);
+        // segment 6` from epoch 7 // sealed in epoch 9
+        streamCut2.put(epoch7.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(1).getKey(), keyRanges.get(1).getValue())).findAny().get().segmentId(), 10L);
+        // segment 12 from epoch 10 // never sealed
+        streamCut2.put(epoch10.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(2).getKey(), keyRanges.get(2).getValue())).findAny().get().segmentId(), 10L);
+        // segment 8` from epoch 7 // sealed in epoch 11
+        streamCut2.put(epoch7.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(3).getKey(), keyRanges.get(3).getValue())).findAny().get().segmentId(), 10L);
+        // segment 14 from epoch 12 // never sealed
+        streamCut2.put(epoch12.getSegments().stream().filter(x -> x.overlaps(keyRanges.get(4).getKey(), keyRanges.get(4).getValue())).findAny().get().segmentId(), 10L);
+        Map<StreamSegmentRecord, Integer> span2 = stream.computeStreamCutSpan(streamCut2).join();
+        
+        assertEquals(5, span2.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 5)
+                            .findAny().get().getValue().intValue());
+        assertEquals(8, span2.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 6)
+                            .findAny().get().getValue().intValue());
+        assertEquals(12, span2.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 12)
+                            .findAny().get().getValue().intValue());
+        assertEquals(10, span2.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 8)
+                            .findAny().get().getValue().intValue());
+        assertEquals(12, span2.entrySet().stream()
+                            .filter(x -> x.getKey().getSegmentNumber() == startingSegmentNumber + 14)
+                            .findAny().get().getValue().intValue());
+
+
+        Set<StreamSegmentRecord> segmentsBetween = stream.segmentsBetweenStreamCutSpans(span1, span2).join();
+        Set<Long> segmentIdsBetween = segmentsBetween.stream().map(x -> x.segmentId()).collect(Collectors.toSet());
+        // create a streamCut1 using 0, 6, 7, 8, 9`
+        // create a streamCut2 5, 6`, 12, 8`, 14
+
+        // 0, 5, 6, 1`, 6`, 7, 2`, 7`, 12, 8, 3`, 8`, 9`, 14
+        Set<Long> expected = new HashSet<>();
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 0, 0));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 5, 1));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 6, 2));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 1, 6));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 6, 7));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 7, 3));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 2, 6));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 7, 7));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 12, 10));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 8, 4));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 3, 6));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 8, 7));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 9, 7));
+        expected.add(StreamSegmentNameUtils.computeSegmentId(startingSegmentNumber + 14, 12));
+        assertEquals(expected, segmentIdsBetween);
+
+        // Note: all sealed segments have sizes 100L. So expected size = 1400 - 10x5 - 90 x 5 = 900
+
+        long sizeBetween = stream.sizeBetweenStreamCuts(streamCut1, streamCut2, segmentsBetween).join();
+        assertEquals(900L, sizeBetween);
+    }
+    // endregion
+    
     /*
      Segment mapping of stream8 used for the below tests.
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
@@ -48,9 +48,9 @@ public class ZooKeeperStreamTest extends StreamTestBase {
     void createScope(String scope) {
         store.createScope(scope).join();
     }
-
+    
     @Override
-    PersistentStreamBase getStream(String scope, String stream) {
-        return new ZKStream(scope, stream, storeHelper);
+    PersistentStreamBase getStream(String scope, String stream, int chunkSize, int shardSize) {
+        return new ZKStream(scope, stream, storeHelper, () -> 0, chunkSize, shardSize);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
@@ -48,7 +48,7 @@ public class ZooKeeperStreamTest extends StreamTestBase {
     void createScope(String scope) {
         store.createScope(scope).join();
     }
-    
+
     @Override
     PersistentStreamBase getStream(String scope, String stream, int chunkSize, int shardSize) {
         return new ZKStream(scope, stream, storeHelper, () -> 0, chunkSize, shardSize);


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Unit test of all stream metadata operations with large number of epochs spilling over multiple chunks and shards of history time series chunks and sealed segment sizes map shards. 

**Purpose of the change**  
Fixes #3058 

**What the code does**  
`PersistentStreamBase` is updated to expose new @VisibleForTesting` methods for setting unit testable chunk and shard map sizes. New unit tests are added to trigger scenarios where metadata spills over multiple chunks and shards.

Found three issues that have been fixed. 
 1. reduce method in `getEpochsFromHistoryChunk` tried including identity twice if `first` was ahead of `from`, resulting in duplicate exception. Fixed it. 
2. `truncationTest` `DataNotFoundException`: this happened because we were using segment number instead of epoch for finding the sealed shard. Fixed it. 
3. `sizeBetweenStreamCut` fetches `sealedSegmentMapShard` for all segments that are part of its computation. However, if no segment mapping to shard was sealed, then the shard is not created and can result in `DataNotFoundException`. We now handle `DataNotFound` and return `emptyMap` for it. 

Also, `fetchEpochs` now takes `ignoreCache` flag. 
UI call (scale metadata) sends `ignoreCache = false`, whereby taking the cached value.
All other flows that invoke this method will not use the cached metadata for computation, but retrieve the latest value from store so that the answer is always accurate at the time of computation. 
We also make sure when we always fetch history chunks from store until the chunk is full to its capacity. From then onward we can fetch it from cache.  

**How to verify it**  
Unit tests added. 