### PR TITLE
Issue 2933: (SegmentStore) testEndToEndWithFencing fixes

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
@@ -19,7 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.hadoop.service.ServiceOperations;
 
 /**
  * Base class for any StreamSegmentStore Integration Test that uses BookKeeper and RocksDB.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.host;
 
 import io.pravega.common.io.FileHelpers;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.segmentstore.server.store.ServiceConfig;
 import io.pravega.segmentstore.server.store.StreamSegmentStoreTestBase;
 import io.pravega.segmentstore.storage.impl.rocksdb.RocksDBConfig;
 import java.io.File;
@@ -18,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.apache.hadoop.service.ServiceOperations;
 
 /**
  * Base class for any StreamSegmentStore Integration Test that uses BookKeeper and RocksDB.
@@ -71,9 +73,11 @@ abstract class BookKeeperIntegrationTestBase extends StreamSegmentStoreTestBase 
      * @return A ServiceBuilderConfig instance.
      */
     protected ServiceBuilderConfig getBuilderConfig(ServiceBuilderConfig.Builder configBuilder, int instanceId) {
+        String id = Integer.toString(instanceId);
         return configBuilder
                 .makeCopy()
-                .include(RocksDBConfig.builder().with(RocksDBConfig.DATABASE_DIR, Paths.get(getRocksDBDir().toString(), Integer.toString(instanceId)).toString()))
+                .include(ServiceConfig.builder().with(ServiceConfig.INSTANCE_ID, id))
+                .include(RocksDBConfig.builder().with(RocksDBConfig.DATABASE_DIR, Paths.get(getRocksDBDir().toString(), id).toString()))
                 .build();
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -18,7 +18,6 @@ import io.pravega.segmentstore.server.CachePolicy;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.time.Duration;
-import lombok.Generated;
 import lombok.Getter;
 import lombok.SneakyThrows;
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -18,6 +18,7 @@ import io.pravega.segmentstore.server.CachePolicy;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import lombok.Generated;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
@@ -52,6 +53,7 @@ public class ServiceConfig {
     public static final Property<Integer> CACHE_POLICY_MAX_TIME = Property.named("cacheMaxTimeSeconds", 30 * 60);
     public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cacheGenerationTimeSeconds", 5);
     public static final Property<Boolean> REPLY_WITH_STACK_TRACE_ON_ERROR = Property.named("replyWithStackTraceOnError", false);
+    public static final Property<String> INSTANCE_ID = Property.named("instanceId", "");
 
     public static final String COMPONENT_CODE = "pravegaservice";
 
@@ -244,6 +246,14 @@ public class ServiceConfig {
     @Getter
     private final boolean replyWithStackTraceOnError;
 
+    /**
+     * Gets a value that uniquely identifies the Service. This is useful if multiple Service Instances share the same
+     * log files or during testing, when multiple Service Instances run in the same process. This value will be prefixed
+     * to the names of all Threads used by this Service Instance, which should make log parsing easier.
+     */
+    @Getter
+    private final String instanceId;
+
     //endregion
 
     //region Constructor
@@ -299,6 +309,7 @@ public class ServiceConfig {
         int cachePolicyGenerationTime = properties.getInt(CACHE_POLICY_GENERATION_TIME);
         this.cachePolicy = new CachePolicy(cachePolicyMaxSize, Duration.ofSeconds(cachePolicyMaxTime), Duration.ofSeconds(cachePolicyGenerationTime));
         this.replyWithStackTraceOnError = properties.getBoolean(REPLY_WITH_STACK_TRACE_ON_ERROR);
+        this.instanceId = properties.get(INSTANCE_ID);
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -83,7 +83,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int TRANSACTIONS_PER_SEGMENT = 1;
     private static final int APPENDS_PER_SEGMENT = 100;
     private static final int ATTRIBUTE_UPDATES_PER_SEGMENT = 100;
-    private static final int MAX_INSTANCE_COUNT = 5;
+    private static final int MAX_INSTANCE_COUNT = 4;
     private static final List<UUID> ATTRIBUTES = Arrays.asList(Attributes.EVENT_COUNT, UUID.randomUUID(), UUID.randomUUID());
     private static final int EXPECTED_ATTRIBUTE_VALUE = APPENDS_PER_SEGMENT + ATTRIBUTE_UPDATES_PER_SEGMENT;
     private static final Duration TIMEOUT = Duration.ofSeconds(120);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.segmentstore.server.store;
 
-import com.google.common.collect.Iterators;
 import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.TimeoutTimer;


### PR DESCRIPTION
**Change log description**  
- Simplified the `StreamSegmentStoreTestBase.testEndToEndWithFencing` to do fewer fencing tests (4, down from 5) and to not do segment mergers or seals. 
- Added the ability to assign an Instance Id to a Segment Store instance, which will be output during logging. 
- Fixed two bugs in `RollingStorage` which could leave upstream code in a bad state.

**Purpose of the change**  
Fixes #2933.

**What the code does**  
- Instance Id is useful if multiple Segment Store instances run in the same process or output to the same log files. This will be included in the Thread names so that log output can be properly associated with an instance.
    - This is defaulted to empty string, which means for normal, production code, it will not add anything. It's just set for integration tests for now.
- The `testEndToEndWithFencing` was too complex and was taking too much time. It has been simplified with fewer operations that will execute.
- `RollingStorage`
    - Removed a parameter check which was violating the Javadoc contract. It would disallow reading 0 bytes from offset 0 of an empty file, when normally that should return an empty result.
    - Handling a concurrent rollover scenario, in case a different instance of the `RollingStorage` class executes a rollover on the Segment at or around the same time as this instance. This will force-refresh the handle and either move on or re-throw the original exception, depending on the case.

**How to verify it**  
`testEndToEndWithFencing` must pass consistently.
