### PR TITLE
Issue 3313: Add workaround for client blocking

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
@@ -44,13 +44,13 @@ public class SegmentStatsFactory implements AutoCloseable {
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store,
                                                            EventStreamClientFactory clientFactory,
                                                            AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory, executor, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store,
                 executor, maintenanceExecutor);
     }
 
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store, AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, executor, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store, executor, maintenanceExecutor);
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -76,11 +76,11 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
 
         AutoScaleProcessor monitor = new AutoScaleProcessor(writer,
                 AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
-                        .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
-                        .with(AutoScalerConfig.AUTH_ENABLED, authEnabled)
-                        .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
-                        .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executorService());
+                                          .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
+                                          .with(AutoScalerConfig.AUTH_ENABLED, authEnabled)
+                                          .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
+                                          .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
+                executorService(), executorService());
 
         String streamSegmentName1 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM1, 0L);
         String streamSegmentName2 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM2, 0L);
@@ -125,10 +125,10 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
                 scaleDownFuture.completeExceptionally(new RuntimeException());
             }
         }), AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
-                .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
-                .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
-                .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executorService());
+                                      .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
+                                      .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
+                                      .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
+                executorService(), executorService());
         String streamSegmentName1 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM1, 0L);
         monitor.notifyCreated(streamSegmentName1, WireCommands.CreateSegment.IN_EVENTS_PER_SEC, 10);
 


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Adding a timeout/retry to flush in SegmentOutputStreamImpl.
* Putting AutoScaleProcessor's send in a background thread.

**Purpose of the change**  
Provides a workaround for #3313 

**What the code does**  
Adds a timeout to the flush call inside of SegmentOutputStream so that in the event that the server does not reply, eventually the situation is resolved by restarting the connection.
Moves the logic in AutoScaleProcessor that calls into the client onto a background thread pool. This relates to the underlying issue in #3313 because there the ack was being held up because the thread on the server to ack the event was blocked on invoking a write method on the client library which was itself blocked on the server somehow.

**How to verify it**  
Please note this is a *workaround* this may not fix the root cause of the issue, and currently lacks testing to specifically cover the new code path.
