### PR TITLE
Issue 3082: HDFS misconfiguration in Docker Swarm deployment

### DIFF
--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -41,6 +41,8 @@ services:
     environment:
       WAIT_FOR: bookkeeper:3181,${HDFS_URL:-hdfs:8020}
       HDFS_URL: hdfs://${HDFS_URL:-hdfs:8020}
+      TIER2_STORAGE: HDFS
+      HDFS_REPLICATION: 1
       ZK_URL: ${ZK_URL:-zookeeper:2181}
       CONTROLLER_URL: tcp://controller:9090
       JAVA_OPTS: |


### PR DESCRIPTION
**Change log description**  
Fixed HDFS configuration parameters in `pravega.yml`.

**Purpose of the change**  
Fixes #3082 (original problems reported in #3051 and #2998). 

**What the code does**  
This PR contains two configuration fixes in `pravega.yml`:
1. It adds one missing configuration parameter to specify Tier 2 implementation (`TIER2_STORAGE`). Without this parameter, the Segment Store may fall back to `INMEMORY_STORAGE` and throw an out of memory exception.
2. Given that the current HDFS Docker image (`hdfs.yml`) is a single Docker with one namenode and one datanote, then we should set the replication factor of Tier 2 to 1 to avoid errors in the Segment Store (`HDFS_REPLICATION: 1`).

**How to verify it**  
I run a Pravega Swarm by building new Docker images with the code in this PR (`./gradlew docker`):
```
# docker ps
CONTAINER ID        IMAGE                                                                               COMMAND                  CREATED             STATUS              PORTS                                                          NAMES 07f58f2e5543        pravega/pravega:0.5.0-2007.d604df2-SNAPSHOT                                         "/opt/pravega/scri..."   4 seconds ago       Up 3 seconds        9090-9091/tcp, 10000/tcp, 12345/tcp                            pravega_segmentstore.1.9y6ehyi3v7h13obv0q5aanteh
a0e4562d69a4        pravega/pravega:0.5.0-2007.d604df2-SNAPSHOT                                         "/opt/pravega/scri..."   5 seconds ago       Up 4 seconds        9090-9091/tcp, 10000/tcp, 12345/tcp                            pravega_controller.1.y8opqkripzvm79y36b4kjubl9
09ae40e303bb        pravega/bookkeeper:0.5.0-2007.d604df2-SNAPSHOT                                      "/bin/sh -c /opt/b..."   5 seconds ago       Up 4 seconds        3181/tcp                                                       pravega_bookkeeper.1.qx4taenv7o00m2hv5k4ob0j4i
11916fbdf824        pravega/bookkeeper:0.5.0-2007.d604df2-SNAPSHOT                                      "/bin/sh -c /opt/b..."   5 seconds ago       Up 4 seconds        3181/tcp                                                       pravega_bookkeeper.2.a4hde6p3dwj83ycdk6vrh2qkr
ba4b7504eac8        pravega/bookkeeper:0.5.0-2007.d604df2-SNAPSHOT                                      "/bin/sh -c /opt/b..."   5 seconds ago       Up 4 seconds        3181/tcp                                                       pravega_bookkeeper.3.xdnem52pv55jsvk63ccyk9k3e
53bc155a39dd        zookeeper@sha256:1cb0ea64320184ebe360692dd1a8dbd3db8394bde029558863563d625e99f46a   "/docker-entrypoin..."   6 seconds ago       Up 6 seconds        2181/tcp, 2888/tcp, 3888/tcp                                   pravega_zookeeper.1.pzcao02pkmz0agdx3604js55d
8e06f0fdbfee        dsrw/hdfs@sha256:322a4b59c1bc96faff2ed530819da942ae2393e1048c6d75ead4444a16d5ca4f   "/opt/hadoop/start..."   7 seconds ago       Up 6 seconds        22/tcp, 8020/tcp, 50020/tcp, 50070/tcp, 50075/tcp, 50090/tcp   pravega_hdfs.1.m6hr6qxnkmmb2jhsc1z5lpdow
```

Then, I executed the same workload than the one reported in #3051 and #2998 (`pravega-benchmark`): 
```
time ./pravega-benchmark/bin/pravega-benchmark  --controller tcp://10.246.154.60:9090 --stream StreamName-r10  -producers 5 --size 1000  -eventspersec 30000 --runtime 60 --randomkey true  --writeonly true
```

The benchmark tool output is:
```
    8940 records Writing,    8940.0 records/sec,     8.526 MB/sec,  0.1119 ms avg latency.
   62720 records Writing,   62160.6 records/sec,    59.281 MB/sec,  0.0161 ms avg latency.
   78368 records Writing,   78055.8 records/sec,    74.440 MB/sec,  0.0128 ms avg latency.
   79099 records Writing,   78315.8 records/sec,    74.688 MB/sec,  0.0128 ms avg latency.
   80678 records Writing,   80196.8 records/sec,    76.482 MB/sec,  0.0125 ms avg latency.
   79941 records Writing,   79861.1 records/sec,    76.162 MB/sec,  0.0125 ms avg latency.
   79495 records Writing,   79415.6 records/sec,    75.737 MB/sec,  0.0126 ms avg latency.
   88922 records Writing,   88922.0 records/sec,    84.803 MB/sec,  0.0112 ms avg latency.
   83866 records Writing,   83782.2 records/sec,    79.901 MB/sec,  0.0119 ms avg latency.
   92735 records Writing,   92273.6 records/sec,    87.999 MB/sec,  0.0108 ms avg latency.
   87819 records Writing,   87382.1 records/sec,    83.334 MB/sec,  0.0114 ms avg latency.
   86737 records Writing,   86650.3 records/sec,    82.636 MB/sec,  0.0115 ms avg latency.
   78610 records Writing,   78531.5 records/sec,    74.893 MB/sec,  0.0127 ms avg latency.
...
 86042 records Writing,   85956.0 records/sec,    81.974 MB/sec,  0.0116 ms avg latency.
3000000 records Writing, 50660.272 records/sec, 1000 bytes record size, 47.780 MB/sec, 0.1973 ms avg latency, 2.8388 ms max latency

real    1m2.061s
user    1m29.480s
sys     1m22.130s
```

The results of monitoring the Segment Store memory (`top` command) are:
```
138932 root      20   0 2980204 562896  18016 S   1.7  0.3   0:18.90 java
138932 root      20   0 2980204 562896  18016 S   1.0  0.3   0:18.93 java
138932 root      20   0 2980204 562944  18016 S   1.0  0.3   0:18.96 java
138932 root      20   0 3017212 564944  18040 S  22.8  0.3   0:19.65 java
138932 root      20   0 3104332 744576  18404 S 739.5  0.4   0:41.91 java
138932 root      20   0 3173700 852188  18540 S 528.1  0.4   0:57.86 java
138932 root      20   0 3154344 859392  18548 S 492.7  0.4   1:12.74 java
138932 root      20   0 3137732 838408  18548 S 381.5  0.4   1:24.26 java
138932 root      20   0 3176724 878856  18552 S 383.8  0.4   1:35.85 java
138932 root      20   0 3159280 847360  18552 S 371.9  0.4   1:47.08 java
138932 root      20   0 3110028 913296  18552 S 403.3  0.5   1:59.26 java
138932 root      20   0 3188264   1.1g  18552 S 298.7  0.6   2:08.28 java
138932 root      20   0 3143120   1.0g  18552 S  21.3  0.6   2:08.92 java
138932 root      20   0 3128760   1.0g  18552 S  18.2  0.5   2:09.47 java
138932 root      20   0 3143888   1.1g  18552 S 370.9  0.6   2:20.67 java
138932 root      20   0 3171588   1.2g  18552 S 347.0  0.7   2:31.15 java
138932 root      20   0 3166984   1.3g  18552 S 346.0  0.7   2:41.60 java
138932 root      20   0 3128760   1.2g  18552 S 244.7  0.6   2:48.99 java
138932 root      20   0 3146200   1.2g  18552 S  56.0  0.7   2:50.68 java
138932 root      20   0 3120548   1.2g  18552 S  13.3  0.6   2:51.08 java
138932 root      20   0 3132864   1.2g  18552 S  24.8  0.6   2:51.83 java
138932 root      20   0 3173144   1.2g  18552 S 299.3  0.7   3:00.87 java
138932 root      20   0 3142128   1.2g  18552 S 380.8  0.6   3:12.37 java
138932 root      20   0 3134948   1.2g  18552 S 224.5  0.6   3:19.15 java
138932 root      20   0 3147520   1.2g  18552 S 124.6  0.6   3:22.90 java
138932 root      20   0 3159060   1.2g  18552 S 143.0  0.7   3:27.22 java
138932 root      20   0 3167264   1.2g  18552 S  13.2  0.7   3:27.62 java
138932 root      20   0 3143672   1.2g  18552 S  25.8  0.6   3:28.40 java
138932 root      20   0 3141188   1.2g  18552 S 169.5  0.6   3:33.52 java
138932 root      20   0 3138480   1.2g  18552 S 140.9  0.6   3:37.76 java
138932 root      20   0 3142476   1.2g  18552 S 160.9  0.6   3:42.62 java
138932 root      20   0 3143108   1.2g  18552 S 180.1  0.7   3:48.06 java
138932 root      20   0 3143324   1.2g  18552 S 140.2  0.6   3:52.28 java
138932 root      20   0 3143244   1.2g  18552 S 141.1  0.6   3:56.54 java
138932 root      20   0 3142216   1.2g  18552 S 112.9  0.6   3:59.95 java
138932 root      20   0 3143504   1.2g  18552 S 163.2  0.6   4:04.88 java
138932 root      20   0 3143760   1.2g  18552 S 128.9  0.6   4:08.76 java
138932 root      20   0 3143380   1.2g  18552 S 116.2  0.6   4:12.27 java
138932 root      20   0 3141284   1.2g  18552 S 112.3  0.6   4:15.65 java
138932 root      20   0 3141664   1.2g  18552 S  33.1  0.6   4:16.65 java
138932 root      20   0 3141664   1.2g  18552 S  39.4  0.6   4:17.84 java
138932 root      20   0 3141664   1.2g  18552 S  38.4  0.6   4:19.00 java
138932 root      20   0 3141664   1.2g  18552 S  34.4  0.6   4:20.04 java
```

As can be observed, the memory does not grow in function of the written data as happened before this PR.
