### PR TITLE
Issue 2669: Prevent NPE by defaulting to no tls if no scheme is specified

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -60,8 +60,11 @@ public class ClientConfig implements Serializable {
     private boolean validateHostName;
 
     public boolean isEnableTls() {
-        return this.controllerURI.getScheme().equals("tls") || this.controllerURI.getScheme().equals("ssl")
-                || this.controllerURI.getScheme().equals("pravegas");
+        String scheme = this.controllerURI.getScheme();
+        if (scheme == null) {
+            return false;
+        }
+        return scheme.equals("tls") || scheme.equals("ssl") || scheme.equals("pravegas");
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
If no scheme is specified in the controller URI, rather than throwing an exception, it now defaults to TCP.

**Purpose of the change**  
Fixes #2669 
