### PR TITLE
Issue 3138: Use HOSTNAME envvar as metrics prefix

### DIFF
--- a/docker/pravega/entrypoint.sh
+++ b/docker/pravega/entrypoint.sh
@@ -23,6 +23,7 @@ add_system_property() {
 }
 
 configure_controller() {
+    [ ! -z "$HOSTNAME" ] && add_system_property "config.controller.metricmetricsPrefix" "${HOSTNAME}"
     add_system_property "config.controller.server.zk.url" "${ZK_URL}"
     add_system_property "config.controller.server.store.host.type" "Zookeeper"
     echo "JAVA_OPTS=${JAVA_OPTS}"
@@ -102,6 +103,7 @@ configure_tier2() {
     esac
 }
 configure_segmentstore() {
+    [ ! -z "$HOSTNAME" ] && add_system_property "metrics.metricsPrefix" "${HOSTNAME}"
     add_system_property "pravegaservice.zkURL" "${ZK_URL}"
     add_system_property "autoScale.controllerUri" "${CONTROLLER_URL}"
     add_system_property "bookkeeper.zkAddress" "${BK_ZK_URL:-${ZK_URL}}"


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Uses HOSTNAME environment variable as metrics prefix.

**Purpose of the change**  
Backporting changes for issue #3138.

**What the code does**  
Uses the hostname configured via environment variable to set the metrics prefix. It checks in `entrypoint.sh` whether the environment variable exists, and if it does, then is uses it. 

**How to verify it**  
Reported metrics should be prefixed with the host names.