### PR TITLE
Issue 3173: Add assertions and tests

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -724,12 +724,12 @@ public class ControllerImpl implements Controller {
         }, this.executor);
         return result.thenApply(ranges -> {
             log.debug("Received the following data from the controller {}", ranges.getSegmentRangesList());
-            NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
+            NavigableMap<Double, SegmentWithRange> rangeMap = new TreeMap<>();
             for (SegmentRange r : ranges.getSegmentRangesList()) {
                 Preconditions.checkState(r.getMinKey() <= r.getMaxKey(),
                                          "Min keyrange %s was not less than maximum keyRange %s for segment %s",
                                          r.getMinKey(), r.getMaxKey(), r.getSegmentId());
-                rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
+                rangeMap.put(r.getMaxKey(), new SegmentWithRange(ModelHelper.encode(r.getSegmentId()), r.getMinKey(), r.getMaxKey()));
             }
             return new StreamSegments(rangeMap, ranges.getDelegationToken());
         }).whenComplete((x, e) -> {
@@ -812,11 +812,11 @@ public class ControllerImpl implements Controller {
     }
 
     private TxnSegments convert(CreateTxnResponse response) {
-        NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
+        NavigableMap<Double, SegmentWithRange> rangeMap = new TreeMap<>();
 
         for (SegmentRange r : response.getActiveSegmentsList()) {
             Preconditions.checkState(r.getMinKey() <= r.getMaxKey());
-            rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
+            rangeMap.put(r.getMaxKey(), new SegmentWithRange(ModelHelper.encode(r.getSegmentId()), r.getMinKey(), r.getMaxKey()));
         }
         StreamSegments segments = new StreamSegments(rangeMap, response.getDelegationToken());
         return new TxnSegments(segments, ModelHelper.encode(response.getTxnId()));

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -155,15 +155,13 @@ public class StreamSegments {
             Preconditions.checkArgument(replacedSegment.getLow() >= getLowerBound(replacements));
         }
         for (Entry<Long, List<SegmentWithRange>> ranges : replacementRanges.entrySet()) {
-            double upperReplacementRange = getUpperBound(ranges.getValue());
-            double lowerReplacementRange = getLowerBound(ranges.getValue());
-            Entry<Double, SegmentWithRange> upperReplacedSegment = segments.floorEntry(upperReplacementRange);
-            Entry<Double, SegmentWithRange> lowerReplacedSegment =  segments.higherEntry(lowerReplacementRange);
+            Entry<Double, SegmentWithRange> upperReplacedSegment = segments.floorEntry(getUpperBound(ranges.getValue()));
+            Entry<Double, SegmentWithRange> lowerReplacedSegment = segments.higherEntry(getLowerBound(ranges.getValue()));
             Preconditions.checkArgument(upperReplacedSegment != null, "Missing replaced replacement segments %s",
                                         replacementSegments);
             Preconditions.checkArgument(lowerReplacedSegment != null, "Missing replaced replacement segments %s",
                                         replacementSegments);
-         }
+        }
     }
 
     private double getLowerBound(List<SegmentWithRange> values) {

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -137,7 +137,7 @@ public class StreamSegments {
     }
     
     /**
-     * Checks that replacementSegments provided are consistent with the segments that currently being used.
+     * Checks that replacementSegments provided are consistent with the segments that are currently being used.
      * @param replacedSegment The segment on which EOS was reached
      * @param replacementSegments The StreamSegmentsWithPredecessors to verify
      */

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -37,9 +37,9 @@ public class StreamSegments {
     /**
      * Maps the upper end of a range to the corresponding segment. The range in the value is the
      * range of keyspace the segment has been assigned. The range in the value is NOT the same as
-     * the difference between two keys. The keys correspond to the range that the client client
+     * the difference between two keys. The keys correspond to the range that the client
      * should route to, where as the one in the value is the range the segment it assigned. These
-     * may be different if a client still has a preceding segment in it's map. In which case a
+     * may be different if a client still has a preceding segment in its map. In which case a
      * segment's keys may not contain the full assigned range.
      */
     private final NavigableMap<Double, SegmentWithRange> segments;
@@ -113,6 +113,10 @@ public class StreamSegments {
         return new StreamSegments(result, delegationToken);
     }
     
+    /**
+     * This combines consecutive entries in the map that refer to the same segment.
+     * This happens following a merge because the preceeding segments are replaced one at a time.
+     */
     private void removeDuplicates(NavigableMap<Double, SegmentWithRange> result) {
         Segment last = null;
         for (Iterator<SegmentWithRange> iterator = result.descendingMap().values().iterator(); iterator.hasNext();) {
@@ -162,9 +166,9 @@ public class StreamSegments {
          }
     }
 
-    private double getLowerBound(List<SegmentWithRange> value) {
+    private double getLowerBound(List<SegmentWithRange> values) {
         double lowerReplacementRange = 1;
-        for (SegmentWithRange range : value) {
+        for (SegmentWithRange range : values) {
             lowerReplacementRange = Math.min(lowerReplacementRange, range.getLow());
         }
         return lowerReplacementRange;

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -93,6 +93,7 @@ public class StreamSegments {
         List<SegmentWithRange> replacements = replacedRanges.get(segment.getSegmentId());
         Preconditions.checkNotNull(replacements, "Empty set of replacements for: {}", segment.getSegmentId());
         replacements.sort(Comparator.comparingDouble(SegmentWithRange::getHigh).reversed());
+        verifyContinuous(replacements);
         for (Entry<Double, SegmentWithRange> existingEntry : segments.descendingMap().entrySet()) { // iterate from the highest key.
             final SegmentWithRange existingSegment = existingEntry.getValue();
             if (existingSegment.equals(replacedSegment)) { // Segment needs to be replaced.
@@ -161,6 +162,14 @@ public class StreamSegments {
                                         replacementSegments);
             Preconditions.checkArgument(lowerReplacedSegment != null, "Missing replaced replacement segments %s",
                                         replacementSegments);
+        }
+    }
+    
+    private void verifyContinuous(List<SegmentWithRange> newSegments) {
+        double previous = newSegments.get(0).getHigh();
+        for (SegmentWithRange s : newSegments) {
+            Preconditions.checkArgument(previous == s.getHigh(), "Replacement segments were not continious: {}", newSegments);
+            previous = s.getLow();
         }
     }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -94,8 +94,8 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
     }
 
     private StreamSegments getSegments(Segment segment) {
-        NavigableMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(1.0, segment);
+        NavigableMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        segments.put(1.0, new SegmentWithRange(segment, 0.0, 1.0));
         return new StreamSegments(segments, "");
     }
     

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
@@ -47,11 +47,11 @@ public class SegmentSelectorTest {
         Controller controller = Mockito.mock(Controller.class);
         SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
         SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
-        TreeMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(0.25, new Segment(scope, streamName, 0));
-        segments.put(0.5, new Segment(scope, streamName, 1));
-        segments.put(0.75, new Segment(scope, streamName, 2));
-        segments.put(1.0, new Segment(scope, streamName, 3));
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        addNewSegment(segments, 0, 0.0, 0.25);
+        addNewSegment(segments, 1, 0.25, 0.5);
+        addNewSegment(segments, 2, 0.5, 0.75);
+        addNewSegment(segments, 3, 0.75, 1.0);
         StreamSegments streamSegments = new StreamSegments(segments, "");
 
         when(controller.getCurrentSegments(scope, streamName))
@@ -69,16 +69,20 @@ public class SegmentSelectorTest {
         }
     }
 
+    private void addNewSegment(TreeMap<Double, SegmentWithRange> segments, int number, double low, double high) {
+        segments.put(high, new SegmentWithRange(new Segment(scope, streamName, number), low, high));
+    }
+
     @Test
     public void testNullRoutingKey() {
         Controller controller = Mockito.mock(Controller.class);
         SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
         SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
-        TreeMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(0.25, new Segment(scope, streamName, 0));
-        segments.put(0.5, new Segment(scope, streamName, 1));
-        segments.put(0.75, new Segment(scope, streamName, 2));
-        segments.put(1.0, new Segment(scope, streamName, 3));
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        addNewSegment(segments, 0, 0.0, 0.25);
+        addNewSegment(segments, 1, 0.25, 0.5);
+        addNewSegment(segments, 2, 0.5, 0.75);
+        addNewSegment(segments, 3, 0.75, 1.0);
         StreamSegments streamSegments = new StreamSegments(segments, "");
 
         when(controller.getCurrentSegments(scope, streamName))
@@ -101,11 +105,11 @@ public class SegmentSelectorTest {
         Controller controller = Mockito.mock(Controller.class);
         SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
         SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
-        TreeMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(0.25, new Segment(scope, streamName, 0));
-        segments.put(0.5, new Segment(scope, streamName, 1));
-        segments.put(0.75, new Segment(scope, streamName, 2));
-        segments.put(1.0, new Segment(scope, streamName, 3));
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        addNewSegment(segments, 0, 0.0, 0.25);
+        addNewSegment(segments, 1, 0.25, 0.5);
+        addNewSegment(segments, 2, 0.5, 0.75);
+        addNewSegment(segments, 3, 0.75, 1.0);
         StreamSegments streamSegments = new StreamSegments(segments, "");
 
         when(controller.getCurrentSegments(scope, streamName))
@@ -141,9 +145,9 @@ public class SegmentSelectorTest {
 
         Controller controller = Mockito.mock(Controller.class);
         SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
-        TreeMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(0.5, segment0);
-        segments.put(1.0, segment1);
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        addNewSegment(segments, 0, 0.0, 0.5);
+        addNewSegment(segments, 1, 0.5, 1.0);
         StreamSegments streamSegments = new StreamSegments(segments, "");
 
         when(controller.getCurrentSegments(scope, streamName))

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -1017,7 +1017,7 @@ public class StreamSegmentsTest {
         assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.6));
         assertEquals(getSegment(2, 0), streamSegments.getSegmentForKey(0.8));
 
-        // 3 is slit into 5 and 6.
+        // 3 is split into 5 and 6.
         newRange = new HashMap<>();
         newRange.put(new SegmentWithRange(getSegment(5, 2), 0.66, 1.0), ImmutableList.of(computeSegmentId(3, 1)));
         newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
@@ -1045,7 +1045,7 @@ public class StreamSegmentsTest {
         assertEquals(getSegment(6, 2), streamSegments.getSegmentForKey(0.6));
         assertEquals(getSegment(3, 1), streamSegments.getSegmentForKey(0.8));
         
-        // 3 is slit into 5 and 6.
+        // 3 is split into 5 and 6.
         newRange = new HashMap<>();
         newRange.put(new SegmentWithRange(getSegment(5, 2), 0.66, 1.0), ImmutableList.of(computeSegmentId(3, 1)));
         newRange.put(new SegmentWithRange(getSegment(6, 2), 0.33, 0.66),
@@ -1314,20 +1314,18 @@ public class StreamSegmentsTest {
         segmentMap.put(1.0, new SegmentWithRange(createSegment(1, 0), 0.0, 1.0));
         ranges.put(createSegment(1, 0), Range.openClosed(0.0, 1.0));
         StreamSegments streamSegments = new StreamSegments(segmentMap, "");
-        int segumentNumber = 10;
+        int segmentNumber = 10;
 
         for (int epoch = 1; epoch < 1000; epoch++) {
-            System.out.println("Begin epoch " + epoch);
             LinkedHashMap<Segment, Integer> counts = getCounts(streamSegments);
-            System.out.println("Counts are: " + counts);
             List<Segment> toSplit = findSegmentsToSplit(counts);
 
             HashMap<Segment, StreamSegmentsWithPredecessors> toApply = new HashMap<>();
 
             for (Segment s : toSplit) {
                 if (r.nextDouble() < .2) {
-                    Segment lower = createSegment(segumentNumber++, epoch);
-                    Segment upper = createSegment(segumentNumber++, epoch);
+                    Segment lower = createSegment(segmentNumber++, epoch);
+                    Segment upper = createSegment(segmentNumber++, epoch);
                     toApply.putAll(splitSegment(ranges, s, lower, upper));
                 }
             }
@@ -1335,7 +1333,7 @@ public class StreamSegmentsTest {
             Map<Segment, Segment> toMerge = findSegmentsToMerge(streamSegments, counts);
             for (Entry<Segment, Segment> pair : toMerge.entrySet()) {
                 if (r.nextDouble() < .2) {
-                    Segment combined = createSegment(segumentNumber++, epoch);
+                    Segment combined = createSegment(segmentNumber++, epoch);
                     toApply.putAll(mergeSegments(ranges, pair, combined));
                 }
             }
@@ -1346,8 +1344,6 @@ public class StreamSegmentsTest {
             Set<Segment> expectedSegments = ranges.keySet();
 
             assertEquals(expectedSegments, actualSegments);
-            System.out.println(ranges);
-            System.out.println(streamSegments);
         }
     }
 
@@ -1379,7 +1375,6 @@ public class StreamSegmentsTest {
         Map<SegmentWithRange, List<Long>> newSegments = new HashMap<>();
         newSegments.put(new SegmentWithRange(combined, lowerRange.lowerEndpoint(), upperRange.upperEndpoint()),
                         ImmutableList.of(pair.getKey().getSegmentId(), pair.getValue().getSegmentId()));
-        System.out.println("Merging " + lowerRange + " and " + upperRange);
         StreamSegmentsWithPredecessors replacementRanges = new StreamSegmentsWithPredecessors(newSegments, "");
         HashMap<Segment, StreamSegmentsWithPredecessors> replacements = new HashMap<>();
         replacements.put(pair.getKey(), replacementRanges);
@@ -1424,7 +1419,6 @@ public class StreamSegmentsTest {
                         Collections.singletonList(oldSegment.getSegmentId()));
         newSegments.put(new SegmentWithRange(upper, midpoint, range.upperEndpoint()),
                         Collections.singletonList(oldSegment.getSegmentId()));
-        System.out.println("Splitting " + range + " at " + midpoint);
         StreamSegmentsWithPredecessors replacementRanges = new StreamSegmentsWithPredecessors(newSegments, "");
 
         HashMap<Segment, StreamSegmentsWithPredecessors> replacements = new HashMap<>();

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -181,8 +181,8 @@ public class StreamSegmentsTest {
     private StreamSegments initStreamSegments(int num) {
         TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
         double stride = 1.0 / num;
-        for (int i=0; i < num;i++) {            
-            addNewSegment(segments, i, i * stride, (i+1) * stride);
+        for (int i = 0; i < num; i++) {
+            addNewSegment(segments, i, i * stride, (i + 1) * stride);
         }
         StreamSegments streamSegments = new StreamSegments(segments, "");
         return streamSegments;

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -37,8 +37,8 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
     public Timeout globalTimeout = Timeout.seconds(10);
 
     private StreamSegments getSegments(Segment segment) {
-        NavigableMap<Double, Segment> segments = new TreeMap<>();
-        segments.put(1.0, segment);
+        NavigableMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        segments.put(1.0, new SegmentWithRange(segment, 0.0, 1.0));
         return new StreamSegments(segments, "");
     }
     

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -24,6 +24,7 @@ import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.impl.CancellableRequest;
 import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.impl.StreamSegmentSuccessors;
 import io.pravega.client.stream.impl.StreamSegments;
@@ -262,10 +263,13 @@ public class MockController implements Controller {
     
     private StreamSegments getCurrentSegments(Stream stream) {
         List<Segment> segmentsInStream = getSegmentsForStream(stream);
-        TreeMap<Double, Segment> segments = new TreeMap<>();
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
         double increment = 1.0 / segmentsInStream.size();
         for (int i = 0; i < segmentsInStream.size(); i++) {
-            segments.put((i + 1) * increment, new Segment(stream.getScope(), stream.getStreamName(), i));
+            segments.put((i + 1) * increment,
+                         new SegmentWithRange(new Segment(stream.getScope(), stream.getStreamName(), i),
+                                              i * increment,
+                                              (i + 1) * increment));
         }
         return new StreamSegments(segments, "");
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -282,9 +282,9 @@ public class LocalController implements Controller {
     }
 
     private StreamSegments getStreamSegments(List<SegmentRange> ranges) {
-        NavigableMap<Double, Segment> rangeMap = new TreeMap<>();
+        NavigableMap<Double, SegmentWithRange> rangeMap = new TreeMap<>();
         for (SegmentRange r : ranges) {
-            rangeMap.put(r.getMaxKey(), ModelHelper.encode(r.getSegmentId()));
+            rangeMap.put(r.getMaxKey(), new SegmentWithRange(ModelHelper.encode(r.getSegmentId()), r.getMinKey(), r.getMaxKey()));
         }
         return new StreamSegments(rangeMap, retrieveDelegationToken());
     }


### PR DESCRIPTION
**Change log description**  
Add more tests and sanity checks on the client when dealing with splits and merges.

**Purpose of the change**  
Adds assertions and more information to the in-memory structure which should prevent issues like #3173 from occurring and detect them quickly if they do. Adds more test coverage for this code path.

**What the code does**  
Adds more tests and assertions. Should not have functional changes.

*Caveat*: In the code before this change in a split followed by a merge where the segments were accessed in a staggered way, (Such as in `testOutOfOrderSplit` and `testOutOfOrderSplit2` which are included in this PR.) it previously could have included a new segment into the map for part of its range overlapping an old sealed segment. This is inconsistent and would result in unnecessary round trips, but it would self-correct when the seal of was encountered on the sealed segment and it's successors were fetched.

**How to verify it**  
@shrids Please carefully audit the algorithm and ask for comments added to anything that is not clear. It's a complicated function, but I want to make sure it is sufficiently readable.
