### PR TITLE
Make tests pass on JDK11 - disable TLS 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: java
 install: true
 jdk:
  - oraclejdk8
+ - openjdk11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ language: java
 install: true
 jdk:
  - oraclejdk8
- - openjdk11
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
         }
         test {
           // From JDK11+ Java will try to use TLSv1.3, we don't need it in tests
-          // systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
+          systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
         }
     }
     // Plugin configurations

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,6 @@ allprojects {
             compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
             testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         }
-        test {
-          // From JDK11+ Java will try to use TLSv1.3, we don't need it in tests
-          systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
-        }
     }
     // Plugin configurations
     apply from: "$rootDir/gradle/application.gradle"
@@ -698,8 +694,6 @@ project('standalone') {
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
-        systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
-
 
         if (systemProperties.get("extDirs") != null) {
             classpath += files(systemProperties.get("extDirs"))
@@ -777,7 +771,6 @@ project('test:system') {
         systemProperty "imageVersion", System.getProperty("imageVersion")
         systemProperty "skipServiceInstallation", System.getProperty("skipServiceInstallation")
         systemProperty "segmentStoreExtraEnv", System.getProperty("segmentStoreExtraEnv")
-        systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
 
         if (System.getProperty("execType") == null) {
             systemProperty "execType", "REMOTE_SEQUENTIAL"

--- a/build.gradle
+++ b/build.gradle
@@ -702,6 +702,8 @@ project('standalone') {
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
+        systemProperty "io.netty.tryReflectionSetAccessible", "true"
+        systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
 
         if (systemProperties.get("extDirs") != null) {
             classpath += files(systemProperties.get("extDirs"))
@@ -779,6 +781,8 @@ project('test:system') {
         systemProperty "imageVersion", System.getProperty("imageVersion")
         systemProperty "skipServiceInstallation", System.getProperty("skipServiceInstallation")
         systemProperty "segmentStoreExtraEnv", System.getProperty("segmentStoreExtraEnv")
+        systemProperty "io.netty.tryReflectionSetAccessible", "true"
+        systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
 
         if (System.getProperty("execType") == null) {
             systemProperty "execType", "REMOTE_SEQUENTIAL"

--- a/build.gradle
+++ b/build.gradle
@@ -51,13 +51,8 @@ allprojects {
             compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
             testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         test {
-          // From JDK9+ Netty will try not to access JDK internals
-          // in order not to produce scary "illegal access" warnings.
-          // This will slow down performances.
-          // We don't care about the warning but we care about performance.
-          systemProperty "io.netty.tryReflectionSetAccessible", "true"
           // From JDK11+ Java will try to use TLSv1.3, we don't need it in tests
-          systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
+          // systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
         }
     }
     // Plugin configurations
@@ -702,8 +697,8 @@ project('standalone') {
         systemProperties System.getProperties()
         systemProperties 'logback.configurationFile' : new File('config/logback.xml').absolutePath
         systemProperties 'singlenode.configurationFile' : new File("config/standalone-config.properties").absolutePath
-        systemProperty "io.netty.tryReflectionSetAccessible", "true"
-        systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
+        systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
+
 
         if (systemProperties.get("extDirs") != null) {
             classpath += files(systemProperties.get("extDirs"))
@@ -781,8 +776,7 @@ project('test:system') {
         systemProperty "imageVersion", System.getProperty("imageVersion")
         systemProperty "skipServiceInstallation", System.getProperty("skipServiceInstallation")
         systemProperty "segmentStoreExtraEnv", System.getProperty("segmentStoreExtraEnv")
-        systemProperty "io.netty.tryReflectionSetAccessible", "true"
-        systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
+        systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"
 
         if (System.getProperty("execType") == null) {
             systemProperty "execType", "REMOTE_SEQUENTIAL"

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,14 @@ allprojects {
             testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
             compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
             testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+        test {
+          // From JDK9+ Netty will try not to access JDK internals
+          // in order not to produce scary "illegal access" warnings.
+          // This will slow down performances.
+          // We don't care about the warning but we care about performance.
+          systemProperty "io.netty.tryReflectionSetAccessible", "true"
+          // From JDK11+ Java will try to use TLSv1.3, we don't need it in tests
+          systemProperty "https.protocols", "TLSv1,TLSv1.1,TLSv1.2"
         }
     }
     // Plugin configurations

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ allprojects {
             testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
             compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
             testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+        }
         test {
           // From JDK11+ Java will try to use TLSv1.3, we don't need it in tests
           // systemProperty "jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2"


### PR DESCRIPTION
This is only a test branch, to run test on Travis and JDK11, in order to fix a failing test