### PR TITLE
Issue 3244: Checkstyle fails on JDK11 while using Gradle daemon - needs an absolute path

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -12,7 +12,7 @@
     <property name="header" value="/\*\*\n *"/>
   </module>
   <module name="SuppressionFilter">
-        <property name="file" value="checkstyle/suppressions.xml"/>
+        <property name="file" value="${suppressionsFile}"/>
   </module>
   <module name="SuppressWarningsFilter"/>
   <module name="FileTabCharacter"/>

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -13,7 +13,8 @@ plugins.withId('checkstyle') {
         toolVersion = checkstyleToolVersion
 
         configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
+        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml",
+                            suppressionsFile: "$rootDir/checkstyle/suppressions.xml"]
     }
 
     plugins.withId('java') {


### PR DESCRIPTION

**Change log description**  
The fix is to use an absolute path in order to refer to the suppressions.xml file.

See detailed explanation in #3244 

**Purpose of the change**  
Fixes #3244

**What the code does**  
Compute the absolute path during the execution of the build configuration script and do not rely on relative paths

**How to verify it**  
run this command without errors
`JAVA_HOME=/path/to/jdk11 ./gradlew checkstyleMain checkstyleTest
`