### PR TITLE
Issue 3137: Added prefix to StatsD reporter

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
@@ -83,7 +83,8 @@ class StatsProviderImpl implements StatsProvider {
         if (conf.isEnableStatsdReporter()) {
             log.info("Configuring stats with statsD at {}:{}", conf.getStatsDHost(), conf.getStatsDPort());
             reporters.add(StatsDReporter.forRegistry(getMetrics())
-                          .build(conf.getStatsDHost(), conf.getStatsDPort()));
+                                        .prefixedWith(conf.getMetricsPrefix())
+                                        .build(conf.getStatsDHost(), conf.getStatsDPort()));
         }
         if (conf.isEnableGraphiteReporter()) {
             log.info("Configuring stats with graphite at {}:{}", conf.getGraphiteHost(), conf.getGraphitePort());


### PR DESCRIPTION
**Change log description**  
Added prefix in configuration of StatsD reporter.

**Purpose of the change**  
Fixes #3137.

**What the code does**  
Adds a prefix in StatsD reporter.

**How to verify it**  
StatsD metrics should be prefixed with value. 
All tests should be passing as before this PR.
