### PR TITLE
Issue 3313: Add workaround for client blocking

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -44,6 +44,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -68,7 +69,8 @@ import static com.google.common.base.Preconditions.checkState;
 @Slf4j
 @ToString(of = {"segmentName", "writerId", "state"})
 class SegmentOutputStreamImpl implements SegmentOutputStream {
-
+    private static final long FLUSH_TIMEOUT = 30000;
+    
     @Getter
     private final String segmentName;
     private final Controller controller;
@@ -111,9 +113,10 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
 
         /**
          * Block until all events are acked by the server.
+         * @throws TimeoutException If the timeout is reached.
          */
-        private void waitForInflight() {
-           Exceptions.handleInterrupted(() -> waitingInflight.await());
+        private void waitForInflight(long timeout) throws TimeoutException {
+           Exceptions.handleInterrupted(() -> waitingInflight.await(timeout));
         }
 
         private boolean isAlreadySealed() {
@@ -489,22 +492,28 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
     @Override
     public void flush() throws SegmentSealedException {
         int numInflight = state.getNumInflight();
-        log.debug("Flushing writer: {} with {} inflight events", writerId, numInflight);
-        if (numInflight != 0) {
+        while (numInflight != 0) {
+            log.debug("Flushing writer: {} with {} inflight events", writerId, numInflight);
             try {
                 ClientConnection connection = Futures.getThrowingException(getConnection());
                 connection.send(new KeepAlive());
             } catch (Exception e) {
                 failConnection(e);
             }
-            state.waitForInflight();
-            Exceptions.checkNotClosed(state.isClosed(), this);
-            /* SegmentSealedException is thrown if either of the below conditions are true
+            try {
+                state.waitForInflight(FLUSH_TIMEOUT);
+                Exceptions.checkNotClosed(state.isClosed(), this);
+                /* SegmentSealedException is thrown if either of the below conditions are true
                  - resendToSuccessorsCallback has been invoked.
                  - the segment corresponds to an aborted Transaction.
-             */
-            if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
-                throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
+                 */
+                if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
+                    throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
+                }
+                numInflight = 0;
+            } catch (TimeoutException e) {
+                failConnection(e);
+                numInflight = state.getNumInflight();
             }
         }
     }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -30,6 +30,7 @@ import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.protocol.netty.WireCommands;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,13 +62,16 @@ public class AutoScaleProcessor {
     private final AtomicReference<EventStreamWriter<AutoScaleEvent>> writer;
     private final EventWriterConfig writerConfig;
     private final AutoScalerConfig configuration;
+    private final ExecutorService executor;
     private final ScheduledExecutorService maintenanceExecutor;
     private final Supplier<Long> requestIdGenerator = RandomFactory.create()::nextLong;
 
 
     AutoScaleProcessor(AutoScalerConfig configuration,
+                       ExecutorService executor, 
                        ScheduledExecutorService maintenanceExecutor) {
         this.configuration = configuration;
+        this.executor = executor;
         this.maintenanceExecutor = maintenanceExecutor;
 
         serializer = new JavaSerializer<>();
@@ -89,17 +93,18 @@ public class AutoScaleProcessor {
     }
 
     @VisibleForTesting
-    AutoScaleProcessor(EventStreamWriter<AutoScaleEvent> writer, AutoScalerConfig configuration, ScheduledExecutorService maintenanceExecutor) {
-        this(configuration, maintenanceExecutor);
+    AutoScaleProcessor(EventStreamWriter<AutoScaleEvent> writer, AutoScalerConfig configuration,
+            ExecutorService executor, ScheduledExecutorService maintenanceExecutor) {
+        this(configuration, executor, maintenanceExecutor);
         this.writer.set(writer);
         this.initialized.set(true);
         maintenanceExecutor.scheduleAtFixedRate(cache::cleanUp, 0, configuration.getCacheCleanup().getSeconds(), TimeUnit.SECONDS);
     }
 
     @VisibleForTesting
-    AutoScaleProcessor(AutoScalerConfig configuration, ClientFactory cf,
-                       ScheduledExecutorService maintenanceExecutor) {
-        this(configuration, maintenanceExecutor);
+    AutoScaleProcessor(AutoScalerConfig configuration, ClientFactory cf, ExecutorService executor,
+            ScheduledExecutorService maintenanceExecutor) {
+        this(configuration, executor, maintenanceExecutor);
         clientFactory.set(cf);
     }
 
@@ -164,7 +169,7 @@ public class AutoScaleProcessor {
                 AutoScaleEvent event = new AutoScaleEvent(segment.getScope(), segment.getStreamName(), segment.getSegmentId(),
                         AutoScaleEvent.UP, timestamp, numOfSplits, false, requestId);
                 // Mute scale for timestamp for both scale up and down
-                writeRequest(event).thenAccept(x -> cache.put(streamSegmentName, new ImmutablePair<>(timestamp, timestamp)));
+                writeRequest(event, () -> cache.put(streamSegmentName, new ImmutablePair<>(timestamp, timestamp)));
             }
         }
     }
@@ -186,7 +191,7 @@ public class AutoScaleProcessor {
                 Segment segment = Segment.fromScopedName(streamSegmentName);
                 AutoScaleEvent event = new AutoScaleEvent(segment.getScope(), segment.getStreamName(), segment.getSegmentId(),
                         AutoScaleEvent.DOWN, timestamp, 0, silent, requestId);
-                writeRequest(event).thenAccept(x -> {
+                writeRequest(event, () -> {
                     if (!silent) {
                         // mute only scale downs
                         cache.put(streamSegmentName, new ImmutablePair<>(0L, timestamp));
@@ -196,13 +201,16 @@ public class AutoScaleProcessor {
         }
     }
 
-    private CompletableFuture<Void> writeRequest(AutoScaleEvent event) {
-        return writer.get().writeEvent(event.getKey(), event).whenComplete((r, e) -> {
-            if (e != null) {
-                log.error(event.getTimestamp(), "error sending request to requeststream {}", e);
-            } else {
-                log.debug(event.getTimestamp(), "scale event posted successfully");
-            }
+    private void writeRequest(AutoScaleEvent event, Runnable onSuccess) {
+        executor.execute(() -> {
+            writer.get().writeEvent(event.getKey(), event).whenComplete((r, e) -> {
+                if (e != null) {
+                    log.error(event.getTimestamp(), "error sending request to requeststream {}", e);
+                } else {
+                    log.debug(event.getTimestamp(), "scale event posted successfully");
+                    onSuccess.run();
+                }
+            });
         });
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsFactory.java
@@ -45,13 +45,13 @@ public class SegmentStatsFactory implements AutoCloseable {
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store,
                                                            ClientFactory clientFactory,
                                                            AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, clientFactory, executor, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store,
                 executor, maintenanceExecutor);
     }
 
     public SegmentStatsRecorder createSegmentStatsRecorder(StreamSegmentStore store, AutoScalerConfig configuration) {
-        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, maintenanceExecutor);
+        AutoScaleProcessor monitor = new AutoScaleProcessor(configuration, executor, maintenanceExecutor);
         return new SegmentStatsRecorderImpl(monitor, store, executor, maintenanceExecutor);
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -76,11 +76,11 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
 
         AutoScaleProcessor monitor = new AutoScaleProcessor(writer,
                 AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
-                        .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
-                        .with(AutoScalerConfig.AUTH_ENABLED, authEnabled)
-                        .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
-                        .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executorService());
+                                          .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
+                                          .with(AutoScalerConfig.AUTH_ENABLED, authEnabled)
+                                          .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
+                                          .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
+                executorService(), executorService());
 
         String streamSegmentName1 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM1, 0L);
         String streamSegmentName2 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM2, 0L);
@@ -125,10 +125,10 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
                 scaleDownFuture.completeExceptionally(new RuntimeException());
             }
         }), AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
-                .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
-                .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
-                .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
-                executorService());
+                                      .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
+                                      .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 1)
+                                      .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 1).build(),
+                executorService(), executorService());
         String streamSegmentName1 = StreamSegmentNameUtils.getQualifiedStreamSegmentName(SCOPE, STREAM1, 0L);
         monitor.notifyCreated(streamSegmentName1, WireCommands.CreateSegment.IN_EVENTS_PER_SEC, 10);
 


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>
This is the same as: https://github.com/pravega/pravega/pull/3323 but ported to the 0.4 branch.

**Change log description**  
* Adding a timeout/retry to flush in SegmentOutputStreamImpl.
* Putting AutoScaleProcessor's send in a background thread.

**Purpose of the change**  
Provides a workaround for #3313 

**What the code does**  
Adds a timeout to the flush call inside of SegmentOutputStream so that in the event that the server does not reply, eventually the situation is resolved by restarting the connection.
Moves the logic in AutoScaleProcessor that calls into the client onto a background thread pool. This relates to the underlying issue in #3313 because there the ack was being held up because the thread on the server to ack the event was blocked on invoking a write method on the client library which was itself blocked on the server somehow.

**How to verify it**  
Please note this is a *workaround* this may not fix the root cause of the issue, and currently lacks testing to specifically cover the new code path.
