### PR TITLE
Issue 3224: Fix metrics reporter start in r0.4

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -24,6 +24,7 @@ import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
 import io.pravega.controller.timeout.TimeoutServiceConfig;
 import io.pravega.controller.util.Config;
 import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.StatsProvider;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,9 +36,12 @@ public class Main {
 
     public static void main(String[] args) {
 
+        StatsProvider statsProvider = null;
         try {
             //0. Initialize metrics provider
             MetricsProvider.initialize(Config.getMetricsConfig());
+            statsProvider = MetricsProvider.getMetricsProvider();
+            statsProvider.start();
 
             ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder()
                     .connectionString(Config.ZK_URL)
@@ -91,6 +95,10 @@ public class Main {
         } catch (Throwable e) {
             log.error("Controller service failed", e);
             System.exit(-1);
+        } finally {
+            if (statsProvider != null) {
+                statsProvider.close();
+            }
         }
     }
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -105,7 +105,6 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore implements AutoC
     @VisibleForTesting
     ZKStreamMetadataStore(CuratorFramework client, int bucketCount, Executor executor, Duration gcPeriod) {
         super(new ZKHostIndex(client, "/hostTxnIndex", executor), bucketCount);
-        initialize();
         storeHelper = new ZKStoreHelper(client, executor);
         bucketCacheMap = new ConcurrentHashMap<>();
         bucketOwnershipCacheRef = new AtomicReference<>();
@@ -116,10 +115,6 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore implements AutoC
         this.completedTxnGC = new ZKGarbageCollector(COMPLETED_TXN_GC_NAME, storeHelper, this::gcCompletedTxn, gcPeriod);
         this.completedTxnGC.startAsync();
         this.completedTxnGC.awaitRunning();
-    }
-
-    private void initialize() {
-        METRICS_PROVIDER.start();
     }
 
     private CompletableFuture<Void> gcCompletedTxn() {


### PR DESCRIPTION
**Change log description**  
This PR moves the initialization of metrics from `ZKStreamMetadataStore` to `Main` in the Controller. This change has been taken from PR #3117.

**Purpose of the change**  
Fixes #3224.

**What the code does**  
Changes the location of initialization of metrics in the Controller to avoid problems on Controller restarts. Manifestations of these problems can be seen in issues #3077, #3170 (i.e., `java.lang.IllegalArgumentException: Reporter already started`).

**How to verify it**  
All test should be passing as before. Checked in a local deployment that metrics are being reported by the Controller.
