### PR TITLE
Issue 3232: Enable private docker registry configuration for Kubernetes framework.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -742,7 +742,16 @@ project('test:system') {
 
         ext.repoUrl = project.hasProperty("repoUrl") ? project.repoUrl : ""
         systemProperty "execType", "KUBERNETES"
-        systemProperty "imageVersion", System.getProperty("imageVersion")
+        systemProperty "pravegaOperatorVersion", System.getProperty("pravegaOperatorVersion") // default value is "latest"
+        // The below properties are used to to specify the pravega docker image properties
+        // e.g: private-docker-repo/pravega-prefix/pravega:version
+        if (System.getProperty("dockerRegistryUrl") != null) { // docker images are pulled from dockerhub if dockerRegistryUrl is not specified.
+            systemProperty "dockerRegistryUrl", System.getProperty("dockerRegistryUrl") + "/"
+        }
+        systemProperty "imagePrefix", System.getProperty("imagePrefix")  // the default value of imagePrefix is pravega.
+        systemProperty "imageVersion", System.getProperty("imageVersion") // pravega version.
+        // bookkeeper version defaults to pravega version.
+        systemProperty "pravegaBookkeeperVersion", System.getProperty("pravegaBookkeeperVersion", System.getProperty("imageVersion"))
         systemProperty "segmentStoreExtraEnv", System.getProperty("segmentStoreExtraEnv")
 
         if (System.getProperty("imageVersion") == null) {
@@ -750,8 +759,6 @@ project('test:system') {
         }
 
         maxParallelForks = 1
-        systemProperty "testVersion", pravegaVersion
-
     }
 
     task execShellScript(type: Exec) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -68,9 +68,10 @@ public abstract class AbstractService implements Service {
     static final String PRAVEGA_SEGMENTSTORE_LABEL = "pravega-segmentstore";
     static final String BOOKKEEPER_LABEL = "bookie";
     static final String PRAVEGA_ID = "pravega";
-    static final String IMAGE_PULL_POLICY = System.getProperty("ImagePullPolicy", "IfNotPresent");
-    private static final String DOCKER_REGISTRY =  System.getProperty("dockerImageRegistry", "");
+    static final String IMAGE_PULL_POLICY = System.getProperty("imagePullPolicy", "IfNotPresent");
+    private static final String DOCKER_REGISTRY =  System.getProperty("dockerRegistryUrl", "");
     private static final String PRAVEGA_VERSION = System.getProperty("imageVersion", "latest");
+    private static final String PRAVEGA_BOOKKEEPER_VERSION = System.getProperty("pravegaBookkeeperVersion", PRAVEGA_VERSION);
     private static final String PRAVEGA_OPERATOR_VERSION = System.getProperty("pravegaOperatorVersion", "latest");
     private static final String PREFIX = System.getProperty("imagePrefix", "pravega");
 
@@ -110,7 +111,7 @@ public abstract class AbstractService implements Service {
         final Map<String, Object> bkPersistentVolumeSpec = getPersistentVolumeClaimSpec("10Gi", "standard");
         // use the latest version of bookkeeper.
         final Map<String, Object> bookeeperSpec = ImmutableMap.<String, Object>builder().put("image",
-                                                                                             getImageSpec(DOCKER_REGISTRY + PREFIX + "/bookkeeper", "latest"))
+                                                                                             getImageSpec(DOCKER_REGISTRY + PREFIX + "/bookkeeper", PRAVEGA_BOOKKEEPER_VERSION))
                                                                                         .put("replicas", bookieCount)
                                                                                         .put("storage", ImmutableMap.builder()
                                                                                                                     .put("ledgerVolumeClaimTemplate", bkPersistentVolumeSpec)
@@ -139,8 +140,7 @@ public abstract class AbstractService implements Service {
                                                                                       .put("cacheVolumeClaimTemplate", pravegaPersistentVolumeSpec)
                                                                                       .put("options", options)
                                                                                       .put("image",
-                                                                                           getImageSpec(DOCKER_REGISTRY + PREFIX + "/pravega",
-                                                                                                        PRAVEGA_VERSION))
+                                                                                           getImageSpec(DOCKER_REGISTRY + PREFIX + "/pravega", PRAVEGA_VERSION))
                                                                                       .put("tier2", tier2Spec("pravega-tier2"))
                                                                                       .build();
         return ImmutableMap.<String, Object>builder()
@@ -234,7 +234,7 @@ public abstract class AbstractService implements Service {
 
     private V1Deployment getPravegaOperatorDeployment() {
         V1Container container = new V1ContainerBuilder().withName(PRAVEGA_OPERATOR)
-                                                        .withImage(DOCKER_REGISTRY + PREFIX + "/pravega-operator:" + PRAVEGA_OPERATOR_VERSION)
+                                                        .withImage("pravega/pravega-operator:" + PRAVEGA_OPERATOR_VERSION)
                                                         .withPorts(new V1ContainerPortBuilder().withContainerPort(60000).build())
                                                         .withCommand(PRAVEGA_OPERATOR)
                                                         .withImagePullPolicy(IMAGE_PULL_POLICY)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -75,8 +75,6 @@ public class K8SequentialExecutor implements TestExecutor {
     }
 
     private V1Pod getTestPod(String className, String methodName, String podName) {
-        String repoUrl = System.getProperty("repoUrl");
-        String testVersion = System.getProperty("testVersion");
         return new V1PodBuilder()
                 .withNewMetadata().withName(podName).withNamespace(NAMESPACE).withLabels(ImmutableMap.of("POD_NAME", podName)).endMetadata()
                 .withNewSpec().withServiceAccountName(SERVICE_ACCOUNT).withAutomountServiceAccountToken(true)


### PR DESCRIPTION
**Change log description**  

1. Private docker registry url can be configured by passing a system property `-DdockerRegistryUrl`.
2. Ensure bookkeeper docker image version can be configured via system property.

**Purpose of the change**  
Fixes #3232 

**What the code does**  
Ensure the system properties passed to the Gradle task `startK8SystemTests` are actually passed to the test java process.

The command to invoke tests using a custom docker registry where the pravega docker image is 
`custom/pravega:issueFix`  , bookeeper docker image is `custom/bookkeeper:issueFix`  is shown below.

`gradle --info startK8SystemTests -DdockerRegistryUrl=devops.repo.com:8116 -DimagePrefix=custom -DimageVersion=issueFix --tests io.pravega.test.system.PravegaTest
`

**How to verify it**  
This has been verified against a private docker registry.
