### PR TITLE
Issue #3287: Exclude "passwd" extensions from rat.

### DIFF
--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -16,7 +16,7 @@ rat {
             '**/*.iml',
             '**/*.iws',
             '**/*.ipr',
-            '**/passwd',
+            '**/*passwd',
             '**/gradle/wrapper/**',
             '**/build/**',
             '**/out/**',


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Exclude passwd files from the build.

**Purpose of the change**  
Fixes #3287

**What the code does**  
Changes the rat configuration to exclude all files ending in 'passwd' as opposed to just those named 'passwd'

