### PR TITLE
Issue 3258: Build fails on JDK11: Bytecode is targeted jdk11 and not jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: java
 install: true
 jdk:
  - oraclejdk8
+ - openjdk11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ language: java
 install: true
 jdk:
  - oraclejdk8
- - openjdk11
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ allprojects {
 
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
+            sourceCompatibility = "8"
+            targetCompatibility = "8"
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
     }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -16,8 +16,6 @@ plugins.withId('java') {
     apply plugin: 'maven'
 
     compileJava {
-        sourceCompatibility = "8"
-        targetCompatibility = "8"
         
         options.compilerArgs.addAll([
                 "-Xlint:deprecation",


### PR DESCRIPTION

**Change log description**  
Force java source and target version to be "8", by setting sourceCompatibility and targetCompatibily after project 'evaluation'.
Current configuration is not working correctly as it is not really applied to every project.


**Purpose of the change**  
Fixes #3258 

**What the code does**  
Change Gradle configuration in order to force Java Bytecode compatibility level

**How to verify it**  
`JAVA_HOME=/path/to/jdk11 ./gradlew build`
