### PR TITLE
Issue 2208: Tone down logging on connection close.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -127,7 +127,11 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
     }
     
     private void closeConnection(String message) {
-        log.info("Closing connection as a result of receiving: {}", message);
+        if (closed.get()) {
+            log.debug("Closing connection as a result of receiving: {} for segment: {}", message, segmentId);
+        } else {
+            log.warn("Closing connection as a result of receiving: {} for segment: {}", message, segmentId);
+        }
         RawClient c;
         synchronized (lock) {
             c = client;

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -73,7 +73,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
     }
 
     private void closeConnection(Throwable exceptionToInflightRequests) {
-        log.info("Closing connection with exception: {}", exceptionToInflightRequests.getMessage());
+        log.debug("Closing connection with exception: {}", exceptionToInflightRequests.getMessage());
         RawClient c;
         synchronized (lock) {
             c = client;


### PR DESCRIPTION
**Change log description**  
Tone down logging on connection close .

**Purpose of the change**  
Fixes #2208 

**What the code does**  
Reduce the amount of logging during connection close.

**How to verify it**  
All the existing tests should continue to pass.
