### PR TITLE
Issue #3183: Enable more spotbugs checks

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -279,7 +279,9 @@ public class FileSystemStorage implements SyncStorage {
         FileAttribute<Set<PosixFilePermission>> fileAttributes = PosixFilePermissions.asFileAttribute(READ_WRITE_PERMISSION);
 
         Path path = Paths.get(config.getRoot(), streamSegmentName);
-        Files.createDirectories(path.getParent());
+        Path parent = path.getParent();
+        assert parent != null;
+        Files.createDirectories(parent);
         Files.createFile(path, fileAttributes);
         LoggerHelpers.traceLeave(log, "create", traceId);
         return this.doGetStreamSegmentInfo(streamSegmentName);

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3FileSystemImpl.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3FileSystemImpl.java
@@ -72,7 +72,9 @@ public class S3FileSystemImpl extends S3ImplBase {
         }
         try {
             Path path = Paths.get(this.baseDir, request.getBucketName(), request.getKey());
-            Files.createDirectories(path.getParent());
+            Path parent = path.getParent();
+            assert parent != null;
+            Files.createDirectories(parent);
             Files.createFile(path);
         } catch (IOException e) {
             throw new S3Exception(e.getMessage(), 0, e);

--- a/checkstyle/spotbugs-exclude.xml
+++ b/checkstyle/spotbugs-exclude.xml
@@ -2,9 +2,6 @@
     <Match> <!-- generated code -->
         <Package name="io.pravega.controller.stream.api.grpc.v1" />
     </Match>
-    <Match> <!-- experimental checks have a lot of false positives -->
-        <Bug category="EXPERIMENTAL" />
-    </Match>
     <Match> <!-- does not work well with futures -->
         <Bug pattern="NP_NONNULL_PARAM_VIOLATION" />
     </Match>

--- a/checkstyle/spotbugs-exclude.xml
+++ b/checkstyle/spotbugs-exclude.xml
@@ -2,6 +2,9 @@
     <Match> <!-- generated code -->
         <Package name="io.pravega.controller.stream.api.grpc.v1" />
     </Match>
+    <Match> <!-- experimental checks have a lot of false positives -->
+        <Bug category="EXPERIMENTAL" />
+    </Match>
     <Match> <!-- does not work well with futures -->
         <Bug pattern="NP_NONNULL_PARAM_VIOLATION" />
     </Match>

--- a/checkstyle/spotbugs-include.xml
+++ b/checkstyle/spotbugs-include.xml
@@ -26,13 +26,11 @@
         accepted. In previous versions of FindBugs, this category was known as Style. -->
     <Match>
         <Bug category="STYLE" />
-        <Rank value="14"/>
     </Match>
 
     <!-- code that is not necessarily incorrect but may be inefficient -->
     <Match>
         <Bug category="PERFORMANCE" />
-        <Rank value="14"/>
     </Match>
 
     <!-- code that is vulnerable to attacks from untrusted code -->
@@ -48,7 +46,7 @@
     <!-- Experimental and not fully vetted bug patterns -->
     <Match>
         <Bug category="EXPERIMENTAL" />
-        <Rank value="9"/>
+        <Confidence value="1"/>
     </Match>
 
 </FindBugsFilter>

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -415,7 +415,6 @@ public class StreamTransactionMetadataTasksTest {
         assertEquals(TxnStatus.ABORTING, txnTasks.abortTxn(SCOPE, STREAM, tx2, null, null).join());
 
         // Create commit and abort event processors.
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
         BlockingQueue<CommitEvent> processedCommitEvents = new LinkedBlockingQueue<>();
         BlockingQueue<AbortEvent> processedAbortEvents = new LinkedBlockingQueue<>();
         createEventProcessor("commitRG", "commitStream", commitReader, commitWriter,

--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -13,7 +13,7 @@
 plugins.withId('com.github.spotbugs') {
     spotbugs {
         toolVersion = spotbugsVersion
-        effort = "default"        
+        effort = "max"        
         includeFilter = file("$rootDir/checkstyle/spotbugs-include.xml")
         excludeFilter = file("$rootDir/checkstyle/spotbugs-exclude.xml")
 

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,16 +37,19 @@ abstract class AbstractScaleTests extends AbstractReadWriteTest {
     @Getter(lazy = true)
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
     @Getter(lazy = true)
-    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(
-            ControllerImplConfig.builder().clientConfig(
-                    ClientConfig.builder().controllerURI(getControllerURI()).build())
-                                .build(), getConnectionFactory().getInternalExecutor()));
+    private final ControllerImpl controller = createController();
     @Getter(lazy = true)
-    private final ControllerImpl controller = new ControllerImpl(
-            ControllerImplConfig.builder().clientConfig(
-                    ClientConfig.builder().controllerURI(getControllerURI()).build()
-            ).build(), getConnectionFactory().getInternalExecutor());
+    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, getController());
 
+    private ControllerImpl createController() {
+        return new ControllerImpl(ControllerImplConfig.builder()
+                                                      .clientConfig(ClientConfig.builder()
+                                                                                .controllerURI(getControllerURI())
+                                                                                .build())
+                                                      .build(),
+                                  getConnectionFactory().getInternalExecutor());
+    }
+    
     private URI createControllerURI() {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -480,11 +480,10 @@ public class AssertExtensions {
     public static boolean nearlyEquals(Double a, Double b, double precision) {
         if (a == null && b == null) {
             return true;
-        } else if (a == null && b != null) {
-            return false;
-        } else if (a != null && b == null) {
-            return false;
         }
-        return Math.abs(a - b) <= precision;
+        if (a != null && b != null) {
+            return Math.abs(a - b) <= precision;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
**Change log description**  
Enables more, and more aggressive spotbugs checks

**Purpose of the change**  
Fixes #3183

**What the code does**  
* Sets the analysis effort to 'max'
* Removes some of the filters on different types of bugs.
* Includes only high confidence bugs from the experimental filter set.
* Changes code to eliminate all the false positives that arose from the new filters.
* Removes one real 'useless variable' that was located.