### PR TITLE
Issue 2001: Make a defensive copy of streamCut's position map

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Stream;
 import io.pravega.common.Exceptions;
@@ -60,7 +61,7 @@ public class StreamCutImpl extends StreamCutInternal {
     @Builder(builderClassName = "StreamCutBuilder")
     public StreamCutImpl(Stream stream, Map<Segment, Long> positions) {
         this.stream = stream;
-        this.positions = positions;
+        this.positions = ImmutableMap.copyOf(positions);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Make a defensive copy of streamCut's position map

**Purpose of the change**  
Fixes #2001

**What the code does**  
Makes a defensive copy. This shouldn't be needed, I verified all the call sites, but as there are now many, it's better to be careful.
