### PR TITLE
Issue 3167: Update DNS name for accessing Kubernetes API

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -17,9 +17,9 @@ k8() {
     local bearer=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     local cacert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     if [ -z "$namespace" ]; then
-        retval=$( curl --cacert ${cacert} -H "Authorization: Bearer ${bearer}" https://kubernetes/api/v1/${resource_type}/${resource_name} 2> /dev/null | jq -rM "${jsonpath}" 2> /dev/null )
+        retval=$( curl --cacert ${cacert} -H "Authorization: Bearer ${bearer}" https://kubernetes.default.svc/api/v1/${resource_type}/${resource_name} 2> /dev/null | jq -rM "${jsonpath}" 2> /dev/null )
     else
-        retval=$( curl --cacert ${cacert} -H "Authorization: Bearer ${bearer}" https://kubernetes/api/v1/namespaces/${namespace}/${resource_type}/${resource_name} 2> /dev/null | jq -rM "${jsonpath}" 2> /dev/null )
+        retval=$( curl --cacert ${cacert} -H "Authorization: Bearer ${bearer}" https://kubernetes.default.svc/api/v1/namespaces/${namespace}/${resource_type}/${resource_name} 2> /dev/null | jq -rM "${jsonpath}" 2> /dev/null )
     fi
 
     echo "$retval"


### PR DESCRIPTION
**Change log description**  
- Update DNS name for accessing Kubernetes API from inside a container running on Kubernetes. The new DNS name used is `kubernetes.default.svc` instead of `kubernetes` as suggested in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod).

**Purpose of the change**  
Fix https://github.com/pravega/pravega-operator/issues/104
Fixes #3167 

**What the code does**  
Update the DNS name in [`docker/pravega/scripts/init_kubernetes.sh`](https://github.com/pravega/pravega/blob/d2c856ae1bf611f75db0cedd488f2735ba22a805/docker/pravega/scripts/init_kubernetes.sh#L20) from `kubernetes` to `kubernetes.default.svc`

**How to verify it**  
Deploy Pravega in a namespace different than `default` as explained [here](https://github.com/pravega/pravega-operator/blob/1dbb9728476c9e38bec5181d498e0a93d63e0724/README.md#installing-on-a-custom-namespace-with-rbac-enabled) using a Pravega Docker image generated from this branch.

---

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com> 