### PR TITLE
Issue 2361:Unwrap `CompletionException` in `StreamManagerImpl`

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -58,69 +58,77 @@ public class StreamManagerImpl implements StreamManager {
 
     @Override
     public boolean createStream(String scopeName, String streamName, StreamConfiguration config) {
-        log.info("Creating scope/stream: {}/{} with configuration: {}", scopeName, streamName, config);
         NameUtils.validateUserStreamName(streamName);
-        return Futures.getAndHandleExceptions(controller.createStream(scopeName, streamName, StreamConfiguration.builder()
+        NameUtils.validateUserScopeName(scopeName);
+        log.info("Creating scope/stream: {}/{} with configuration: {}", scopeName, streamName, config);
+        return  Futures.getThrowingException(controller.createStream(scopeName, streamName, StreamConfiguration.builder()
                         .scalingPolicy(config.getScalingPolicy())
                         .retentionPolicy(config.getRetentionPolicy())
-                        .build()),
-                RuntimeException::new);
+                        .build()));
     }
 
     @Override
     public boolean updateStream(String scopeName, String streamName, StreamConfiguration config) {
+        NameUtils.validateUserStreamName(streamName);
+        NameUtils.validateUserScopeName(scopeName);
         log.info("Updating scope/stream: {}/{} with configuration: {}", scopeName, streamName, config);
-        return Futures.getAndHandleExceptions(controller.updateStream(scopeName, streamName, StreamConfiguration.builder()
+        return Futures.getThrowingException(controller.updateStream(scopeName, streamName, StreamConfiguration.builder()
                         .scalingPolicy(config.getScalingPolicy())
                         .retentionPolicy(config.getRetentionPolicy())
-                        .build()),
-                RuntimeException::new);
+                        .build()));
     }
 
     @Override
     public boolean truncateStream(String scopeName, String streamName, StreamCut streamCut) {
+        NameUtils.validateUserStreamName(streamName);
+        NameUtils.validateUserScopeName(scopeName);
         Preconditions.checkNotNull(streamCut);
-
         log.info("Truncating scope/stream: {}/{} with stream cut: {}", scopeName, streamName, streamCut);
-        return Futures.getAndHandleExceptions(controller.truncateStream(scopeName, streamName, streamCut),
-                RuntimeException::new);
+        return Futures.getThrowingException(controller.truncateStream(scopeName, streamName, streamCut));
     }
 
     @Override
     public boolean sealStream(String scopeName, String streamName) {
-        return Futures.getAndHandleExceptions(controller.sealStream(scopeName, streamName), RuntimeException::new);
+        NameUtils.validateUserStreamName(streamName);
+        NameUtils.validateUserScopeName(scopeName);
+        log.info("Sealing scope/stream: {}/{}", scopeName, streamName);
+        return Futures.getThrowingException(controller.sealStream(scopeName, streamName));
     }
 
     @Override
-    public boolean deleteStream(String scopeName, String toDelete) {
-        return Futures.getAndHandleExceptions(controller.deleteStream(scopeName, toDelete), RuntimeException::new);
+    public boolean deleteStream(String scopeName, String streamName) {
+        NameUtils.validateUserStreamName(streamName);
+        NameUtils.validateUserScopeName(scopeName);
+        log.info("Deleting scope/stream: {}/{}", scopeName, streamName);
+        return  Futures.getThrowingException(controller.deleteStream(scopeName, streamName));
     }
 
     @Override
     public boolean createScope(String scopeName) {
         NameUtils.validateUserScopeName(scopeName);
-        return Futures.getAndHandleExceptions(controller.createScope(scopeName),
-                RuntimeException::new);
-        
+        log.info("Creating scope: {}", scopeName);
+        return  Futures.getThrowingException(controller.createScope(scopeName));
     }
 
     @Override
     public boolean deleteScope(String scopeName) {
-        return Futures.getAndHandleExceptions(controller.deleteScope(scopeName),
-                RuntimeException::new);
+        NameUtils.validateUserScopeName(scopeName);
+        log.info("Deleting scope: {}", scopeName);
+        return  Futures.getThrowingException(controller.deleteScope(scopeName));
     }
 
     @Override
     public StreamInfo getStreamInfo(String scopeName, String streamName) {
+        NameUtils.validateUserStreamName(streamName);
+        NameUtils.validateUserScopeName(scopeName);
         log.info("Fetching StreamInfo for scope/stream: {}/{}", scopeName, streamName);
-        CompletableFuture<StreamInfo> streamInfo = getStreamInfo(Stream.of(scopeName, streamName));
-        return Futures.getAndHandleExceptions(streamInfo, RuntimeException::new);
+        return Futures.getThrowingException(getStreamInfo(Stream.of(scopeName, streamName)));
     }
 
     /**
      * Fetch the {@link StreamInfo} for a given stream.
-     * Note: The access level of this method can be reduced once the deprecated method {@link io.pravega.client.BatchClientFactory#getStreamInfo(Stream)}
-     * is removed.
+     * Note: The access level of this method can be reduced once the deprecated method
+     * {@link io.pravega.client.batch.BatchClient#getStreamInfo(Stream)} is removed.
      *
      * @param stream The Stream.
      * @return A future representing {@link StreamInfo}.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -976,7 +976,11 @@ public class ControllerImpl implements Controller {
         @Override
         public void onError(Throwable t) {
             log.warn("gRPC call for {} with trace id {} failed with server error.", method, traceId, t);
-            future.completeExceptionally(t);
+            if (t instanceof RuntimeException) {
+                future.completeExceptionally(t);
+            } else {
+                future.completeExceptionally(new RuntimeException(t));
+            }
         }
 
         @Override


### PR DESCRIPTION
**Change log description**  
Ensure StreamManagerImpl does not throw a wrapped exception inside a RuntimeException.

**Purpose of the change**  
Fixes #2361 

**What the code does**  
The older code would wrap all the exceptions inside a `RuntimeException`. This PR changes this behavior so that user of StreamManager can catch specific exceptions and handle it appropriately.
```
try (StreamManager streamManager = new StreamManagerImpl(controller, cf)) {
       streamManager.createScope("testScope");
 } catch (RetriesExhaustedException e) { // the controller api performs retries in case of a connect failure.
      // connection failure exception handling
 }
```
Also, the streamManger api throws `java.lang.IllegalArgumentException` in case of invalid arguments.
All other exceptions (if any) are of type RuntimeException, indicating an error on the Pravega end.

**How to verify it**  
All the existing tests should continue to pass.
