### PR TITLE
Issue 2200: Properly handle ReinitializationRequiredException in client

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
@@ -9,23 +9,23 @@
  */
 package io.pravega.client.stream;
 
-public class ReinitializationRequiredException extends RuntimeException {
+public class ReaderNotInReaderGroupException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public ReinitializationRequiredException() {
+    public ReaderNotInReaderGroupException() {
         super();
     }
 
-    public ReinitializationRequiredException(Throwable e) {
+    public ReaderNotInReaderGroupException(Throwable e) {
         super(e);
     }
 
-    public ReinitializationRequiredException(String msg, Throwable e) {
+    public ReaderNotInReaderGroupException(String msg, Throwable e) {
         super(msg, e);
     }
 
-    public ReinitializationRequiredException(String msg) {
+    public ReaderNotInReaderGroupException(String msg) {
         super(msg);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
@@ -9,23 +9,17 @@
  */
 package io.pravega.client.stream;
 
+import lombok.Getter;
+
 public class ReaderNotInReaderGroupException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public ReaderNotInReaderGroupException() {
-        super();
-    }
-
-    public ReaderNotInReaderGroupException(Throwable e) {
-        super(e);
-    }
-
-    public ReaderNotInReaderGroupException(String msg, Throwable e) {
-        super(msg, e);
-    }
-
-    public ReaderNotInReaderGroupException(String msg) {
-        super(msg);
+    @Getter
+    private final String readerId;
+    
+    public ReaderNotInReaderGroupException(String readerId) {
+        super("Reader: "+readerId);
+        this.readerId = readerId;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
@@ -11,15 +11,19 @@ package io.pravega.client.stream;
 
 import lombok.Getter;
 
+/**
+ * Read was invoked on a reader that the reader group does not consider a member.
+ * This likely means the reader was declared dead by invoking {@link ReaderGroup#readerOffline(String, Position)}
+ */
 public class ReaderNotInReaderGroupException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
     @Getter
     private final String readerId;
-    
+ 
     public ReaderNotInReaderGroupException(String readerId) {
-        super("Reader: "+readerId);
+        super("Reader: " + readerId);
         this.readerId = readerId;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -237,7 +237,7 @@ public class ControllerImpl implements Controller {
                     throw new ControllerFailureException("Failed to delete scope: " + scopeName);
                 case SCOPE_NOT_EMPTY:
                     log.warn(requestId, "Cannot delete non empty scope: {}", scopeName);
-                    throw new IllegalStateException("Scope "+ scopeName + " is not empty.");
+                    throw new IllegalStateException("Scope " + scopeName + " is not empty.");
                 case SCOPE_NOT_FOUND:
                     log.warn(requestId, "Scope not found: {}", scopeName);
                     return false;

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -83,47 +83,56 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     public EventRead<Type> readNextEvent(long timeout) throws ReinitializationRequiredException, TruncatedDataException {
         synchronized (readers) {
             Preconditions.checkState(!closed, "Reader is closed");
-            long waitTime = Math.min(timeout, ReaderGroupStateManager.TIME_UNIT.toMillis());
-            Timer timer = new Timer();
-            Segment segment = null;
-            long offset = -1;
-            ByteBuffer buffer;
-            do { 
-                String checkpoint = updateGroupStateIfNeeded();
-                if (checkpoint != null) {
-                     return createEmptyEvent(checkpoint);
-                }
-                EventSegmentReader segmentReader = orderer.nextSegment(readers);
-                if (segmentReader == null) {
-                    Exceptions.handleInterrupted(() -> Thread.sleep(waitTime));
-                    buffer = null;
-                } else {
-                    segment = segmentReader.getSegmentId();
-                    offset = segmentReader.getOffset();
-                    try {
-                        buffer = segmentReader.read(waitTime);
-                    } catch (EndOfSegmentException e) {
-                        boolean fetchSuccessors = e.getErrorType().equals(ErrorType.END_OF_SEGMENT_REACHED);
-                        handleEndOfSegment(segmentReader, fetchSuccessors);
-                        buffer = null;
-                    } catch (SegmentTruncatedException e) {
-                        handleSegmentTruncated(segmentReader);
-                        buffer = null;
-                    }
-                }
-            } while (buffer == null && timer.getElapsedMillis() < timeout);
-            
-            if (buffer == null) {
-               return createEmptyEvent(null);
-            } 
-            lastRead = Sequence.create(segment.getSegmentId(), offset);
-            int length = buffer.remaining() + WireCommands.TYPE_PLUS_LENGTH_SIZE;
-            return new EventReadImpl<>(lastRead,
-                    deserializer.deserialize(buffer),
-                    getPosition(),
-                    new EventPointerImpl(segment, offset, length),
-                    null);
+            try {
+                return readNextEventInternal(timeout);
+            } catch (ReinitializationRequiredException e) {
+                close();
+                throw e;
+            }
         }
+    }
+    
+    private EventRead<Type> readNextEventInternal(long timeout) throws ReinitializationRequiredException, TruncatedDataException {
+        long waitTime = Math.min(timeout, ReaderGroupStateManager.TIME_UNIT.toMillis());
+        Timer timer = new Timer();
+        Segment segment = null;
+        long offset = -1;
+        ByteBuffer buffer;
+        do { 
+            String checkpoint = updateGroupStateIfNeeded();
+            if (checkpoint != null) {
+                return createEmptyEvent(checkpoint);
+            }
+            EventSegmentReader segmentReader = orderer.nextSegment(readers);
+            if (segmentReader == null) {
+                Exceptions.handleInterrupted(() -> Thread.sleep(waitTime));
+                buffer = null;
+            } else {
+                segment = segmentReader.getSegmentId();
+                offset = segmentReader.getOffset();
+                try {
+                    buffer = segmentReader.read(waitTime);
+                } catch (EndOfSegmentException e) {
+                    boolean fetchSuccessors = e.getErrorType().equals(ErrorType.END_OF_SEGMENT_REACHED);
+                    handleEndOfSegment(segmentReader, fetchSuccessors);
+                    buffer = null;
+                } catch (SegmentTruncatedException e) {
+                    handleSegmentTruncated(segmentReader);
+                    buffer = null;
+                }
+            }
+        } while (buffer == null && timer.getElapsedMillis() < timeout);
+
+        if (buffer == null) {
+            return createEmptyEvent(null);
+        } 
+        lastRead = Sequence.create(segment.getSegmentId(), offset);
+        int length = buffer.remaining() + WireCommands.TYPE_PLUS_LENGTH_SIZE;
+        return new EventReadImpl<>(lastRead,
+                deserializer.deserialize(buffer),
+                getPosition(),
+                new EventPointerImpl(segment, offset, length),
+                null);
     }
 
     private EventRead<Type> createEmptyEvent(String checkpoint) {
@@ -154,29 +163,24 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
      */
     @GuardedBy("readers")
     private String updateGroupStateIfNeeded() throws ReinitializationRequiredException {
-        try {
-            if (atCheckpoint != null) {
-                groupState.checkpoint(atCheckpoint, getPosition());
-                releaseSegmentsIfNeeded();
-            }
-            atCheckpoint = groupState.getCheckpoint();
-            if (atCheckpoint != null) {
-                log.info("{} at checkpoint {}", this, atCheckpoint);
-                if (groupState.isCheckpointSilent(atCheckpoint)) {
-                    // Checkpoint the reader immediately with the current position. Checkpoint Event is not generated.
-                    groupState.checkpoint(atCheckpoint, getPosition());
-                    atCheckpoint = null;
-                    return null;
-                } else {
-                    return atCheckpoint;
-                }
-            }
-            acquireSegmentsIfNeeded();
-            return null;
-        } catch (ReinitializationRequiredException e) {
-            close();
-            throw e;
+        if (atCheckpoint != null) {
+            groupState.checkpoint(atCheckpoint, getPosition());
+            releaseSegmentsIfNeeded();
         }
+        atCheckpoint = groupState.getCheckpoint();
+        if (atCheckpoint != null) {
+            log.info("{} at checkpoint {}", this, atCheckpoint);
+            if (groupState.isCheckpointSilent(atCheckpoint)) {
+                // Checkpoint the reader immediately with the current position. Checkpoint Event is not generated.
+                groupState.checkpoint(atCheckpoint, getPosition());
+                atCheckpoint = null;
+                return null;
+            } else {
+                return atCheckpoint;
+            }
+        }
+        acquireSegmentsIfNeeded();
+        return null;
     }
 
     @GuardedBy("readers")
@@ -217,15 +221,10 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     }
     
     private void handleEndOfSegment(EventSegmentReader oldSegment, boolean fetchSuccessors) throws ReinitializationRequiredException {
-        try {
-            log.info("{} encountered end of segment {} ", this, oldSegment.getSegmentId());
-            readers.remove(oldSegment);
-            oldSegment.close();
-            groupState.handleEndOfSegment(oldSegment.getSegmentId(), fetchSuccessors);
-        } catch (ReinitializationRequiredException e) {
-            close();
-            throw e;
-        }
+        log.info("{} encountered end of segment {} ", this, oldSegment.getSegmentId());
+        readers.remove(oldSegment);
+        oldSegment.close();
+        groupState.handleEndOfSegment(oldSegment.getSegmentId(), fetchSuccessors);
     }
     
     private void handleSegmentTruncated(EventSegmentReader segmentReader) throws ReinitializationRequiredException, TruncatedDataException {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -14,7 +14,7 @@ import com.google.common.base.Preconditions;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.stream.Position;
-import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ReaderNotInReaderGroupException;
 import io.pravega.client.stream.impl.ReaderGroupState.AcquireSegment;
 import io.pravega.client.stream.impl.ReaderGroupState.AddReader;
 import io.pravega.client.stream.impl.ReaderGroupState.CheckpointReader;
@@ -153,7 +153,7 @@ public class ReaderGroupStateManager {
     /**
      * Handles a segment being completed by calling the controller to gather all successors to the completed segment.
      */
-    void handleEndOfSegment(Segment segmentCompleted, boolean fetchSuccesors) throws ReinitializationRequiredException {
+    void handleEndOfSegment(Segment segmentCompleted, boolean fetchSuccesors) throws ReaderNotInReaderGroupException {
         final Map<Segment, List<Long>> segmentToPredecessor;
         if (fetchSuccesors) {
             val successors = getAndHandleExceptions(controller.getSuccessors(segmentCompleted), RuntimeException::new);
@@ -173,7 +173,7 @@ public class ReaderGroupStateManager {
             }
         });
         if (reinitRequired.get()) {
-            throw new ReinitializationRequiredException();
+            throw new ReaderNotInReaderGroupException();
         }
         acquireTimer.zero();
     }
@@ -240,9 +240,9 @@ public class ReaderGroupStateManager {
      * @param lastOffset The offset from which the new owner should start reading from.
      * @param timeLag How far the reader is from the tail of the stream in time.
      * @return a boolean indicating if the segment was successfully released.
-     * @throws ReinitializationRequiredException If the reader has been declared offline.
+     * @throws ReaderNotInReaderGroupException If the reader has been declared offline.
      */
-    boolean releaseSegment(Segment segment, long lastOffset, long timeLag) throws ReinitializationRequiredException {
+    boolean releaseSegment(Segment segment, long lastOffset, long timeLag) throws ReaderNotInReaderGroupException {
         sync.updateState((state, updates) -> {
             Set<Segment> segments = state.getSegments(readerId);
             if (segments != null && segments.contains(segment) && state.getCheckpointForReader(readerId) == null
@@ -255,7 +255,7 @@ public class ReaderGroupStateManager {
         releaseTimer.reset(calculateReleaseTime(readerId, state));
         acquireTimer.reset(calculateAcquireTime(readerId, state));
         if (!state.isReaderOnline(readerId)) {
-            throw new ReinitializationRequiredException();
+            throw new ReaderNotInReaderGroupException();
         }
         return !state.getSegments(readerId).contains(segment);
     }
@@ -269,7 +269,7 @@ public class ReaderGroupStateManager {
      * If there are unassigned segments and this host has not acquired one in a while, acquires them.
      * @return A map from the new segment that was acquired to the offset to begin reading from within the segment.
      */
-    Map<Segment, Long> acquireNewSegmentsIfNeeded(long timeLag) throws ReinitializationRequiredException {
+    Map<Segment, Long> acquireNewSegmentsIfNeeded(long timeLag) throws ReaderNotInReaderGroupException {
         fetchUpdatesIfNeeded();
         if (shouldAcquireSegment()) {
             return acquireSegment(timeLag);
@@ -296,11 +296,11 @@ public class ReaderGroupStateManager {
         }
     }
     
-    private boolean shouldAcquireSegment() throws ReinitializationRequiredException {
+    private boolean shouldAcquireSegment() throws ReaderNotInReaderGroupException {
         synchronized (decisionLock) {
             ReaderGroupState state = sync.getState();
             if (!state.isReaderOnline(readerId)) {
-                throw new ReinitializationRequiredException();
+                throw new ReaderNotInReaderGroupException();
             }
             if (acquireTimer.hasRemaining()) {
                 return false;
@@ -320,7 +320,7 @@ public class ReaderGroupStateManager {
         }
     }
 
-    private Map<Segment, Long> acquireSegment(long timeLag) throws ReinitializationRequiredException {
+    private Map<Segment, Long> acquireSegment(long timeLag) throws ReaderNotInReaderGroupException {
         AtomicBoolean reinitRequired = new AtomicBoolean();
         Map<Segment, Long> result = sync.updateState((state, updates) -> {
             if (!state.isReaderOnline(readerId)) {
@@ -348,7 +348,7 @@ public class ReaderGroupStateManager {
             return acquired;
         });
         if (reinitRequired.get()) {
-            throw new ReinitializationRequiredException();
+            throw new ReaderNotInReaderGroupException();
         }
         releaseTimer.reset(calculateReleaseTime(readerId, sync.getState()));
         acquireTimer.reset(calculateAcquireTime(readerId, sync.getState()));
@@ -373,12 +373,12 @@ public class ReaderGroupStateManager {
         return TIME_UNIT.multipliedBy(state.getNumberOfReaders() - state.getRanking(readerId));
     }
     
-    String getCheckpoint() throws ReinitializationRequiredException {
+    String getCheckpoint() throws ReaderNotInReaderGroupException {
         fetchUpdatesIfNeeded();
         ReaderGroupState state = sync.getState();
         long automaticCpInterval = state.getConfig().getAutomaticCheckpointIntervalMillis();
         if (!state.isReaderOnline(readerId)) {
-            throw new ReinitializationRequiredException();
+            throw new ReaderNotInReaderGroupException();
         }
         String checkpoint = state.getCheckpointForReader(readerId);
         if (checkpoint != null) {
@@ -400,7 +400,7 @@ public class ReaderGroupStateManager {
         return state.getCheckpointForReader(readerId);
     }
 
-    void checkpoint(String checkpointName, PositionInternal lastPosition) throws ReinitializationRequiredException {
+    void checkpoint(String checkpointName, PositionInternal lastPosition) throws ReaderNotInReaderGroupException {
         AtomicBoolean reinitRequired = new AtomicBoolean(false);
         sync.updateState((state, updates) -> {
             if (!state.isReaderOnline(readerId)) {
@@ -411,7 +411,7 @@ public class ReaderGroupStateManager {
             }
         });
         if (reinitRequired.get()) {
-            throw new ReinitializationRequiredException();
+            throw new ReaderNotInReaderGroupException();
         }
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -173,7 +173,7 @@ public class ReaderGroupStateManager {
             }
         });
         if (reinitRequired.get()) {
-            throw new ReaderNotInReaderGroupException();
+            throw new ReaderNotInReaderGroupException(readerId);
         }
         acquireTimer.zero();
     }
@@ -255,7 +255,7 @@ public class ReaderGroupStateManager {
         releaseTimer.reset(calculateReleaseTime(readerId, state));
         acquireTimer.reset(calculateAcquireTime(readerId, state));
         if (!state.isReaderOnline(readerId)) {
-            throw new ReaderNotInReaderGroupException();
+            throw new ReaderNotInReaderGroupException(readerId);
         }
         return !state.getSegments(readerId).contains(segment);
     }
@@ -300,7 +300,7 @@ public class ReaderGroupStateManager {
         synchronized (decisionLock) {
             ReaderGroupState state = sync.getState();
             if (!state.isReaderOnline(readerId)) {
-                throw new ReaderNotInReaderGroupException();
+                throw new ReaderNotInReaderGroupException(readerId);
             }
             if (acquireTimer.hasRemaining()) {
                 return false;
@@ -348,7 +348,7 @@ public class ReaderGroupStateManager {
             return acquired;
         });
         if (reinitRequired.get()) {
-            throw new ReaderNotInReaderGroupException();
+            throw new ReaderNotInReaderGroupException(readerId);
         }
         releaseTimer.reset(calculateReleaseTime(readerId, sync.getState()));
         acquireTimer.reset(calculateAcquireTime(readerId, sync.getState()));
@@ -378,7 +378,7 @@ public class ReaderGroupStateManager {
         ReaderGroupState state = sync.getState();
         long automaticCpInterval = state.getConfig().getAutomaticCheckpointIntervalMillis();
         if (!state.isReaderOnline(readerId)) {
-            throw new ReaderNotInReaderGroupException();
+            throw new ReaderNotInReaderGroupException(readerId);
         }
         String checkpoint = state.getCheckpointForReader(readerId);
         if (checkpoint != null) {
@@ -411,7 +411,7 @@ public class ReaderGroupStateManager {
             }
         });
         if (reinitRequired.get()) {
-            throw new ReaderNotInReaderGroupException();
+            throw new ReaderNotInReaderGroupException(readerId);
         }
     }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -24,6 +24,7 @@ import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderNotInReaderGroupException;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
@@ -53,7 +54,7 @@ public class EventStreamReaderTest {
     private final EventWriterConfig writerConfig = EventWriterConfig.builder().build();
 
     @Test(timeout = 10000)
-    public void testEndOfSegmentWithoutSuccessors() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testEndOfSegmentWithoutSuccessors() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -161,7 +162,7 @@ public class EventStreamReaderTest {
     }
 
     @Test(timeout = 10000)
-    public void testRead() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testRead() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -184,7 +185,7 @@ public class EventStreamReaderTest {
     }
 
     @Test(timeout = 10000)
-    public void testReleaseSegment() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testReleaseSegment() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -230,7 +231,7 @@ public class EventStreamReaderTest {
 
     @SuppressWarnings("unused")
     @Test(timeout = 10000)
-    public void testAcquireSegment() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testAcquireSegment() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -265,7 +266,7 @@ public class EventStreamReaderTest {
     }
     
     @Test
-    public void testEventPointer() throws SegmentSealedException, NoSuchEventException, ReinitializationRequiredException {
+    public void testEventPointer() throws SegmentSealedException, NoSuchEventException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -294,7 +295,7 @@ public class EventStreamReaderTest {
     }
 
     @Test(timeout = 10000)
-    public void testCheckpoint() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testCheckpoint() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -323,7 +324,7 @@ public class EventStreamReaderTest {
     }
     
     @Test(timeout = 10000)
-    public void testRestore() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testRestore() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();
@@ -348,7 +349,7 @@ public class EventStreamReaderTest {
     }
 
     @Test(timeout = 10000)
-    public void testDataTruncated() throws SegmentSealedException, ReinitializationRequiredException {
+    public void testDataTruncated() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
         Orderer orderer = new Orderer();

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -20,7 +20,7 @@ import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ReaderNotInReaderGroupException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.impl.ReaderGroupState.CreateCheckpoint;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
@@ -70,7 +70,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
-    public void testCompaction() throws ReinitializationRequiredException {
+    public void testCompaction() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -133,7 +133,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 20000)
-    public void testSegmentSplit() throws ReinitializationRequiredException {
+    public void testSegmentSplit() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -174,7 +174,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 20000)
-    public void testSegmentMerge() throws ReinitializationRequiredException {
+    public void testSegmentMerge() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -217,7 +217,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
-    public void testAddReader() throws ReinitializationRequiredException {
+    public void testAddReader() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -248,7 +248,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
-    public void testRemoveReader() throws ReinitializationRequiredException {
+    public void testRemoveReader() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -291,7 +291,7 @@ public class ReaderGroupStateManagerTest {
         assertEquals(Long.valueOf(789L), newSegments.get(new Segment(scope, stream, 0)));
         
         ReaderGroupStateManager.readerShutdown("testReader2", null, stateSynchronizer);
-        AssertExtensions.assertThrows(ReinitializationRequiredException.class,
+        AssertExtensions.assertThrows(ReaderNotInReaderGroupException.class,
                 () -> readerState2.releaseSegment(new Segment(scope, stream, 0), 711L, 0L));
 
         clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
@@ -299,12 +299,12 @@ public class ReaderGroupStateManagerTest {
         assertEquals(1, newSegments.size());
         assertEquals(Long.valueOf(789L), newSegments.get(new Segment(scope, stream, 0)));
 
-        AssertExtensions.assertThrows(ReinitializationRequiredException.class,
+        AssertExtensions.assertThrows(ReaderNotInReaderGroupException.class,
                 () -> readerState2.acquireNewSegmentsIfNeeded(0L));
     }
 
     @Test(timeout = 10000)
-    public void testRemoveReaderWithNullPosition() throws ReinitializationRequiredException {
+    public void testRemoveReaderWithNullPosition() throws ReaderNotInReaderGroupException {
 
         String scope = "scope";
         String stream = "stream";
@@ -366,7 +366,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 5000)
-    public void testReleaseAndAcquireTimes() throws ReinitializationRequiredException {
+    public void testReleaseAndAcquireTimes() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -425,7 +425,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 5000)
-    public void testAcquireRace() throws ReinitializationRequiredException {
+    public void testAcquireRace() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -471,7 +471,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 10000)
-    public void testSegmentsAssigned() throws ReinitializationRequiredException {
+    public void testSegmentsAssigned() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -545,7 +545,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 20000)
-    public void testReleaseWhenReadersAdded() throws ReinitializationRequiredException {
+    public void testReleaseWhenReadersAdded() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -634,7 +634,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 10000)
-    public void testCheckpoint() throws ReinitializationRequiredException {
+    public void testCheckpoint() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -678,7 +678,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
-    public void testCheckpointContainsAllShards() throws ReinitializationRequiredException {
+    public void testCheckpointContainsAllShards() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
@@ -717,7 +717,7 @@ public class ReaderGroupStateManagerTest {
     }
 
     @Test(timeout = 10000)
-    public void testCheckpointUpdatesAssignedSegments() throws ReinitializationRequiredException {
+    public void testCheckpointUpdatesAssignedSegments() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         String checkpointId = "checkpoint";
@@ -776,7 +776,7 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
-    public void testSegmentsCannotBeReleasedWithoutCheckpoint() throws ReinitializationRequiredException {
+    public void testSegmentsCannotBeReleasedWithoutCheckpoint() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**
* Make ReinitializationRequiredException Runtime
* Always call close when ReinitializationRequiredException is thrown.

**Purpose of the change**  
Fixes #2199 and Fixes #2200.

**What the code does**  
Moves the wrapping try-catch-rethrow from the site where the exception is generated to readNextEvent which is the only public method that can throw the exception. Because we need to explicitly handle this case internally but an external caller no longer needs to, the exception is split into two:
* The internal Cause ReaderNotInReaderGroupException which is checked an explicitly handled.
* The public exception ReinitializationRequiredException which is the same as before but now extends from RuntimeException instead of Exception.

