### PR TITLE
Issue 3131: Curator.close causes background curator calls to never complete

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -13,9 +13,7 @@ import io.pravega.common.LoggerHelpers;
 import io.pravega.controller.store.client.StoreClient;
 import io.pravega.controller.store.client.StoreClientFactory;
 import io.pravega.controller.store.client.StoreType;
-import io.pravega.controller.util.ZKUtils;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.Monitor;
 import lombok.extern.slf4j.Slf4j;
@@ -134,7 +132,6 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
                     // stop ControllerServiceStarter.
                     if (sessionExpiryFuture.isDone()) {
                         log.info("ZK session expired");
-                        storeClient.close();
                     }
                 } else {
                     this.serviceStopFuture.join();
@@ -146,6 +143,10 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
 
                 log.info("Awaiting termination of ControllerServiceStarter");
                 starter.awaitTerminated();
+                
+                if (hasZkConnection) {
+                    storeClient.close();
+                }
             }
         } catch (Exception e) {
             log.error("Controller Service Main thread exited exceptionally", e);
@@ -207,13 +208,5 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
         } finally {
             monitor.leave();
         }
-    }
-
-    @VisibleForTesting
-    public void forceClientSessionExpiry() throws Exception {
-        Preconditions.checkState(serviceConfig.isControllerClusterListenerEnabled(),
-                "Controller Cluster not enabled");
-        awaitServiceStarting();
-        ZKUtils.simulateZkSessionExpiry((CuratorFramework) this.storeClient.getClient());
     }
 }

--- a/controller/src/main/java/io/pravega/controller/util/ZKUtils.java
+++ b/controller/src/main/java/io/pravega/controller/util/ZKUtils.java
@@ -15,10 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
-
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Helper ZK functions.
@@ -50,28 +46,4 @@ public final class ZKUtils {
             throw new RuntimeException("Exception while creating znode: " + basePath, e);
         }
     }
-
-    /**
-     * Simulates ZK session expiry. Refer https://wiki.apache.org/hadoop/ZooKeeper/FAQ#A4
-     *
-     * @param curatorClient Curator client object
-     * @throws Exception Error fetching sessionId or sessionPassword from curator client
-     */
-    public static void simulateZkSessionExpiry(CuratorFramework curatorClient) throws Exception {
-        final long sessionId = curatorClient.getZookeeperClient().getZooKeeper().getSessionId();
-        final byte[] sessionPwd = curatorClient.getZookeeperClient().getZooKeeper().getSessionPasswd();
-        CountDownLatch connectedLatch = new CountDownLatch(1);
-        // Create a new ZK client with the same sessionId an sessionPwd as original one.
-        ZooKeeper zk2 = new ZooKeeper(curatorClient.getZookeeperClient().getCurrentConnectionString(),
-                5000, event -> {
-            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
-                connectedLatch.countDown();
-            }
-        }, sessionId, sessionPwd);
-        // Await its connection.
-        connectedLatch.await();
-        // Close connection. This will cause original session to expire.
-        zk2.close();
-    }
-
 }


### PR DESCRIPTION
**Change log description**  
If we call curator.close as there are outstanding asynchronous zk calls, they are never completed (callbacks never invoked). This causes grpc to keep awaiting completion of outstanding calls which never complete. 

**Purpose of the change**  
Fixes #3131 

**What the code does**  
In ControllerServiceMain we close curator client as the last step after having successfully shutdown all other modules. 

**How to verify it**  
Unit test for zkSessionExpiration updated which uses mockControllerServiceStarter that waits for all curator calls to complete. We make a background call into curator client after injection of session expiration, which should fail in finite time and allow shutdown of mockStarter to complete. 
