### PR TITLE
Issue 3310: Wait for transactions to be committed in ReadWithAutoScaleTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -211,7 +211,6 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
         return CompletableFuture.runAsync(() -> {
             while (!stopFlag.get()) {
                 Transaction<String> transaction = null;
-                AtomicBoolean txnIsDone = new AtomicBoolean(false);
 
                 try {
                     transaction = writer.beginTxn();
@@ -234,7 +233,6 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
                     }
                     //commit Txn
                     transaction.commit();
-                    txnIsDone.set(true);
 
                     //wait for transaction to get committed
                     testState.txnStatusFutureList.add(checkTxnStatus(transaction, NUM_EVENTS_PER_TRANSACTION));
@@ -242,7 +240,6 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
                     // Given that we have retry logic both in the interaction with controller and
                     // segment store, we should fail the test case in the presence of any exception
                     // caught here.
-                    txnIsDone.set(true);
                     log.warn("Exception while writing events in the transaction: ", e);
                     if (transaction != null) {
                         log.debug("Transaction with id: {}  failed", transaction.getTxnId());

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -158,6 +158,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
                             }
                         }), scaleExecutorService)
                 .thenCompose(v -> Futures.allOf(writers))
+                .thenRun(this::waitForTxnsToComplete)
                 .thenCompose(v -> {
                     stopReadFlag.set(true);
                     log.info("All writers have stopped. Setting Stop_Read_Flag. Event Written Count:{}, Event Read " +


### PR DESCRIPTION
**Change log description**  
Make ReadWithAutoScaleTest to wait for transactions to be in committed state before stopping the readers.

**Purpose of the change**  
Fixes #3310.

**What the code does**  
Executes `waitForTxnsToComplete()` in `ReadWithAutoScaleTest` after signalling all the writers to stop for ensuring that all the transactions are in `committed` state before stopping the readers. This is the approach followed by the other tests working on transactions. We also deleted a useless flag in `AbstractReadWriteTest` related to transactional writers.

**How to verify it**  
`ReadWithAutoScaleTest` should pass consistently in system tests (at the moment, 1 successful test execution).
