### PR TITLE
Issue 3252: Wrong metrics configuration parameter (dynamicTTLSeconds)

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -160,11 +160,11 @@ metrics.enableStatistics=false
 # in scenarios where there are large number of active Stream Segments.
 #metrics.dynamicCacheSize=100000
 
-# Number of seconds to keep dynamic metric statistic objects in memory.
+# Number of minutes to keep dynamic metric statistic objects in memory.
 # Valid values: Positive integer.
-# Recommended values: 60 to 300. The higher the value, the more memory used, but it may improve performance slightly
+# Recommended values: 1 to 60. The higher the value, the more memory used, but it may improve performance slightly
 # in scenarios where there are large number of active Stream Segments.
-#metrics.dynamicTTLSeconds=120
+#metrics.dynamicCacheEvictionDurationMs=30
 
 # Number of seconds between statistics reports.
 # Valid values: Positive integer.

--- a/config/config.properties
+++ b/config/config.properties
@@ -164,7 +164,7 @@ metrics.enableStatistics=false
 # Valid values: Positive integer.
 # Recommended values: 1 to 60. The higher the value, the more memory used, but it may improve performance slightly
 # in scenarios where there are large number of active Stream Segments.
-#metrics.dynamicCacheEvictionDurationMs=30
+#metrics.dynamicCacheEvictionDurationMinutes=30
 
 # Number of seconds between statistics reports.
 # Valid values: Positive integer.

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -287,7 +287,7 @@ public class MetricsConfig extends ComponentConfig {
     public final static String COMPONENT_CODE = "metrics";
     public final static String ENABLE_STATISTICS = "enableStatistics"; //enable metric, or will report nothing, default = true,  
     public final static Property<Long> DYNAMIC_CACHE_SIZE = "dynamicCacheSize"; //dynamic cache size , default = 10000000L
-    public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = "dynamicCacheEvictionDurationMs"; //dynamic cache evcition duration, default = 30
+    public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = "dynamicCacheEvictionDurationMinutes"; //dynamic cache evcition duration, default = 30
     public final static String OUTPUT_FREQUENCY = "statsOutputFrequencySeconds"; //reporter output frequency, default = 60
     public final static String METRICS_PREFIX = "metricsPrefix"; //Metrics Prefix, default = "pravega"
     public final static String CSV_ENDPOINT = "csvEndpoint"; // CSV reporter output dir, default = "/tmp/csv"

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -41,7 +41,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         this.metrics = metrics;
         this.underlying = statsLogger;
         this.cacheSize = metricsConfig.getDynamicCacheSize();
-        this.cacheEvictionDuration = metricsConfig.getDynamicCacheEvictionDurationMs();
+        this.cacheEvictionDuration = metricsConfig.getDynamicCacheEvictionDurationMinutes();
 
         countersCache = CacheBuilder.newBuilder().
                 maximumSize(cacheSize).expireAfterAccess(cacheEvictionDuration, TimeUnit.MILLISECONDS).

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -41,7 +41,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         this.metrics = metrics;
         this.underlying = statsLogger;
         this.cacheSize = metricsConfig.getDynamicCacheSize();
-        this.cacheEvictionDuration = metricsConfig.getDynamicCacheEvictionDurationMinutes();
+        this.cacheEvictionDuration = metricsConfig.getDynamicCacheEvictionDurationMinutes().toMillis();
 
         countersCache = CacheBuilder.newBuilder().
                 maximumSize(cacheSize).expireAfterAccess(cacheEvictionDuration, TimeUnit.MILLISECONDS).

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -24,7 +24,7 @@ public class MetricsConfig {
     //region Config Names
     public final static Property<Boolean> ENABLE_STATISTICS = Property.named("enableStatistics", true);
     public final static Property<Long> DYNAMIC_CACHE_SIZE = Property.named("dynamicCacheSize", 10000000L);
-    public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = Property.named("dynamicCacheEvictionDurationMs", 30);
+    public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = Property.named("dynamicCacheEvictionDurationMinutes", 30);
     public final static Property<Integer> OUTPUT_FREQUENCY = Property.named("statsOutputFrequencySeconds", 60);
     public final static Property<String> METRICS_PREFIX = Property.named("metricsPrefix", "pravega");
     public final static Property<String> CSV_ENDPOINT = Property.named("csvEndpoint", "/tmp/csv");
@@ -64,7 +64,7 @@ public class MetricsConfig {
      */
 
     @Getter
-    private long dynamicCacheEvictionDurationMs;
+    private long dynamicCacheEvictionDurationMinutes;
 
     /**
      * Gets a value indicating output frequency in seconds.
@@ -174,7 +174,7 @@ public class MetricsConfig {
     private MetricsConfig(TypedProperties properties) throws ConfigurationException {
         this.enableStatistics = properties.getBoolean(ENABLE_STATISTICS);
         this.dynamicCacheSize = properties.getLong(DYNAMIC_CACHE_SIZE);
-        this.dynamicCacheEvictionDurationMs = Duration.ofMinutes(properties.getInt(DYNAMIC_CACHE_EVICTION_DURATION_MINUTES)).toMillis();
+        this.dynamicCacheEvictionDurationMinutes = Duration.ofMinutes(properties.getInt(DYNAMIC_CACHE_EVICTION_DURATION_MINUTES)).toMillis();
         this.statsOutputFrequencySeconds = properties.getInt(OUTPUT_FREQUENCY);
         this.metricsPrefix = properties.get(METRICS_PREFIX);
         this.csvEndpoint = properties.get(CSV_ENDPOINT);
@@ -204,8 +204,8 @@ public class MetricsConfig {
 
 
     @VisibleForTesting
-    public void setDynamicCacheEvictionDurationMs(long duration) {
-        this.dynamicCacheEvictionDurationMs = duration;
+    public void setDynamicCacheEvictionDurationMinutes(long duration) {
+        this.dynamicCacheEvictionDurationMinutes = duration;
     }
 
     //endregion

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -64,13 +64,13 @@ public class MetricsConfig {
      */
 
     @Getter
-    private long dynamicCacheEvictionDurationMinutes;
+    private Duration dynamicCacheEvictionDurationMinutes;
 
     /**
      * Gets a value indicating output frequency in seconds.
      */
     @Getter
-    private final int statsOutputFrequencySeconds;
+    private final Duration statsOutputFrequencySeconds;
 
     /**
      * The metrics prefix.
@@ -174,8 +174,8 @@ public class MetricsConfig {
     private MetricsConfig(TypedProperties properties) throws ConfigurationException {
         this.enableStatistics = properties.getBoolean(ENABLE_STATISTICS);
         this.dynamicCacheSize = properties.getLong(DYNAMIC_CACHE_SIZE);
-        this.dynamicCacheEvictionDurationMinutes = Duration.ofMinutes(properties.getInt(DYNAMIC_CACHE_EVICTION_DURATION_MINUTES)).toMillis();
-        this.statsOutputFrequencySeconds = properties.getInt(OUTPUT_FREQUENCY);
+        this.dynamicCacheEvictionDurationMinutes = Duration.ofMinutes(properties.getInt(DYNAMIC_CACHE_EVICTION_DURATION_MINUTES));
+        this.statsOutputFrequencySeconds = Duration.ofSeconds(properties.getInt(OUTPUT_FREQUENCY));
         this.metricsPrefix = properties.get(METRICS_PREFIX);
         this.csvEndpoint = properties.get(CSV_ENDPOINT);
         this.statsDHost = properties.get(STATSD_HOST);
@@ -204,7 +204,7 @@ public class MetricsConfig {
 
 
     @VisibleForTesting
-    public void setDynamicCacheEvictionDurationMinutes(long duration) {
+    public void setDynamicCacheEvictionDuration(Duration duration) {
         this.dynamicCacheEvictionDurationMinutes = duration;
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
@@ -127,7 +127,7 @@ class StatsProviderImpl implements StatsProvider {
                 .build());
         }
         for (ScheduledReporter r : reporters) {
-            r.start(conf.getStatsOutputFrequencySeconds(), TimeUnit.SECONDS);
+            r.start(conf.getStatsOutputFrequencySeconds().getSeconds(), TimeUnit.SECONDS);
         }
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -36,6 +36,7 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
@@ -84,7 +85,7 @@ public class ControllerMetricsTest {
                                                    .with(MetricsConfig.ENABLE_CSV_REPORTER, false)
                                                    .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                                                    .build();
-        metricsConfig.setDynamicCacheEvictionDurationMinutes(300000);
+        metricsConfig.setDynamicCacheEvictionDuration(Duration.ofMinutes(5));
 
         MetricsProvider.initialize(metricsConfig);
         statsProvider = MetricsProvider.getMetricsProvider();

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -84,7 +84,7 @@ public class ControllerMetricsTest {
                                                    .with(MetricsConfig.ENABLE_CSV_REPORTER, false)
                                                    .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                                                    .build();
-        metricsConfig.setDynamicCacheEvictionDurationMs(300000);
+        metricsConfig.setDynamicCacheEvictionDurationMinutes(300000);
 
         MetricsProvider.initialize(metricsConfig);
         statsProvider = MetricsProvider.getMetricsProvider();

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -107,7 +107,7 @@ public class MetricsTest {
         MetricsConfig metricsConfig = MetricsConfig.builder()
                 .with(MetricsConfig.ENABLE_CSV_REPORTER, false).with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
-        metricsConfig.setDynamicCacheEvictionDurationMs(5000);
+        metricsConfig.setDynamicCacheEvictionDurationMinutes(5000);
 
         MetricsProvider.initialize(metricsConfig);
         statsProvider = MetricsProvider.getMetricsProvider();

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -41,6 +41,7 @@ import io.pravega.shared.metrics.StatsProvider;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class MetricsTest {
         MetricsConfig metricsConfig = MetricsConfig.builder()
                 .with(MetricsConfig.ENABLE_CSV_REPORTER, false).with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
-        metricsConfig.setDynamicCacheEvictionDurationMinutes(5000);
+        metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(5));
 
         MetricsProvider.initialize(metricsConfig);
         statsProvider = MetricsProvider.getMetricsProvider();


### PR DESCRIPTION
**Change log description**  
Enable `dynamicCacheEvictionDurationMs` to be configured in `config.properties` file (replaces the existing `dynamicTTLSeconds` entry in configuration).

**Purpose of the change**  
Fixes #3252.

**What the code does**  
In `config.properties`, there is a metrics configuration parameter that is not used anywhere: `dynamicTTLSeconds`. The description of this parameter matches the purpose of `dynamicCacheEvictionDurationMs`, which is the actual one used in `MetricsConfig.java`. This PR just replaces the apparently mistaken parameter name by the correct one in the configuration.

**How to verify it**  
No changes in the code. All the tests should be working as before.