### PR TITLE
[issue-3119] added API support for client to write event to a particular segment

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -69,6 +69,23 @@ public class SegmentSelector {
         return writers.get(getSegmentForEvent(routingKey));
     }
 
+    /**
+     * Selects which segment an event should be written to.
+     *
+     * @param segmentId The id of segment to which the event should go to.
+     *                  the method should be used only for fixed segment(s).
+     * @return The SegmentOutputStream for the segment that has been selected or null if
+     *         the id is out of range.
+     */
+    @Synchronized
+    public SegmentOutputStream getSegmentOutputStreamForId(int segmentId) {
+        if (currentSegments == null) {
+            return null;
+        }
+        Segment segment = getSegmentForId(segmentId);
+        return segment == null ? null : writers.get(segment);
+    }
+
     @Synchronized
     public Segment getSegmentForEvent(String routingKey) {
         if (currentSegments == null) {
@@ -79,6 +96,15 @@ public class SegmentSelector {
         }
         return currentSegments.getSegmentForKey(routingKey);
     }
+
+    @Synchronized
+    public Segment getSegmentForId(int segmentId) {
+        if (currentSegments == null) {
+            return null;
+        }
+        return currentSegments.getSegmentForId(segmentId);
+    }
+
 
     public List<PendingEvent> refreshSegmentEventWritersUponSealed(Segment sealedSegment, Consumer<Segment>
             segmentSealedCallback) {

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -67,6 +67,15 @@ public class StreamSegments {
         return segments.ceilingEntry(key).getValue();
     }
 
+    public Segment getSegmentForId(int id) {
+        int index = 0;
+        for(Segment segment: segments.values()) {
+            if (index++ == id)
+                return segment;
+        }
+        return null;
+    }
+
     public Collection<Segment> getSegments() {
         return segments.values();
     }

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
@@ -42,6 +42,11 @@ public class ControllerEventStreamWriterMock implements EventStreamWriter<Contro
     }
 
     @Override
+    public CompletableFuture<Void> writeEventToSegment(int segmentId, ControllerEvent event) {
+        return writeEvent(event);
+    }
+
+    @Override
     public Transaction<ControllerEvent> beginTxn() {
         return null;
     }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
@@ -40,6 +40,12 @@ public class EventStreamWriterMock<T> implements EventStreamWriter<T> {
     }
 
     @Override
+    public CompletableFuture<Void> writeEventToSegment(int segmentId, T event) {
+        eventList.add(event);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public Transaction<T> beginTxn() {
         throw new NotImplementedException("beginTxn");
     }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -848,6 +848,12 @@ public class ScaleRequestHandlerTest {
         }
 
         @Override
+        public CompletableFuture<Void>  writeEventToSegment(int segmentId, ControllerEvent event) {
+            queue.add(event);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
         public Transaction<ControllerEvent> beginTxn() {
             return null;
         }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1155,6 +1155,11 @@ public class StreamMetadataTasksTest {
         }
 
         @Override
+        public CompletableFuture<Void> writeEventToSegment(int segmentId, ControllerEvent event) {
+            return writeEvent(event);
+        }
+
+        @Override
         public Transaction<ControllerEvent> beginTxn() {
             return null;
         }

--- a/documentation/src/docs/basic-reader-and-writer.md
+++ b/documentation/src/docs/basic-reader-and-writer.md
@@ -211,6 +211,13 @@ EventStreamWriter can also be used to begin a Transaction.  We cover
 Transactions in more detail elsewhere ([Working with Pravega:
 Transactions](transactions.md)).
 
+With the need to write events in sequence into Pravega stream, there are two options:
+1. Create a stream with fixed one segment only, using ScalingPolicy.fixed(1); no writing parallelism for 
+this option as there is only one segment available. 
+2. Create a stream with fixed multiple segments using ScalingPolicy.fixed(n), then write event directly to 
+a segment using writer.writeEvent(segmentId, message). Note segmentId is between 0 to (n-1) inclusive.
+With this option, writing parallelism could be provided by the client side instead of Pravega. 
+
 That's it for writing Events.  Now lets take a look at how to read Events using
 Pravega.
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -151,6 +151,12 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
             }
 
             @Override
+            public CompletableFuture<Void> writeEventToSegment(int segmentId, AutoScaleEvent event) {
+                consumer.accept(event);
+                return CompletableFuture.<Void>completedFuture(null);
+            }
+
+            @Override
             public Transaction<AutoScaleEvent> beginTxn() {
                 return null;
             }


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
Added writeEventToSegment(int segmentId, Type event) to EventStreamWriter
Currently with the need to keep sequence of all events, application can only create a stream with one fixed segment to fulfill the purpose, but parallelism is not possible with this option.
With this new method, application can write event to a particular segment, hence the partition and parallelism can be provided by client side, where the order of events is still kept inside Pravega stream.

**Purpose of the change**  
Fixes #3119. (Also fixes Pravega-samples issue 162)

**What the code does**  
When writeEventToSegment is called, instead of use hash function to select the segment writer, the code directly select the available segment based on the segment id. 
If the segment id is not valid, no writing happens.

**How to verify it**  
Pravega Terasort sample code will write all the randomly generated event into stream "in sequence", which means:
In a given segment, all the events inside are in order, which means the key (first 10 bytes of the event) are in order;
Segments are in order too, which means keys in segments with smaller id will be less than all keys in segments with greater id.