### PR TITLE
Issue 3221: Fix Invalid Precondition check in SegmentInputStreamImpl 

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -61,8 +61,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
         Preconditions.checkArgument(startOffset >= 0);
         Preconditions.checkNotNull(asyncInput);
         Preconditions.checkNotNull(endOffset, "endOffset");
-        Preconditions.checkArgument(endOffset > startOffset + WireCommands.TYPE_PLUS_LENGTH_SIZE,
-                "Invalid end offset.");
+        Preconditions.checkArgument(endOffset >= startOffset, "Invalid end offset.");
         this.asyncInput = asyncInput;
         this.offset = startOffset;
         this.endOffset = endOffset;

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -414,10 +414,9 @@ public class SegmentInputStreamTest {
     public void testReadWithInvalidEndOffset() {
         AsyncSegmentInputStream mockAsyncInputStream = mock(AsyncSegmentInputStream.class);
 
-        //Set the end offset which is less than startOffset+WireCommands.TYPE_PLUS_LENGTH_SIZE
+        //Set the end offset which is less than startOffset
         @Cleanup
-        EventSegmentReaderImpl stream = SegmentInputStreamFactoryImpl.getEventSegmentReader(mockAsyncInputStream, 0,
-                WireCommands.TYPE_PLUS_LENGTH_SIZE - 1, SegmentInputStreamImpl.DEFAULT_BUFFER_SIZE);
+        EventSegmentReaderImpl stream = SegmentInputStreamFactoryImpl.getEventSegmentReader(mockAsyncInputStream, 10, 9, SegmentInputStreamImpl.DEFAULT_BUFFER_SIZE);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -166,6 +166,41 @@ public class BoundedStreamReaderTest {
     }
 
     @Test(timeout = 60000)
+    public void testReaderGroupWithSameBounds() throws Exception {
+        createScope(SCOPE);
+        createStream(STREAM1);
+
+        @Cleanup
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        @Cleanup
+        EventStreamWriter<String> writer1 = clientFactory.createEventWriter(STREAM1, serializer,
+                                                                            EventWriterConfig.builder().build());
+        // 1. Prep the stream with data.
+        // Write events with event size of 30
+        writer1.writeEvent(keyGenerator.get(), getEventData.apply(1)).get();
+        writer1.writeEvent(keyGenerator.get(), getEventData.apply(2)).get();
+
+        // 2. Create a StreamCut Pointing to offset 30L
+        StreamCut streamCut = getStreamCut(STREAM1, 30L, 0);
+
+        // 3. Create a ReaderGroup where the lower and upper bound are the same.
+        @Cleanup
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        groupManager.createReaderGroup("group", ReaderGroupConfig
+                .builder().disableAutomaticCheckpoints()
+                .stream(Stream.of(SCOPE, STREAM1), streamCut, streamCut)
+                .build());
+
+        // 4. Create a reader
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader("readerId", "group", serializer,
+                                                                      ReaderConfig.builder().build());
+
+        // 5. Verify if configuration is enforced.
+        Assert.assertNull("Null is expected", reader.readNextEvent(1000).getEvent());
+    }
+
+    @Test(timeout = 60000)
     public void testBoundedStreamWithScaleTest() throws Exception {
         createScope(SCOPE);
         createStream(STREAM1);


### PR DESCRIPTION
**Change log description**  
Ensure the precondition check inside `SegmentInputStreamImpl` checks if `endOffset >= startOffset`

**Purpose of the change**  
Fixes #3221 

**What the code does**  
Correct the precondition check.

**How to verify it**  
All the tests should continue to pass. 
Verified that the `io.pravega.test.system.StreamCutsTest` passes on a PKS cluster.
