### PR TITLE
Issue 3266: Ensure bookkeeper.bkAckQuorumSize is 3 for BookieFailover test. (Do not merge).

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -129,6 +129,7 @@ public abstract class AbstractService implements Service {
                 .put("autoScale.cacheExpiryInSeconds", "120")
                 .put("autoScale.cacheCleanUpInSeconds", "120")
                 .put("curator-default-session-timeout", "10000")
+                .put("bookkeeper.bkAckQuorumSize", "3")
                 // Controller properties.
                 .put("MAX_LEASE_VALUE", "60000")
                 .put("RETENTION_FREQUENCY_MINUTES", "2")


### PR DESCRIPTION
(This has to be merged once the pravega-operator issue has been fixed).

**Change log description**  
Ensure `bookkeeper.bkAckQuorumSize` is configured as 3 during system tests.

**Purpose of the change**  
Fixes #3266 

**What the code does**  
The bookieFailover test expects bkAckQuorumSize  to be 3.

**How to verify it**  
The BookieFailoverTest should pass once https://github.com/pravega/pravega-operator/issues/116 is resolved.
