### PR TITLE
Issue 3144: Windows script text overwritten

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ project('segmentstore:server:host') {
             def scriptFile = file getUnixScript()
             scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
             def winScriptFile = file getWindowsScript()
-            winScriptFile.text = scriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
+            winScriptFile.text = winScriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
         }
     }
 
@@ -496,7 +496,7 @@ project('controller') {
             def scriptFile = file getUnixScript()
             scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
             def winScriptFile = file getWindowsScript()
-            winScriptFile.text = scriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
+            winScriptFile.text = winScriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
         }
     }
     applicationDistribution.from('src/conf') {
@@ -580,7 +580,7 @@ project('standalone') {
             def scriptFile = file getUnixScript()
             scriptFile.text = scriptFile.text.replace('$APP_HOME/lib/pluginlib', '$APP_HOME/pluginlib/*')
             def winScriptFile = file getWindowsScript()
-            winScriptFile.text = scriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
+            winScriptFile.text = winScriptFile.text.replace('%APP_HOME%\\lib\\pluginlib', '%APP_HOME%\\pluginlib\\*')
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira <flavio.junqueira@emc.com>

**Change log description**  
* Renames script variables in build.gradle

**Purpose of the change**  
Fixes #3144 

**What the code does**  
A bug was introduced in a previous PR such that the text of the windows script was being overwritten. This change renames some script variables to make sure that the windows BAT files have the right content.

*Note that this PR is for `master`*

**How to verify it**  
Run `./gradlew clean distribution` and verify that the pravega zip contains the expected script files under `bin/`.