### PR TITLE
Issue 3213: Fix System test framework and test issues.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -548,7 +548,7 @@ public class K8sClient {
      */
     public CompletableFuture<Void> downloadLogs(final V1Pod fromPod, final String toFile) {
 
-        return Retry.withExpBackoff(500, 10, 2)
+        return Retry.withExpBackoff(500, 10, 3)
                     .retryingOn(TestFrameworkException.class)
                     .throwingOn(RuntimeException.class)
                     .runInExecutor(() -> {
@@ -556,8 +556,8 @@ public class K8sClient {
                         log.debug("copy logs from pod {} to file {}", podName, toFile);
                         try {
                             @Cleanup
-                            InputStream r1 = logUtility.streamNamespacedPodLog(fromPod);
-                            Files.copy(r1, Paths.get(toFile));
+                            InputStream logStream = logUtility.streamNamespacedPodLog(fromPod);
+                            Files.copy(logStream, Paths.get(toFile));
                             log.debug("log copy completed for pod {}", podName);
                         } catch (ApiException | IOException e) {
                             log.error("Error while copying files from pod {}.", podName);

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -74,6 +74,7 @@ public class K8sClient {
     private static final int DEFAULT_TIMEOUT_MINUTES = 5; // timeout of http client.
     private static final int RETRY_MAX_DELAY_MS = 10_000; // max time between retries to check if pod has completed.
     private static final int RETRY_COUNT = 50; // Max duration of a pod is 1 hour.
+    private static final int LOG_DOWNLOAD_RETRY_COUNT = 4;
     private static final String PRETTY_PRINT = "false";
     private final ApiClient client;
     private final PodLogs logUtility;
@@ -548,7 +549,7 @@ public class K8sClient {
      */
     public CompletableFuture<Void> downloadLogs(final V1Pod fromPod, final String toFile) {
 
-        return Retry.withExpBackoff(500, 10, 3)
+        return Retry.withExpBackoff(500, 10, LOG_DOWNLOAD_RETRY_COUNT, RETRY_MAX_DELAY_MS)
                     .retryingOn(TestFrameworkException.class)
                     .throwingOn(RuntimeException.class)
                     .runInExecutor(() -> {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -71,6 +71,7 @@ public abstract class AbstractService implements Service {
     static final String IMAGE_PULL_POLICY = System.getProperty("ImagePullPolicy", "IfNotPresent");
     private static final String DOCKER_REGISTRY =  System.getProperty("dockerImageRegistry", "");
     private static final String PRAVEGA_VERSION = System.getProperty("imageVersion", "latest");
+    private static final String PRAVEGA_OPERATOR_VERSION = System.getProperty("pravegaOperatorVersion", "latest");
     private static final String PREFIX = System.getProperty("imagePrefix", "pravega");
 
     final K8sClient k8sClient;
@@ -233,8 +234,7 @@ public abstract class AbstractService implements Service {
 
     private V1Deployment getPravegaOperatorDeployment() {
         V1Container container = new V1ContainerBuilder().withName(PRAVEGA_OPERATOR)
-                                                        //.withImage("pravega/pravega-operator:latest") //TODO: depends on issue pravega/pravega-operator/issues/82
-                                                        .withImage("adrianmo/pravega-operator:issue-82-1")
+                                                        .withImage(DOCKER_REGISTRY + PREFIX + "/pravega-operator:" + PRAVEGA_OPERATOR_VERSION)
                                                         .withPorts(new V1ContainerPortBuilder().withContainerPort(60000).build())
                                                         .withCommand(PRAVEGA_OPERATOR)
                                                         .withImagePullPolicy(IMAGE_PULL_POLICY)

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,15 +37,18 @@ abstract class AbstractScaleTests extends AbstractReadWriteTest {
     @Getter(lazy = true)
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
     @Getter(lazy = true)
-    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(
-            ControllerImplConfig.builder().clientConfig(
-                    ClientConfig.builder().controllerURI(getControllerURI()).build())
-                                .build(), getConnectionFactory().getInternalExecutor()));
+    private final ControllerImpl controller = createController();
     @Getter(lazy = true)
-    private final ControllerImpl controller = new ControllerImpl(
-            ControllerImplConfig.builder().clientConfig(
-                    ClientConfig.builder().controllerURI(getControllerURI()).build()
-            ).build(), getConnectionFactory().getInternalExecutor());
+    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, getController());
+
+    private ControllerImpl createController() {
+        return new ControllerImpl(ControllerImplConfig.builder()
+                                                      .clientConfig(ClientConfig.builder()
+                                                                                .controllerURI(getControllerURI())
+                                                                                .build())
+                                                      .build(),
+                                  getConnectionFactory().getInternalExecutor());
+    }
 
     private URI createControllerURI() {
         Service conService = Utils.createPravegaControllerService(null);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -37,19 +37,16 @@ abstract class AbstractScaleTests extends AbstractReadWriteTest {
     @Getter(lazy = true)
     private final ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
     @Getter(lazy = true)
-    private final ControllerImpl controller = createController();
+    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, new ControllerImpl(
+            ControllerImplConfig.builder().clientConfig(
+                    ClientConfig.builder().controllerURI(getControllerURI()).build())
+                                .build(), getConnectionFactory().getInternalExecutor()));
     @Getter(lazy = true)
-    private final ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, getController());
+    private final ControllerImpl controller = new ControllerImpl(
+            ControllerImplConfig.builder().clientConfig(
+                    ClientConfig.builder().controllerURI(getControllerURI()).build()
+            ).build(), getConnectionFactory().getInternalExecutor());
 
-    private ControllerImpl createController() {
-        return new ControllerImpl(ControllerImplConfig.builder()
-                                                      .clientConfig(ClientConfig.builder()
-                                                                                .controllerURI(getControllerURI())
-                                                                                .build())
-                                                      .build(),
-                                  getConnectionFactory().getInternalExecutor());
-    }
-    
     private URI createControllerURI() {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -112,16 +112,15 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
         final int offsetEvents = RG_PARALLELISM * 20;
         final int batchIterations = 4;
         final Stream stream = Stream.of(SCOPE, STREAM);
+        final ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURI).build();
         @Cleanup
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder()
-                                                                           .clientConfig(ClientConfig.builder()
-                                                                           .controllerURI(controllerURI).build()).build(),
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(clientConfig).build(),
                                                                             connectionFactory.getInternalExecutor());
         @Cleanup
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, controller);
         @Cleanup
-        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, ClientConfig.builder().build());
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig);
         log.info("Invoking batchClientSimpleTest test with Controller URI: {}", controllerURI);
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -155,7 +155,7 @@ public class PravegaTest extends AbstractReadWriteTest {
                 fail("Reinitialization Exception is not expected");
             }
             // try reading until all the written events are read, else the test will timeout.
-        } while ((event.getEvent() != null || event.isCheckpoint()) && readCount < NUM_EVENTS);
+        } while ((event.getEvent() == null || event.isCheckpoint()) && readCount < NUM_EVENTS);
         assertEquals("Read count should be equal to write count", NUM_EVENTS, readCount);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -155,7 +155,7 @@ public class PravegaTest extends AbstractReadWriteTest {
                 fail("Reinitialization Exception is not expected");
             }
             // try reading until all the written events are read, else the test will timeout.
-        } while ((event.getEvent() == null || event.isCheckpoint()) && readCount < NUM_EVENTS);
+        } while (readCount < NUM_EVENTS);
         assertEquals("Read count should be equal to write count", NUM_EVENTS, readCount);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -145,7 +145,7 @@ public class PravegaTest extends AbstractReadWriteTest {
         EventRead<String> event = null;
         do {
             try {
-                event = reader.readNextEvent(1000);
+                event = reader.readNextEvent(10_000);
                 log.debug("Read event: {}.", event.getEvent());
                 if (event.getEvent() != null) {
                     readCount++;
@@ -155,7 +155,7 @@ public class PravegaTest extends AbstractReadWriteTest {
                 fail("Reinitialization Exception is not expected");
             }
             // try reading until all the written events are read, else the test will timeout.
-        } while (readCount < NUM_EVENTS);
+        } while ((event.getEvent() != null || event.isCheckpoint()) && readCount < NUM_EVENTS);
         assertEquals("Read count should be equal to write count", NUM_EVENTS, readCount);
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -50,9 +50,9 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     private static final int ADD_NUM_WRITERS = 2;
     private static final int NUM_READERS = 2;
     private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
-    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 30 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(25 * 60);
+    public Timeout globalTimeout = Timeout.seconds(30 * 60);
     private final String scope = "testReadTxnWriteAutoScaleScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private final String stream = "testReadTxnWriteAutoScaleStream";
     private final String readerGroupName = "testReadTxnWriteAutoScaleReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -50,9 +50,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     private static final int NUM_READERS = 2;
     private static final int TOTAL_NUM_WRITERS = INIT_NUM_WRITERS + ADD_NUM_WRITERS;
 
-    //The execution time for @Before + @After + @Test methods should be less than 25 mins. Else the test will timeout.
+    //The execution time for @Before + @After + @Test methods should be less than 30 mins. Else the test will timeout.
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(25 * 60);
+    public Timeout globalTimeout = Timeout.seconds(30 * 60);
 
     private final String scope = "testReadWriteAndAutoScaleScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private final String readerGroupName = "testReadWriteAndAutoScaleReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -98,12 +98,11 @@ public class RetentionTest extends AbstractSystemTest {
 
     @Test
     public void retentionTest() throws Exception {
+        final ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURI).build();
         @Cleanup
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(
-                ClientConfig.builder().controllerURI(controllerURI).build())
-                .build(),
-                 connectionFactory.getInternalExecutor());
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(clientConfig).build(),
+                                                       connectionFactory.getInternalExecutor());
         @Cleanup
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, controller);
         log.info("Invoking Writer test with Controller URI: {}", controllerURI);


### PR DESCRIPTION
**Change log description**  
- Ensure pravega operator version is configurable.
- Increase retries for log download.
- Fix bug in PravegaTest.

**Purpose of the change**  
Fixes #3213

**What the code does**  
- On slower / resource starved clusters log download would fail as the pod creation would take a longer time. Now the framework retries for  a longer duration.
- A bug in PravegaTest has been fixed which caused the test to exit when the read timed out.
- Pravega operator is now configurable.

**How to verify it**  
All the tests should continue to pass.
