### PR TITLE
Issue 3326: Fix compilation issue in BoundedStreamReaderTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -170,7 +170,7 @@ public class BoundedStreamReaderTest {
         createStream(STREAM1);
 
         @Cleanup
-        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        ClientFactory clientFactory = ClientFactory.withScope(SCOPE, controllerUri);
         @Cleanup
         EventStreamWriter<String> writer1 = clientFactory.createEventWriter(STREAM1, serializer,
                                                                             EventWriterConfig.builder().build());


### PR DESCRIPTION
**Change log description**  
Fix a compilation issue caused due to a cherry pick of PR 3222.

**Purpose of the change**  
Fixes #3326 

**What the code does**  
Fixes the build issue due to cherry pick.

**How to verify it**  
No changes in functionality. All the existing tests should continue to pass.
