### PR TITLE
Issue 3111: Remove usage of Class#newInstance deprecated since JDK10

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApi.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/generated/api/ScopesApi.java
@@ -49,7 +49,7 @@ public class ScopesApi  {
          String implClass = servletContext.getInitParameter("ScopesApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (ScopesApiService) Class.forName(implClass).newInstance();
+               delegate = (ScopesApiService) Class.forName(implClass).getConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }


### PR DESCRIPTION
Signed-off-by: Enrico Olivelli <eolivelli@apache.org>

**Change log description**  
Use suggested API Class#getConstructor()#newInstance() instead of Class#newInstance() 
see
https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#newInstance()

**Purpose of the change**  
Fixes #3111 

**What the code does**  
Use suggested API Class#getConstructor()#newInstance() instead of Class#newInstance() 


**How to verify it**  
Tests must pass