### PR TITLE
Issue 2523: Fix test bug in EndToEndChannelLeakTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
@@ -58,7 +58,7 @@ public class EndToEndChannelLeakTest {
     private static final String SCOPE = "test";
     private static final String STREAM_NAME = "test";
     private static final String READER_GROUP = "reader";
-    private static final long ASSERT_TIMEOUT = 3000;
+    private static final long ASSERT_TIMEOUT = 5000;
 
     private final int controllerPort = TestUtils.getAvailableListenPort();
     private final String serviceHost = "localhost";
@@ -223,9 +223,12 @@ public class EndToEndChannelLeakTest {
         assertEventuallyEquals(expectedChannelCount, () -> connectionFactory.getActiveChannelCount());
 
         //Write more events.
-        writer.writeEvent("0", "one").get();
-        writer.writeEvent("0", "two").get();
-        writer.writeEvent("1", "three").get();
+        writer.writeEvent("1", "one").get();
+        writer.writeEvent("2", "two").get();
+        writer.writeEvent("3", "three").get();
+        writer.writeEvent("4", "four").get();
+        writer.writeEvent("5", "five").get();
+        writer.writeEvent("6", "six").get();
 
         //2 new connections are opened.(+3 connections to the segments 1,2,3 after scale by the writer,
         // -1 connection to segment 0 which is sealed.)
@@ -240,7 +243,7 @@ public class EndToEndChannelLeakTest {
         expectedChannelCount += 4;
 
         event = reader1.readNextEvent(10000);
-        assertNotNull(event);
+        assertNotNull(event.getEvent());
 
         //+1 connection (-1 since segment 0 of stream is sealed + 2 connections to two segments of stream (there are
         // 2 readers and 3 segments and the reader1 will be assigned 2 segments))
@@ -248,7 +251,7 @@ public class EndToEndChannelLeakTest {
         assertEventuallyEquals(expectedChannelCount, () -> connectionFactory.getActiveChannelCount());
 
         event = reader2.readNextEvent(10000);
-        assertNotNull(event);
+        assertNotNull(event.getEvent());
 
         //+1 connection (a new connection to the remaining stream segment)
         expectedChannelCount += 1;


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Make sure there is an event for each segment in EndToEndChannelLeakTest

**Purpose of the change**  
Fixes #2523

**What the code does**  
`EndToEndChannelLeakTest.testDetectChannelLeakMultiReader()` was slow and mistakenly passing. It was asserting that the EventRead was null, when it was intended to assert that the Event itself was non-null. When this was changed the test failed because no events were being written to the segment. The test now sends events to the segment and asserts that the second reader actually gets one of these events.
