### PR TITLE
Issue 3279: Client is performing blocking operations inside Netty Event Loop

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
@@ -42,9 +42,9 @@ public interface ClientConnection extends AutoCloseable {
      * Sends a wire command asynchronously.
      *
      * @param cmd The wire command to be sent.
-     * @throws ConnectionFailedException If sending fails for some reason.
+     * @param callback A callback to be invoked when the operation is complete
      */
-    void sendAsync(WireCommand cmd) throws ConnectionFailedException;
+    void sendAsync(WireCommand cmd, CompletedCallback callback);
 
     /**
      * Sends the provided append commands.

--- a/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
@@ -125,7 +125,7 @@ public class RawClient implements AutoCloseable {
             synchronized (lock) {
                 requests.put(requestId, reply);
             }
-            c.sendAsync(request, (cfe) -> {
+            c.sendAsync(request, cfe -> {
                 if (cfe != null) {
                     synchronized (lock) {
                         requests.remove(requestId);

--- a/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
@@ -36,14 +36,14 @@ public class RawClient implements AutoCloseable {
 
     private final CompletableFuture<ClientConnection> connection;
     private final Segment segmentId;
-    
+
     private final Object lock = new Object();
     @GuardedBy("lock")
     private final Map<Long, CompletableFuture<Reply>> requests = new HashMap<>();
     private final ResponseProcessor responseProcessor = new ResponseProcessor();
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final class ResponseProcessor extends FailingReplyProcessor {
-        
+
         @Override
         public void process(Reply reply) {
             if (reply instanceof Hello) {
@@ -57,7 +57,7 @@ public class RawClient implements AutoCloseable {
                 reply(reply);
             }
         }
-        
+
         @Override
         public void connectionDropped() {
             closeConnection(new ConnectionFailedException());
@@ -68,14 +68,14 @@ public class RawClient implements AutoCloseable {
             log.warn("Processing failure: ", error);
             closeConnection(error);
         }
-        
+
         @Override
         public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
             log.warn("Auth token failure: ", authTokenCheckFailed);
             closeConnection(new AuthenticationException(authTokenCheckFailed.toString()));
         }
     }
-    
+
     public RawClient(Controller controller, ConnectionFactory connectionFactory, Segment segmentId) {
         this.segmentId = segmentId;
         this.connection = controller.getEndpointForSegment(segmentId.getScopedName())
@@ -92,7 +92,7 @@ public class RawClient implements AutoCloseable {
             future.complete(reply);
         }
     }
-    
+
     private void closeConnection(Throwable exceptionToInflightRequests) {
         if (closed.get() || exceptionToInflightRequests instanceof ConnectionClosedException) {
             log.debug("Closing connection to segment {} with exception {}", this.segmentId, exceptionToInflightRequests);
@@ -117,7 +117,7 @@ public class RawClient implements AutoCloseable {
             request.completeExceptionally(exceptionToInflightRequests);
         }
     }
-    
+
     public <T extends Request & WireCommand> CompletableFuture<Reply> sendRequest(long requestId, T request) {
         return connection.thenCompose(c -> {
             log.debug("Sending request: {}", request);
@@ -125,19 +125,23 @@ public class RawClient implements AutoCloseable {
             synchronized (lock) {
                 requests.put(requestId, reply);
             }
-            try {
-                c.send(request);
-            } catch (ConnectionFailedException e) {
-                closeConnection(e);
-            }
+            c.sendAsync(request, (cfe) -> {
+                if (cfe != null) {
+                    synchronized (lock) {
+                        requests.remove(requestId);
+                    }
+                    reply.completeExceptionally(cfe);
+                    closeConnection(cfe);
+                }
+            });
             return reply;
         });
     }
-    
+
     public boolean isClosed() {
         return closed.get();
     }
-    
+
     @Override
     public void close() {
         closeConnection(new ConnectionClosedException());

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.GuardedBy;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -190,7 +189,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
             return result;
         }
         log.trace("Sending read request {}", request);
-        c.sendAsync(request, (cfe) -> {
+        c.sendAsync(request, cfe -> {
             if (cfe != null) {
                 log.error("Error while sending request {}", request, cfe);
                 synchronized (lock) {

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -181,12 +181,12 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         
     private CompletableFuture<SegmentRead> sendRequestOverConnection(WireCommands.ReadSegment request, ClientConnection c) {
         CompletableFuture<WireCommands.SegmentRead> result = new CompletableFuture<>();            
-        synchronized (lock) {
-            outstandingRequests.put(request.getOffset(), result);
-        }
         if (closed.get()) {
             result.completeExceptionally(new ConnectionClosedException());
             return result;
+        }
+        synchronized (lock) {
+            outstandingRequests.put(request.getOffset(), result);
         }
         log.trace("Sending read request {}", request);
         c.sendAsync(request, cfe -> {

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -85,7 +85,8 @@ public class StreamManagerImplTest {
                                  .process(new WireCommands.SegmentCreated(request.getRequestId(), request.getSegment()));
                 return null;
             }
-        }).when(connection).send(Mockito.any(WireCommands.CreateSegment.class));
+        }).when(connection).sendAsync(Mockito.any(WireCommands.CreateSegment.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
 
         Mockito.doAnswer(new Answer<Void>() {
             @Override
@@ -96,7 +97,8 @@ public class StreamManagerImplTest {
                                                                              false, false, 0, 0, 0));
                 return null;
             }
-        }).when(connection).send(Mockito.any(WireCommands.GetStreamSegmentInfo.class));
+        }).when(connection).sendAsync(Mockito.any(WireCommands.GetStreamSegmentInfo.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
                                                            connectionFactory);

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -121,7 +121,8 @@ public class BatchClientImplTest {
                                  .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
                 return null;
             }
-        }).when(connection).send(Mockito.any(CreateSegment.class));
+        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
 
         Mockito.doAnswer(new Answer<Void>() {
             @Override
@@ -132,7 +133,8 @@ public class BatchClientImplTest {
                                          false, false, 0, 0, 0));
                 return null;
             }
-        }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));
+        }).when(connection).sendAsync(Mockito.any(GetStreamSegmentInfo.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
                 connectionFactory);
@@ -177,7 +179,8 @@ public class BatchClientImplTest {
                                  .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
                 return null;
             }
-        }).when(connection).send(Mockito.any(CreateSegment.class));
+        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         Mockito.doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -187,7 +190,8 @@ public class BatchClientImplTest {
                                                                 false, false, 0, 0, 0));
                 return null;
             }
-        }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));
+        }).when(connection).sendAsync(Mockito.any(GetStreamSegmentInfo.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         return connectionFactory;
     }

--- a/client/src/test/java/io/pravega/client/byteStream/ByteStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/byteStream/ByteStreamReaderTest.java
@@ -53,7 +53,8 @@ public class ByteStreamReaderTest {
                                  .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
                 return null;
             }
-        }).when(connection).send(Mockito.any(CreateSegment.class));
+        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(endpoint, connection);
         controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         controller.createScope(SCOPE);

--- a/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
@@ -56,7 +56,8 @@ public class ByteStreamWriterTest {
                                  .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
                 return null;
             }
-        }).when(connection).send(Mockito.any(CreateSegment.class));
+        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(endpoint, connection);
         controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
         controller.createScope(SCOPE);

--- a/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
@@ -45,7 +45,8 @@ public class RawClientTest {
         RawClient rawClient = new RawClient(controller, connectionFactory, new Segment("scope", "testHello", 0));
 
         rawClient.sendRequest(1, new WireCommands.Hello(0, 0));
-        Mockito.verify(connection).send(new WireCommands.Hello(0, 0));
+        Mockito.verify(connection).sendAsync(Mockito.eq(new WireCommands.Hello(0, 0)),
+                                             Mockito.any(ClientConnection.CompletedCallback.class));
         rawClient.close();
         Mockito.verify(connection).close();
     }
@@ -65,7 +66,8 @@ public class RawClientTest {
         UUID id = UUID.randomUUID();
         ConditionalAppend request = new ConditionalAppend(id, 1, 0, new Event(Unpooled.EMPTY_BUFFER));
         CompletableFuture<Reply> future = rawClient.sendRequest(1, request);
-        Mockito.verify(connection).send(request);
+        Mockito.verify(connection).sendAsync(Mockito.eq(request),
+                                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertFalse(future.isDone());
         ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
         DataAppended reply = new DataAppended(id, 1, 0);

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -35,6 +35,7 @@ import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -73,16 +74,19 @@ public class AsyncSegmentInputStreamTest {
                 connectionFactory.getProcessor(endpoint).segmentRead(segmentRead);
                 return null;
             }
-        }).when(c).sendAsync(Mockito.any(ReadSegment.class));
+        }).when(c).sendAsync(any(ReadSegment.class), any(ClientConnection.CompletedCallback.class));
         
         CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
         assertEquals(segmentRead, readFuture.join());
         assertTrue(Futures.isSuccessful(readFuture));
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, ""));
+        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         verifyNoMoreInteractions(c);
     }
     
@@ -122,7 +126,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);            
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(segmentRead, readFuture.join());
         verifyNoMoreInteractions(c);
@@ -151,7 +156,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentIsTruncated(segmentIsTruncated);
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
         assertThrows(SegmentTruncatedException.class, () -> readFuture.get());
         verifyNoMoreInteractions(c);
@@ -163,7 +169,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, ""));
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture2));
         assertEquals(segmentRead, readFuture2.join());
         verifyNoMoreInteractions(c);
@@ -187,7 +194,8 @@ public class AsyncSegmentInputStreamTest {
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.wrap(bad)));            
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.wrap(good)));         
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""));
+        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
+                                    any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(ByteBuffer.wrap(good), readFuture.join().getData());
         verifyNoMoreInteractions(c);

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -79,14 +79,14 @@ public class AsyncSegmentInputStreamTest {
         CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
         assertEquals(segmentRead, readFuture.join());
         assertTrue(Futures.isSuccessful(readFuture));
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "")),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "")),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, "")),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
         verifyNoMoreInteractions(c);
     }
     
@@ -126,8 +126,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);            
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "")),
+                            Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(segmentRead, readFuture.join());
         verifyNoMoreInteractions(c);
@@ -156,8 +156,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentIsTruncated(segmentIsTruncated);
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "")),
+                            Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
         assertThrows(SegmentTruncatedException.class, () -> readFuture.get());
         verifyNoMoreInteractions(c);
@@ -169,8 +169,8 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, "")),
+                            Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture2));
         assertEquals(segmentRead, readFuture2.join());
         verifyNoMoreInteractions(c);
@@ -194,8 +194,8 @@ public class AsyncSegmentInputStreamTest {
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.wrap(bad)));            
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.wrap(good)));         
         });
-        verify(c).sendAsync(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, ""),
-                                    any(ClientConnection.CompletedCallback.class));
+        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "")),
+                            Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(ByteBuffer.wrap(good), readFuture.join().getData());
         verifyNoMoreInteractions(c);

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -61,7 +61,7 @@ public class ConditionalOutputStreamTest {
                 }
                 return null;
             }
-        }).when(mock).send(any(ConditionalAppend.class));
+        }).when(mock).sendAsync(any(ConditionalAppend.class), any(ClientConnection.CompletedCallback.class));
         assertTrue(cOut.write(data, 0));
         assertFalse(cOut.write(data, 1));
         assertTrue(cOut.write(data, 2));
@@ -121,7 +121,7 @@ public class ConditionalOutputStreamTest {
                                                               argument.getWriterId(), 0));
                 return null;
             }
-        }).when(mock).send(any(SetupAppend.class));
+        }).when(mock).sendAsync(any(SetupAppend.class), any(ClientConnection.CompletedCallback.class));
     }
     
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -105,7 +105,7 @@ public class ConditionalOutputStreamTest {
                 }                
                 return null;
             }
-        }).when(mock).send(any(ConditionalAppend.class));
+        }).when(mock).sendAsync(any(ConditionalAppend.class), any(ClientConnection.CompletedCallback.class));
         assertTrue(cOut.write(data, 0));
         assertEquals(3, count.get());
     }
@@ -146,7 +146,7 @@ public class ConditionalOutputStreamTest {
                 processor.process(new WireCommands.SegmentIsSealed(argument.getEventNumber(), segment.getScopedName(), mockClientReplyStackTrace));
                 return null;
             }
-        }).when(mock).send(any(ConditionalAppend.class));
+        }).when(mock).sendAsync(any(ConditionalAppend.class), any(ClientConnection.CompletedCallback.class));
         AssertExtensions.assertThrows(SegmentSealedException.class, () -> cOut.write(data, 0));
     }
     
@@ -178,7 +178,7 @@ public class ConditionalOutputStreamTest {
                 }
                 return null;
             }
-        }).when(mock).send(any(ConditionalAppend.class));
+        }).when(mock).sendAsync(any(ConditionalAppend.class), any(ClientConnection.CompletedCallback.class));
         replies.add(true);
         replies.add(false);
         assertTrue(cOut.write(data, 0));

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -62,7 +62,8 @@ public class SegmentMetadataClientTest {
                                                                   123, 121));
                 return null;
             }
-        }).when(connection).send(new WireCommands.GetStreamSegmentInfo(1, segment.getScopedName(), ""));
+        }).when(connection).sendAsync(Mockito.eq(new WireCommands.GetStreamSegmentInfo(1, segment.getScopedName(), "")),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         long length = client.fetchCurrentSegmentLength();
         assertEquals(123, length);
     }
@@ -88,9 +89,11 @@ public class SegmentMetadataClientTest {
                 processor.process(new SegmentTruncated(1, segment.getScopedName()));
                 return null;
             }
-        }).when(connection).send(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, ""));
+        }).when(connection).sendAsync(Mockito.eq(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, "")),
+                                 Mockito.any(ClientConnection.CompletedCallback.class));
         client.truncateSegment(123L);
-        Mockito.verify(connection).send(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, ""));
+        Mockito.verify(connection).sendAsync(Mockito.eq(new WireCommands.TruncateSegment(1, segment.getScopedName(), 123L, "")),
+                                 Mockito.any(ClientConnection.CompletedCallback.class));
     }
     
     @Test(timeout = 10000)
@@ -114,9 +117,11 @@ public class SegmentMetadataClientTest {
                 processor.process(new WireCommands.SegmentSealed(1, segment.getScopedName()));
                 return null;
             }
-        }).when(connection).send(new WireCommands.SealSegment(1, segment.getScopedName(), ""));
+        }).when(connection).sendAsync(Mockito.eq(new WireCommands.SealSegment(1, segment.getScopedName(), "")),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         client.sealSegment();
-        Mockito.verify(connection).send(new WireCommands.SealSegment(1, segment.getScopedName(), ""));
+        Mockito.verify(connection).sendAsync(Mockito.eq(new WireCommands.SealSegment(1, segment.getScopedName(), "")),
+                                             Mockito.any(ClientConnection.CompletedCallback.class));
     }  
 
     
@@ -143,7 +148,8 @@ public class SegmentMetadataClientTest {
                 processor.process(new WireCommands.SegmentAttribute(1, 123));
                 return null;
             }
-        }).when(connection).send(new WireCommands.GetSegmentAttribute(1, segment.getScopedName(), attributeId, ""));
+        }).when(connection).sendAsync(Mockito.eq(new WireCommands.GetSegmentAttribute(1, segment.getScopedName(), attributeId, "")),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         long value = client.fetchProperty(SegmentAttribute.RevisionStreamClientMark);
         assertEquals(123, value);
     }
@@ -167,8 +173,9 @@ public class SegmentMetadataClientTest {
                 processor.process(new SegmentAttributeUpdated(1, true));
                 return null;
             }
-        }).when(connection).send(new WireCommands.UpdateSegmentAttribute(1, segment.getScopedName(), attributeId, 1234,
-                                                                         -1234, ""));
+        }).when(connection).sendAsync(Mockito.eq(new WireCommands.UpdateSegmentAttribute(1, segment.getScopedName(), attributeId, 1234,
+                                                                         -1234, "")),
+                                      Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(client.compareAndSetAttribute(SegmentAttribute.RevisionStreamClientMark, -1234, 1234));
     }
 
@@ -194,7 +201,7 @@ public class SegmentMetadataClientTest {
                 processor.connectionDropped();
                 return null;
             }
-        }).when(connection).send(getSegmentInfo1);
+        }).when(connection).sendAsync(Mockito.eq(getSegmentInfo1), Mockito.any(ClientConnection.CompletedCallback.class));
         WireCommands.GetStreamSegmentInfo getSegmentInfo2 = new WireCommands.GetStreamSegmentInfo(2, segment.getScopedName(), "");
         Mockito.doAnswer(new Answer<Void>() {
             @Override
@@ -204,13 +211,13 @@ public class SegmentMetadataClientTest {
                                                                   123, 121));
                 return null;
             }
-        }).when(connection).send(getSegmentInfo2);
+        }).when(connection).sendAsync(Mockito.eq(getSegmentInfo2), Mockito.any(ClientConnection.CompletedCallback.class));
         long length = client.fetchCurrentSegmentLength();
         InOrder order = Mockito.inOrder(connection, cf);
         order.verify(cf).establishConnection(eq(endpoint), any(ReplyProcessor.class));
-        order.verify(connection).send(getSegmentInfo1);
+        order.verify(connection).sendAsync(Mockito.eq(getSegmentInfo1), Mockito.any(ClientConnection.CompletedCallback.class));
         order.verify(cf).establishConnection(eq(endpoint), any(ReplyProcessor.class));
-        order.verify(connection).send(getSegmentInfo2);
+        order.verify(connection).sendAsync(Mockito.eq(getSegmentInfo2), Mockito.any(ClientConnection.CompletedCallback.class));
         order.verify(cf).getProcessor(eq(endpoint));
         order.verifyNoMoreInteractions();
         assertEquals(123, length);
@@ -241,7 +248,14 @@ public class SegmentMetadataClientTest {
                    }
                });
         WireCommands.GetStreamSegmentInfo getSegmentInfo1 = new WireCommands.GetStreamSegmentInfo(2, segment.getScopedName(), "");
-        Mockito.doThrow(new ConnectionFailedException()).when(connection1).send(getSegmentInfo1);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ClientConnection.CompletedCallback callback = invocation.getArgument(1);
+                callback.complete(new ConnectionFailedException());
+                return null;
+            }
+        }).when(connection1).sendAsync(Mockito.eq(getSegmentInfo1), Mockito.any(ClientConnection.CompletedCallback.class));
         WireCommands.GetStreamSegmentInfo getSegmentInfo2 = new WireCommands.GetStreamSegmentInfo(3, segment.getScopedName(), "");
         Mockito.doAnswer(new Answer<Void>() {
             @Override
@@ -250,16 +264,16 @@ public class SegmentMetadataClientTest {
                                                                   123, 121));
                 return null;
             }
-        }).when(connection2).send(getSegmentInfo2);
+        }).when(connection2).sendAsync(Mockito.eq(getSegmentInfo2), Mockito.any(ClientConnection.CompletedCallback.class));
         @Cleanup
         SegmentMetadataClientImpl client = new SegmentMetadataClientImpl(segment, controller, cf, "");
         InOrder order = Mockito.inOrder(connection1, connection2, cf);
         long length = client.fetchCurrentSegmentLength();
         order.verify(cf, Mockito.times(2)).establishConnection(Mockito.eq(endpoint), Mockito.any());
-        order.verify(connection1).send(getSegmentInfo1);
+        order.verify(connection1).sendAsync(Mockito.eq(getSegmentInfo1), Mockito.any(ClientConnection.CompletedCallback.class));
         order.verify(connection1).close();
         order.verify(cf).establishConnection(Mockito.eq(endpoint), Mockito.any());
-        order.verify(connection2).send(getSegmentInfo2);
+        order.verify(connection2).sendAsync(Mockito.eq(getSegmentInfo2), Mockito.any(ClientConnection.CompletedCallback.class));
         order.verifyNoMoreInteractions();
         assertEquals(123, length);
     }

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -52,6 +52,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
+import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -300,7 +301,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
                 callback.complete(null);
                 return null;
             }
-        }).when(connection).sendAsync(Mockito.any(), Mockito.any());
+        }).when(connection).sendAsync(Mockito.any(List.class), Mockito.any(CompletedCallback.class));
     }
 
     private void sendAndVerifyEvent(UUID cid, ClientConnection connection, SegmentOutputStreamImpl output,
@@ -763,7 +764,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
                 }
                 return null;
             }
-        }).when(connection).sendAsync(Mockito.any(), Mockito.any());
+        }).when(connection).sendAsync(Mockito.any(List.class), Mockito.any(CompletedCallback.class));
         
         doAnswer(new Answer<Void>() {
             @Override

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -466,11 +466,12 @@ public class MockController implements Controller {
         resultFuture.whenComplete((result, e) -> {
             connection.close();
         });
-        try {
-            connection.send(request);
-        } catch (Exception e) {
-            resultFuture.completeExceptionally(e);
-        }
+
+        connection.sendAsync(request, (cfe) -> {
+            if (cfe != null) {
+                resultFuture.completeExceptionally(cfe);
+            }
+        });
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -467,7 +467,7 @@ public class MockController implements Controller {
             connection.close();
         });
 
-        connection.sendAsync(request, (cfe) -> {
+        connection.sendAsync(request, cfe -> {
             if (cfe != null) {
                 resultFuture.completeExceptionally(cfe);
             }

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -615,9 +615,7 @@ public class SegmentHelper {
                 connection.sendAsync(request, cfe -> {
                     if (cfe != null) {
                         Throwable cause = Exceptions.unwrap(cfe);
-                        if (cause instanceof WireCommandFailedException) {
-                            resultFuture.completeExceptionally(cause);
-                        } else if (cause instanceof ConnectionFailedException) {
+                        if (cause instanceof ConnectionFailedException) {
                             resultFuture.completeExceptionally(new WireCommandFailedException(cause, request.getType(), WireCommandFailedException.Reason.ConnectionFailed));
                         } else {
                             resultFuture.completeExceptionally(new RuntimeException(cause));

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -611,27 +611,20 @@ public class SegmentHelper {
                 resultFuture.completeExceptionally(new WireCommandFailedException(new ConnectionFailedException(e),
                         request.getType(),
                         WireCommandFailedException.Reason.ConnectionFailed));
-            } else {
-                try {
-                    connection.send(request);
-                } catch (ConnectionFailedException cfe) {
-                    throw new WireCommandFailedException(cfe,
-                            request.getType(),
-                            WireCommandFailedException.Reason.ConnectionFailed);
-                } catch (Exception e2) {
-                    throw new RuntimeException(e2);
-                }
+            } else {                
+                connection.sendAsync(request, cfe -> {
+                    if (cfe != null) {
+                        Throwable cause = Exceptions.unwrap(cfe);
+                        if (cause instanceof WireCommandFailedException) {
+                            resultFuture.completeExceptionally(cause);
+                        } else if (cause instanceof ConnectionFailedException) {
+                            resultFuture.completeExceptionally(new WireCommandFailedException(cause, request.getType(), WireCommandFailedException.Reason.ConnectionFailed));
+                        } else {
+                            resultFuture.completeExceptionally(new RuntimeException(cause));
+                        }                        
+                    }
+                });                
             }
-        }).exceptionally(e -> {
-            Throwable cause = Exceptions.unwrap(e);
-            if (cause instanceof WireCommandFailedException) {
-                resultFuture.completeExceptionally(cause);
-            } else if (cause instanceof ConnectionFailedException) {
-                resultFuture.completeExceptionally(new WireCommandFailedException(cause, request.getType(), WireCommandFailedException.Reason.ConnectionFailed));
-            } else {
-                resultFuture.completeExceptionally(new RuntimeException(cause));
-            }
-            return null;
         });
         resultFuture.whenComplete((result, e) -> {
             connectionFuture.thenAccept(ClientConnection::close);

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -234,7 +234,7 @@ public class SegmentHelperTest {
         }
 
         @Override
-        public void sendAsync(WireCommand cmd) throws ConnectionFailedException {
+        public void sendAsync(WireCommand cmd, CompletedCallback callback) {
 
         }
 


### PR DESCRIPTION
**Change log description**  
- enable ClientConnection callers to be notified of errors
- switch to ClientConnection#sendAsync in SegmentHelper and RawClient in order not to perform blocking calls inside Netty EventLoops


**Purpose of the change**  
Fixes #3279

**What the code does**  
Add a CompletedCallback parameter to ClientConnection#sendAsync.
Replace calls to ClientConnection#send in SegmentHelper and RawClient with sendAsync, this way we won't perform a blocking operation inside the Netty event loop.

**How to verify it**  
Tests must pass.
Cherry picking this change on top of #3192 will make tests which are failing due to BlockingOperationException pass