### PR TITLE
Issue #2768: Rename PravegaCredsWrapper class and its member variable

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -173,7 +173,7 @@ public class ControllerImpl implements Controller {
         ControllerServiceStub client = ControllerServiceGrpc.newStub(this.channel);
         Credentials credentials = config.getClientConfig().getCredentials();
         if (credentials != null) {
-            PravegaCredsWrapper wrapper = new PravegaCredsWrapper(credentials);
+            PravegaCredentialsWrapper wrapper = new PravegaCredentialsWrapper(credentials);
             client = client.withCallCredentials(MoreCallCredentials.from(wrapper));
         }
         this.client = client;

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
@@ -17,21 +17,21 @@ import java.util.List;
 import java.util.Map;
 
 public class PravegaCredentialsWrapper extends com.google.auth.Credentials {
-    private final Credentials creds;
+    private final Credentials credentials;
 
-    public PravegaCredentialsWrapper(Credentials creds) {
-        this.creds = creds;
+    public PravegaCredentialsWrapper(Credentials credentials) {
+        this.credentials = credentials;
     }
 
     @Override
     public String getAuthenticationType() {
-        return creds.getAuthenticationType();
+        return credentials.getAuthenticationType();
     }
 
     @Override
     public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
-        String token = creds.getAuthenticationToken();
-        String credential = creds.getAuthenticationType() + " " + token;
+        String token = credentials.getAuthenticationToken();
+        String credential = credentials.getAuthenticationType() + " " + token;
         return Collections.singletonMap(AuthConstants.AUTHORIZATION, Collections.singletonList(credential));
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
@@ -16,10 +16,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class PravegaCredsWrapper extends com.google.auth.Credentials {
+public class PravegaCredentialsWrapper extends com.google.auth.Credentials {
     private final Credentials creds;
 
-    public PravegaCredsWrapper(Credentials creds) {
+    public PravegaCredentialsWrapper(Credentials creds) {
         this.creds = creds;
     }
 


### PR DESCRIPTION
**Change log description**  

The class name ``PravegaCredsWrapper`` and variables ``creds`` were slightly confusing terms, and can tax a reader's memory. 

**Purpose of the change**  
Fixes #2768. 

Note that the other change mentioned in #2768, i.e. relocating CredentialsExtractorTest.java, wasn't found necessary. This is because the test really exercises a method of ClientConfigBuilder class, which in turn happens to be the same package (``io.pravega.client``) as the test class. 

**What the code does**  
Renamed ``PravegaCredsWrapper`` class and ``creds`` variables to ``PravegaCredentialsWrapper`` and ``credentials`` respectively.

**How to verify it**  
Manual inspection, apart from the successful run of automated tests.
