### PR TITLE
Issue 3078: Fix Swarm-based system tests

### DIFF
--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --update \
     nfs-utils \
     libc6-compat \
     python \
+    iproute2 \
   && rm -rf /var/cache/apk/*
 
 EXPOSE 9090 9091 10000 12345

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -14,7 +14,6 @@ RUN apk add --update \
     nfs-utils \
     libc6-compat \
     python \
-    iproute2 \
   && rm -rf /var/cache/apk/*
 
 EXPOSE 9090 9091 10000 12345

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -190,9 +190,9 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
         }
     }
 
-    // Default Health Check which uses Socket Statistics command to ensure the service is  up and running.
+    // Default Health Check which uses netstat command to ensure the service is  up and running.
     List<String> defaultHealthCheck(int port) {
-        return  customHealthCheck("ss -l | grep "+port+" || exit 1");
+        return  customHealthCheck("netstat -plnt | grep "+port+" || exit 1");
     }
 
     //Custom Health check with the command provided by the service.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -31,6 +31,7 @@ import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 @Slf4j
 public class HDFSDockerService extends DockerBasedService {
 
+    private static final int HDFS_PORT = 8020;
     private final int instances = 1;
     private final double cpu = 0.5;
     private final double mem = 2048.0;
@@ -65,7 +66,7 @@ public class HDFSDockerService extends DockerBasedService {
                 .builder()
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .containerSpec(ContainerSpec.builder().image(hdfsimage).env(Arrays.asList(env1, env2))
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(8020)).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(customHealthCheck("ss -l | grep " + HDFS_PORT + " || exit 1")).build())
                         .mounts(mount)
                         .labels(labels)
                         .hostname(serviceName)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -61,7 +61,7 @@ public class ZookeeperDockerService extends DockerBasedService {
                 .containerSpec(ContainerSpec.builder().image(ZK_IMAGE)
                         .hostname(serviceName)
                         .labels(labels)
-                        .healthcheck(ContainerConfig.Healthcheck.builder().test(customHealthCheck("netstat -plnt | grep "+ ZKSERVICE_ZKPORT+" || exit 1")).build()).build())
+                        .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(ZKSERVICE_ZKPORT)).build()).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()
                         .limits(Resources.builder().memoryBytes(mem).nanoCpus((long) cpu).build())


### PR DESCRIPTION
**Change log description**  
Docker Swarm system tests fail when deploying Bookkeeper. The current health check used for the Bookkeeper service (and other services using the default health check) is `ss -l | grep "+port+" || exit` ([ref](https://github.com/pravega/pravega/blob/592ea91c0b8067a752f07e2a57080f0d3b18f66d/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java#L195)). The base image for Pravega and Bookkeper Docker containers was changed to use Alpine as part of #2987 and `ss` command is not pre-installed on the new Alpine-based images.

This PR makes the following changes:
- Changes the default health check task from using the `ss` command to `netstat`, which is present in all images except from the HDFS one.
- Changes the HDFS health check from `netstat` (not present) to `ss` (present).

**Purpose of the change**  
Fix #3078 

**What the code does**  
Fixes the health checks used in the Docker-based system tests.

**How to verify it**  
Run Swarm-based system tests: `./gradlew startSystemTestsWithDocker`.

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>