### PR TITLE
Issue 2821: Replace UnixPrincipal with a custom Principal implementation

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
@@ -12,7 +12,6 @@ package io.pravega.controller.server.rpc.auth;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.sun.security.auth.UnixPrincipal;
 import io.pravega.auth.AuthConstants;
 import io.pravega.auth.AuthException;
 import io.pravega.auth.AuthHandler;
@@ -81,10 +80,10 @@ public class PasswordAuthHandler implements AuthHandler {
 
         try {
             if (userMap.containsKey(userName) && encryptor.checkPassword(password, userMap.get(userName).encryptedPassword)) {
-                return new UnixPrincipal(userName);
+                return new UserPrincipal(userName);
             }
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            log.warn("Excpetion during password authentication", e);
+            log.warn("Exception during password authentication", e);
             throw new AuthenticationException(e);
         }
         throw new AuthenticationException("User authentication exception");

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.controller.server.rpc.auth;
 
-import com.sun.security.auth.UnixPrincipal;
 import io.pravega.auth.AuthHandler;
 import io.pravega.auth.ServerConfig;
 import java.security.Principal;
@@ -26,7 +25,7 @@ public class TestAuthHandler implements AuthHandler {
 
     @Override
     public Principal authenticate(String token) {
-        return new UnixPrincipal(token);
+        return new UserPrincipal(token);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.rpc.auth;
+
+import io.pravega.common.Exceptions;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * A {@code Principal} represents an identity (of a subject). This class implements
+ * {@code Principal} and represents identity in the form of a user's name.
+ */
+@ToString
+@EqualsAndHashCode
+public class UserPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    /**
+     * Constructs a {@code Principal} representing the given user name.
+     *
+     * @param name the user name
+     */
+    public UserPrincipal (String name) {
+        Exceptions.checkNotNullOrEmpty(name, "name");
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of this {@code Principal}
+     *
+     * @return the name of this {@code Principal}
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
@@ -34,13 +34,13 @@ public class UserPrincipal implements Principal, Serializable {
      *
      * @param name the user name
      */
-    public UserPrincipal (String name) {
+    public UserPrincipal(String name) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         this.name = name;
     }
 
     /**
-     * Returns the name of this {@code Principal}
+     * Returns the name of this {@code Principal}.
      *
      * @return the name of this {@code Principal}
      */

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/UserPrincipalTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/UserPrincipalTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.rpc.auth;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the UserPrincipal class.
+ */
+public class UserPrincipalTest {
+
+    @Test (expected = NullPointerException.class)
+    public void testCtorThrowsExceptionWhenInputIsNull() {
+        new UserPrincipal(null);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testCtorThrowsExceptionWhenInputIsEmpty() {
+        new UserPrincipal("");
+    }
+
+    @Test
+    public void testObjectsWithSameNameAreEqual() {
+        assertEquals(new UserPrincipal("abc"), new UserPrincipal("abc"));
+    }
+}


### PR DESCRIPTION
**Change log description**  
Classes ``PasswordAuthHandler`` and ``TestAuthHandler`` were using ``com.sun.security.auth.UnixPrincipal`` as the principal identifying the user. ``UnixPrincipal`` is an internal implementation class of Oracle's JDK and is not intended to be used outside. Using it had the following disadvantages: 
* Being an internal implementation class, it can be changed or dropped any time. It may also cause issues due to modularization in JDK 9 or above. 
* It was a poor abstraction for the entity it was supposed to represent in Pravega. 

Besides, for what it's worth, presumably Java implementations other than Oracle/OpenJDK may not have this class. 

**Purpose of the change**  
Resolves #2821. 

**What the code does**  
* Adds an implementation of ``java.security.Principal`` interface - ``UserPrincipal`` representing identity in the form of user's name. 
* Modifies existing code that used UnixPrincipal to use UserPrincipal instead.

**How to verify it**  
* Existing tests should pass. 
* UserPrincipalTest class has some unit tests covering UserPrincipal's functionalities.