### PR TITLE
Issue 3138: Use HOSTNAME envvar as metrics prefix

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -173,7 +173,7 @@ metrics.enableStatistics=false
 #metrics.statsOutputFrequencySeconds=60
 
 # Prefix to add to all Metrics counters.
-#metrics.metricsPrefix=metrics.host
+#metrics.metricsPrefix=pravega
 
 # Whether to enable CSV reporting.
 # Valid values: 'true' or 'false'.

--- a/docker/pravega/scripts/init_controller.sh
+++ b/docker/pravega/scripts/init_controller.sh
@@ -10,6 +10,7 @@
 #
 
 init_controller() {
+    [ ! -z "$HOSTNAME" ] && add_system_property "config.controller.metricmetricsPrefix" "${HOSTNAME}"
     add_system_property "config.controller.server.zk.url" "${ZK_URL}"
     add_system_property "config.controller.server.store.host.type" "Zookeeper"
     echo "JAVA_OPTS=${JAVA_OPTS}"

--- a/docker/pravega/scripts/init_segmentstore.sh
+++ b/docker/pravega/scripts/init_segmentstore.sh
@@ -13,6 +13,7 @@ init_segmentstore() {
     [ ! -z "$PUBLISHED_ADDRESS" ] && add_system_property "pravegaservice.publishedIPAddress" "${PUBLISHED_ADDRESS}"
     [ ! -z "$PUBLISHED_ADDRESS" ] && add_system_property "pravegaservice.listeningIPAddress" "0.0.0.0"
     [ ! -z "$PUBLISHED_PORT" ] && add_system_property "pravegaservice.publishedPort" "${PUBLISHED_PORT}"
+    [ ! -z "$HOSTNAME" ] && add_system_property "metrics.metricsPrefix" "${HOSTNAME}"
     add_system_property "pravegaservice.zkURL" "${ZK_URL}"
     add_system_property "autoScale.controllerUri" "${CONTROLLER_URL}"
     add_system_property "bookkeeper.zkAddress" "${BK_ZK_URL:-${ZK_URL}}"

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -289,7 +289,7 @@ public class MetricsConfig extends ComponentConfig {
     public final static Property<Long> DYNAMIC_CACHE_SIZE = "dynamicCacheSize"; //dynamic cache size , default = 10000000L
     public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = "dynamicCacheEvictionDurationMs"; //dynamic cache evcition duration, default = 30
     public final static String OUTPUT_FREQUENCY = "statsOutputFrequencySeconds"; //reporter output frequency, default = 60
-    public final static String METRICS_PREFIX = "metricsPrefix"; //Metrics Prefix, default = "metrics.host"
+    public final static String METRICS_PREFIX = "metricsPrefix"; //Metrics Prefix, default = "pravega"
     public final static String CSV_ENDPOINT = "csvEndpoint"; // CSV reporter output dir, default = "/tmp/csv"
     public final static String STATSD_HOST = "statsDHost"; // StatsD server host for the reporting, default = "localhost"
     public final static String STATSD_PORT = "statsDPort"; // StatsD server port, default = "8125"

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -26,7 +26,7 @@ public class MetricsConfig {
     public final static Property<Long> DYNAMIC_CACHE_SIZE = Property.named("dynamicCacheSize", 10000000L);
     public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = Property.named("dynamicCacheEvictionDurationMs", 30);
     public final static Property<Integer> OUTPUT_FREQUENCY = Property.named("statsOutputFrequencySeconds", 60);
-    public final static Property<String> METRICS_PREFIX = Property.named("metricsPrefix", "metrics.host");
+    public final static Property<String> METRICS_PREFIX = Property.named("metricsPrefix", "pravega");
     public final static Property<String> CSV_ENDPOINT = Property.named("csvEndpoint", "/tmp/csv");
     public final static Property<String> STATSD_HOST = Property.named("statsDHost", "localhost");
     public final static Property<Integer> STATSD_PORT = Property.named("statsDPort", 8125);


### PR DESCRIPTION
**Change log description**  
- Use `HOSTNAME` environment variable as metrics prefix (re-apply changes made originally by @RaulGracia in #3141).

**Purpose of the change**  
Fix #3138

**What the code does**  
Updates Docker init scripts to obtain the `HOSTNAME` environment variable and set it as the metrics prefix in case it is set. `HOSTNAME` is built-in variable that should be present and correctly set by default. 

**How to verify it**  
Reported metrics should be prefixed with the host names.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>
