### PR TITLE
Issue 3037: BK degree of replication in Swarm

### DIFF
--- a/docker/compose/docker-compose-extendeds3.yml
+++ b/docker/compose/docker-compose-extendeds3.yml
@@ -84,6 +84,9 @@ services:
       JAVA_OPTS: |
         -Dmetrics.enableCSVReporter=false
         -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Dbookkeeper.bkEnsembleSize=2
+        -Dbookkeeper.bkAckQuorumSize=2
+        -Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -85,6 +85,9 @@ services:
       JAVA_OPTS: |
         -Dmetrics.enableCSVReporter=false
         -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Dbookkeeper.bkEnsembleSize=2
+        -Dbookkeeper.bkAckQuorumSize=2
+        -Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -91,6 +91,9 @@ services:
       JAVA_OPTS: |
         -Dmetrics.enableCSVReporter=false
         -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Dbookkeeper.bkEnsembleSize=2
+        -Dbookkeeper.bkAckQuorumSize=2
+        -Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -95,6 +95,9 @@ services:
       JAVA_OPTS: |
         -Dmetrics.enableCSVReporter=false
         -Dpravegaservice.publishedIPAddress=${HOST_IP}
+        -Dbookkeeper.bkEnsembleSize=2
+        -Dbookkeeper.bkAckQuorumSize=2
+        -Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -50,8 +50,8 @@ services:
         -Dpravegaservice.publishedIPAddress=${PUBLISHED_ADDRESS}
         -Dpravegaservice.listeningIPAddress=${LISTENING_ADDRESS}
         -Dbookkeeper.bkEnsembleSize=2
-	-Dbookkeeper.bkAckQuorumSize=2
-	-Dbookkeeper.bkWriteQuorumSize=2
+        -Dbookkeeper.bkAckQuorumSize=2
+        -Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -7,7 +7,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-version: '3'
+version: '4'
 services:
   bookkeeper:
     image: pravega/bookkeeper
@@ -49,6 +49,9 @@ services:
         -Dmetrics.enableCSVReporter=false
         -Dpravegaservice.publishedIPAddress=${PUBLISHED_ADDRESS}
         -Dpravegaservice.listeningIPAddress=${LISTENING_ADDRESS}
+        -Dbookkeeper.bkEnsembleSize=2
+	-Dbookkeeper.bkAckQuorumSize=2
+	-Dbookkeeper.bkWriteQuorumSize=2
         -Xmx900m
         -XX:OnError="kill -9 p%"
         -XX:+ExitOnOutOfMemoryError

--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -7,7 +7,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-version: '4'
+version: '3'
 services:
   bookkeeper:
     image: pravega/bookkeeper

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -61,7 +61,7 @@ for instance in to_create:
           -e HDFS_URL={hdfs_url} \
           -e ZK_URL={zk_url} \
           -e CONTROLLER_URL=tcp://controller:9090 \
-          -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \
+          -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Dbookkeeper.bkEnsembleSize=2 -Dbookkeeper.bkAckQuorumSize=2 -Dbookkeeper.bkWriteQuorumSize=2 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \
           pravega/pravega segmentstore"""
 
     cmd = template.format(

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -32,7 +32,7 @@ public class BookKeeperConfig {
     public static final Property<Integer> ZK_HIERARCHY_DEPTH = Property.named("zkHierarchyDepth", 2);
     public static final Property<Integer> MAX_WRITE_ATTEMPTS = Property.named("maxWriteAttempts", 5);
     public static final Property<Integer> BK_ENSEMBLE_SIZE = Property.named("bkEnsembleSize", 3);
-    public static final Property<Integer> BK_ACK_QUORUM_SIZE = Property.named("bkAckQuorumSize", 3);
+    public static final Property<Integer> BK_ACK_QUORUM_SIZE = Property.named("bkAckQuorumSize", 2);
     public static final Property<Integer> BK_WRITE_QUORUM_SIZE = Property.named("bkWriteQuorumSize", 3);
     public static final Property<Integer> BK_WRITE_TIMEOUT = Property.named("bkWriteTimeoutMillis", 5000);
     public static final Property<Integer> BK_READ_TIMEOUT = Property.named("readTimeoutMillis", 5000);


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Changes the degree of replication of BK to 2
* Updates pravega.yml and scale_segmentstore

**Purpose of the change**  
Fixes #3037 

**What the code does**  
The current swarm configuration is such that the number of bookies is three and the degree of replication is also three, which leaves no room for a bookie failure. It would be good to update the configuration such that we can tolerate at least one bookie failure, but the question is: should we update to make it look more the minimum we expect in production or leave numbers that are more appropriate for dev/testing? Concretely, the options I propose are:

1- **Dev/testing**: Change the degree of replication to two, and leave the number of deployed bookies at three.
2- **Minimum in production**: Change the number of bookies deployed to at least four.

Option 1 is the one currently reflected in this PR. It changes configuration such that the degree of replication is two, while the size of the bookie pool is three. Note that the default in the segment store remains to be three, but changing it could also be an option. 

**How to verify it**  
Deploy Pravega with Swarm.
