### PR TITLE
Issue 2599: Ensure spurious warnings are not thrown by AsyncSegmentInputStreamImpl

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -162,7 +162,10 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
 
         return backoffSchedule.retryWhen(t -> {
             Throwable ex = Exceptions.unwrap(t);
-            log.warn("Exception while reading from Segment : {}", segmentId, ex);
+            log.debug("Exception while reading from Segment : {}", segmentId, ex);
+            if (!closed.get()) {
+                log.warn("Exception while reading from Segment : {}", segmentId, ex);
+            }
             return ex instanceof Exception && !(ex instanceof ConnectionClosedException) && !(ex instanceof SegmentTruncatedException);
         }).runAsync(() -> {
             return getConnection()

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -162,8 +162,9 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
 
         return backoffSchedule.retryWhen(t -> {
             Throwable ex = Exceptions.unwrap(t);
-            log.debug("Exception while reading from Segment : {}", segmentId, ex);
-            if (!closed.get()) {
+            if (closed.get()) {
+                log.debug("Exception while reading from Segment : {}", segmentId, ex);
+            } else {
                 log.warn("Exception while reading from Segment : {}", segmentId, ex);
             }
             return ex instanceof Exception && !(ex instanceof ConnectionClosedException) && !(ex instanceof SegmentTruncatedException);


### PR DESCRIPTION
**Change log description**  

Ensure spurious warnings are not thrown by the AsyncSegmentInputStreamImpl for a planned close() invocation.

**Purpose of the change**  
Fixes #2599 

**What the code does**  
When AsyncSegmentInputStreamImpl.close() is invoked ensure no spurious warnings are thrown.
 

**How to verify it**  
The spurious warn message should be observed on closing the reader.