### PR TITLE
Issue 3249: Increase storage thread pool size.

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -47,8 +47,8 @@ pravegaservice.containerCount=4
 
 # Maximum number of threads in the Thread Pool used for Tier2 tasks (reading, writing, create, delete, etc.).
 # Valid values: Positive integer.
-# Recommended setting: 2 * Number of containers per node, minimum 20.
-#pravegaservice.storageThreadPoolSize=20
+# Recommended setting: reasonably large number which does not cause thrashing, minimum 20, recommended value 200.
+#pravegaservice.storageThreadPoolSize=200
 
 # TCP port where the SegmentStore will be listening for incoming requests.
 # Valid values: Positive integer in the valid TCP port ranges.

--- a/docker/pravega/scripts/init_segmentstore.sh
+++ b/docker/pravega/scripts/init_segmentstore.sh
@@ -17,5 +17,6 @@ init_segmentstore() {
     add_system_property "pravegaservice.zkURL" "${ZK_URL}"
     add_system_property "autoScale.controllerUri" "${CONTROLLER_URL}"
     add_system_property "bookkeeper.zkAddress" "${BK_ZK_URL:-${ZK_URL}}"
+    add_system_property "pravegaservice.storageThreadPoolSize" "${STORAGE_THREAD_POOL_SIZE}"
     echo "JAVA_OPTS=${JAVA_OPTS}"
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -29,7 +29,7 @@ public class ServiceConfig {
 
     public static final Property<Integer> CONTAINER_COUNT = Property.named("containerCount");
     public static final Property<Integer> THREAD_POOL_SIZE = Property.named("threadPoolSize", 30);
-    public static final Property<Integer> STORAGE_THREAD_POOL_SIZE = Property.named("storageThreadPoolSize", 20);
+    public static final Property<Integer> STORAGE_THREAD_POOL_SIZE = Property.named("storageThreadPoolSize", 200);
     public static final Property<Integer> LISTENING_PORT = Property.named("listeningPort", 12345);
     public static final Property<Integer> PUBLISHED_PORT = Property.named("publishedPort");
     public static final Property<String> LISTENING_IP_ADDRESS = Property.named("listeningIPAddress", "");


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Increase default size of storage thread pool.

**Purpose of the change**  
Fixes #3249

**What the code does**  
The code changes the default value of number of storage threads.
Storage threads are mostly i/o bound and are blocked while i/o is pending. As such the throughput is constrained by available threads, so bigger the thread pool the better. 
The number is 10 times previous value. (Although during testing I have seen no negative impact with upto 1K threads.)

**How to verify it**  
This is only a config change.
All usual tests should continue to pass.
Performance tests should show increased throughput.
