### PR TITLE
Issue 3173: Prevent mis-routing of events

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -14,6 +14,7 @@ import io.pravega.client.segment.impl.Segment;
 import io.pravega.common.hash.HashHelper;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -75,7 +76,8 @@ public class StreamSegments {
         NavigableMap<Double, Segment> result = new TreeMap<>();
         Map<Long, List<SegmentWithRange>> replacedRanges = replacementRanges.getReplacementRanges();
         List<SegmentWithRange> replacements = replacedRanges.get(replacedSegment.getSegmentId());
-        replacements.sort((a, b) -> Double.compare(b.getHigh(), a.getHigh()));
+        Preconditions.checkNotNull(replacements, "Empty set of replacements for: {}", replacedSegment.getSegmentId());
+        replacements.sort(Comparator.comparingDouble(SegmentWithRange::getHigh).reversed());
         Segment lastSegmentValue = null;
         for (Entry<Double, Segment> existingEntry : segments.descendingMap().entrySet()) { // iterate from the highest key.
             final Segment existingSegment = existingEntry.getValue();

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -86,10 +86,8 @@ public class StreamSegments {
             if (existingSegment.equals(replacedSegment)) { // Segment needs to be replaced.
                 // Invariant: The successor segment(s)'s range should be limited to the replaced segment's range, thereby
                 // ensuring that newer writes to the successor(s) happen only for the replaced segment's range.
-                if (replacements != null) {
-                    for (SegmentWithRange segmentWithRange : replacements) {                        
-                        result.put(Math.min(segmentWithRange.getHigh(), existingEntry.getKey()), segmentWithRange.getSegment());
-                    }
+                for (SegmentWithRange segmentWithRange : replacements) {                        
+                    result.put(Math.min(segmentWithRange.getHigh(), existingEntry.getKey()), segmentWithRange.getSegment());
                 }
             } else {
                 // update remaining values.

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -408,6 +408,12 @@ public class StreamSegmentsTest {
         segments.put(1.0, getSegment(2, 0));
         StreamSegments streamSegments = new StreamSegments(segments, "");
 
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+        
         // 1 and 2 are merged into 3.
         Map<SegmentWithRange, List<Long>> newRange = new HashMap<>();
         newRange.put(new SegmentWithRange(getSegment(3, 1), 0.5, 1.0),
@@ -484,6 +490,130 @@ public class StreamSegmentsTest {
 
     }
 
+    
+    /**
+     * This is the same as {@link #testUnevenRangeReplacement()} except that 5 is observed before 4.
+    Segment Map used by the test.
+           ^
+           |
+       1.0 +---------+---------+-------->
+           |         |         |
+           |    2    |         |    5
+           |         |    3    |
+       0.66+---------|         +-------->
+           |         |         |
+           |    1    |---------+    6
+           |         |         |
+       0.33+---------|         |-------->
+           |         |    4    |
+           |    0    |         |    7
+           |         |         |
+           +-------------------+-------->
+           +         1         2
+     */
+    @Test
+    public void testOutOfOrderUnevenRangeReplacement() {
+        TreeMap<Double, Segment> segments = new TreeMap<>();
+        segments.put(0.33, getSegment(0, 0));
+        segments.put(0.66, getSegment(1, 0));
+        segments.put(1.0, getSegment(2, 0));
+        StreamSegments streamSegments = new StreamSegments(segments, "");
+
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+        
+        // 1 and 2 are merged into 3.
+        Map<SegmentWithRange, List<Long>> newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(3, 1), 0.5, 1.0),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(2, 0)));
+        // 1 and 0 are merged into 4.
+        newRange.put(new SegmentWithRange(getSegment(4, 1), 0.0, 0.5),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(0, 0)));
+
+        // Simulate fetch successors for segment 1.
+        streamSegments = streamSegments.withReplacementRange(getSegment(1, 0),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(4, 1), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+
+        // 3 is merged into 5 and 6.
+        newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(5, 2), 0.66, 1.0), ImmutableList.of(computeSegmentId(3, 1)));
+        newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
+                     ImmutableList.of(computeSegmentId(3, 1), computeSegmentId(4, 1)));
+        // Simulate fetch successors for segment 3.
+        streamSegments = streamSegments.withReplacementRange(getSegment(3, 1),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(4, 1), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+        
+        newRange = new HashMap<>();
+        // 1 and 0 are merged into 4.
+        newRange.put(new SegmentWithRange(getSegment(4, 1), 0.0, 0.5),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(0, 0)));
+
+        // Simulate fetch successors for segment 0.
+        streamSegments = streamSegments.withReplacementRange(getSegment(0, 0),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(4, 1), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(4, 1), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+        
+        // 4 is merged into 6 and 7.
+        newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
+                     ImmutableList.of(computeSegmentId(3, 1), computeSegmentId(4, 1)));
+        newRange.put(new SegmentWithRange(getSegment(7, 2), 0.0, 0.33), ImmutableList.of(computeSegmentId(4, 1)));
+
+        // Simulate fetch successors for segment 4.
+        streamSegments = streamSegments.withReplacementRange(getSegment(4, 1),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(7, 2), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+        
+        // 1 and 2 are merged into 3.
+        newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(3, 1), 0.5, 1.0),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(2, 0)));
+
+        // Simulate fetch successor for segment 2.
+        streamSegments = streamSegments.withReplacementRange(getSegment(2, 0),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(7, 2), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.8));
+        
+        // 3 is merged into 5 and 6.
+        newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(5, 2), 0.66, 1.0), ImmutableList.of(computeSegmentId(3, 1)));
+        newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
+                     ImmutableList.of(computeSegmentId(3, 1), computeSegmentId(4, 1)));
+        // Simulate fetch successors for segment 3.
+        streamSegments = streamSegments.withReplacementRange(getSegment(3, 1),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(7, 2), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(5, 2), streamSegments.getSegmentForKey(0.8));
+    }
+    
     private Segment getSegment(int segmentNumber, int epoch) {
         return new Segment(scope, streamName, computeSegmentId(segmentNumber, epoch));
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -614,6 +614,74 @@ public class StreamSegmentsTest {
         assertEquals(getSegment(5, 2), streamSegments.getSegmentForKey(0.8));
     }
     
+    
+    
+    /**
+     * This is the same as {@link #testUnevenRangeReplacement()} except that 5 is observed before 4.
+         Segment Map used by the test.
+             ^
+             |
+         1.0 +---------+---------+-------->
+             |         |         |
+             |    2    |         |    5
+             |         |    3    |
+         0.66+---------|         +-------->
+             |         |         |
+             |    1    |         +    6
+             |         |         |
+         0.33+---------|---------|------>
+             |
+             |    0
+             |
+             +-------------------+-------->
+                       1         2
+     */
+    @Test
+    public void testOutOfOrderUnevenRangeReplacementWithEvenSPlit() {
+        TreeMap<Double, Segment> segments = new TreeMap<>();
+        segments.put(0.33, getSegment(0, 0));
+        segments.put(0.66, getSegment(1, 0));
+        segments.put(1.0, getSegment(2, 0));
+        StreamSegments streamSegments = new StreamSegments(segments, "");
+
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(1, 0), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+
+        // 1 and 2 are merged into 3.
+        Map<SegmentWithRange, List<Long>> newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(3, 1), 0.33, 1.0),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(2, 0)));
+        // 1 and 0 are merged into 4.
+        newRange.put(new SegmentWithRange(getSegment(4, 1), 0.0, 0.33),
+                     ImmutableList.of(computeSegmentId(1, 0), computeSegmentId(0, 0)));
+
+        // Simulate fetch successors for segment 1.
+        streamSegments = streamSegments.withReplacementRange(getSegment(1, 0),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+
+        // 3 is merged into 5 and 6.
+        newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(getSegment(5, 2), 0.66, 1.0), ImmutableList.of(computeSegmentId(3, 1)));
+        newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
+                     ImmutableList.of(computeSegmentId(3, 1), computeSegmentId(4, 1)));
+        // Simulate fetch successors for segment 3.
+        streamSegments = streamSegments.withReplacementRange(getSegment(3, 1),
+                                                             new StreamSegmentsWithPredecessors(newRange, ""));
+        // Verify.
+        assertEquals(getSegment(0, 0), streamSegments.getSegmentForKey(0.2));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.4));
+        assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
+        assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
+    }
+
     private Segment getSegment(int segmentNumber, int epoch) {
         return new Segment(scope, streamName, computeSegmentId(segmentNumber, epoch));
     }


### PR DESCRIPTION
**Change log description**  
* Prevents a bug in a rare edge case where events from a writer would be consistently sent to the 'incorrect' segment because the internal map was incorrect.

**Purpose of the change**  
Hopefully fixes #3173

**What the code does**  
In the case where a segment was sealed and replaced unevenly (not a simple split or merge) and the uneven segments were sealed and replaced before any data was written to them, but and the writer saw the successor to the successor segment before one of the segments from the original generation was sealed AND the controller returned the replacement segments in a non-ascending order, then the writer would alter the end range for the final segment effectively expanding it's keyspace. 

This could lead to bad load-balancing or the inability for splitting or merging to correctly manage the load.

Prior to this patch if a writer is in this state, simply restarting it will correct the problem. 

This won't explicitly violate our ordering guarantees because while events would be sent to the 'wrong' segment it would be done consistently. (On a cross writer basis the same key would end up on different segments, which is unusual, but not something we explicitly guarantee doesn't happen at the moment.)

**How to verify it**  
We need to run again with the same client in #3173 and see if the events are routed appropriately.
