### PR TITLE
Issue 3328: Wrong target log path in Docker Swarm Pravega services

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -66,7 +66,7 @@ public class BookkeeperDockerService extends DockerBasedService {
 
         Mount mount1 = Mount.builder().type("volume").source("index-volume").target("/bk/index")
                 .build();
-        Mount mount2 = Mount.builder().type("volume").source("logs-volume")
+        Mount mount2 = Mount.builder().type("volume").source("bookkeeper-logs")
                 .target("/opt/dl_all/distributedlog-service/logs/")
                 .build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -58,7 +58,7 @@ public class HDFSDockerService extends DockerBasedService {
     private ServiceSpec setServiceSpec() {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.task.name", serviceName);
-        Mount mount = Mount.builder().type("volume").source("hadoop-logs-volume").target("/opt/hadoop/logs").build();
+        Mount mount = Mount.builder().type("volume").source("hadoop-logs").target("/opt/hadoop/logs").build();
         String env1 = "SSH_PORT=2222";
         String env2 = "HDFS_HOST=" + serviceName;
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -66,7 +66,7 @@ public class PravegaControllerDockerService extends DockerBasedService {
     }
 
     private ServiceSpec setServiceSpec() {
-        Mount mount = Mount.builder().type("Volume").source("volume-logs").target("/tmp/logs").build();
+        Mount mount = Mount.builder().type("Volume").source("volume-logs").target("/opt/pravega/logs").build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         Map<String, String> stringBuilderMap = new HashMap<>();
         stringBuilderMap.put("ZK_URL", zk);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -66,7 +66,7 @@ public class PravegaControllerDockerService extends DockerBasedService {
     }
 
     private ServiceSpec setServiceSpec() {
-        Mount mount = Mount.builder().type("Volume").source("volume-logs").target("/opt/pravega/logs").build();
+        Mount mount = Mount.builder().type("Volume").source("controller-logs").target("/opt/pravega/logs").build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         Map<String, String> stringBuilderMap = new HashMap<>();
         stringBuilderMap.put("ZK_URL", zk);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -71,7 +71,7 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.task.name", serviceName);
 
-        Mount mount = Mount.builder().type("volume").source("logs-volume").target("/opt/pravega/logs").build();
+        Mount mount = Mount.builder().type("volume").source("segmentstore-logs").target("/opt/pravega/logs").build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         //System properties to configure SS service.
         Map<String, String> stringBuilderMap = new HashMap<>();

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -71,7 +71,7 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.task.name", serviceName);
 
-        Mount mount = Mount.builder().type("volume").source("logs-volume").target("/tmp/logs").build();
+        Mount mount = Mount.builder().type("volume").source("logs-volume").target("/opt/pravega/logs").build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         //System properties to configure SS service.
         Map<String, String> stringBuilderMap = new HashMap<>();


### PR DESCRIPTION
**Change log description**  
Renamed and standardize log volumes.

**Purpose of the change**  
Fixes #3328.

**What the code does**  
This PR fixes the path used to mount the logs directory of Pravega services on the host machine. This allows us to persistently store Pravega logs in the host machine, so they can survive to the lifecycle of containers. 

**How to verify it**  
Now logs are being persistently stored in the host machine:
```
[root@xxx-slave-2 ~]# ls /var/lib/docker/volumes/logs-volume/_data/
segmentstore_2019-01-30.0.log.gz  segmentstore_2019-01-30.1.log.gz  segmentstore_2019-01-30.2.log.gz  segmentstore_2019-01-30.3.log.gz  segmentstore.log
[root@xxx-slave-2 ~]# ls /var/lib/docker/volumes/volume-logs/_data/
controller_2019-01-30.0.log.gz  controller.log
```


