### PR TITLE
Issue 3247: (SegmentStore) Fixed ContainerKeyIndexTests.testRecovery

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -398,8 +398,18 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val getUnindexedKeysResult = getUnindexedKeys.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         checkKeyOffsets(hashes, keysWithOffsets, getBucketOffsetsResult);
         Assert.assertEquals("Unexpected result from unblocked getBackpointerOffset().", -1L, (long) getBackpointersResult);
-        Assert.assertEquals("Unexpected result from unblocked conditional update.", segmentLength + 1L, (long) conditionalUpdateResult.get(0));
-        Assert.assertEquals("Unexpected result size from unblocked getUnindexedKeyHashes().", 1, getUnindexedKeysResult.size());
+        Assert.assertEquals("Unexpected result from unblocked conditional update.",
+                segmentLength + 1L, (long) conditionalUpdateResult.get(0));
+
+        // Depending on the order in which the internal recovery tracker (implemented by CompletableFuture.thenCompose)
+        // executes its callbacks, the result of this call may be either 1 or 2 (it may unblock prior to the conditional
+        // update unblocking or the other way around).
+        Assert.assertTrue("Unexpected result size from unblocked getUnindexedKeyHashes().",
+                getUnindexedKeysResult.size() == 1 || getUnindexedKeysResult.size() == 2);
+
+        // However, verify that in the end, we have 2 unindexed keys.
+        val finalGetUnindexedKeysResult = context.index.getUnindexedKeyHashes(context.segment).get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected result size from final getUnindexedKeyHashes().", 2, finalGetUnindexedKeysResult.size());
 
         // 4. Verify no new requests are blocked now.
         getBucketOffsets.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS); // A timeout check will suffice


### PR DESCRIPTION
Signed-off-by: Andrei Paduroiu <andrei.paduroiu@emc.com>

**Change log description**  
- `ContainerKeyIndexTests.testRecovery` was failing sporadically due to the internal recovery tracker (backed by `CompletableFuture.thenCompose`) executing its callbacks in an unpredictable order.
- This was fixed (in the unit test) to add more wiggle room and to do a final check of the result.

**Purpose of the change**  
Fixes #3247.

**What the code does**  
- ContainerKeyIndex uses a recovery tracker to block all conditional updates, gets and other operations on the initial recovery of a segment post failover (a rather quick operation). This is done by keeping a `CompletableFuture` and adding callbacks to it via `thenCompose`. When the recovery is done, the future is completed and so are its callbacks.
- These callbacks are not executed in the order in which they were queued up (and neither do we care if they are). However the unit test was assuming so, and, as such, it was fixed to allow for some variance in the results.

**How to verify it**  
Unit tests must pass consistently
