### PR TITLE
Issue 1761: Differing segment count/split/merges metrics for same stream

### DIFF
--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -18,6 +18,7 @@ import static io.pravega.shared.MetricsNames.CREATE_STREAM_LATENCY;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM_FAILED;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM_LATENCY;
+import static io.pravega.shared.MetricsNames.INITIAL_SEGMENTS_COUNT;
 import static io.pravega.shared.MetricsNames.OPEN_TRANSACTIONS;
 import static io.pravega.shared.MetricsNames.RETENTION_FREQUENCY;
 import static io.pravega.shared.MetricsNames.SEAL_STREAM;
@@ -57,11 +58,8 @@ public final class StreamMetrics extends AbstractControllerMetrics implements Au
      */
     public void createStream(String scope, String streamName, int minNumSegments, Duration latency) {
         DYNAMIC_LOGGER.incCounterValue(CREATE_STREAM, 1);
-        DYNAMIC_LOGGER.reportGaugeValue(OPEN_TRANSACTIONS, 0, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_COUNT, minNumSegments, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.incCounterValue(SEGMENTS_SPLITS, 0, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.incCounterValue(SEGMENTS_MERGES, 0, streamTags(scope, streamName));
-
+        // Report the initial number of segments in the Stream.
+        DYNAMIC_LOGGER.reportGaugeValue(INITIAL_SEGMENTS_COUNT, minNumSegments, streamTags(scope, streamName));
         createStreamLatency.reportSuccessValue(latency.toMillis());
     }
 
@@ -211,10 +209,10 @@ public final class StreamMetrics extends AbstractControllerMetrics implements Au
      * @param merges        Number of segment merges in the scale operation.
      */
     public static void reportSegmentSplitsAndMerges(String scope, String streamName, long splits, long merges) {
-        DYNAMIC_LOGGER.updateCounterValue(globalMetricName(SEGMENTS_SPLITS), splits);
-        DYNAMIC_LOGGER.updateCounterValue(SEGMENTS_SPLITS, splits, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.updateCounterValue(globalMetricName(SEGMENTS_MERGES), merges);
-        DYNAMIC_LOGGER.updateCounterValue(SEGMENTS_MERGES, merges, streamTags(scope, streamName));
+        DYNAMIC_LOGGER.reportGaugeValue(globalMetricName(SEGMENTS_SPLITS), splits);
+        DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_SPLITS, splits, streamTags(scope, streamName));
+        DYNAMIC_LOGGER.reportGaugeValue(globalMetricName(SEGMENTS_MERGES), merges);
+        DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_MERGES, merges, streamTags(scope, streamName));
     }
 
     @Override

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -441,11 +441,10 @@ controller.retention.truncated_size - with tags {"scope", $scope, "stream", $str
 
 - Controller Stream Segment operations (counters) and open/timed out Transactions on a Stream (gauge/counter) metrics - all with tags {"scope", $scope, "stream", $stream}:
 ```
-controller.transactions.opened
-controller.transactions.timedout
-controller.segments.count
-controller.segment.splits
-controller.segment.merges
+controller.segments.count - with tags {"scope", $scope, "stream", $stream}
+controller.segments.initial_count - with tags {"scope", $scope, "stream", $stream}
+controller.segment.splits - with tags {"scope", $scope, "stream", $stream}
+controller.segment.merges - with tags {"scope", $scope, "stream", $stream}
 ```
 
 - Controller Transaction operation latency metrics:
@@ -471,6 +470,8 @@ controller.transactions.aborted - with tags {"scope", $scope, "stream", $stream}
 controller.transactions.abort_failed_global
 controller.transactions.abort_failed - with tags {"scope", $scope, "stream", $stream}
 controller.transactions.abort_failed - with tags {"scope", $scope, "stream", $stream, "transaction", $txnId}
+controller.transactions.opened - with tags {"scope", $scope, "stream", $stream}
+controller.transactions.timedout - with tags {"scope", $scope, "stream", $stream}
 ```
 
 - Controller hosts available (gauge) and host failure (counter) metrics:

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -178,9 +178,10 @@ public final class MetricsNames {
     public static final String CONTAINER_FAILOVERS = "controller.container.failovers";    // Counter and Per-container Counter
 
     // Stream segment counts
-    public static final String SEGMENTS_COUNT = "controller.segments.count";    // Per-stream Gauge
-    public static final String SEGMENTS_SPLITS = "controller.segment.splits";   // Per-stream Counter
-    public static final String SEGMENTS_MERGES = "controller.segment.merges";   // Per-stream Counter
+    public static final String SEGMENTS_COUNT = "controller.segments.count";                    // Per-stream Gauge
+    public static final String INITIAL_SEGMENTS_COUNT = "controller.segments.initial_count";    // Per-stream Gauge
+    public static final String SEGMENTS_SPLITS = "controller.segment.splits";                   // Per-stream Gauge
+    public static final String SEGMENTS_MERGES = "controller.segment.merges";                   // Per-stream Gauge
 
     // Stream retention operations
     public static final String RETENTION_FREQUENCY = "controller.retention.frequency";   // Per-stream Counter

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -150,7 +150,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         } else if (value instanceof Integer) {
             newGauge = underlying.registerGauge(keys.getRegistryKey(), value::intValue, tags);
         } else if (value instanceof Long) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::longValue);
+            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::longValue, tags);
         }
 
         if (null == newGauge) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -271,7 +271,7 @@ public class ControllerMetricsTest {
      *
      * @throws InterruptedException
      */
-    @Test(timeout = 150000)
+    @Test(timeout = 20000)
     public void mergesSplitsAndSegmentCountMetricsTest() throws Exception {
         final String scope = "mergesSplitsAndSegmentCountMetricsTestScope";
         final String streamName = "mergesSplitsAndSegmentCountMetricsTestStream";

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -510,9 +510,9 @@ public class AssertExtensions {
     }
 
     /**
-     * Actively tests for an equality assertion to be met in case where values are not immediately available. The
-     * polling is performed for a limited amount of time (e.g., 5 seconds). If the assertion is not met within that time
-     * period, an {@link AssertionError} will be raised.
+     * Actively tests for an (near) equality assertion to be met in case where values are not immediately available. The
+     * polling is performed for a limited amount of time. If the assertion is not met within that time period, an
+     * {@link AssertionError} will be raised.
      *
      * @param expected  Expected value for the comparison.
      * @param eval      Function to be evaluated until the assertion is met.

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.junit.Assert;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Additional Assert Methods that are useful during testing.
@@ -515,16 +515,18 @@ public class AssertExtensions {
      *
      * @param expected  Expected value for the comparison.
      * @param eval      Function to be evaluated until the assertion is met.
+     * @param timeout   Timeout for actively testing the equality condition.
+     * @throws Exception if a problem occurs.
      */
-    public static <T extends Number> void assertEventuallyEquals(T expected, Callable<T> eval) throws Exception {
-        final int assertTimeout = 5000;
-        long endTime = System.currentTimeMillis() + assertTimeout;
+    public static void assertEventuallyNearlyEquals(double expected, Callable<Double> eval, int timeout) throws Exception {
+        final double precision = 0.1;
+        long endTime = System.currentTimeMillis() + timeout;
         while (endTime > System.currentTimeMillis()) {
-            if (expected == eval.call()) {
+            if (nearlyEquals(expected, eval.call(), precision)) {
                 return;
             }
-            Thread.sleep(10);
+            Thread.sleep(100);
         }
-        assertEquals(expected, eval.call());
+        assertTrue(nearlyEquals(expected, eval.call(), precision));
     }
 }

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.junit.Assert;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -507,4 +507,24 @@ public class AssertExtensions {
         }
         return false;
     }
+
+    /**
+     * Actively tests for an equality assertion to be met in case where values are not immediately available. The
+     * polling is performed for a limited amount of time (e.g., 5 seconds). If the assertion is not met within that time
+     * period, an {@link AssertionError} will be raised.
+     *
+     * @param expected  Expected value for the comparison.
+     * @param eval      Function to be evaluated until the assertion is met.
+     */
+    public static <T extends Number> void assertEventuallyEquals(T expected, Callable<T> eval) throws Exception {
+        final int assertTimeout = 5000;
+        long endTime = System.currentTimeMillis() + assertTimeout;
+        while (endTime > System.currentTimeMillis()) {
+            if (expected == eval.call()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertEquals(expected, eval.call());
+    }
 }


### PR DESCRIPTION
**Change log description**  
This PR removes the initialization of `segment_split` and `segment_merges` metrics upon a Stream creation in the Controller. Now we have `initial_segments_count` and the existing `segments_count` to avoid conflicts among Controller instances reporting the segments of a Stream. Fixed reporting of `segment_split` and `segment_merges`, as they should be gauges (not counters).

**Purpose of the change**  
Fixes #1761.

**What the code does**  
The original problem was that multiple Controller instances could be reporting concurrently count/split/merges metrics for same Stream. This leads to bogus metrics values. The reason for this to happen is that, upon a Stream creation, the Controller was initializing `segment_split`, `segment_merges` and `segment_count` metrics. This yields that the instance handling the Stream creation starts reporting these metrics. Then, if another Controller instance handles an operation on the same Stream that involves reporting these metrics (e.g., scale), then the conflict appears.

To solve this problem, this PR contains the following changes:
1.- Removed from `createStream` the initialization of `SEGMENTS_SPLITS` and `SEGMENTS_MERGES`.
2.- Now, we have 2 metrics to report the segments of a Stream; one called `initial_segments_count` and the existing `segments_count`. In `initial_segments_count`, the Controller handling the Stream creation will publish the initial number of segments for a Stream. Then, the Controller handling scale events for that Stream will publish the active segments values in `segments_count` metric, as regular. This avoids conflicts across Controllers and we use metrics in the way they are supposed to be used (values published by an individual process, no coordination).
3.- As an additional problem, `SEGMENTS_SPLITS` and `SEGMENTS_MERGES` were being reported as counters. However, they should be gauges, as the values that is being published are already "totals" provided by the Controller.
4.- Moreover, to avoid conflicts on Controller restarts, we delete all the metrics and close the stats provider when the Controller shuts down. For this reason, this PR moves the initialization of metrics from `Main.java` to `ControllerServiceStarter.java`.

**How to verify it**  
It has been tested (locally and in a distributed deployment) that segment count/split/merges are being reported by a single Controller instance. All tests should be passing as before.