### PR TITLE
Issue 3240: Disable Spotbugs rules not working on JDK11:

### DIFF
--- a/checkstyle/spotbugs-exclude.xml
+++ b/checkstyle/spotbugs-exclude.xml
@@ -26,6 +26,12 @@
     <Match> <!-- Lots of harmless calls to System.exit() in our codebase -->
         <Bug pattern="DM_EXIT" />
     </Match>
+    <Match> <!-- does not work from JDK11 onwards https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match> <!-- does not work from JDK11 onwards https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
     <Match> <!-- Returning a java.lang.Boolean is common with Streams/Lambdas -->
         <Bug pattern="NP_BOOLEAN_RETURN_NULL" />
     </Match>


### PR DESCRIPTION
javac from JDK11+ adds a null-check in try-with-resources
Spotbugs reports this as a reduntant check
See the discussion at  https://github.com/spotbugs/spotbugs/issues/756

The only work-around is to disable the rules

Signed-off-by: Enrico Olivelli <eolivelli@apache.org>

**Change log description**  
Disable Redundant-Null-Check related rules

**Purpose of the change**  
Fixes #3240

**What the code does**  
Disable Redundant-Null-Check related rules

**How to verify it**  

JAVA_HOME=/path/to/jdk11 ./gradlew spotbugsMain spotbugsTest
(unfortunately current master cannot build on JDK11)