### PR TITLE
Issue #3289: Use compile-time dependencies where possible

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -44,7 +44,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -453,7 +452,7 @@ public class ExtendedS3Storage implements SyncStorage {
             throw new ArrayIndexOutOfBoundsException(e.getMessage());
         }
 
-        throw Lombok.sneakyThrow(e);
+        throw Exceptions.sneakyThrow(e);
     }
 
     /**

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -48,7 +48,6 @@ import java.security.AccessControlException;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -426,7 +425,7 @@ public class FileSystemStorage implements SyncStorage {
             throw new StreamSegmentSealedException(segmentName, e);
         }
 
-        throw Lombok.sneakyThrow(e);
+        throw Exceptions.sneakyThrow(e);
     }
 
     //endregion

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSExceptionHelpers.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSExceptionHelpers.java
@@ -9,12 +9,12 @@
  */
 package io.pravega.storage.hdfs;
 
+import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import java.io.FileNotFoundException;
-import lombok.Lombok;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.hdfs.protocol.AclException;
@@ -45,7 +45,7 @@ final class HDFSExceptionHelpers {
         } else if (e instanceof AclException) {
             return new StreamSegmentSealedException(segmentName, e);
         } else {
-            throw Lombok.sneakyThrow(e);
+            throw Exceptions.sneakyThrow(e);
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         classpath group: 'ru.vyarus', name: 'gradle-mkdocs-plugin', version: gradleMkdocsPluginVersion
         classpath group: 'gradle.plugin.com.github.spotbugs', name: 'spotbugs-gradle-plugin', version: spotbugsPluginVersion
         classpath "org.ajoberstar:grgit:${gradleGitPluginVersion}"
+        classpath "io.franzbecker:gradle-lombok:${gradleLombokPluginVersion}"
     }
 }
 
@@ -39,6 +40,17 @@ allprojects {
     apply plugin: 'eclipse'
     if (file("src/main/java").isDirectory()) {
         apply plugin: 'java'
+		apply plugin: 'io.franzbecker.gradle-lombok'
+   		lombok {
+			version = lombokVersion
+		}
+		dependencies {
+			//These are compile time only dependencies needed accross all targets. Lombok uses them and may generate strange errors if they are missing.
+			compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+        	testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+        	compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+        	testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+		}
     }
     // Plugin configurations
     apply from: "$rootDir/gradle/application.gradle"
@@ -71,7 +83,7 @@ allprojects {
     }
     version = getProjectVersion()
     group = "io.pravega"
-
+    
     configurations.all {
         resolutionStrategy {
             //failOnVersionConflict()
@@ -95,10 +107,6 @@ project('common') {
         testCompile project(':test:testcommon')
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         //Do NOT add any additional dependencies here.
     }
 
@@ -132,10 +140,7 @@ project('shared:authplugin') {
 project ('shared') {
     dependencies {
         compile project(':common')
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         compile group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3Version
         compile group: 'org.apache.curator', name: 'curator-recipes', version: apacheCuratorVersion
         testCompile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
@@ -148,10 +153,6 @@ project ('shared') {
 
 project ('shared:metrics') {
     dependencies {
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-
         compile group: 'com.readytalk', name :'metrics3-statsd', version : metrics3StatsdVersion
         // https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core
         compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: metricsVersion
@@ -174,26 +175,19 @@ project ('shared:metrics') {
 project('shared:protocol') {
     dependencies {
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
     }
 }
 
 project('client') {
     dependencies {
-        compile group: 'com.google.guava', name: 'guava', version: guavaVersion
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-        compile group: 'io.netty', name: 'netty-all', version: nettyVersion
-
         compile project(':common')
         compile project(':shared')
         compile project(':shared:authplugin')
         compile project(':shared:protocol')
         compile project(":shared:controller-api")
+        compile group: 'io.netty', name: 'netty-all', version: nettyVersion
+        compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
@@ -211,9 +205,6 @@ project('test:testcommon') {
         compile group: 'junit', name :'junit', version: junitVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         compile group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3Version
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLogger
@@ -239,13 +230,11 @@ project('segmentstore:storage') {
 
 project('segmentstore:storage:impl') {
     dependencies {
-        compile group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: bookKeeperVersion, withoutLogger
-
-        compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
-
         compile project(':common')
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
+        compile group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: bookKeeperVersion, withoutLogger
+        compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
     }
@@ -319,6 +308,7 @@ project('segmentstore:server:host') {
         compile project(':segmentstore:storage:impl')
         compile project(':bindings')
         compile project(':segmentstore:server')
+        compile 'io.jsonwebtoken:jjwt:0.9.0'
         compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
@@ -327,7 +317,6 @@ project('segmentstore:server:host') {
         testCompile project(path:':segmentstore:storage:impl', configuration:'testRuntime')
         testCompile project(path:':bindings', configuration:'testRuntime')
         testCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
-        compile 'io.jsonwebtoken:jjwt:0.9.0'
     }
 
     task createAppWithGCLogging(type: CreateStartScripts) {
@@ -461,9 +450,6 @@ project('shared:controller-api') {
         compile project(':common')
 
         compile group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3Version
-        compile group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
 
@@ -473,7 +459,7 @@ project('shared:controller-api') {
         compile "io.grpc:grpc-stub:" + grpcVersion
         compile group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: nettyBoringSSLVersion
          // Since Java 10 javax.annotation is no more bundled with the JRE
-        compile group: 'javax.annotation', name: 'javax.annotation-api', version: javaxAnnotationVersion
+        compileOnly group: 'javax.annotation', name: 'javax.annotation-api', version: javaxAnnotationVersion
     }
 
     javadoc {
@@ -529,8 +515,6 @@ project('controller') {
         compile(group: 'io.swagger', name : 'swagger-jersey2-jaxrs', version :swaggerJersey2JaxrsVersion) {
             exclude group: 'com.google.guava', module: 'guava'
         }
-        compile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        compile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
         compile group: 'com.typesafe', name: 'config', version: typesafeConfigVersion
         compile group: 'org.apache.curator', name: 'curator-framework', version: apacheCuratorVersion
         compile group: 'org.apache.curator', name: 'curator-recipes', version: apacheCuratorVersion
@@ -590,6 +574,8 @@ project('standalone') {
     }
 
     dependencies {
+        runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+
         compile project(':common')
         compile project(':client')
         compile project(':segmentstore:server')
@@ -602,14 +588,12 @@ project('standalone') {
 
         compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
         compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: javaxwsrsApiVersion
-        runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion
         // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common
         compile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion, withoutLogger
         compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion, withoutLogger
         compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLogger
         compile group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: nettyBoringSSLVersion
-
         testCompile project(':test:testcommon')
         testCompile project(path:':common', configuration:'testRuntime')
         testCompile project(path:':segmentstore:server', configuration:'testRuntime')

--- a/build.gradle
+++ b/build.gradle
@@ -40,17 +40,17 @@ allprojects {
     apply plugin: 'eclipse'
     if (file("src/main/java").isDirectory()) {
         apply plugin: 'java'
-		apply plugin: 'io.franzbecker.gradle-lombok'
-   		lombok {
-			version = lombokVersion
-		}
-		dependencies {
-			//These are compile time only dependencies needed accross all targets. Lombok uses them and may generate strange errors if they are missing.
-			compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        	testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
-        	compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-        	testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
-		}
+        apply plugin: 'io.franzbecker.gradle-lombok'
+        lombok {
+            version = lombokVersion
+        }
+        dependencies {
+            //These are compile time only dependencies needed accross all targets. Lombok uses them and may generate strange errors if they are missing.
+            compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+            testCompile group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
+            compileOnly group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+            testCompile group: 'net.jcip', name: 'jcip-annotations', version: jcipAnnotationsVersion
+        }
     }
     // Plugin configurations
     apply from: "$rootDir/gradle/application.gradle"
@@ -83,7 +83,7 @@ allprojects {
     }
     version = getProjectVersion()
     group = "io.pravega"
-    
+
     configurations.all {
         resolutionStrategy {
             //failOnVersionConflict()

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -33,6 +33,7 @@ import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.ReaderGroupImpl;
 import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.common.Exceptions;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.shared.NameUtils;
 import java.io.IOException;
@@ -40,7 +41,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
 import lombok.Cleanup;
-import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -109,7 +109,7 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
                                              } else {
                                                  log.warn("Failed to delete stream", e);
                                              }
-                                             throw Lombok.sneakyThrow(e);
+                                             throw Exceptions.sneakyThrow(e);
                                          }),
                                RuntimeException::new);
         

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -13,6 +13,7 @@ import io.netty.buffer.Unpooled;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.RawClient;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.common.Exceptions;
 import io.pravega.common.util.Retry.RetryWithBackoff;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.Reply;
@@ -31,7 +32,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
-import lombok.Lombok;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
@@ -118,11 +118,11 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         if (reply instanceof WireCommands.NoSuchSegment) {
             throw new NoSuchSegmentException(reply.toString());
         } else if (reply instanceof SegmentIsSealed) {
-            throw Lombok.sneakyThrow(new SegmentSealedException(reply.toString()));
+            throw Exceptions.sneakyThrow(new SegmentSealedException(reply.toString()));
         } else if (reply instanceof WrongHost) {
-            throw Lombok.sneakyThrow(new ConnectionFailedException(reply.toString()));
+            throw Exceptions.sneakyThrow(new ConnectionFailedException(reply.toString()));
         } else {
-            throw Lombok.sneakyThrow(new ConnectionFailedException("Unexpected reply of " + reply + " when expecting an AppendSetup"));
+            throw Exceptions.sneakyThrow(new ConnectionFailedException("Unexpected reply of " + reply + " when expecting an AppendSetup"));
         }
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -51,7 +51,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Getter;
-import lombok.Lombok;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -543,7 +542,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                          } catch (ConnectionFailedException e1) {
                              // This needs to be invoked here because call to failConnection from netty may occur before state.newConnection above.
                              state.failConnection(e1);
-                             throw Lombok.sneakyThrow(e1);
+                             throw Exceptions.sneakyThrow(e1);
                          }
                          return connectionSetupFuture.exceptionally(t -> {
                              Throwable exception = Exceptions.unwrap(t);
@@ -555,7 +554,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                                  log.info("Ending reconnect attempts on writer {} to {} because segment is truncated", writerId, segmentName);
                                  return null;
                              }
-                             throw Lombok.sneakyThrow(t);
+                             throw Exceptions.sneakyThrow(t);
                          });
                      }, connectionFactory.getInternalExecutor());
                  }, connectionFactory.getInternalExecutor());

--- a/common/src/main/java/io/pravega/common/Exceptions.java
+++ b/common/src/main/java/io/pravega/common/Exceptions.java
@@ -12,7 +12,6 @@ package io.pravega.common;
 import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.Map;
-
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import lombok.SneakyThrows;
@@ -22,6 +21,32 @@ import lombok.SneakyThrows;
  */
 public final class Exceptions {
 
+    /**
+     * Throws any throwable 'sneakily' - you don't need to catch it, nor declare that you throw it onwards.
+     * The exception is still thrown - javac will just stop whining about it.
+     * <p>
+     * Example usage:
+     * <pre>public void run() {
+     *     throw sneakyThrow(new IOException("You don't need to catch me!"));
+     * }</pre>
+     * <p>
+     * NB: The exception is not wrapped, ignored, swallowed, or redefined. The JVM actually does not know or care
+     * about the concept of a 'checked exception'. All this method does is hide the act of throwing a checked exception
+     * from the java compiler.
+     * <p>
+     * Note that this method has a return type of {@code RuntimeException}; it is advised you always call this
+     * method as argument to the {@code throw} statement to avoid compiler errors regarding no return
+     * statement and similar problems. This method won't of course return an actual {@code RuntimeException} -
+     * it never returns, it always throws the provided exception.
+     * 
+     * @param t The throwable to throw without requiring you to catch its type.
+     * @return A dummy RuntimeException; this method never returns normally, it <em>always</em> throws an exception!
+     */
+    @SneakyThrows
+    public static RuntimeException sneakyThrow(Throwable t) {
+        throw t;
+    }
+    
     /**
      * Determines if the given Throwable represents a fatal exception and cannot be handled.
      *

--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -34,7 +34,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Data;
-import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.val;
 
@@ -153,9 +152,9 @@ public final class Futures {
             return future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Lombok.sneakyThrow(e);
+            throw Exceptions.sneakyThrow(e);
         } catch (Exception e) {
-            throw Lombok.sneakyThrow(Exceptions.unwrap(e));
+            throw Exceptions.sneakyThrow(Exceptions.unwrap(e));
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -55,7 +55,6 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Lombok;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -104,7 +103,7 @@ public class ControllerService {
                         .collect(Collectors.toList());
             } catch (ClusterException e) {
                 // cluster implementation throws checked exceptions which cannot be thrown inside completable futures.
-                throw Lombok.sneakyThrow(e);
+                throw Exceptions.sneakyThrow(e);
             }
         }, executor);
     }

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -9,19 +9,11 @@
  */
 package io.pravega.controller.store.checkpoint;
 
-import io.pravega.common.util.Retry;
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.JavaSerializer;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Lombok;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.data.Stat;
-
+import io.pravega.common.Exceptions;
+import io.pravega.common.util.Retry;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -32,6 +24,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
 
 /**
  * Zookeeper based checkpoint store.
@@ -157,12 +156,12 @@ class ZKCheckpointStore implements CheckpointStore {
 
             updateReaderGroupData(path, groupData -> {
                 if (groupData.getState() == ReaderGroupData.State.Sealed) {
-                    throw Lombok.sneakyThrow(new CheckpointStoreException(CheckpointStoreException.Type.Sealed,
+                    throw Exceptions.sneakyThrow(new CheckpointStoreException(CheckpointStoreException.Type.Sealed,
                             "ReaderGroup is sealed"));
                 }
                 List<String> list = groupData.getReaderIds();
                 if (list.contains(readerId)) {
-                    throw Lombok.sneakyThrow(new CheckpointStoreException(CheckpointStoreException.Type.NodeExists,
+                    throw Exceptions.sneakyThrow(new CheckpointStoreException(CheckpointStoreException.Type.NodeExists,
                             "Duplicate readerId"));
                 }
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -35,10 +35,6 @@ import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
-import lombok.Lombok;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,6 +57,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
@@ -638,7 +636,7 @@ public abstract class PersistentStreamBase implements Stream {
                                   return false;
                               } else {
                                   log.warn("Exception while trying to validate a stream cut for stream {}/{}", scope, name);
-                                  throw Lombok.sneakyThrow(e);
+                                  throw Exceptions.sneakyThrow(e);
                               }
                           } else {
                               return true;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
@@ -15,21 +15,19 @@ import com.google.common.util.concurrent.AbstractService;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.util.RetryHelper;
-import lombok.Lombok;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.curator.framework.recipes.cache.NodeCacheListener;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
 
 /**
  * Garbage Collector class performs two functions periodically.
@@ -186,7 +184,7 @@ class ZKGarbageCollector extends AbstractService implements AutoCloseable {
                 try {
                     x.close();
                 } catch (IOException e) {
-                    throw Lombok.sneakyThrow(e);
+                    throw Exceptions.sneakyThrow(e);
                 }
             }
             return x;

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ spotbugsAnnotationsVersion=3.1.8
 spotbugsPluginVersion=1.6.5
 jcipAnnotationsVersion=1.0
 gradleDockerPlugin=3.1.0
+gradleLombokPluginVersion=1.14
 gradleMkdocsPluginVersion=1.0.0
 gradleSshPluginVersion=2.9.0
 grpcVersion=1.8.0

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -41,10 +41,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
-import lombok.Lombok;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Single-thread Processor for Operations. Queues all incoming entries in a BlockingDrainingQueue, then picks them all
@@ -329,7 +328,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
 
                     // But first, fail any Operations that we did not have a chance to process yet.
                     cancelIncompleteOperations(operations, ex);
-                    throw Lombok.sneakyThrow(ex);
+                    throw Exceptions.sneakyThrow(ex);
                 }
             }
         }

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -44,11 +44,6 @@ import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.TestFrameworkException;
-import lombok.Cleanup;
-import lombok.Lombok;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -63,6 +58,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.pravega.common.concurrent.Futures.exceptionallyExpecting;
 import static io.pravega.test.system.framework.TestFrameworkException.Type.ConnectionFailed;
@@ -276,7 +274,7 @@ public class K8sClient {
                         api.patchNamespacedCustomObjectAsync(customResourceGroup, version, namespace, plural, name, request, cb1);
                         return cb1.getFuture();
                     } catch (ApiException e) {
-                        throw Lombok.sneakyThrow(e);
+                        throw Exceptions.sneakyThrow(e);
                     }
                 }).exceptionally(t -> {
                     log.warn("Exception while trying to fetch instance {} of custom resource {}, try to create it.", name, customResourceGroup, t);
@@ -286,7 +284,7 @@ public class K8sClient {
                         api.createNamespacedCustomObjectAsync(customResourceGroup, version, namespace, plural, request, PRETTY_PRINT, cb);
                         return cb.getFuture();
                     } catch (ApiException e) {
-                        throw Lombok.sneakyThrow(e);
+                        throw Exceptions.sneakyThrow(e);
                     }
                 });
     }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Changes Lombok, spotbugs-annotations, and jcip-annotations into compile time dependencies (as opposed to being required at runtime.

**Purpose of the change**  
Fixes #3289.

**What the code does**  
Should have no functional impact.

**How to verify it**  
We need to test the build on all appropriate environments.
