### PR TITLE
Issue 3269: Fix invalid initialization order in AbstractScaleTests.

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -44,8 +44,8 @@ abstract class AbstractScaleTests extends AbstractReadWriteTest {
     public AbstractScaleTests() {
         controllerURI = createControllerURI();
         connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        clientFactory = new ClientFactoryImpl(SCOPE, getController());
         controller = createController();
+        clientFactory = new ClientFactoryImpl(SCOPE, getController());
     }
 
     private ControllerImpl createController() {


### PR DESCRIPTION
**Change log description**  
Fix the initialization order in AbstractScaleTests.

**Purpose of the change**  
Fixes #3269 

**What the code does**  
Correct the initialization order.

**How to verify it**  
Verified that 
`io.pravega.test.system.AutoScaleTest.scaleTests` and 
`io.pravega.test.system.ReadWithAutoScaleTest.scaleTestsWithReader` work fine with this change.
