### PR TITLE
Issue 3171: Transaction commits metric not being reported

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -592,17 +592,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     public CompletableFuture<TxnStatus> commitTransaction(final String scope, final String streamName,
                                                           final UUID txId, final OperationContext context,
                                                           final Executor executor) {
-        Stream stream = getStream(scope, streamName, context);
-        CompletableFuture<TxnStatus> future = withCompletion(stream.commitTransaction(txId), executor);
-
-        future.thenCompose(result -> {
-            return stream.getNumberOfOngoingTransactions().thenAccept(count -> {
-                DYNAMIC_LOGGER.incCounterValue(nameFromStream(COMMIT_TRANSACTION, scope, streamName), 1);
-                DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, streamName), count);
-            });
-        });
-
-        return future;
+        return withCompletion(getStream(scope, streamName, context).commitTransaction(txId), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -34,6 +34,8 @@ import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.shared.metrics.DynamicLogger;
+import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
 import lombok.Lombok;
 import lombok.SneakyThrows;
@@ -62,12 +64,16 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.pravega.shared.MetricsNames.COMMIT_TRANSACTION;
+import static io.pravega.shared.MetricsNames.OPEN_TRANSACTIONS;
+import static io.pravega.shared.MetricsNames.nameFromStream;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static java.util.stream.Collectors.toMap;
 
 @Slf4j
 public abstract class PersistentStreamBase implements Stream {
+    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     private final String scope;
     private final String name;
     private final AtomicInteger historyChunkSize;
@@ -1346,12 +1352,14 @@ public abstract class PersistentStreamBase implements Stream {
                     // mark transaction as committed in metadata store.
                     .thenCompose(x -> commitTransaction(txnId)
                             .thenAccept(done -> {
+                                DYNAMIC_LOGGER.incCounterValue(nameFromStream(COMMIT_TRANSACTION, scope, name), 1);
                                 log.debug("transaction {} on stream {}/{} committed successfully", txnId, scope, name);
                             }));
         }
-        return future
-                .thenCompose(x -> Futures.toVoid(updateCommittingTxnRecord(new Data(CommittingTransactionsRecord.EMPTY.toBytes(),
-                        record.getVersion()))));
+        return future.thenCompose(x -> Futures.toVoid(updateCommittingTxnRecord(new Data(CommittingTransactionsRecord.EMPTY.toBytes(),
+                             record.getVersion()))))
+                     .thenRun(() -> getNumberOfOngoingTransactions().thenAccept(count ->
+                             DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), count)));
     }
 
     private CompletableFuture<Map<UUID, ActiveTxnRecord>> getTransactionsInEpoch(final int epoch) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -175,8 +175,17 @@ public class ControllerMetricsTest {
 
     private void checkCommitOrAbortMetric(Counter metric, int expectedValue) {
         // Check that the metric is being correctly reported.
-        Assert.assertNotNull(metric);
-        Assert.assertEquals(expectedValue, metric.getCount());
+        boolean updatedCounter = false;
+        do {
+            try {
+                Assert.assertNotNull(metric);
+                Assert.assertEquals(expectedValue, metric.getCount());
+                updatedCounter = true;
+            } catch (AssertionError e) {
+                log.info("Metric not updated in the cache. Retrying.", e);
+                Exceptions.handleInterrupted(() -> Thread.sleep(100));
+            }
+        } while (!updatedCounter);
     }
 
     private static String getCounterMetricName(String metricName) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -123,7 +123,6 @@ public class ControllerMetricsTest {
         final int parallelism = 4;
         int iterations = 6;
 
-        // At this point, we have at least 6 internal streams.
         StreamConfiguration streamConfiguration = StreamConfiguration.builder()
                                                                      .scalingPolicy(ScalingPolicy.fixed(parallelism))
                                                                      .build();
@@ -152,6 +151,7 @@ public class ControllerMetricsTest {
                 transaction.writeEvent(String.valueOf(j));
             }
 
+            // Test counters for aborted and committed transactions.
             if (i % 2 == 0) {
                 transaction.commit();
                 checkCommitOrAbortMetric(getCounter(getCounterMetricName(COMMIT_TRANSACTION + "." + scope + "." + streamName)), i / 2 + 1);

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -127,6 +127,7 @@ public class ControllerMetricsTest {
         StreamConfiguration streamConfiguration = StreamConfiguration.builder()
                                                                      .scalingPolicy(ScalingPolicy.fixed(parallelism))
                                                                      .build();
+        @Cleanup
         StreamManager streamManager = StreamManager.create(controllerURI);
         streamManager.createScope(scope);
         streamManager.createStream(scope, streamName, streamConfiguration);
@@ -134,6 +135,7 @@ public class ControllerMetricsTest {
         ClientFactory clientFactory = ClientFactory.withScope(scope, ClientConfig.builder()
                                                                                  .controllerURI(controllerURI)
                                                                                  .build());
+        @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
 

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+import com.codahale.metrics.Counter;
+import io.pravega.client.ClientConfig;
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.Transaction;
+import io.pravega.client.stream.TxnFailedException;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.shared.metrics.MetricRegistryUtils;
+import io.pravega.shared.metrics.MetricsConfig;
+import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.StatsProvider;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.pravega.shared.MetricsNames.ABORT_TRANSACTION;
+import static io.pravega.shared.MetricsNames.COMMIT_TRANSACTION;
+import static io.pravega.shared.MetricsNames.CREATE_TRANSACTION;
+
+/**
+ * Check the end to end correctness of metrics published by the Controller.
+ */
+@Slf4j
+public class ControllerMetricsTest {
+
+    private final int controllerPort = TestUtils.getAvailableListenPort();
+    private final String serviceHost = "localhost";
+    private final URI controllerURI = URI.create("tcp://" + serviceHost + ":" + controllerPort);
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final int containerCount = 4;
+    private TestingServer zkTestServer;
+    private PravegaConnectionListener server;
+    private ControllerWrapper controllerWrapper;
+    private ServiceBuilder serviceBuilder;
+    private ScheduledExecutorService executor;
+    private StatsProvider statsProvider = null;
+
+    @Before
+    public void setUp() throws Exception {
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                                                   .with(MetricsConfig.ENABLE_CSV_REPORTER, false)
+                                                   .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
+                                                   .build();
+        metricsConfig.setDynamicCacheEvictionDurationMs(300000);
+
+        MetricsProvider.initialize(metricsConfig);
+        statsProvider = MetricsProvider.getMetricsProvider();
+        statsProvider.start();
+        log.info("Metrics Stats provider is started");
+
+        executor = Executors.newSingleThreadScheduledExecutor();
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+
+        server = new PravegaConnectionListener(false, servicePort, store);
+        server.startListening();
+
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                containerCount);
+        controllerWrapper.awaitRunning();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.statsProvider != null) {
+            statsProvider.close();
+            statsProvider = null;
+            log.info("Metrics statsProvider is now closed.");
+        }
+
+        ExecutorServiceHelpers.shutdown(executor);
+        controllerWrapper.close();
+        server.close();
+        serviceBuilder.close();
+        zkTestServer.close();
+    }
+
+    /**
+     * Verify that transaction metrics counters are being correctly reported.
+     */
+    @Test(timeout = 40000)
+    public void transactionMetricsTest() throws TxnFailedException {
+        final String scope = "transactionMetricsTestScope";
+        final String streamName = "transactionMetricsTestStream";
+        final int parallelism = 4;
+        int iterations = 6;
+
+        // At this point, we have at least 6 internal streams.
+        StreamConfiguration streamConfiguration = StreamConfiguration.builder()
+                                                                     .scalingPolicy(ScalingPolicy.fixed(parallelism))
+                                                                     .build();
+        StreamManager streamManager = StreamManager.create(controllerURI);
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName, streamConfiguration);
+        @Cleanup
+        ClientFactory clientFactory = ClientFactory.withScope(scope, ClientConfig.builder()
+                                                                                 .controllerURI(controllerURI)
+                                                                                 .build());
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+
+        for (int i = 0; i < iterations; i++) {
+            Transaction<String> transaction = writer.beginTxn();
+
+            // Leave some time to (async) report the metric.
+            Exceptions.handleInterrupted(() -> Thread.sleep(2000));
+            Counter createTransactions = MetricRegistryUtils.getCounter(getCounterMetricName(CREATE_TRANSACTION +
+                    "." + scope + "." + streamName));
+            Assert.assertNotNull(createTransactions);
+            Assert.assertEquals(i + 1, createTransactions.getCount());
+
+            // Write some data in the transaction.
+            for (int j = 0; j < 100; j++) {
+                transaction.writeEvent(String.valueOf(j));
+            }
+
+            if (i % 2 == 0) {
+                transaction.commit();
+                // Leave some time to (async) report the metric.
+                Exceptions.handleInterrupted(() -> Thread.sleep(2000));
+                checkCommitOrAbortMetric(getCounterMetricName(COMMIT_TRANSACTION + "." + scope + "." + streamName), i / 2 + 1);
+            } else {
+                transaction.abort();
+                // Leave some time to (async) report the metric.
+                Exceptions.handleInterrupted(() -> Thread.sleep(2000));
+                checkCommitOrAbortMetric(getCounterMetricName(ABORT_TRANSACTION + "." + scope + "." + streamName), i / 2 + 1);
+            }
+        }
+    }
+
+    private void checkCommitOrAbortMetric(String metricToCheck, int expectedValue) {
+        // Check that commit transactions metric is being correctly reported.
+        Counter metric = MetricRegistryUtils.getCounter(metricToCheck);
+        Assert.assertNotNull(metric);
+        Assert.assertEquals(expectedValue, metric.getCount());
+    }
+
+    private static String getCounterMetricName(String metricName) {
+        return "pravega." + metricName + ".Counter";
+    }
+}


### PR DESCRIPTION
**Change log description**  
This PR reallocates the reporting logic of transaction commits metric, as it was not being used in its former location.

**Purpose of the change**  
Fixes #3171.

**What the code does**  
Due to changes in PR #2971, the logic for reporting committed transactions metric (contained in `AbstractStreamMetadataStore.java`) was not being invoked. To fix this, this PR:
1.- Moves the reporting logic OF committed transactions metric to `CommitRequestHandler.java`.
2.- Minimizes the number of invocations to `getNumberOfOngoingTransactions()` upon commits, as it is an expensive metadata call. Now, instead of calling this method per transaction commit, we execute it once when a batch of transaction commits finishes in `AbstractStreamMetadataStore` (`completeCommitTransactions` method).

**How to verify it**  
I verified that this metric is being reported in a local Pravega deployment (inspecting `csv` files).
A new integration test has been added to verify that transaction-related counters are being reported.
All tests should be passing as before (2 successful Jenkins builds).