### PR TITLE
Issue 3264: Return a SegmentHandle from Storage create method.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -138,7 +138,7 @@ public class ExtendedS3Storage implements SyncStorage {
     }
 
     @Override
-    public SegmentProperties create(String streamSegmentName) throws StreamSegmentException {
+    public SegmentHandle create(String streamSegmentName) throws StreamSegmentException {
         return execute(streamSegmentName, () -> doCreate(streamSegmentName));
     }
 
@@ -273,7 +273,7 @@ public class ExtendedS3Storage implements SyncStorage {
         }
     }
 
-    private SegmentProperties doCreate(String streamSegmentName) throws StreamSegmentExistsException {
+    private SegmentHandle doCreate(String streamSegmentName) throws StreamSegmentExistsException {
         long traceId = LoggerHelpers.traceEnter(log, "create", streamSegmentName);
 
         if (!client.listObjects(config.getBucket(), config.getRoot() + streamSegmentName).getObjects().isEmpty()) {
@@ -311,7 +311,7 @@ public class ExtendedS3Storage implements SyncStorage {
         client.putObject(request);
 
         LoggerHelpers.traceLeave(log, "create", traceId);
-        return doGetStreamSegmentInfo(streamSegmentName);
+        return ExtendedS3SegmentHandle.getWriteHandle(streamSegmentName);
     }
 
     private Void doWrite(SegmentHandle handle, long offset, InputStream data, int length) throws StreamSegmentException {

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -147,7 +147,7 @@ public class FileSystemStorage implements SyncStorage {
     }
 
     @Override
-    public SegmentProperties create(String streamSegmentName) throws StreamSegmentException {
+    public SegmentHandle create(String streamSegmentName) throws StreamSegmentException {
         return execute(streamSegmentName, () -> doCreate(streamSegmentName));
     }
 
@@ -274,7 +274,7 @@ public class FileSystemStorage implements SyncStorage {
         return Files.exists(Paths.get(config.getRoot(), streamSegmentName));
     }
 
-    private SegmentProperties doCreate(String streamSegmentName) throws IOException {
+    private SegmentHandle doCreate(String streamSegmentName) throws IOException {
         long traceId = LoggerHelpers.traceEnter(log, "create", streamSegmentName);
         FileAttribute<Set<PosixFilePermission>> fileAttributes = PosixFilePermissions.asFileAttribute(READ_WRITE_PERMISSION);
 
@@ -285,7 +285,7 @@ public class FileSystemStorage implements SyncStorage {
         Files.createFile(path, fileAttributes);
         LoggerHelpers.traceLeave(log, "create", traceId);
         FileSystemMetrics.CREATE_COUNT.inc();
-        return this.doGetStreamSegmentInfo(streamSegmentName);
+        return FileSystemSegmentHandle.writeHandle(streamSegmentName);
     }
 
     private Void doWrite(SegmentHandle handle, long offset, InputStream data, int length) throws Exception {

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -431,7 +431,7 @@ class HDFSStorage implements SyncStorage {
     }
 
     @Override
-    public SegmentProperties create(String streamSegmentName) throws StreamSegmentException {
+    public SegmentHandle create(String streamSegmentName) throws StreamSegmentException {
         // Creates a file with the lowest possible epoch (0).
         // There is a possible race during create where more than one segmentstore may be trying to create a streamsegment.
         // If one create is delayed, it is possible that other segmentstore will be able to create the file with
@@ -479,7 +479,9 @@ class HDFSStorage implements SyncStorage {
             log.warn("Exception while deleting a file with epoch 0.", e);
         }
         LoggerHelpers.traceLeave(log, "create", traceId, streamSegmentName);
-        return StreamSegmentInformation.builder().name(streamSegmentName).build();
+
+        // return handle
+        return HDFSSegmentHandle.write(streamSegmentName);
     }
     //endregion
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -159,9 +159,7 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
                 .exceptionallyComposeExpecting(
                         this.storage.openWrite(attributeSegmentName).thenAccept(this.handle::set),
                         ex -> ex instanceof StreamSegmentNotExistsException,
-                        () -> this.storage.create(attributeSegmentName, this.config.getAttributeSegmentRollingPolicy(), timer.getRemaining())
-                                          .thenComposeAsync(si -> this.storage.openWrite(attributeSegmentName)
-                                          .thenAccept(this.handle::set), this.executor))
+                        () -> this.storage.create(attributeSegmentName, this.config.getAttributeSegmentRollingPolicy(), timer.getRemaining()).thenAccept(this.handle::set))
                 .thenComposeAsync(v -> this.index.initialize(timer.getRemaining()), this.executor)
                 .thenRun(() -> log.debug("{}: Initialized.", this.traceObjectId))
                 .exceptionally(this::handleIndexOperationException);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -160,7 +160,8 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
                         this.storage.openWrite(attributeSegmentName).thenAccept(this.handle::set),
                         ex -> ex instanceof StreamSegmentNotExistsException,
                         () -> this.storage.create(attributeSegmentName, this.config.getAttributeSegmentRollingPolicy(), timer.getRemaining())
-                                          .thenComposeAsync(si -> this.storage.openWrite(attributeSegmentName).thenAccept(this.handle::set), this.executor))
+                                          .thenComposeAsync(si -> this.storage.openWrite(attributeSegmentName)
+                                          .thenAccept(this.handle::set), this.executor))
                 .thenComposeAsync(v -> this.index.initialize(timer.getRemaining()), this.executor)
                 .thenRun(() -> log.debug("{}: Initialized.", this.traceObjectId))
                 .exceptionally(this::handleIndexOperationException);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1124,7 +1124,6 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
                             this.storage.create(this.metadata.getName(), rollingPolicy, timeout),
                             ex -> ex instanceof StreamSegmentExistsException,
                             null)
-                    .thenCompose(v -> this.storage.openWrite(this.metadata.getName()))
                     .thenComposeAsync(handle -> {
                         this.handle.set(handle);
                         return toRun.get();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
@@ -90,7 +90,7 @@ public class TestStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> create(String streamSegmentName, Duration timeout) {
+    public CompletableFuture<SegmentHandle> create(String streamSegmentName, Duration timeout) {
         return ErrorInjector.throwAsyncExceptionIfNeeded(this.createErrorInjector,
                 () -> this.wrappedStorage.create(streamSegmentName, timeout))
                             .thenApply(sp -> {
@@ -100,7 +100,7 @@ public class TestStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout) {
+    public CompletableFuture<SegmentHandle> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout) {
         return ErrorInjector.throwAsyncExceptionIfNeeded(this.createErrorInjector,
                 () -> this.wrappedStorage.create(streamSegmentName, rollingPolicy, timeout))
                             .thenApply(sp -> {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerTests.java
@@ -64,7 +64,6 @@ public class ReadOnlySegmentContainerTests extends ThreadPooledTestSuite {
 
         // Create a segment, add some data, set some attributes, "truncate" it and then seal it.
         val storageInfo = context.storage.create(SEGMENT_NAME, TIMEOUT)
-                .thenCompose(si -> context.storage.openWrite(si.getName()))
                 .thenCompose(handle -> context.storage.write(handle, 0, new ByteArrayInputStream(new byte[10]), 10, TIMEOUT))
                 .thenCompose(v -> context.storage.getStreamSegmentInfo(SEGMENT_NAME, TIMEOUT)).join();
         val expectedInfo = StreamSegmentInformation.from(storageInfo)
@@ -133,7 +132,6 @@ public class ReadOnlySegmentContainerTests extends ThreadPooledTestSuite {
         rnd.nextBytes(data);
 
         context.storage.create(SEGMENT_NAME, TIMEOUT)
-                       .thenCompose(si -> context.storage.openWrite(si.getName()))
                        .thenCompose(handle -> context.storage
                                .write(handle, 0, new ByteArrayInputStream(data), data.length, TIMEOUT)
                                .thenCompose(v -> context.storage.truncate(handle, truncationOffset, TIMEOUT))).join();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -84,7 +84,7 @@ public class AsyncStorageWrapper implements Storage {
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout) {
+    public CompletableFuture<SegmentHandle> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout) {
         return supplyAsync(() -> this.syncStorage.create(streamSegmentName, rollingPolicy), streamSegmentName);
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.segmentstore.storage;
 
-import io.pravega.segmentstore.contracts.SegmentProperties;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -44,14 +43,14 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
      *
      * @param streamSegmentName The full name of the StreamSegment.
      * @param timeout           Timeout for the operation.
-     * @return A CompletableFuture that, when completed, will indicate that the StreamSegment has been created (and will
-     * contain a StreamSegmentInformation for an empty Segment). If the operation failed, it will contain the cause of the
+     * @return A CompletableFuture that, when completed, will contain a read-write SegmentHandle that can be used to access
+     * the segment for read and write activities (ex: read, get, write, seal, concat). If the operation failed, it will contain the cause of the
      * failure. Notable exceptions:
      * <ul>
      * <li> StreamSegmentExistsException: When the given Segment already exists in Storage.
      * </ul>
      */
-    default CompletableFuture<SegmentProperties> create(String streamSegmentName, Duration timeout) {
+    default CompletableFuture<SegmentHandle> create(String streamSegmentName, Duration timeout) {
         return create(streamSegmentName, SegmentRollingPolicy.NO_ROLLING, timeout);
     }
 
@@ -61,14 +60,14 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
      * @param streamSegmentName The full name of the StreamSegment.
      * @param rollingPolicy     The Rolling Policy to apply to this StreamSegment.
      * @param timeout           Timeout for the operation.
-     * @return A CompletableFuture that, when completed, will indicate that the StreamSegment has been created (and will
-     * contain a StreamSegmentInformation for an empty Segment). If the operation failed, it will contain the cause of the
+     * @return A CompletableFuture that, when completed, will contain a read-write SegmentHandle that can be used to access
+     *      * the segment for read and write activities (ex: read, get, write, seal, concat). If the operation failed, it will contain the cause of the
      * failure. Notable exceptions:
      * <ul>
      * <li> StreamSegmentExistsException: When the given Segment already exists in Storage.
      * </ul>
      */
-    CompletableFuture<SegmentProperties> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout);
+    CompletableFuture<SegmentHandle> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout);
 
     /**
      * Writes the given data to the StreamSegment.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
@@ -94,20 +94,22 @@ public interface SyncStorage extends AutoCloseable {
      * Creates a new StreamSegment.
      *
      * @param streamSegmentName The full name of the StreamSegment.
-     * @return A SegmentProperties describing the newly created Segment.
+     * @return A read-write SegmentHandle that can be used to access the segment for read and write activities (ex: read,
+     * write, seal, concat).
      * @throws StreamSegmentException If an exception occurred.
      */
-    SegmentProperties create(String streamSegmentName) throws StreamSegmentException;
+    SegmentHandle create(String streamSegmentName) throws StreamSegmentException;
 
     /**
      * Creates a new StreamSegment with given SegmentRollingPolicy.
      *
      * @param streamSegmentName The full name of the StreamSegment.
      * @param rollingPolicy     The Rolling Policy to apply to this StreamSegment.
-     * @return A SegmentProperties describing the newly created Segment.
+     * @return A read-write SegmentHandle that can be used to access the segment for read and write activities (ex: read,
+     * write, seal, concat).
      * @throws StreamSegmentException If an exception occurred.
      */
-    default SegmentProperties create(String streamSegmentName, SegmentRollingPolicy rollingPolicy) throws StreamSegmentException {
+    default SegmentHandle create(String streamSegmentName, SegmentRollingPolicy rollingPolicy) throws StreamSegmentException {
         // By default this creates a blank Segment. This is the default behavior for Storage implementations that do not
         // support Segment Rolling.
         return create(streamSegmentName);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -87,7 +87,7 @@ public class InMemoryStorage implements SyncStorage {
     }
 
     @Override
-    public SegmentProperties create(String streamSegmentName) throws StreamSegmentExistsException {
+    public SegmentHandle create(String streamSegmentName) throws StreamSegmentException {
         ensurePreconditions();
         synchronized (this.lock) {
             if (this.streamSegments.containsKey(streamSegmentName)) {
@@ -95,9 +95,8 @@ public class InMemoryStorage implements SyncStorage {
             }
 
             StreamSegmentData data = new StreamSegmentData(streamSegmentName, this.syncContext);
-            data.openWrite();
             this.streamSegments.put(streamSegmentName, data);
-            return data.getInfo();
+            return data.openWrite();
         }
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
@@ -232,12 +232,12 @@ public class RollingStorage implements SyncStorage {
     //region SyncStorage Implementation
 
     @Override
-    public SegmentProperties create(String streamSegmentName) throws StreamSegmentException {
+    public SegmentHandle create(String streamSegmentName) throws StreamSegmentException {
         return create(streamSegmentName, this.defaultRollingPolicy);
     }
 
     @Override
-    public SegmentProperties create(String segmentName, SegmentRollingPolicy rollingPolicy) throws StreamSegmentException {
+    public SegmentHandle create(String segmentName, SegmentRollingPolicy rollingPolicy) throws StreamSegmentException {
         Preconditions.checkNotNull(rollingPolicy, "rollingPolicy");
         String headerName = StreamSegmentNameUtils.getHeaderSegmentName(segmentName);
         long traceId = LoggerHelpers.traceEnter(log, "create", segmentName, rollingPolicy);
@@ -279,8 +279,9 @@ public class RollingStorage implements SyncStorage {
             throw ex;
         }
 
+        val handle = openHandle(segmentName, false);
         LoggerHelpers.traceLeave(log, "create", traceId, segmentName);
-        return StreamSegmentInformation.builder().name(segmentName).build();
+        return handle;
     }
 
     @Override

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
@@ -79,7 +79,7 @@ public class AsyncStorageWrapperTests extends ThreadPooledTestSuite {
         val s = new AsyncStorageWrapper(innerStorage, executorService());
 
         // Create
-        toReturn.set(StreamSegmentInformation.builder().name(segmentName).build());
+        toReturn.set(handle);
         validator.set((o, segment) -> {
             Assert.assertEquals(TestStorage.CREATE, o);
             Assert.assertEquals(segmentName, segment);
@@ -401,8 +401,8 @@ public class AsyncStorageWrapperTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public SegmentProperties create(String streamSegmentName) {
-            return (SegmentProperties) this.methodInvoked.apply(CREATE, streamSegmentName);
+        public SegmentHandle create(String streamSegmentName) {
+            return (SegmentHandle) this.methodInvoked.apply(CREATE, streamSegmentName);
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Segment create returns a read-write SegmentHandle . This  eliminates the redundant fencing/ checks.

**Purpose of the change**  
Fixes [#3264](https://github.com/pravega/pravega/issues/3264)

**What the code does**  
All SyncStorage implementations now return  read-write SegmentHandle (and avoid redundant checks/file access)
 
**How to verify it**  
All unit tests and integration tests should pass.
Some improvement in performance.
