### PR TITLE
Issue 3285: Always pull images in k8 system test framework

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -68,7 +68,7 @@ public abstract class AbstractService implements Service {
     static final String PRAVEGA_SEGMENTSTORE_LABEL = "pravega-segmentstore";
     static final String BOOKKEEPER_LABEL = "bookie";
     static final String PRAVEGA_ID = "pravega";
-    static final String IMAGE_PULL_POLICY = System.getProperty("imagePullPolicy", "IfNotPresent");
+    static final String IMAGE_PULL_POLICY = System.getProperty("imagePullPolicy", "Always");
     private static final String DOCKER_REGISTRY =  System.getProperty("dockerRegistryUrl", "");
     private static final String PRAVEGA_VERSION = System.getProperty("imageVersion", "latest");
     private static final String PRAVEGA_BOOKKEEPER_VERSION = System.getProperty("pravegaBookkeeperVersion", PRAVEGA_VERSION);


### PR DESCRIPTION
**Change log description**  
Set image pull policy to "Always" in k8 system test framework.

**Purpose of the change**  
Fixes #3285.

**What the code does**  
Sets the default `IMAGE_PULL_POLICY` to `Always` in k8 system test framework. Otherwise, we could end up using an old (cached) image version unexpectedly. 

**How to verify it**  
System tests should pass and use the latest version of the images available.
