### PR TITLE
Issue-3239: make DYNAMIC_LOGGER non-static to avoid test code race condition

### DIFF
--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -268,7 +268,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 This is an example from io.pravega.segmentstore.server.SegmentStoreMetrics. In this class, we report a Dynamic Meter which represents the segments created.
 ```java
 public final class SegmentStoreMetrics {
-    private static final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
+    private final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
     
     public void createSegment() {
             dynamicLogger.recordMeterEvents(this.createSegmentCount, 1);  // Record event for meter metric createSegmentCount

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -121,7 +121,7 @@ This is an example from io.pravega.segmentstore.server.host.handler.PravegaReque
 public class PravegaRequestProcessor extends FailingRequestProcessor implements RequestProcessor {
     
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
-    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
+    private DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
     
     private final OpStatsLogger createStreamSegment = STATS_LOGGER.createStats(SEGMENT_CREATE_LATENCY);
     
@@ -139,7 +139,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 ByteBuffer data = copyData(cachedEntries);
                 SegmentRead reply = new SegmentRead(segment, request.getOffset(), atTail, endOfSegment, data);
                 connection.send(reply);
-                DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length); // Increasing the counter value for the counter metric SEGMENT_READ_BYTES
+                dynamicLogger.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length); // Increasing the counter value for the counter metric SEGMENT_READ_BYTES
             } else if (truncated) {
                 // We didn't collect any data, instead we determined that the current read offset was truncated.
                 // Determine the current Start Offset and send that back.
@@ -155,7 +155,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                             ByteBuffer data = copyData(Collections.singletonList(contents));
                             SegmentRead reply = new SegmentRead(segment, nonCachedEntry.getStreamSegmentOffset(), false, endOfSegment, data);
                             connection.send(reply);
-                            DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length); // Increasing the counter value for the counter metric SEGMENT_READ_BYTES
+                            dynamicLogger.incCounterValue(nameFromSegment(SEGMENT_READ_BYTES, segment), reply.getData().array().length); // Increasing the counter value for the counter metric SEGMENT_READ_BYTES
                         })
                         .exceptionally(e -> {
                             if (Exceptions.unwrap(e) instanceof StreamSegmentTruncatedException) {
@@ -240,7 +240,7 @@ This is an example from io.pravega.controller.store.stream.AbstractStreamMetadat
 public abstract class AbstractStreamMetadataStore implements StreamMetadataStore  {
     ...
     private static final OpStatsLogger CREATE_STREAM = STATS_LOGGER.createStats(MetricsNames.CREATE_STREAM); // get stats logger from MetricsProvider
-    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger(); // get dynamic logger from MetricsProvider
+    private DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger(); // get dynamic logger from MetricsProvider
        
     ...
     @Override
@@ -254,7 +254,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                     .thenApply(result -> {
                         if (result.getStatus().equals(CreateStreamResponse.CreateStatus.NEW)) {
                             CREATE_STREAM.reportSuccessValue(1); // Report success event for histogram metric CREATE_STREAM
-                            DYNAMIC_LOGGER.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), 0); // Report gauge value for Dynamic Gauge metric OPEN_TRANSACTIONS 
+                            dynamicLogger.reportGaugeValue(nameFromStream(OPEN_TRANSACTIONS, scope, name), 0); // Report gauge value for Dynamic Gauge metric OPEN_TRANSACTIONS 
                         }
     
                         return result;
@@ -268,10 +268,10 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
 This is an example from io.pravega.segmentstore.server.SegmentStoreMetrics. In this class, we report a Dynamic Meter which represents the segments created.
 ```java
 public final class SegmentStoreMetrics {
-    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
+    private static final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
     
     public void createSegment() {
-            DYNAMIC_LOGGER.recordMeterEvents(this.createSegmentCount, 1);  // Record event for meter metric createSegmentCount
+            dynamicLogger.recordMeterEvents(this.createSegmentCount, 1);  // Record event for meter metric createSegmentCount
     } 
 }
 ```
@@ -317,7 +317,7 @@ public class AddMetrics {
     // Step 2. In the class that need Metrics: get StatsLogger through MetricsProvider; then get Metrics from StatsLogger; at last report it at the right place.
 
     static final StatsLogger STATS_LOGGER = MetricsProvider.getStatsLogger(); // <--- 1
-    static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
+    DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
     
      static class Metrics { // < --- 2
         //Using Stats Logger
@@ -335,16 +335,16 @@ public class AddMetrics {
     //to report success or increment
     Metrics.CREATE_STREAM.reportSuccessValue(1); // < --- 3
     Metrics.createStreamSegment.reportSuccessEvent(timer.getElapsed());
-    DYNAMIC_LOGGER.incCounterValue(Metrics.SEGMENT_READ_BYTES, 1);
-    DYNAMIC_LOGGER.reportGaugeValue(OPEN_TRANSACTIONS, 0);
+    dynamicLogger.incCounterValue(Metrics.SEGMENT_READ_BYTES, 1);
+    dynamicLogger.reportGaugeValue(OPEN_TRANSACTIONS, 0);
     
     //in case of failure
     Metrics.CREATE_STREAM.reportFailValue(1);
     Metrics.createStreamSegment.reportFailEvent(timer.getElapsed());
     
     //to freeze
-    DYNAMIC_LOGGER.freezeCounter(Metrics.SEGMENT_READ_BYTES);
-    DYNAMIC_LOGGER.freezeGaugeValue(OPEN_TRANSACTIONS);
+    dynamicLogger.freezeCounter(Metrics.SEGMENT_READ_BYTES);
+    dynamicLogger.freezeGaugeValue(OPEN_TRANSACTIONS);
 }
 ```
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.concurrent.GuardedBy;
+
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -87,8 +89,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);
     private static final String EMPTY_STACK_TRACE = "";
     @VisibleForTesting
-    @Setter
-    private DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
+    @Setter(AccessLevel.PACKAGE)
+    private DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
     private final StreamSegmentStore store;
     private final ServerConnection connection;
     @Getter
@@ -302,13 +304,13 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 log.trace("Sending DataAppended : {}", dataAppendedAck);
                 connection.send(dataAppendedAck);
 
-                DYNAMIC_LOGGER.incCounterValue(globalMetricName(SEGMENT_WRITE_BYTES), append.getDataLength());
-                DYNAMIC_LOGGER.incCounterValue(globalMetricName(SEGMENT_WRITE_EVENTS), append.getEventCount());
+                dynamicLogger.incCounterValue(globalMetricName(SEGMENT_WRITE_BYTES), append.getDataLength());
+                dynamicLogger.incCounterValue(globalMetricName(SEGMENT_WRITE_EVENTS), append.getEventCount());
                 //Don't report segment specific metrics if segment is a transaction
                 //The parent segment metrics will be updated once the transaction is merged
                 if (!StreamSegmentNameUtils.isTransactionSegment(append.getSegment())) {
-                    DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
-                    DYNAMIC_LOGGER.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
+                    dynamicLogger.incCounterValue(nameFromSegment(SEGMENT_WRITE_BYTES, append.getSegment()), append.getDataLength());
+                    dynamicLogger.incCounterValue(nameFromSegment(SEGMENT_WRITE_EVENTS, append.getSegment()), append.getEventCount());
                 }
             }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -62,6 +62,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -83,9 +84,11 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     private static final int HIGH_WATER_MARK = 128 * 1024;
     private static final int LOW_WATER_MARK = 64 * 1024;
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
-    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     private static final OpStatsLogger WRITE_STREAM_SEGMENT = STATS_LOGGER.createStats(SEGMENT_WRITE_LATENCY);
     private static final String EMPTY_STACK_TRACE = "";
+    @VisibleForTesting
+    @Setter
+    private DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     private final StreamSegmentStore store;
     private final ServerConnection connection;
     @Getter

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -35,6 +35,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.protocol.netty.AppendDecoder;
 import io.pravega.shared.protocol.netty.CommandDecoder;
 import io.pravega.shared.protocol.netty.CommandEncoder;
@@ -157,9 +158,10 @@ public final class PravegaConnectionListener implements AutoCloseable {
                          lsh);
                  lsh.setRequestProcessor(new AppendProcessor(store,
                          lsh,
-                         new PravegaRequestProcessor(store, lsh, statsRecorder, tokenVerifier, replyWithStackTraceOnError),
+                         new PravegaRequestProcessor(store, lsh, statsRecorder, tokenVerifier, MetricsProvider.getDynamicLogger(), replyWithStackTraceOnError),
                          statsRecorder,
                          tokenVerifier,
+                         MetricsProvider.getDynamicLogger(),
                          replyWithStackTraceOnError));
              }
          });

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -86,6 +86,7 @@ import java.util.function.Consumer;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.slf4j.LoggerFactory;
@@ -122,9 +123,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     private static final TagLogger log = new TagLogger(LoggerFactory.getLogger(PravegaRequestProcessor.class));
     private static final int MAX_READ_SIZE = 2 * 1024 * 1024;
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
-    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(new byte[0]);
     private static final String EMPTY_STACK_TRACE = "";
+    @VisibleForTesting
+    @Setter
+    private DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)
     private final OpStatsLogger createStreamSegment = STATS_LOGGER.createStats(SEGMENT_CREATE_LATENCY);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -42,7 +42,6 @@ import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_BYTES;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_EVENTS;
 import static io.pravega.shared.MetricsNames.globalMetricName;
 import static io.pravega.shared.MetricsNames.nameFromSegment;
-import static io.pravega.test.common.TestUtils.setFinalStatic;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,9 +65,9 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(AppendProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
+        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -101,9 +100,9 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(AppendProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
+        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -176,9 +175,9 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(AppendProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
+        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -215,9 +214,9 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(AppendProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
+        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -341,9 +340,9 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(AppendProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
+        DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -67,7 +67,7 @@ public class AppendProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -102,7 +102,7 @@ public class AppendProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -177,7 +177,7 @@ public class AppendProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -216,7 +216,7 @@ public class AppendProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -342,7 +342,7 @@ public class AppendProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -65,9 +65,8 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null, mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -100,9 +99,8 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null, mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -175,9 +173,8 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null, mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -214,9 +211,8 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null, mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
@@ -340,9 +336,8 @@ public class AppendProcessorTest {
         byte[] data = new byte[] { 1, 2, 3, 4, 6, 7, 8, 9 };
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         ServerConnection connection = mock(ServerConnection.class);
-        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null);
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        AppendProcessor processor = new AppendProcessor(store, connection, new FailingRequestProcessor(), null, mockedDynamicLogger);
 
         setupGetAttributes(streamSegmentName, clientId, store);
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.server.host.handler;
 
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.protocol.netty.WireCommands;
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +28,7 @@ public class PravegaRequestProcessorAuthFailedTest {
     public void setUp() throws Exception {
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         connection = mock(ServerConnection.class);
-        processor = new PravegaRequestProcessor(store, connection, null, (resource, token, expectedLevel) -> false, false);
+        processor = new PravegaRequestProcessor(store, connection, null, (resource, token, expectedLevel) -> false, MetricsProvider.getDynamicLogger(), false);
     }
 
     @After

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -406,10 +406,8 @@ public class PravegaRequestProcessorTest {
         //test txn segment merge
         CompletableFuture<SegmentProperties> txnFuture = CompletableFuture.completedFuture(createSegmentProperty(streamSegmentName, txnId));
         doReturn(txnFuture).when(store).mergeStreamSegment(anyString(), anyString(), any());
-        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection);
-
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection, mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));
@@ -422,10 +420,8 @@ public class PravegaRequestProcessorTest {
         //test non-txn segment merge
         CompletableFuture<SegmentProperties> nonTxnFuture = CompletableFuture.completedFuture(createSegmentProperty(streamSegmentName, null));
         doReturn(nonTxnFuture).when(store).mergeStreamSegment(anyString(), anyString(), any());
-        processor = new PravegaRequestProcessor(store, connection);
-
         mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDynamicLogger(mockedDynamicLogger);
+        processor = new PravegaRequestProcessor(store, connection, mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.CompletableFuture;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_BYTES;
 import static io.pravega.shared.MetricsNames.SEGMENT_WRITE_EVENTS;
 import static io.pravega.shared.MetricsNames.nameFromSegment;
-import static io.pravega.test.common.TestUtils.setFinalStatic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -410,7 +409,7 @@ public class PravegaRequestProcessorTest {
         PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection);
 
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(PravegaRequestProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));
@@ -426,7 +425,7 @@ public class PravegaRequestProcessorTest {
         processor = new PravegaRequestProcessor(store, connection);
 
         mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        setFinalStatic(PravegaRequestProcessor.class.getDeclaredField("DYNAMIC_LOGGER"), mockedDynamicLogger);
+        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -409,7 +409,7 @@ public class PravegaRequestProcessorTest {
         PravegaRequestProcessor processor = new PravegaRequestProcessor(store, connection);
 
         DynamicLogger mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));
@@ -425,7 +425,7 @@ public class PravegaRequestProcessorTest {
         processor = new PravegaRequestProcessor(store, connection);
 
         mockedDynamicLogger = Mockito.mock(DynamicLogger.class);
-        processor.setDYNAMIC_LOGGER(mockedDynamicLogger);
+        processor.setDynamicLogger(mockedDynamicLogger);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName,
                 WireCommands.CreateSegment.NO_SCALE, 0, ""));


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
Made DYNAMIC_LOGGER of AppendProcessor and PravegaRequestProcessor non-static,  hence we don't have to overwrite static variable in test code which may cause race condition when concurrent tests run

**Purpose of the change**  
Fixes #3239

**What the code does**  
Changed DYNAMIC_LOGGER of AppendProcessor and PravegaRequestProcessor from static to non-static, and added setter for it. 
In the test code, DYNAMIC_LOGGER is set up with mock object, which is of instance scope, to prevent race condition.

**How to verify it**  
Unit tests passed. 
Need to observe further at Travis to ensure no race condition to happen.
