### PR TITLE
Issue 2975: Update HDFS Docker image to pravega/pravega:2.7.7

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "2181:2181"
 
   hdfs:
-    image: dsrw/hdfs:2.7.3-1
+    image: pravega/hdfs:2.7.7
     ports:
       - "2222:2222"
       - "8020:8020"

--- a/docker/compose/swarm/hdfs.yml
+++ b/docker/compose/swarm/hdfs.yml
@@ -10,6 +10,6 @@
 version: '3'
 services:
   hdfs:
-    image: dsrw/hdfs:2.7.3-1
+    image: pravega/hdfs:2.7.7
     environment:
       HDFS_HOST: hdfs

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -35,7 +35,7 @@ public class HDFSDockerService extends DockerBasedService {
     private final int instances = 1;
     private final double cpu = 0.5;
     private final double mem = 2048.0;
-    private final String hdfsimage = "dsrw/hdfs:2.7.3-1";
+    private final String hdfsimage = "pravega/hdfs:2.7.7";
 
     public HDFSDockerService(final String serviceName) {
         super(serviceName);


### PR DESCRIPTION
**Change log description**  
Update HDFS Docker image reference from the outdated `dsrw/hdfs:2.7.3-1` to the newer `pravega/hdfs:2.7.7`.

**Purpose of the change**  
- Fix #2975 

**What the code does**  
Update image reference in Docker Compose, Swarm, and Docker-based testing framework.

**How to verify it**  
- Run a Docker Compose or Swarm Pravega cluster from `/docker/compose`.
- Run Docker-based system tests.

---

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>