### PR TITLE
Issue 1142 : Implement a shaded in-proc Pravega cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         classpath group: 'ru.vyarus', name: 'gradle-mkdocs-plugin', version: gradleMkdocsPluginVersion
         classpath group: 'gradle.plugin.com.github.spotbugs', name: 'spotbugs-gradle-plugin', version: spotbugsPluginVersion
         classpath "org.ajoberstar:grgit:${gradleGitPluginVersion}"
+        classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
     }
 }
 
@@ -570,6 +571,7 @@ project('controller') {
 
 project('standalone') {
     apply plugin: 'application'
+    apply plugin: "com.github.johnrengelman.shadow"
     applicationName = "pravega-standalone"
     mainClassName = "io.pravega.local.LocalPravegaEmulator"
     applicationDefaultJvmArgs = ["-server", "-Xmx4g", "-XX:+HeapDumpOnOutOfMemoryError",
@@ -622,8 +624,8 @@ project('standalone') {
     }
 
     task startStandalone(type: JavaExec) {
-        main = "io.pravega.local.LocalPravegaEmulator"
-        classpath = sourceSets.main.runtimeClasspath
+        main = "-jar"
+        args = [jar.archivePath]
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
@@ -633,6 +635,26 @@ project('standalone') {
         }
 
         jvmArgs "-Xdebug", "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n"
+    }
+
+    jar.configure {
+        classifier = 'original'
+    }
+
+    shadowJar {
+        classifier = null
+        
+        mergeServiceFiles()
+        
+        relocate "com.google", "io.pravega.shaded.com.google"
+        relocate "io.dropwizard", "io.pravega.shaded.io.dropwizard"
+        relocate "io.grpc", "io.pravega.shaded.io.grpc"
+        relocate "io.netty", "io.pravega.shaded.io.netty"
+        relocate "org.apache", "io.pravega.shaded.org.apache"
+
+
+        relocate 'META-INF/native/libnetty', 'META-INF/native/libio_pravega_shaded_netty'
+        relocate 'META-INF/native/netty', 'META-INF/native/io_pravega_shaded_netty'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -572,6 +572,7 @@ project('controller') {
 
 project('standalone') {
     apply plugin: 'application'
+    apply plugin: 'maven'
     apply plugin: "com.github.johnrengelman.shadow"
     
     applicationName = "pravega-standalone"
@@ -673,6 +674,12 @@ project('standalone') {
 
     startStandalone.dependsOn shadowJar
     installDist.dependsOn shadowJar
+    assemble.dependsOn shadowJar
+    
+    artifacts {
+        archives file: shadowJar.archivePath, builtBy: shadowJar
+    }
+    
 }
 
 project('test:system') {

--- a/build.gradle
+++ b/build.gradle
@@ -491,6 +491,7 @@ project('controller') {
     apply plugin: 'application'
     applicationName = "pravega-controller"
     mainClassName = "io.pravega.controller.server.Main"
+    
     applicationDefaultJvmArgs = ["-server", "-Xms128m", "-XX:+HeapDumpOnOutOfMemoryError",
                                  "-Dconfig.file=PRAVEGA_APP_HOME/conf/controller.conf",
                                  "-Dlogback.configurationFile=PRAVEGA_APP_HOME/conf/logback.xml",
@@ -624,9 +625,41 @@ project('standalone') {
         runtime.exclude group: "com.sun.jersey", module: "jersey-server"
     }
 
+    // This is a workaround that seems to have worked. 
+    // https://github.com/gradle/gradle/issues/7807
+    jar.classifier = 'unshaded'
+    shadowJar.classifier = null
+    
+    distZip.classifier = 'unshaded'
+    distTar.classifier = 'unshaded'
+    
+    shadowDistZip.classifier = null
+    shadowDistTar.classifier = null
+    
+
+    jar.configure {
+        classifier = 'unshaded'
+    }
+
+    shadowJar {
+        classifier = null
+
+        mergeServiceFiles()
+
+        relocate "com.google", "io.pravega.shaded.com.google"
+        relocate "io.dropwizard", "io.pravega.shaded.io.dropwizard"
+        relocate "io.grpc", "io.pravega.shaded.io.grpc"
+        relocate "io.netty", "io.pravega.shaded.io.netty"
+        relocate "org.apache", "io.pravega.shaded.org.apache"
+
+
+        relocate 'META-INF/native/libnetty', 'META-INF/native/libio_pravega_shaded_netty'
+        relocate 'META-INF/native/netty', 'META-INF/native/io_pravega_shaded_netty'
+    }
+
     task startStandalone(type: JavaExec) {
         main = "-jar"
-        args = [jar.archivePath]
+        args = [shadowJar.archivePath]
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
@@ -638,33 +671,8 @@ project('standalone') {
         jvmArgs "-Xdebug", "-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n"
     }
 
-    jar.configure {
-        classifier = 'unshaded'
-    }
-
-    // This is a workaround that seems to have worked. 
-    // https://github.com/gradle/gradle/issues/7807
-    distZip.classifier = 'unshaded'
-    distTar.classifier = 'unshaded'
-    
-    shadowDistZip.classifier = null
-    shadowDistTar.classifier = null
-
-    shadowJar {
-        classifier = null
-        
-        mergeServiceFiles()
-        
-        relocate "com.google", "io.pravega.shaded.com.google"
-        relocate "io.dropwizard", "io.pravega.shaded.io.dropwizard"
-        relocate "io.grpc", "io.pravega.shaded.io.grpc"
-        relocate "io.netty", "io.pravega.shaded.io.netty"
-        relocate "org.apache", "io.pravega.shaded.org.apache"
-
-
-        relocate 'META-INF/native/libnetty', 'META-INF/native/libio_pravega_shaded_netty'
-        relocate 'META-INF/native/netty', 'META-INF/native/io_pravega_shaded_netty'
-    }
+    startStandalone.dependsOn shadowJar
+    installDist.dependsOn shadowJar
 }
 
 project('test:system') {

--- a/build.gradle
+++ b/build.gradle
@@ -572,6 +572,7 @@ project('controller') {
 project('standalone') {
     apply plugin: 'application'
     apply plugin: "com.github.johnrengelman.shadow"
+    
     applicationName = "pravega-standalone"
     mainClassName = "io.pravega.local.LocalPravegaEmulator"
     applicationDefaultJvmArgs = ["-server", "-Xmx4g", "-XX:+HeapDumpOnOutOfMemoryError",
@@ -638,8 +639,16 @@ project('standalone') {
     }
 
     jar.configure {
-        classifier = 'original'
+        classifier = 'unshaded'
     }
+
+    // This is a workaround that seems to have worked. 
+    // https://github.com/gradle/gradle/issues/7807
+    distZip.classifier = 'unshaded'
+    distTar.classifier = 'unshaded'
+    
+    shadowDistZip.classifier = null
+    shadowDistTar.classifier = null
 
     shadowJar {
         classifier = null

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,7 @@ protobufGradlePlugin=0.8.3
 protobufProtocVersion=3.3.0
 qosLogbackVersion=1.2.3
 rocksdbjniVersion=5.8.6
+shadowGradlePlugin=4.0.3
 swaggerJersey2JaxrsVersion=1.5.16
 slf4jApiVersion=1.7.25
 typesafeConfigVersion=1.3.1


### PR DESCRIPTION
**Change log description**  
Build a shaded JAR that isolates LocalPravegaEmulator dependencies.

**Purpose of the change**  
Fixes #1142 Implement a shaded in-proc Pravega cluster

**What the code does**  
Modify jar task for standalone project to include dependencies and create a 'fat'jar.
Modify startStandalone task to launch fat jar instead of providing dependencies on classpath

**How to verify it**  
The task :standalone:startStandalone should start normally as before and work without any class load exceptions.
