### PR TITLE
Issue 3076: Bugfix for outstanding checkpoint count.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -147,8 +147,14 @@ public class CheckpointState {
         return !uncheckpointedHosts.isEmpty();
     }
 
+    /**
+     * Get the number of outstanding Checkpoints. It should not take silent Checkpoints into account.
+     * @return the number of outstanding Checkpoints.
+     */
     int getOutstandingCheckpoints() {
-        return checkpoints.size();
+        return (int) checkpoints.stream()
+                                .filter(checkpoint -> !(isCheckpointSilent(checkpoint) || isCheckpointComplete(checkpoint)))
+                                .count();
     }
     
     void clearCheckpointsBefore(String checkpointId) {

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.Map;
 import org.junit.Test;
 
+import static io.pravega.client.stream.impl.ReaderGroupImpl.SILENT;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -85,6 +87,35 @@ public class CheckpointStateTest {
         assertEquals("3", state.getCheckpointForReader("a"));
         assertEquals("3", state.getCheckpointForReader("b"));
         assertFalse(state.getPositionsForLatestCompletedCheckpoint().isPresent());
+    }
+
+    @Test
+    public void testOutstandingCheckpoint() {
+        CheckpointState state = new CheckpointState();
+        state.beginNewCheckpoint("1", ImmutableSet.of("a"), Collections.emptyMap());
+        state.beginNewCheckpoint("2", ImmutableSet.of("a"), Collections.emptyMap());
+        state.beginNewCheckpoint("3"+ SILENT, ImmutableSet.of("a"), Collections.emptyMap());
+        state.beginNewCheckpoint("4", ImmutableSet.of("a"), Collections.emptyMap());
+        // Silent checkpoint should not be counted as part of CheckpointState#getOutstandingCheckpoints.
+        assertEquals(3, state.getOutstandingCheckpoints());
+
+        //Complete checkpoint "2"
+        state.readerCheckpointed("2", "a", ImmutableMap.of(getSegment("S1"), 1L));
+        assertTrue(state.isCheckpointComplete("2"));
+        assertEquals( ImmutableMap.of(getSegment("S1"), 1L), state.getPositionsForCompletedCheckpoint("2"));
+        state.clearCheckpointsBefore("2");
+        // All check points before checkpoint id "2" are completed.
+        assertTrue(state.isCheckpointComplete("1"));
+        // Only checkpoint "4" is outstanding as checkpoints "1" and "2" are complete and silent checkpoints are ignored.
+        assertEquals(1, state.getOutstandingCheckpoints());
+
+        state.readerCheckpointed("3"+SILENT, "a", Collections.emptyMap());
+        assertTrue(state.isCheckpointComplete("4"+SILENT));
+        assertEquals(1, state.getOutstandingCheckpoints()); // Checkpoint 4 is outstanding.
+
+        state.readerCheckpointed("4", "a", Collections.emptyMap());
+        assertTrue(state.isCheckpointComplete("4"));
+        assertEquals(0, state.getOutstandingCheckpoints());
     }
 
     private Segment getSegment(String name) {

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import org.junit.Test;
 
 import static io.pravega.client.stream.impl.ReaderGroupImpl.SILENT;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
**Change log description**  
 Silent checkpoints should not be considered while computing the number of outstanding checkpoints.

**Purpose of the change**  
Addresses #3076 

**What the code does**  
Ensures that the outstanding checkpoint count does not include completed and silent checkpoints.

**How to verify it**  
All the existing and newly added tests should pass.
