### PR TITLE
Issue 1931: moved "-fail" suffix out of container id and move into preceding measurement

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -21,6 +21,7 @@ package io.pravega.shared;
  * - segmentstore.storage: metrics related to our long-term storage (Tier 2)
  * - segmentstore.bookkeeper: metrics related to bookkeeper (Tier 1)
  * - segmentstore.container: metrics for segment containers
+ * - segmentstore.thread_pool: metrics for segmentstore thread pool
  * - segmentstore.cache: cache-related metrics (RocksDB)
  * - controller.stream: metrics for operations on streams (e.g., number of streams created)
  * - controller.segments: metrics about segments, per stream (e.g., count, splits, merges)
@@ -47,6 +48,13 @@ package io.pravega.shared;
  * collisions.
  */
 
+
+import com.google.common.base.Strings;
+import com.google.common.primitives.Ints;
+
+import java.util.Arrays;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 public final class MetricsNames {
     // Metrics in Segment Store Service
@@ -108,7 +116,7 @@ public final class MetricsNames {
     public static final String OPERATION_LOG_SIZE = "segmentstore.container.operation.log_size";                                    // Per-container Counter
 
     // Segment container metadata
-    public static final String ACTIVE_SEGMENT_COUNT = "segmentstore.active_segments";   // Per-container Gauge
+    public static final String ACTIVE_SEGMENT_COUNT = "segmentstore.container.active_segments";   // Per-container Gauge
 
     // Thread pool metrics
     public static final String THREAD_POOL_QUEUE_SIZE = "segmentstore.thread_pool.queue_size";          // Histogram
@@ -193,5 +201,18 @@ public final class MetricsNames {
 
     public static String globalMetricName(String stringName) {
         return stringName + "_global";
+    }
+
+    public static String failMetricName(String metricName) {
+        if (Strings.isNullOrEmpty(metricName)) {
+            return metricName;
+        }
+        String[] tags = metricName.split("\\.");
+        if (tags.length >= 2 && Ints.tryParse(tags[tags.length - 1]) != null) {
+            tags[tags.length - 2] += "_fail";
+            return String.join(".", tags);
+        } else {
+            return metricName + "_fail";
+        }
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -200,8 +200,19 @@ public final class MetricsNames {
     }
 
     /**
-     * For some metrics such as OpStats, Pravega generates corresponding fail metrics automatically.
-     * This method provides a standard way to create name of fail metric for a given metric.
+     * For some metrics such as OpStats, Pravega generates corresponding fail metrics automatically,
+     * this method is called to create the name of fail metric for a given metric.
+     *
+     * Some examples of OpStats metrics and their corresponding fail metrics:
+     * pravega.bookkeeper.segmentstore.bookkeeper.write_latency_ms.0
+     * pravega.bookkeeper.segmentstore.bookkeeper.write_latency_ms_fail.0
+     *
+     * pravega.segmentstore.segmentstore.thread_pool.active_threads
+     * pravega.segmentstore.segmentstore.thread_pool.active_threads_fail
+     *
+     * The rule is, if the last segment of the metric is an integer, such as container id, the suffix "_fail"
+     * is appended to the preceeding segment instead of the integer itself; otherwise simply append "_fail"
+     * onto the given metric to get the fail metric.
      *
      * @param metricName the metric name for which fail metric is created
      * @return the name of fail metric

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -203,6 +203,13 @@ public final class MetricsNames {
         return stringName + "_global";
     }
 
+    /**
+     * For some metrics such as OpStats, Pravega generates corresponding fail metrics automatically.
+     * This method provides a standard way to create name of fail metric for a given metric
+     *
+     * @param metricName - the metric name for which fail metric is created
+     * @return - the name of fail metric
+     */
     public static String failMetricName(String metricName) {
         if (Strings.isNullOrEmpty(metricName)) {
             return metricName;

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -52,10 +52,6 @@ package io.pravega.shared;
 import com.google.common.base.Strings;
 import com.google.common.primitives.Ints;
 
-import java.util.Arrays;
-
-import static com.codahale.metrics.MetricRegistry.name;
-
 public final class MetricsNames {
     // Metrics in Segment Store Service
     // Segment-related stats

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -201,10 +201,10 @@ public final class MetricsNames {
 
     /**
      * For some metrics such as OpStats, Pravega generates corresponding fail metrics automatically.
-     * This method provides a standard way to create name of fail metric for a given metric
+     * This method provides a standard way to create name of fail metric for a given metric.
      *
-     * @param metricName - the metric name for which fail metric is created
-     * @return - the name of fail metric
+     * @param metricName the metric name for which fail metric is created
+     * @return the name of fail metric
      */
     public static String failMetricName(String metricName) {
         if (Strings.isNullOrEmpty(metricName)) {

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -13,7 +13,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.concurrent.TimeUnit;

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -13,11 +13,13 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static io.pravega.shared.MetricsNames.failMetricName;
 
 class OpStatsLoggerImpl implements OpStatsLogger {
     //region Members
@@ -32,10 +34,10 @@ class OpStatsLoggerImpl implements OpStatsLogger {
 
     //region Constructor
 
-    OpStatsLoggerImpl(MetricRegistry metricRegistry, String basename, String statName) {
+    OpStatsLoggerImpl(MetricRegistry metricRegistry, String baseName, String statName) {
         this.metricRegistry = Preconditions.checkNotNull(metricRegistry, "metrics");
-        this.successName = name(basename, statName);
-        this.failName = name(basename, statName + "-fail");
+        this.successName = name(baseName, statName);
+        this.failName = name(baseName, failMetricName(statName));
         this.success = this.metricRegistry.timer(this.successName);
         this.fail = this.metricRegistry.timer(this.failName);
     }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.shared;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@Slf4j
+public class MetricsNamesTest {
+
+  @Test
+  public void testFailMetricName() {
+
+    assertEquals(null, MetricsNames.failMetricName(null));
+    assertEquals("", MetricsNames.failMetricName(""));
+    assertEquals("tag_fail", MetricsNames.failMetricName("tag"));
+    assertEquals("0_fail", MetricsNames.failMetricName("0"));
+    assertEquals("tag1_fail", MetricsNames.failMetricName("tag1"));
+    assertEquals("tag.tag_fail", MetricsNames.failMetricName("tag.tag"));
+    assertEquals("tag_fail.1", MetricsNames.failMetricName("tag.1"));
+    assertEquals("tag.tag1_fail", MetricsNames.failMetricName("tag.tag1"));
+    assertEquals("tag1.tag2.tag3_fail", MetricsNames.failMetricName("tag1.tag2.tag3"));
+    assertEquals("tag1.tag2_fail.3", MetricsNames.failMetricName("tag1.tag2.3"));
+  }
+
+}


### PR DESCRIPTION
…receding measurement as "_fail"; also added source for active_segments

Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
moved "-fail" suffix out of container id and move into preceding measurement as "_fail"; also added source for active_segments.

**Purpose of the change**  
Fixes #1931 

**What the code does**  
When fail metric is being created, instead of simply append "-fail" onto the metric name, the code checks if the last segment of metric is an integer (such as container id); if it is, then "_fail" is appended to the preceding measurement instead of the integer itself - this is to easy the filtering of metrics.

**How to verify it**  
Metrics such as "pravega.segmentstore.segmentstore.container.operation.latency_ms.1-fail" now becomes "pravega.segmentstore.segmentstore.container.operation.latency_ms_fail.1"

"segmentstore.active_segments" changes to "segmentstore.container.active_segments"
