### PR TITLE
Issue 1510: List streams in scope throws exception if there is partially created stream with no configuration

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -333,7 +333,12 @@ class InMemoryStreamMetadataStore extends AbstractStreamMetadataStore {
                     .thenApply(streams -> {
                         HashMap<String, StreamConfiguration> result = new HashMap<>();
                         for (String stream : streams) {
-                            result.put(stream, this.getConfiguration(scopeName, stream, null, executor).join());
+                            StreamConfiguration configuration = Futures.exceptionallyExpecting(
+                                    getConfiguration(scopeName, stream, null, executor),
+                                    e -> e instanceof StoreException.DataNotFoundException, null).join();
+                            if (configuration != null) {
+                                result.put(stream, configuration);
+                            }
                         }
                         return result;
                     });


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
If a stream is only partially created, with no configuration created yet (or failed) then `liststreamsinscope` api fails to list streams. 

**Purpose of the change**  
Fixes #1510 

**What the code does**  
Ignores streams for which we get data not found exception while doing getConfiguration. 

**How to verify it**  
Unit test added. 