### PR TITLE
Issue 2895: Enable Tablestore apis on SegmentHelper.

### DIFF
--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -25,11 +25,6 @@ public interface KeyVersion extends Serializable {
         private static final long serialVersionUID = 1L;
 
         @Override
-        public long getSegmentId() {
-            return -1L;
-        }
-
-        @Override
         public long getSegmentVersion() {
             return -1L;
         }
@@ -48,11 +43,6 @@ public interface KeyVersion extends Serializable {
             return NOT_EXISTS;
         }
     };
-
-    /**
-     * Gets a value representing the internal Table Segment Id where this Key Version refers to.
-     */
-    long getSegmentId();
 
     /**
      * Gets a value representing the internal version inside the Table Segment for this Key.

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -9,16 +9,45 @@
  */
 package io.pravega.client.tables.impl;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
 /**
  * Version of a Key in a Table.
  */
-interface KeyVersion {
+public interface KeyVersion extends Serializable {
+
     /**
      * A special KeyVersion which indicates the Key must not exist when performing Conditional Updates.
      */
-    KeyVersion NOT_EXISTS = null; // TODO: replace with actual implementation instance once it exists.
+
+    KeyVersion NOT_EXISTS = new KeyVersion() {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public long getSegmentId() {
+            return -1L;
+        }
+
+        @Override
+        public long getSegmentVersion() {
+            return -1L;
+        }
+
+        @Override
+        public ByteBuffer toBytes() {
+            return ByteBuffer.allocate(0);
+        }
+
+        @Override
+        public String toString() {
+            return "NOT_EXISTS";
+        }
+
+        private Object readResolve() {
+            return NOT_EXISTS;
+        }
+    };
 
     /**
      * Gets a value representing the internal Table Segment Id where this Key Version refers to.
@@ -42,6 +71,9 @@ interface KeyVersion {
      * @return The KeyVersion object.
      */
     static KeyVersion fromBytes(ByteBuffer serializedKeyVersion) {
-        throw new UnsupportedOperationException("Not Implemented");
+        if (!serializedKeyVersion.hasRemaining()) {
+            return NOT_EXISTS;
+        }
+        return KeyVersionImpl.fromBytes(serializedKeyVersion);
     }
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -30,7 +30,6 @@ public class KeyVersionImpl implements KeyVersion {
 
     private static final KeyVersionImplSerializer SERIALIZER = new KeyVersionImpl.KeyVersionImplSerializer();
 
-    private final long segmentId;
     private final long segmentVersion;
 
     @Override
@@ -66,12 +65,10 @@ public class KeyVersionImpl implements KeyVersion {
         }
 
         private void read00(RevisionDataInput revisionDataInput, KeyVersionBuilder builder) throws IOException {
-            builder.segmentId(revisionDataInput.readCompactLong());
             builder.segmentVersion(revisionDataInput.readCompactLong());
         }
 
         private void write00(KeyVersionImpl version, RevisionDataOutput revisionDataOutput) throws IOException {
-            revisionDataOutput.writeCompactLong(version.getSegmentId());
             revisionDataOutput.writeCompactLong(version.getSegmentVersion());
         }
     }

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.tables.impl;
+
+import io.pravega.common.ObjectBuilder;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.common.io.serialization.VersionedSerializer;
+import io.pravega.common.util.ByteArraySegment;
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.SneakyThrows;
+
+@Data
+@Builder(builderClassName = "KeyVersionBuilder")
+@AllArgsConstructor
+public class KeyVersionImpl implements KeyVersion {
+
+    private static final KeyVersionImplSerializer SERIALIZER = new KeyVersionImpl.KeyVersionImplSerializer();
+
+    private final long segmentId;
+    private final long segmentVersion;
+
+    @Override
+    @SneakyThrows(IOException.class)
+    public ByteBuffer toBytes() {
+        ByteArraySegment serialized = SERIALIZER.serialize(this);
+        return ByteBuffer.wrap(serialized.array(), serialized.arrayOffset(), serialized.getLength());
+    }
+
+    @SneakyThrows(IOException.class)
+    public static KeyVersionImpl fromBytes(ByteBuffer buff) {
+        return SERIALIZER.deserialize(new ByteArraySegment(buff));
+    }
+
+
+    private static class KeyVersionBuilder implements ObjectBuilder<KeyVersionImpl> {
+    }
+
+    public static class KeyVersionImplSerializer extends VersionedSerializer.WithBuilder<KeyVersionImpl, KeyVersionBuilder> {
+        @Override
+        protected KeyVersionBuilder newBuilder() {
+            return builder();
+        }
+
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        private void read00(RevisionDataInput revisionDataInput, KeyVersionBuilder builder) throws IOException {
+            builder.segmentId(revisionDataInput.readCompactLong());
+            builder.segmentVersion(revisionDataInput.readCompactLong());
+        }
+
+        private void write00(KeyVersionImpl version, RevisionDataOutput revisionDataOutput) throws IOException {
+            revisionDataOutput.writeCompactLong(version.getSegmentId());
+            revisionDataOutput.writeCompactLong(version.getSegmentVersion());
+        }
+    }
+
+    @SneakyThrows(IOException.class)
+    private Object writeReplace() throws ObjectStreamException {
+        return new KeyVersionImpl.SerializedForm(SERIALIZER.serialize(this).getCopy());
+    }
+
+    @Data
+    private static class SerializedForm implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final byte[] value;
+        @SneakyThrows(IOException.class)
+        Object readResolve() throws ObjectStreamException {
+            return SERIALIZER.deserialize(new ByteArraySegment(value));
+        }
+    }
+}
+

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -22,6 +22,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.SneakyThrows;
 
+/**
+ * Implementation of {@link KeyVersion}.
+ */
 @Data
 public class KeyVersionImpl implements KeyVersion {
 
@@ -74,6 +77,9 @@ public class KeyVersionImpl implements KeyVersion {
         }
     }
 
+    /*
+     * The object returned by this method is serialized to the object stream.
+     */
     @SneakyThrows(IOException.class)
     private Object writeReplace() throws ObjectStreamException {
         return new KeyVersionImpl.SerializedForm(SERIALIZER.serialize(this).getCopy());

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -78,7 +78,8 @@ public class KeyVersionImpl implements KeyVersion {
     }
 
     /*
-     * The object returned by this method is serialized to the object stream.
+     * The object returned by this method is serialized to the object stream. This method is invoked when
+     * {@link java.io.ObjectOutputStream} is preparing to write the object to the stream.
      */
     @SneakyThrows(IOException.class)
     private Object writeReplace() throws ObjectStreamException {

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -18,19 +18,21 @@ import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.SneakyThrows;
 
 @Data
-@Builder(builderClassName = "KeyVersionBuilder")
-@AllArgsConstructor
 public class KeyVersionImpl implements KeyVersion {
 
     private static final KeyVersionImplSerializer SERIALIZER = new KeyVersionImpl.KeyVersionImplSerializer();
 
     private final long segmentVersion;
+
+    @Builder(builderClassName = "KeyVersionBuilder")
+    public KeyVersionImpl(long segmentVersion) {
+        this.segmentVersion = segmentVersion;
+    }
 
     @Override
     @SneakyThrows(IOException.class)

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -46,7 +46,6 @@ public class KeyVersionImpl implements KeyVersion {
         return SERIALIZER.deserialize(new ByteArraySegment(buff));
     }
 
-
     private static class KeyVersionBuilder implements ObjectBuilder<KeyVersionImpl> {
     }
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
@@ -11,6 +11,11 @@ package io.pravega.client.tables.impl;
 
 import lombok.Data;
 
+/**
+ * Implementation of {@link TableEntry}.
+ * @param <KeyT> Key Type.
+ * @param <ValueT> Value Type.
+ */
 @Data
 public class TableEntryImpl<KeyT, ValueT> implements TableEntry<KeyT, ValueT> {
     private final TableKey<KeyT> key;

--- a/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
@@ -9,20 +9,10 @@
  */
 package io.pravega.client.tables.impl;
 
-/**
- * A Table Entry with a Version.
- *
- * @param <KeyT>   Key Type.
- * @param <ValueT> Value Type
- */
-public interface TableEntry<KeyT, ValueT> {
-    /**
-     * The Key.
-     */
-    TableKey<KeyT> getKey();
+import lombok.Data;
 
-    /**
-     * The Value.
-     */
-    ValueT getValue();
+@Data
+public class TableEntryImpl<KeyT, ValueT> implements TableEntry<KeyT, ValueT> {
+    private final TableKey<KeyT> key;
+    private final ValueT value;
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
@@ -14,7 +14,7 @@ package io.pravega.client.tables.impl;
  *
  * @param <KeyT> Type of the Key.
  */
-interface TableKey<KeyT> {
+public interface TableKey<KeyT> {
     /**
      * The Key.
      */

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
@@ -11,6 +11,10 @@ package io.pravega.client.tables.impl;
 
 import lombok.Data;
 
+/**
+ * Implementation of {@link TableKey}.
+ * @param <KeyT> Key Type.
+ */
 @Data
 public class TableKeyImpl<KeyT> implements TableKey<KeyT> {
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
@@ -9,20 +9,12 @@
  */
 package io.pravega.client.tables.impl;
 
-/**
- * A Table Entry with a Version.
- *
- * @param <KeyT>   Key Type.
- * @param <ValueT> Value Type
- */
-public interface TableEntry<KeyT, ValueT> {
-    /**
-     * The Key.
-     */
-    TableKey<KeyT> getKey();
+import lombok.Data;
 
-    /**
-     * The Value.
-     */
-    ValueT getValue();
+@Data
+public class TableKeyImpl<KeyT> implements TableKey<KeyT> {
+
+    private final KeyT key;
+    private final KeyVersion version;
+
 }

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
@@ -23,7 +23,7 @@ public class KeyVersionTest {
 
     @Test
     public void testKeyVersionSerialization() throws Exception {
-        KeyVersion kv = new KeyVersionImpl(123L, 5L);
+        KeyVersion kv = new KeyVersionImpl( 5L);
         assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
         byte[] buf = serialize(kv);
         assertEquals(kv, deSerializeKeyVersion(buf));

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
@@ -23,7 +23,7 @@ public class KeyVersionTest {
 
     @Test
     public void testKeyVersionSerialization() throws Exception {
-        KeyVersion kv = new KeyVersionImpl( 5L);
+        KeyVersion kv = new KeyVersionImpl(5L);
         assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
         byte[] buf = serialize(kv);
         assertEquals(kv, deSerializeKeyVersion(buf));

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.tables.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import lombok.Cleanup;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyVersionTest {
+
+    @Test
+    public void testKeyVersionSerialization() throws Exception {
+        KeyVersion kv = new KeyVersionImpl(123L, 5L);
+        assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
+        byte[] buf = serialize(kv);
+        assertEquals(kv, deSerializeKeyVersion(buf));
+    }
+
+    @Test
+    public void testUnboundedStreamCutSerialization() throws Exception {
+        KeyVersion kv = KeyVersion.NOT_EXISTS;
+        assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
+        byte[] buf = serialize(kv);
+        assertEquals(kv, deSerializeKeyVersion(buf));
+    }
+
+    private byte[] serialize(KeyVersion sc) throws IOException {
+        @Cleanup
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        @Cleanup
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(sc);
+        return baos.toByteArray();
+    }
+
+    private KeyVersion deSerializeKeyVersion(final byte[] buf) throws Exception {
+        @Cleanup
+        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+        @Cleanup
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        return (KeyVersion) ois.readObject();
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -15,6 +15,12 @@ import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.impl.ModelHelper;
+import io.pravega.client.tables.impl.KeyVersion;
+import io.pravega.client.tables.impl.KeyVersionImpl;
+import io.pravega.client.tables.impl.TableEntry;
+import io.pravega.client.tables.impl.TableEntryImpl;
+import io.pravega.client.tables.impl.TableKey;
+import io.pravega.client.tables.impl.TableKeyImpl;
 import io.pravega.common.Exceptions;
 import io.pravega.common.cluster.Host;
 import io.pravega.common.tracing.RequestTag;
@@ -30,10 +36,15 @@ import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommand;
 import io.pravega.shared.protocol.netty.WireCommandType;
 import io.pravega.shared.protocol.netty.WireCommands;
+import java.nio.ByteBuffer;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.LoggerFactory;
@@ -600,6 +611,446 @@ public class SegmentHelper {
                 qualifiedName, delegationToken);
         sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
         return result;
+    }
+
+    /**
+     * This method sends a WireCommand to create a table segment.
+     *
+     * @param scope Stream scope.
+     * @param stream Stream name.
+     * @param segmentId Id of the segment to be created.
+     * @param hostControllerStore Host controller store.
+     * @param clientCF Client connection factory.
+     * @param delegationToken The token to be presented to the segmentstore.
+     * @param clientRequestId Request id.
+     * @return A CompletableFuture that, when completed normally, will indicate the table segment creation completed successfully.
+     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
+     * will be failed with {@link WireCommandFailedException}.
+     */
+    public CompletableFuture<Boolean> createTableSegment(final String scope,
+                                                         final String stream,
+                                                         final long segmentId,
+                                                         final HostControllerStore hostControllerStore,
+                                                         final ConnectionFactory clientCF,
+                                                         String delegationToken,
+                                                         final long clientRequestId) {
+        final CompletableFuture<Boolean> result = new CompletableFuture<>();
+        final String qualifiedStreamSegmentName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final WireCommandType type = WireCommandType.CREATE_TABLE_SEGMENT;
+        final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
+
+        final FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+            @Override
+            public void connectionDropped() {
+                log.warn(requestId, "CreateTableSegment {} Connection dropped", qualifiedStreamSegmentName);
+                result.completeExceptionally(
+                        new WireCommandFailedException(type, WireCommandFailedException.Reason.ConnectionDropped));
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                log.warn(requestId, "CreateTableSegment {} wrong host", qualifiedStreamSegmentName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.UnknownHost));
+            }
+
+            @Override
+            public void segmentAlreadyExists(WireCommands.SegmentAlreadyExists segmentAlreadyExists) {
+                log.info(requestId, "CreateTableSegment {} segmentAlreadyExists", qualifiedStreamSegmentName);
+                result.complete(true);
+            }
+
+            @Override
+            public void segmentCreated(WireCommands.SegmentCreated segmentCreated) {
+                log.info(requestId, "CreateTableSegment {} SegmentCreated", qualifiedStreamSegmentName);
+                result.complete(true);
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                log.error(requestId, "CreateTableSegment {} threw exception", qualifiedStreamSegmentName, error);
+                result.completeExceptionally(error);
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+                result.completeExceptionally(
+                        new WireCommandFailedException(new AuthenticationException(authTokenCheckFailed.toString()),
+                                                       type, WireCommandFailedException.Reason.AuthFailed));
+            }
+        };
+
+        WireCommands.CreateTableSegment request = new WireCommands.CreateTableSegment(requestId, qualifiedStreamSegmentName, delegationToken);
+        sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
+        return result;
+    }
+
+    /**
+     * This method sends a WireCommand to delete a table segment.
+     *
+     * @param scope Stream scope.
+     * @param stream Stream name.
+     * @param segmentId Id of the segment to be created.
+     * @param mustBeEmpty Flag to check if the table segment should be empty before deletion.
+     * @param hostControllerStore Host controller store.
+     * @param clientCF Client connection factory.
+     * @param delegationToken The token to be presented to the segmentstore.
+     * @param clientRequestId Request id.
+     * @return A CompletableFuture that, when completed normally, will indicate the table segment deletion completed successfully.
+     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
+     * will be failed with {@link WireCommandFailedException}.
+     */
+    public CompletableFuture<Boolean> deleteTableSegment(final String scope,
+                                                    final String stream,
+                                                    final long segmentId,
+                                                    final boolean mustBeEmpty,
+                                                    final HostControllerStore hostControllerStore,
+                                                    final ConnectionFactory clientCF,
+                                                    String delegationToken,
+                                                    final long clientRequestId) {
+        final CompletableFuture<Boolean> result = new CompletableFuture<>();
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final WireCommandType type = WireCommandType.DELETE_TABLE_SEGMENT;
+        final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
+
+        final FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+                log.warn(requestId, "deleteTableSegment {} Connection dropped.", qualifiedName);
+                result.completeExceptionally(
+                        new WireCommandFailedException(type, WireCommandFailedException.Reason.ConnectionDropped));
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                log.warn(requestId, "deleteTableSegment {} wrong host.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.UnknownHost));
+            }
+
+            @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                log.info(requestId, "deleteTableSegment {} NoSuchSegment.", qualifiedName);
+                result.complete(true);
+            }
+
+            @Override
+            public void segmentDeleted(WireCommands.SegmentDeleted segmentDeleted) {
+                log.info(requestId, "deleteTableSegment {} SegmentDeleted.", qualifiedName);
+                result.complete(true);
+            }
+
+            @Override
+            public void tableSegmentNotEmpty(WireCommands.TableSegmentNotEmpty tableSegmentNotEmpty) {
+                log.warn(requestId, "deleteTableSegment {} TableSegmentNotEmpty.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableSegmentNotEmpty));
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                log.error(requestId, "deleteTableSegment {} failed.", qualifiedName, error);
+                result.completeExceptionally(error);
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+                result.completeExceptionally(
+                        new WireCommandFailedException(new AuthenticationException(authTokenCheckFailed.toString()),
+                                                       type, WireCommandFailedException.Reason.AuthFailed));
+            }
+        };
+
+        WireCommands.DeleteTableSegment request = new WireCommands.DeleteTableSegment(requestId, qualifiedName, mustBeEmpty, delegationToken);
+        sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
+        return result;
+    }
+
+    /**
+     * This method sends a WireCommand to update table entries.
+     *
+     * @param scope               Stream scope.
+     * @param stream              Stream name.
+     * @param segmentId           Id of the segment to be created.
+     * @param entries             List of {@link TableEntry}s to be updated.
+     * @param hostControllerStore Host controller store.
+     * @param clientCF            Client connection factory.
+     * @param delegationToken     The token to be presented to the segmentstore.
+     * @param clientRequestId     Request id.
+     * @return A CompletableFuture that, when completed normally, will contain the current versions of each {@link TableEntry}
+     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
+     * will be failed with {@link WireCommandFailedException}.
+     */
+    public CompletableFuture<List<KeyVersion>> updateTableEntries(final String scope,
+                                                                  final String stream,
+                                                                  final long segmentId,
+                                                                  final List<TableEntry<byte[], byte[]>> entries,
+                                                                  final HostControllerStore hostControllerStore,
+                                                                  final ConnectionFactory clientCF,
+                                                                  String delegationToken,
+                                                                  final long clientRequestId) {
+        final CompletableFuture<List<KeyVersion>> result = new CompletableFuture<>();
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final WireCommandType type = WireCommandType.UPDATE_TABLE_ENTRIES;
+        final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
+
+        final FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+                log.warn(requestId, "updateTableEntries {} Connection dropped", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.ConnectionDropped));
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                log.warn(requestId, "updateTableEntries {} wrong host", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.UnknownHost));
+            }
+
+            @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                log.warn(requestId, "updateTableEntries {} NoSuchSegment", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.SegmentDoesNotExist));
+            }
+
+            @Override
+            public void tableEntriesUpdated(WireCommands.TableEntriesUpdated tableEntriesUpdated) {
+                log.info(requestId, "updateTableEntries request for {} tableSegment completed.", qualifiedName);
+                result.complete(tableEntriesUpdated.getUpdatedVersions().stream().map(v -> new KeyVersionImpl(-1L, v)).collect(Collectors.toList()));
+            }
+
+            @Override
+            public void tableKeyDoesNotExist(WireCommands.TableKeyDoesNotExist tableKeyDoesNotExist) {
+                log.warn(requestId, "updateTableEntries request for {} tableSegment failed with TableKeyDoesNotExist.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyDoesNotExist));
+            }
+
+            @Override
+            public void tableKeyBadVersion(WireCommands.TableKeyBadVersion tableKeyBadVersion) {
+                log.warn(requestId, "updateTableEntries request for {} tableSegment failed with TableKeyBadVersion.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyBadVersion));
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                log.error(requestId, "updateTableEntries {} failed", qualifiedName, error);
+                result.completeExceptionally(error);
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+                result.completeExceptionally(
+                        new WireCommandFailedException(new AuthenticationException(authTokenCheckFailed.toString()),
+                                                       type, WireCommandFailedException.Reason.AuthFailed));
+            }
+        };
+
+        List<Map.Entry<WireCommands.TableKey, WireCommands.TableValue>> wireCommandEntries = entries.stream().map(te -> {
+            final WireCommands.TableValue value = new WireCommands.TableValue(ByteBuffer.wrap(te.getValue()));
+            final WireCommands.TableKey key = convertToWireCommand(te.getKey());
+            return new AbstractMap.SimpleImmutableEntry<>(key, value);
+        }).collect(Collectors.toList());
+
+        WireCommands.UpdateTableEntries request = new WireCommands.UpdateTableEntries(requestId, qualifiedName, delegationToken,
+                                                                                      new WireCommands.TableEntries(wireCommandEntries));
+        sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
+        return result;
+    }
+
+    /**
+     * This method sends a WireCommand to remove table keys.
+     *
+     * @param scope               Stream scope.
+     * @param stream              Stream name.
+     * @param segmentId           Id of the segment to be created.
+     * @param keys                List of {@link TableKey}s to be removed. Only if all the elements in the list has version as
+     *                            {@link KeyVersion#NOT_EXISTS} then an unconditional update/removal is performed. Else an atomic conditional
+     *                            update (removal) is performed.
+     * @param hostControllerStore Host controller store.
+     * @param clientCF            Client connection factory.
+     * @param delegationToken     The token to be presented to the segmentstore.
+     * @param clientRequestId     Request id.
+     * @return A CompletableFuture that will complete normally when the provided keys are deleted.
+     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
+     * will be failed with {@link WireCommandFailedException}.
+     */
+    public CompletableFuture<Void> removeTableKeys(final String scope,
+                                                   final String stream,
+                                                   final long segmentId,
+                                                   final List<TableKey<byte[]>> keys,
+                                                   final HostControllerStore hostControllerStore,
+                                                   final ConnectionFactory clientCF,
+                                                   String delegationToken,
+                                                   final long clientRequestId) {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final WireCommandType type = WireCommandType.REMOVE_TABLE_KEYS;
+        final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
+
+        final FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+                log.warn(requestId, "removeTableKeys {} Connection dropped", qualifiedName);
+                result.completeExceptionally(
+                        new WireCommandFailedException(type, WireCommandFailedException.Reason.ConnectionDropped));
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                log.warn(requestId, "removeTableKeys {} Wrong host", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.UnknownHost));
+            }
+
+            @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                log.warn(requestId, "removeTableKeys {} NoSuchSegment", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.SegmentDoesNotExist));
+            }
+
+            @Override
+            public void tableKeysRemoved(WireCommands.TableKeysRemoved tableKeysRemoved) {
+                log.info(requestId, "removeTableKeys {} completed.", qualifiedName);
+                result.complete(null);
+            }
+
+            @Override
+            public void tableKeyDoesNotExist(WireCommands.TableKeyDoesNotExist tableKeyDoesNotExist) {
+                log.info(requestId, "removeTableKeys request for {} tableSegment failed with TableKeyDoesNotExist.", qualifiedName);
+                result.complete(null);
+            }
+
+            @Override
+            public void tableKeyBadVersion(WireCommands.TableKeyBadVersion tableKeyBadVersion) {
+                log.warn(requestId, "removeTableKeys request for {} tableSegment failed with TableKeyBadVersion.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyBadVersion));
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                log.error(requestId, "removeTableKeys {} failed", qualifiedName, error);
+                result.completeExceptionally(error);
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+                result.completeExceptionally(
+                        new WireCommandFailedException(new AuthenticationException(authTokenCheckFailed.toString()),
+                                                       type, WireCommandFailedException.Reason.AuthFailed));
+            }
+        };
+
+        List<WireCommands.TableKey> keyList = keys.stream().map(this::convertToWireCommand).collect(Collectors.toList());
+
+        WireCommands.RemoveTableKeys request = new WireCommands.RemoveTableKeys(requestId, qualifiedName, delegationToken, keyList);
+        sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
+        return result;
+    }
+
+    /**
+     * This method sends a WireCommand to read table entries.
+     *
+     * @param scope               Stream scope.
+     * @param stream              Stream name.
+     * @param segmentId           Id of the segment to be created.
+     * @param keys                List of {@link TableKey}s to be read. {@link TableKey#getVersion()} is not used during this operation and
+     *                            the latest version is read.
+     * @param hostControllerStore Host controller store.
+     * @param clientCF            Client connection factory.
+     * @param delegationToken     The token to be presented to the segmentstore.
+     * @param clientRequestId     Request id.
+     * @return A CompletableFuture that, when completed normally, will contain a list of {@link TableEntry} with a value corresponding to
+     * the latest version. If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
+     * will be failed with {@link WireCommandFailedException}.
+     */
+    public CompletableFuture<List<TableEntry<byte[], byte[]>>> readTable(final String scope,
+                                                                         final String stream,
+                                                                         final long segmentId,
+                                                                         final List<TableKey<byte[]>> keys,
+                                                                         final HostControllerStore hostControllerStore,
+                                                                         final ConnectionFactory clientCF,
+                                                                         String delegationToken,
+                                                                         final long clientRequestId) {
+        final CompletableFuture<List<TableEntry<byte[], byte[]>>> result = new CompletableFuture<>();
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final WireCommandType type = WireCommandType.READ_TABLE;
+        final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
+
+        final FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+                log.warn(requestId, "readTable {} Connection dropped", qualifiedName);
+                result.completeExceptionally(
+                        new WireCommandFailedException(type, WireCommandFailedException.Reason.ConnectionDropped));
+            }
+
+            @Override
+            public void wrongHost(WireCommands.WrongHost wrongHost) {
+                log.warn(requestId, "readTable {} wrong host", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.UnknownHost));
+            }
+
+            @Override
+            public void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment) {
+                log.warn(requestId, "readTable {} NoSuchSegment", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.SegmentDoesNotExist));
+            }
+
+            @Override
+            public void tableRead(WireCommands.TableRead tableRead) {
+                log.info(requestId, "readTable {} successful.", qualifiedName);
+                List<TableEntry<byte[], byte[]>> tableEntries = tableRead.getEntries().getEntries().stream()
+                                                                         .map(e -> {
+                                                                             WireCommands.TableKey k = e.getKey();
+                                                                             TableKey<byte[]> tableKey = new TableKeyImpl<>(k.getData().array(), new KeyVersionImpl(-1L, k.getKeyVersion()));
+                                                                             return new TableEntryImpl<>(tableKey, e.getValue().getData().array());
+                                                                         }).collect(Collectors.toList());
+                result.complete(tableEntries);
+            }
+
+            @Override
+            public void tableKeyDoesNotExist(WireCommands.TableKeyDoesNotExist tableKeyDoesNotExist) {
+                log.warn(requestId, "readTable request for {} tableSegment failed with TableKeyDoesNotExist.", qualifiedName);
+                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyDoesNotExist));
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+                log.error(requestId, "readTable {} failed", qualifiedName, error);
+                result.completeExceptionally(error);
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+                result.completeExceptionally(
+                        new WireCommandFailedException(new AuthenticationException(authTokenCheckFailed.toString()),
+                                                       type, WireCommandFailedException.Reason.AuthFailed));
+            }
+        };
+
+        // the version is always NO_VERSION as read returns the latest version of value.
+        List<WireCommands.TableKey> keyList = keys.stream().map(k -> new WireCommands.TableKey(ByteBuffer.wrap(k.getKey()), WireCommands.TableKey.NO_VERSION))
+                                                  .collect(Collectors.toList());
+
+        WireCommands.ReadTable request = new WireCommands.ReadTable(requestId, qualifiedName, delegationToken, keyList);
+        sendRequestAsync(request, replyProcessor, result, clientCF, ModelHelper.encode(uri));
+        return result;
+    }
+
+    private WireCommands.TableKey convertToWireCommand(final TableKey<byte[]> k) {
+        WireCommands.TableKey key;
+        if (k.getVersion() == null) {
+            // unconditional update.
+            key = new WireCommands.TableKey(ByteBuffer.wrap(k.getKey()), WireCommands.TableKey.NO_VERSION);
+        } else {
+            key = new WireCommands.TableKey(ByteBuffer.wrap(k.getKey()), k.getVersion().getSegmentVersion());
+        }
+        return key;
     }
 
     private <ResultT> void sendRequestAsync(final WireCommand request, final ReplyProcessor replyProcessor,

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -616,16 +616,16 @@ public class SegmentHelper {
     /**
      * This method sends a WireCommand to create a table segment.
      *
-     * @param scope Stream scope.
-     * @param stream Stream name.
-     * @param segmentId Id of the segment to be created.
+     * @param scope               Stream scope.
+     * @param stream              Stream name.
+     * @param segmentId           Id of the segment to be created.
      * @param hostControllerStore Host controller store.
-     * @param clientCF Client connection factory.
-     * @param delegationToken The token to be presented to the segmentstore.
-     * @param clientRequestId Request id.
-     * @return A CompletableFuture that, when completed normally, will indicate the table segment creation completed successfully.
-     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
-     * will be failed with {@link WireCommandFailedException}.
+     * @param clientCF            Client connection factory.
+     * @param delegationToken     The token to be presented to the segmentstore.
+     * @param clientRequestId     Request id.
+     * @return A CompletableFuture that, when completed normally, will indicate the table segment creation completed
+     * successfully. If the operation failed, the future will be failed with the causing exception. If the exception
+     * can be retried then the future will be failed with {@link WireCommandFailedException}.
      */
     public CompletableFuture<Boolean> createTableSegment(final String scope,
                                                          final String stream,
@@ -688,26 +688,26 @@ public class SegmentHelper {
     /**
      * This method sends a WireCommand to delete a table segment.
      *
-     * @param scope Stream scope.
-     * @param stream Stream name.
-     * @param segmentId Id of the segment to be created.
-     * @param mustBeEmpty Flag to check if the table segment should be empty before deletion.
+     * @param scope               Stream scope.
+     * @param stream              Stream name.
+     * @param segmentId           Id of the segment to be created.
+     * @param mustBeEmpty         Flag to check if the table segment should be empty before deletion.
      * @param hostControllerStore Host controller store.
-     * @param clientCF Client connection factory.
-     * @param delegationToken The token to be presented to the segmentstore.
-     * @param clientRequestId Request id.
-     * @return A CompletableFuture that, when completed normally, will indicate the table segment deletion completed successfully.
-     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
-     * will be failed with {@link WireCommandFailedException}.
+     * @param clientCF            Client connection factory.
+     * @param delegationToken     The token to be presented to the segmentstore.
+     * @param clientRequestId     Request id.
+     * @return A CompletableFuture that, when completed normally, will indicate the table segment deletion completed
+     * successfully. If the operation failed, the future will be failed with the causing exception. If the exception
+     * can be retried then the future will be failed with {@link WireCommandFailedException}.
      */
     public CompletableFuture<Boolean> deleteTableSegment(final String scope,
-                                                    final String stream,
-                                                    final long segmentId,
-                                                    final boolean mustBeEmpty,
-                                                    final HostControllerStore hostControllerStore,
-                                                    final ConnectionFactory clientCF,
-                                                    String delegationToken,
-                                                    final long clientRequestId) {
+                                                         final String stream,
+                                                         final long segmentId,
+                                                         final boolean mustBeEmpty,
+                                                         final HostControllerStore hostControllerStore,
+                                                         final ConnectionFactory clientCF,
+                                                         String delegationToken,
+                                                         final long clientRequestId) {
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
         final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
         final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
@@ -778,8 +778,8 @@ public class SegmentHelper {
      * @param delegationToken     The token to be presented to the segmentstore.
      * @param clientRequestId     Request id.
      * @return A CompletableFuture that, when completed normally, will contain the current versions of each {@link TableEntry}
-     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
-     * will be failed with {@link WireCommandFailedException}.
+     * If the operation failed, the future will be failed with the causing exception. If the exception can be retried
+     * then the future will be failed with {@link WireCommandFailedException}.
      */
     public CompletableFuture<List<KeyVersion>> updateTableEntries(final String scope,
                                                                   final String stream,
@@ -873,8 +873,8 @@ public class SegmentHelper {
      * @param delegationToken     The token to be presented to the segmentstore.
      * @param clientRequestId     Request id.
      * @return A CompletableFuture that will complete normally when the provided keys are deleted.
-     * If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
-     * will be failed with {@link WireCommandFailedException}.
+     * If the operation failed, the future will be failed with the causing exception. If the exception can be
+     * retried then the future will be failed with {@link WireCommandFailedException}.
      */
     public CompletableFuture<Void> removeTableKeys(final String scope,
                                                    final String stream,
@@ -956,15 +956,16 @@ public class SegmentHelper {
      * @param scope               Stream scope.
      * @param stream              Stream name.
      * @param segmentId           Id of the segment to be created.
-     * @param keys                List of {@link TableKey}s to be read. {@link TableKey#getVersion()} is not used during this operation and
-     *                            the latest version is read.
+     * @param keys                List of {@link TableKey}s to be read. {@link TableKey#getVersion()} is not used
+     *                            during this operation and the latest version is read.
      * @param hostControllerStore Host controller store.
      * @param clientCF            Client connection factory.
      * @param delegationToken     The token to be presented to the segmentstore.
      * @param clientRequestId     Request id.
-     * @return A CompletableFuture that, when completed normally, will contain a list of {@link TableEntry} with a value corresponding to
-     * the latest version. If the operation failed, the future will be failed with the causing exception. If the exception is retryable then the future
-     * will be failed with {@link WireCommandFailedException}.
+     * @return A CompletableFuture that, when completed normally, will contain a list of {@link TableEntry} with
+     * a value corresponding to the latest version. If the operation failed, the future will be failed with the
+     * causing exception. If the exception can be retried then the future will be failed with
+     * {@link WireCommandFailedException}.
      */
     public CompletableFuture<List<TableEntry<byte[], byte[]>>> readTable(final String scope,
                                                                          final String stream,

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -50,6 +50,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.LoggerFactory;
 
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getQualifiedStreamSegmentName;
+import static io.pravega.shared.segment.StreamSegmentNameUtils.getScopedStreamName;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getTransactionNameFromId;
 
@@ -618,7 +619,6 @@ public class SegmentHelper {
      *
      * @param scope               Stream scope.
      * @param stream              Stream name.
-     * @param segmentId           Id of the segment to be created.
      * @param hostControllerStore Host controller store.
      * @param clientCF            Client connection factory.
      * @param delegationToken     The token to be presented to the segmentstore.
@@ -629,14 +629,13 @@ public class SegmentHelper {
      */
     public CompletableFuture<Boolean> createTableSegment(final String scope,
                                                          final String stream,
-                                                         final long segmentId,
                                                          final HostControllerStore hostControllerStore,
                                                          final ConnectionFactory clientCF,
                                                          String delegationToken,
                                                          final long clientRequestId) {
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
-        final String qualifiedStreamSegmentName = getQualifiedStreamSegmentName(scope, stream, segmentId);
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
+        final String qualifiedStreamSegmentName = getScopedStreamName(scope, stream);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, 0L, hostControllerStore);
         final WireCommandType type = WireCommandType.CREATE_TABLE_SEGMENT;
         final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
 
@@ -690,7 +689,6 @@ public class SegmentHelper {
      *
      * @param scope               Stream scope.
      * @param stream              Stream name.
-     * @param segmentId           Id of the segment to be created.
      * @param mustBeEmpty         Flag to check if the table segment should be empty before deletion.
      * @param hostControllerStore Host controller store.
      * @param clientCF            Client connection factory.
@@ -702,15 +700,14 @@ public class SegmentHelper {
      */
     public CompletableFuture<Boolean> deleteTableSegment(final String scope,
                                                          final String stream,
-                                                         final long segmentId,
                                                          final boolean mustBeEmpty,
                                                          final HostControllerStore hostControllerStore,
                                                          final ConnectionFactory clientCF,
                                                          String delegationToken,
                                                          final long clientRequestId) {
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
-        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, 0L, hostControllerStore);
+        final String qualifiedName = getScopedStreamName(scope, stream);
         final WireCommandType type = WireCommandType.DELETE_TABLE_SEGMENT;
         final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
 
@@ -771,7 +768,6 @@ public class SegmentHelper {
      *
      * @param scope               Stream scope.
      * @param stream              Stream name.
-     * @param segmentId           Id of the segment to be created.
      * @param entries             List of {@link TableEntry}s to be updated.
      * @param hostControllerStore Host controller store.
      * @param clientCF            Client connection factory.
@@ -783,15 +779,14 @@ public class SegmentHelper {
      */
     public CompletableFuture<List<KeyVersion>> updateTableEntries(final String scope,
                                                                   final String stream,
-                                                                  final long segmentId,
                                                                   final List<TableEntry<byte[], byte[]>> entries,
                                                                   final HostControllerStore hostControllerStore,
                                                                   final ConnectionFactory clientCF,
                                                                   String delegationToken,
                                                                   final long clientRequestId) {
         final CompletableFuture<List<KeyVersion>> result = new CompletableFuture<>();
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
-        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, 0L, hostControllerStore);
+        final String qualifiedName = getScopedStreamName(scope, stream);
         final WireCommandType type = WireCommandType.UPDATE_TABLE_ENTRIES;
         final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
 
@@ -864,7 +859,6 @@ public class SegmentHelper {
      *
      * @param scope               Stream scope.
      * @param stream              Stream name.
-     * @param segmentId           Id of the segment to be created.
      * @param keys                List of {@link TableKey}s to be removed. Only if all the elements in the list has version as
      *                            {@link KeyVersion#NOT_EXISTS} then an unconditional update/removal is performed. Else an atomic conditional
      *                            update (removal) is performed.
@@ -878,15 +872,14 @@ public class SegmentHelper {
      */
     public CompletableFuture<Void> removeTableKeys(final String scope,
                                                    final String stream,
-                                                   final long segmentId,
                                                    final List<TableKey<byte[]>> keys,
                                                    final HostControllerStore hostControllerStore,
                                                    final ConnectionFactory clientCF,
                                                    String delegationToken,
                                                    final long clientRequestId) {
         final CompletableFuture<Void> result = new CompletableFuture<>();
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
-        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, 0L, hostControllerStore);
+        final String qualifiedName = getScopedStreamName(scope, stream);
         final WireCommandType type = WireCommandType.REMOVE_TABLE_KEYS;
         final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
 
@@ -955,7 +948,6 @@ public class SegmentHelper {
      *
      * @param scope               Stream scope.
      * @param stream              Stream name.
-     * @param segmentId           Id of the segment to be created.
      * @param keys                List of {@link TableKey}s to be read. {@link TableKey#getVersion()} is not used
      *                            during this operation and the latest version is read.
      * @param hostControllerStore Host controller store.
@@ -969,15 +961,14 @@ public class SegmentHelper {
      */
     public CompletableFuture<List<TableEntry<byte[], byte[]>>> readTable(final String scope,
                                                                          final String stream,
-                                                                         final long segmentId,
                                                                          final List<TableKey<byte[]>> keys,
                                                                          final HostControllerStore hostControllerStore,
                                                                          final ConnectionFactory clientCF,
                                                                          String delegationToken,
                                                                          final long clientRequestId) {
         final CompletableFuture<List<TableEntry<byte[], byte[]>>> result = new CompletableFuture<>();
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, segmentId, hostControllerStore);
-        final String qualifiedName = getQualifiedStreamSegmentName(scope, stream, segmentId);
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, 0L, hostControllerStore);
+        final String qualifiedName = getScopedStreamName(scope, stream);
         final WireCommandType type = WireCommandType.READ_TABLE;
         final long requestId = (clientRequestId == RequestTag.NON_EXISTENT_ID) ? idGenerator.get() : clientRequestId;
 

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -818,7 +818,7 @@ public class SegmentHelper {
             @Override
             public void tableEntriesUpdated(WireCommands.TableEntriesUpdated tableEntriesUpdated) {
                 log.info(requestId, "updateTableEntries request for {} tableSegment completed.", qualifiedName);
-                result.complete(tableEntriesUpdated.getUpdatedVersions().stream().map(v -> new KeyVersionImpl(-1L, v)).collect(Collectors.toList()));
+                result.complete(tableEntriesUpdated.getUpdatedVersions().stream().map(KeyVersionImpl::new).collect(Collectors.toList()));
             }
 
             @Override
@@ -1007,7 +1007,7 @@ public class SegmentHelper {
                 List<TableEntry<byte[], byte[]>> tableEntries = tableRead.getEntries().getEntries().stream()
                                                                          .map(e -> {
                                                                              WireCommands.TableKey k = e.getKey();
-                                                                             TableKey<byte[]> tableKey = new TableKeyImpl<>(k.getData().array(), new KeyVersionImpl(-1L, k.getKeyVersion()));
+                                                                             TableKey<byte[]> tableKey = new TableKeyImpl<>(k.getData().array(), new KeyVersionImpl(k.getKeyVersion()));
                                                                              return new TableEntryImpl<>(tableKey, e.getValue().getData().array());
                                                                          }).collect(Collectors.toList());
                 result.complete(tableEntries);

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -843,8 +843,8 @@ public class SegmentHelper {
         };
 
         List<Map.Entry<WireCommands.TableKey, WireCommands.TableValue>> wireCommandEntries = entries.stream().map(te -> {
-            final WireCommands.TableValue value = new WireCommands.TableValue(ByteBuffer.wrap(te.getValue()));
             final WireCommands.TableKey key = convertToWireCommand(te.getKey());
+            final WireCommands.TableValue value = new WireCommands.TableValue(ByteBuffer.wrap(te.getValue()));
             return new AbstractMap.SimpleImmutableEntry<>(key, value);
         }).collect(Collectors.toList());
 

--- a/controller/src/main/java/io/pravega/controller/server/WireCommandFailedException.java
+++ b/controller/src/main/java/io/pravega/controller/server/WireCommandFailedException.java
@@ -11,10 +11,12 @@ package io.pravega.controller.server;
 
 import io.pravega.controller.retryable.RetryableException;
 import io.pravega.shared.protocol.netty.WireCommandType;
+import lombok.Getter;
 
 /**
  * Wire command failed exception.
  */
+
 public class WireCommandFailedException extends RuntimeException implements RetryableException {
 
     public enum Reason {
@@ -23,9 +25,14 @@ public class WireCommandFailedException extends RuntimeException implements Retr
         UnknownHost,
         PreconditionFailed,
         AuthFailed,
+        SegmentDoesNotExist,
+        TableSegmentNotEmpty,
+        TableKeyDoesNotExist,
+        TableKeyBadVersion,
     }
 
     private final WireCommandType type;
+    @Getter
     private final Reason reason;
 
     public WireCommandFailedException(Throwable cause, WireCommandType type, Reason reason) {

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -192,17 +192,17 @@ public class SegmentHelperTest {
         MockConnectionFactory factory = new MockConnectionFactory();
 
         // On receiving SegmentAlreadyExists true should be returned.
-        CompletableFuture<Boolean> result = helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        CompletableFuture<Boolean> result = helper.createTableSegment("", "", new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
         factory.rp.segmentAlreadyExists(new WireCommands.SegmentAlreadyExists(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         assertTrue(result.join());
 
         // On Receiving SegmentCreated true should be returned.
-        result = helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        result = helper.createTableSegment("", "", new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
         factory.rp.segmentCreated(new WireCommands.SegmentCreated(0, getQualifiedStreamSegmentName("", "", 0L)));
         assertTrue(result.join());
 
         // Validate failure conditions.
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.createTableSegment("", "", new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);
         validateConnectionDropped(factory, futureSupplier);
@@ -214,26 +214,26 @@ public class SegmentHelperTest {
     public void testDeleteTableSegment() {
         MockConnectionFactory factory = new MockConnectionFactory();
         // On receiving NoSuchSegment true should be returned.
-        CompletableFuture<Boolean> result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+        CompletableFuture<Boolean> result = helper.deleteTableSegment("", "", true, new MockHostControllerStore(),
                                                                       factory, "", System.nanoTime());
         factory.rp.noSuchSegment(new WireCommands.NoSuchSegment(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         assertTrue(result.join());
 
         // On receiving SegmentDeleted true should be returned.
-        result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+        result = helper.deleteTableSegment("", "", true, new MockHostControllerStore(),
                                                                       factory, "", System.nanoTime());
         factory.rp.segmentDeleted(new WireCommands.SegmentDeleted(0, getQualifiedStreamSegmentName("", "", 0L)));
         assertTrue(result.join());
 
         // On receiving TableSegmentNotEmpty WireCommandFailedException is thrown.
-        result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+        result = helper.deleteTableSegment("", "", true, new MockHostControllerStore(),
                                            factory, "", System.nanoTime());
         factory.rp.tableSegmentNotEmpty(new WireCommands.TableSegmentNotEmpty(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
                                       ex -> ex instanceof WireCommandFailedException &&
                                               (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableSegmentNotEmpty));
 
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(), factory, "", System.nanoTime());
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.deleteTableSegment("", "", true, new MockHostControllerStore(), factory, "", System.nanoTime());
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);
         validateConnectionDropped(factory, futureSupplier);
@@ -254,25 +254,25 @@ public class SegmentHelperTest {
                                                           new KeyVersionImpl(11L));
 
         // On receiving TableEntriesUpdated.
-        CompletableFuture<List<KeyVersion>> result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        CompletableFuture<List<KeyVersion>> result = helper.updateTableEntries("", "", entries, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableEntriesUpdated(new WireCommands.TableEntriesUpdated(0, Arrays.asList(0L, 1L, 11L)));
         assertEquals(expectedVersions, result.join());
 
         // On receiving TableKeyDoesNotExist.
-        result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        result = helper.updateTableEntries("", "", entries, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
                                       ex -> ex instanceof WireCommandFailedException &&
                                               (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyDoesNotExist));
 
         // On receiving TableKeyBadVersion.
-        result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        result = helper.updateTableEntries("", "", entries, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableKeyBadVersion(new WireCommands.TableKeyBadVersion(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
                                       ex -> ex instanceof WireCommandFailedException &&
                                               (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyBadVersion));
 
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.updateTableEntries("", "", entries, new MockHostControllerStore(), factory, "", System.nanoTime());
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);
         validateConnectionDropped(factory, futureSupplier);
@@ -287,24 +287,24 @@ public class SegmentHelperTest {
                                                     new TableKeyImpl<>("k1".getBytes(), KeyVersion.NOT_EXISTS));
 
         // On receiving TableKeysRemoved.
-        CompletableFuture<Void> result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "",
+        CompletableFuture<Void> result = helper.removeTableKeys("", "", keys, new MockHostControllerStore(), factory, "",
                                                                             System.nanoTime());
         factory.rp.tableKeysRemoved(new WireCommands.TableKeysRemoved(0, getQualifiedStreamSegmentName("", "", 0L) ));
         assertTrue(Futures.await(result));
 
         // On receiving TableKeyDoesNotExist.
-        result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        result = helper.removeTableKeys("", "", keys, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         assertTrue(Futures.await(result));
 
         // On receiving TableKeyBadVersion.
-        result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        result = helper.removeTableKeys("", "", keys, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableKeyBadVersion(new WireCommands.TableKeyBadVersion(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
                                       ex -> ex instanceof WireCommandFailedException &&
                                               (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyBadVersion));
 
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(),
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.removeTableKeys("", "", keys, new MockHostControllerStore(),
                                                                                         factory, "", System.nanoTime());
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);
@@ -329,19 +329,19 @@ public class SegmentHelperTest {
         }).collect(Collectors.toList()));
 
         // On receiving TableKeysRemoved.
-        CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", 0L, keys, new MockHostControllerStore(),
+        CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", keys, new MockHostControllerStore(),
                                                                                       factory, "", System.nanoTime());
         factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), resultData));
         assertEquals(entries, result.join());
 
         // On receiving TableKeyDoesNotExist.
-        result = helper.readTable("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        result = helper.readTable("", "", keys, new MockHostControllerStore(), factory, "", System.nanoTime());
         factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
                                       ex -> ex instanceof WireCommandFailedException &&
                                               (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyDoesNotExist));
 
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTable("", "", 0L, keys, new MockHostControllerStore(),
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTable("", "", keys, new MockHostControllerStore(),
                                                                                factory, "", System.nanoTime());
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -13,7 +13,14 @@ import io.pravega.auth.AuthenticationException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.tables.impl.KeyVersion;
+import io.pravega.client.tables.impl.KeyVersionImpl;
+import io.pravega.client.tables.impl.TableEntry;
+import io.pravega.client.tables.impl.TableEntryImpl;
+import io.pravega.client.tables.impl.TableKey;
+import io.pravega.client.tables.impl.TableKeyImpl;
 import io.pravega.common.cluster.Host;
+import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.host.HostControllerStore;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.shared.protocol.netty.Append;
@@ -23,16 +30,26 @@ import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommand;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.test.common.AssertExtensions;
+import java.nio.ByteBuffer;
+import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.val;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static io.pravega.shared.segment.StreamSegmentNameUtils.getQualifiedStreamSegmentName;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SegmentHelperTest {
 
@@ -168,6 +185,206 @@ public class SegmentHelperTest {
                 ex -> ex instanceof WireCommandFailedException
                         && ex.getCause() instanceof AuthenticationException
         );
+    }
+
+    @Test
+    public void testCreateTableSegment() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+
+        // On receiving SegmentAlreadyExists true should be returned.
+        CompletableFuture<Boolean> result = helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        factory.rp.segmentAlreadyExists(new WireCommands.SegmentAlreadyExists(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        assertTrue(result.join());
+
+        // On Receiving SegmentCreated true should be returned.
+        result = helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        factory.rp.segmentCreated(new WireCommands.SegmentCreated(0, getQualifiedStreamSegmentName("", "", 0L)));
+        assertTrue(result.join());
+
+        // Validate failure conditions.
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.createTableSegment("", "", 0, new MockHostControllerStore(), factory, "", Long.MIN_VALUE);
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+
+    }
+
+    @Test
+    public void testDeleteTableSegment() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        // On receiving NoSuchSegment true should be returned.
+        CompletableFuture<Boolean> result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+                                                                      factory, "", System.nanoTime());
+        factory.rp.noSuchSegment(new WireCommands.NoSuchSegment(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        assertTrue(result.join());
+
+        // On receiving SegmentDeleted true should be returned.
+        result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+                                                                      factory, "", System.nanoTime());
+        factory.rp.segmentDeleted(new WireCommands.SegmentDeleted(0, getQualifiedStreamSegmentName("", "", 0L)));
+        assertTrue(result.join());
+
+        // On receiving TableSegmentNotEmpty WireCommandFailedException is thrown.
+        result = helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(),
+                                           factory, "", System.nanoTime());
+        factory.rp.tableSegmentNotEmpty(new WireCommands.TableSegmentNotEmpty(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        AssertExtensions.assertThrows("", result::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableSegmentNotEmpty));
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.deleteTableSegment("", "", 0L, true, new MockHostControllerStore(), factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+
+    }
+
+    @Test
+    public void testUpdateTableEntries() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS), "v".getBytes()),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), null), "v".getBytes()),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k2".getBytes(), new KeyVersionImpl(-1L, 10L)),
+                                                                                      "v".getBytes()));
+
+        List<KeyVersion> expectedVersions = Arrays.asList(new KeyVersionImpl(-1L, 0L),
+                                                          new KeyVersionImpl(-1L, 1L),
+                                                          new KeyVersionImpl(-1L, 11L));
+
+        // On receiving TableEntriesUpdated.
+        CompletableFuture<List<KeyVersion>> result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableEntriesUpdated(new WireCommands.TableEntriesUpdated(0, Arrays.asList(0L, 1L, 11L)));
+        assertEquals(expectedVersions, result.join());
+
+        // On receiving TableKeyDoesNotExist.
+        result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        AssertExtensions.assertThrows("", result::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyDoesNotExist));
+
+        // On receiving TableKeyBadVersion.
+        result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableKeyBadVersion(new WireCommands.TableKeyBadVersion(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        AssertExtensions.assertThrows("", result::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyBadVersion));
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+        validateNoSuchSegment(factory, futureSupplier);
+    }
+
+    @Test
+    public void testRemoveTableKeys() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS),
+                                                    new TableKeyImpl<>("k1".getBytes(), KeyVersion.NOT_EXISTS));
+
+        // On receiving TableKeysRemoved.
+        CompletableFuture<Void> result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "",
+                                                                            System.nanoTime());
+        factory.rp.tableKeysRemoved(new WireCommands.TableKeysRemoved(0, getQualifiedStreamSegmentName("", "", 0L) ));
+        assertTrue(Futures.await(result));
+
+        // On receiving TableKeyDoesNotExist.
+        result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        assertTrue(Futures.await(result));
+
+        // On receiving TableKeyBadVersion.
+        result = helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableKeyBadVersion(new WireCommands.TableKeyBadVersion(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        AssertExtensions.assertThrows("", result::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyBadVersion));
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.removeTableKeys("", "", 0L, keys, new MockHostControllerStore(),
+                                                                                        factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+        validateNoSuchSegment(factory, futureSupplier);
+    }
+
+    @Test
+    public void testReadTable() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS),
+                                                    new TableKeyImpl<>("k1".getBytes(), KeyVersion.NOT_EXISTS));
+
+        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), new KeyVersionImpl(-1L, 10L)), "v".getBytes()),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), new KeyVersionImpl(-1L, 10L)), "v".getBytes()));
+
+        WireCommands.TableEntries resultData = new WireCommands.TableEntries(entries.stream().map(e -> {
+            val k = new WireCommands.TableKey(ByteBuffer.wrap(e.getKey().getKey()), e.getKey().getVersion().getSegmentVersion());
+            val v = new WireCommands.TableValue(ByteBuffer.wrap(e.getValue()));
+            return new AbstractMap.SimpleImmutableEntry<>(k, v);
+        }).collect(Collectors.toList()));
+
+        // On receiving TableKeysRemoved.
+        CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", 0L, keys, new MockHostControllerStore(),
+                                                                                      factory, "", System.nanoTime());
+        factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), resultData));
+        assertEquals(entries, result.join());
+
+        // On receiving TableKeyDoesNotExist.
+        result = helper.readTable("", "", 0L, keys, new MockHostControllerStore(), factory, "", System.nanoTime());
+        factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
+        AssertExtensions.assertThrows("", result::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyDoesNotExist));
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTable("", "", 0L, keys, new MockHostControllerStore(),
+                                                                               factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+        validateNoSuchSegment(factory, futureSupplier);
+    }
+
+    private void validateAuthTokenCheckFailed(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
+        CompletableFuture<?> future = futureSupplier.get();
+        factory.rp.authTokenCheckFailed(new WireCommands.AuthTokenCheckFailed(0, "SomeException"));
+        AssertExtensions.assertThrows("", future::join,
+                                      ex -> ex instanceof WireCommandFailedException && ex.getCause() instanceof AuthenticationException);
+    }
+
+    private void validateNoSuchSegment(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
+        CompletableFuture<?> future = futureSupplier.get();
+        factory.rp.noSuchSegment(new WireCommands.NoSuchSegment(0, "segment", "SomeException"));
+        AssertExtensions.assertThrows("", future::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.SegmentDoesNotExist));
+    }
+
+    private void validateWrongHost(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
+        CompletableFuture<?> future = futureSupplier.get();
+        factory.rp.wrongHost(new WireCommands.WrongHost(0, "segment", "correctHost", "SomeException"));
+        AssertExtensions.assertThrows("", future::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.UnknownHost));
+    }
+
+    private void validateConnectionDropped(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
+        CompletableFuture<?> future = futureSupplier.get();
+        factory.rp.connectionDropped();
+        AssertExtensions.assertThrows("", future::join,
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.ConnectionDropped));
+    }
+
+    private void validateProcessingFailure(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
+        CompletableFuture<?> future = futureSupplier.get();
+        factory.rp.processingFailure(new RuntimeException());
+        AssertExtensions.assertThrows("", future::join, ex -> ex instanceof RuntimeException);
     }
 
     private static class MockHostControllerStore implements HostControllerStore {

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -246,12 +246,12 @@ public class SegmentHelperTest {
         MockConnectionFactory factory = new MockConnectionFactory();
         List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS), "v".getBytes()),
                                                                  new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), null), "v".getBytes()),
-                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k2".getBytes(), new KeyVersionImpl(-1L, 10L)),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k2".getBytes(), new KeyVersionImpl(10L)),
                                                                                       "v".getBytes()));
 
-        List<KeyVersion> expectedVersions = Arrays.asList(new KeyVersionImpl(-1L, 0L),
-                                                          new KeyVersionImpl(-1L, 1L),
-                                                          new KeyVersionImpl(-1L, 11L));
+        List<KeyVersion> expectedVersions = Arrays.asList(new KeyVersionImpl(0L),
+                                                          new KeyVersionImpl(1L),
+                                                          new KeyVersionImpl(11L));
 
         // On receiving TableEntriesUpdated.
         CompletableFuture<List<KeyVersion>> result = helper.updateTableEntries("", "", 0L, entries, new MockHostControllerStore(), factory, "", System.nanoTime());
@@ -319,8 +319,8 @@ public class SegmentHelperTest {
         List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS),
                                                     new TableKeyImpl<>("k1".getBytes(), KeyVersion.NOT_EXISTS));
 
-        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), new KeyVersionImpl(-1L, 10L)), "v".getBytes()),
-                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), new KeyVersionImpl(-1L, 10L)), "v".getBytes()));
+        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), new KeyVersionImpl(10L)), "v".getBytes()),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), new KeyVersionImpl(10L)), "v".getBytes()));
 
         WireCommands.TableEntries resultData = new WireCommands.TableEntries(entries.stream().map(e -> {
             val k = new WireCommands.TableKey(ByteBuffer.wrap(e.getKey().getKey()), e.getKey().getVersion().getSegmentVersion());

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -162,7 +162,7 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
-    public void notEmptyTableSegment(TableSegmentNotEmpty tableSegmentNotEmpty) {
+    public void tableSegmentNotEmpty(TableSegmentNotEmpty tableSegmentNotEmpty) {
         throw new IllegalStateException("Unexpected operation: " + tableSegmentNotEmpty);
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -32,7 +32,7 @@ public interface ReplyProcessor {
 
     void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment);
 
-    void notEmptyTableSegment(WireCommands.TableSegmentNotEmpty tableSegmentNotEmpty);
+    void tableSegmentNotEmpty(WireCommands.TableSegmentNotEmpty tableSegmentNotEmpty);
 
     void invalidEventNumber(WireCommands.InvalidEventNumber invalidEventNumber);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -293,7 +293,7 @@ public final class WireCommands {
 
         @Override
         public void process(ReplyProcessor cp) {
-            cp.notEmptyTableSegment(this);
+            cp.tableSegmentNotEmpty(this);
         }
 
         @Override
@@ -1722,7 +1722,10 @@ public final class WireCommands {
 
     @Data
     public static final class TableKey {
+        public static final long NO_VERSION = Long.MIN_VALUE;
+        public static final long NOT_EXISTS = -1L;
         public final static TableKey EMPTY = new TableKey(ByteBuffer.wrap(new byte[0]), Long.MIN_VALUE);
+
         final ByteBuffer data;
         final long keyVersion;
 


### PR DESCRIPTION
**Change log description**  
Enable Tablestore apis on SegmentHelper. This will ensure the controller can access the TableStore apis.

**Purpose of the change**  
Issue #2895 

**What the code does**  
- Implementation of interfaces `KeyVersion`, `TableKey` and `TableValue` on the client.
- Enable tablestore apis on SegmentHelper.

**How to verify it**  
All the existing and newly added tests should continue to pass.
