### PR TITLE
 Issue 3106: Build fails on JDK10 due to the presence of "finalize" methods

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -221,8 +221,4 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
         return channelGroup.stream().filter(Channel::isActive).collect(Collectors.toList());
     }
 
-    @Override
-    protected void finalize() {
-        close();
-    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -50,10 +50,6 @@ class OpStatsLoggerImpl implements OpStatsLogger {
         this.metricRegistry.remove(this.failName);
     }
 
-    @Override
-    protected void finalize() {
-        close();
-    }
 
     //endregion
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -95,12 +95,7 @@ public class StatsLoggerImpl implements StatsLogger {
         @Override
         public void close() {
             metrics.remove(this.name);
-        }
-
-        @Override
-        protected void finalize() {
-            close();
-        }
+        }        
 
         @Override
         public synchronized void clear() {
@@ -146,10 +141,6 @@ public class StatsLoggerImpl implements StatsLogger {
             metrics.remove(this.name);
         }
 
-        @Override
-        protected void finalize() {
-            close();
-        }
     }
 
     private class MeterImpl implements Meter {
@@ -165,11 +156,6 @@ public class StatsLoggerImpl implements StatsLogger {
         @Override
         public void close() {
             metrics.remove(this.name);
-        }
-
-        @Override
-        protected void finalize() {
-            close();
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: Enrico Olivelli <eolivelli@apache.org>

**Change log description**  
This change removes finalize() methods. All of the usages seem not useful

**Purpose of the change**  
Fixes #3106 

**What the code does**  
It drops finalize() methods

**How to verify it**  
Tests will pass