### PR TITLE
Issue 3131: Controller shutdown is stuck for a long time during zk session expiry. 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
@@ -29,6 +29,7 @@ import org.apache.zookeeper.ZooKeeper;
  */
 @Slf4j
 public class StoreClientFactory {
+    private static final int CURATOR_MAX_SLEEP_MS = 1000;
 
     public static StoreClient createStoreClient(final StoreClientConfig storeClientConfig) {
         switch (storeClientConfig.getStoreType()) {
@@ -61,7 +62,7 @@ public class StoreClientFactory {
                 .namespace(zkClientConfig.getNamespace())
                 .zookeeperFactory(new ZKClientFactory())
                 .retryPolicy(new ExponentialBackoffRetry(zkClientConfig.getInitialSleepInterval(),
-                        zkClientConfig.getMaxRetries()))
+                        zkClientConfig.getMaxRetries(), CURATOR_MAX_SLEEP_MS))
                 .sessionTimeoutMs(zkClientConfig.getSessionTimeoutMs())
                 .build();
         zkClient.start();


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Our intent is to shutdown curator and all processing on controller if we encounter zookeeper session expiry. To achieve this we manage zk client used in curator and return the same zk client whenever curator attempts to create a new one. 
The curator is also configured to use an exponential backoff strategy in case of failures. The defaults passed to this are such that curator will keep retrying internally for very long time if there is some potential recoverable failure like session expiry. 
 This has a side effect that grpc, which waits on all outstanding grpc calls to complete before shutting down, gets stuck waiting for calls to complete while curator keeps retrying internally for a very long time. 

**Purpose of the change**  
Fixes #3131 

**What the code does**  
In the exponential backoff, we supply a max wait time per iteration. This limits the overall processing to few seconds after which curator fails the request and calls our supplied callback function. 

**How to verify it**  
(Optional: steps to verify that the changes are effective)
