### PR TITLE
Issue 3164: Remove redundant handleException invocation.

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -323,20 +323,19 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         long trace = LoggerHelpers.traceEnter(log, operation, updateSegmentAttribute);
         val update = new AttributeUpdate(attributeId, AttributeUpdateType.ReplaceIfEquals, newValue, expectedValue);
         segmentStore.updateAttributes(segmentName, Collections.singletonList(update), TIMEOUT)
-                .whenComplete((v, e) -> {
-                    LoggerHelpers.traceLeave(log, operation, trace, e);
-                    if (e == null) {
-                        connection.send(new SegmentAttributeUpdated(requestId, true));
-                    } else {
-                        if (Exceptions.unwrap(e) instanceof BadAttributeUpdateException) {
-                            log.debug("Updating segment attribute {} failed due to: {}", update, e.getMessage());
-                            connection.send(new SegmentAttributeUpdated(requestId, false));
+                    .whenComplete((v, e) -> {
+                        LoggerHelpers.traceLeave(log, operation, trace, e);
+                        if (e == null) {
+                            connection.send(new SegmentAttributeUpdated(requestId, true));
                         } else {
-                            handleException(requestId, segmentName, operation, e);
+                            if (Exceptions.unwrap(e) instanceof BadAttributeUpdateException) {
+                                log.debug("Updating segment attribute {} failed due to: {}", update, e.getMessage());
+                                connection.send(new SegmentAttributeUpdated(requestId, false));
+                            } else {
+                                handleException(requestId, segmentName, operation, e);
+                            }
                         }
-                    }
-                })
-                .exceptionally(e -> handleException(requestId, segmentName, operation, e));
+                    });
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -578,8 +578,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         } else if (u instanceof StreamSegmentSealedException) {
             log.info(requestId, "Segment '{}' is sealed and cannot perform operation '{}'.",
                      segment, operation);
-            connection.send(new SegmentIsSealed(requestId, segment, clientReplyStackTrace));
-            invokeSafely(connection::send, new SegmentAlreadyExists(requestId, segment, clientReplyStackTrace), failureHandler);
+            invokeSafely(connection::send, new SegmentIsSealed(requestId, segment, clientReplyStackTrace), failureHandler);
         } else if (u instanceof ContainerNotFoundException) {
             int containerId = ((ContainerNotFoundException) u).getContainerId();
             log.warn(requestId, "Wrong host. Segment = '{}' (Container {}) is not owned. Operation = '{}').",


### PR DESCRIPTION
**Change log description**  
Ensure Conditional attribute update failure is not logged at ERROR level.

**Purpose of the change**  
Fixes #3164 

**What the code does**  
The method `io.pravega.segmentstore.server.host.handler.PravegaRequestProcessor#updateSegmentAttribute` used to invoke `handleException()` twice , once via `whenComplete(..)` and once via `exceptionally(...)` block.
This additional invocation of `handleException()` has been removed.
This change also ensures that the log spam during conditional appends is removed.

**How to verify it**  
No changes to functionality, all the existing tests should continue to pass.
