### PR TITLE
Issue 3333: Tolerate partial set of segments in Position object.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -536,13 +536,9 @@ public class ReaderGroupState implements Revisioned {
                 while (iter.hasNext()) {
                     Entry<Segment, Long> entry = iter.next();
                     Segment segment = entry.getKey();
-                    Long offset;
-                    if (ownedSegments == null || ownedSegments.isEmpty()) {
+                    Long offset = ownedSegments.get(segment);
+                    if (offset == null) {
                         offset = entry.getValue();
-                    } else {
-                        offset = ownedSegments.get(segment);
-                        Preconditions.checkState(offset != null,
-                                "No offset in lastPosition for assigned segment: " + segment);
                     }
                     finalPositions.put(segment, offset);
                     state.unassignedSegments.put(segment, offset);

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -137,12 +137,8 @@ public class ReaderGroupStateManager {
                 return;
             }
             log.debug("Removing reader {} from reader grop. CurrentState is: {}", readerId, state);
-            if (lastPosition != null && !lastPosition.asImpl().getOwnedSegments().containsAll(segments)) {
-                throw new IllegalArgumentException(
-                        "When shutting down a reader: Given position does not match the segments it was assigned: \n"
-                                + segments + " \n vs \n " + lastPosition.asImpl().getOwnedSegments());
-            }
-            updates.add(new RemoveReader(readerId, lastPosition == null ? null : lastPosition.asImpl().getOwnedSegmentsWithOffsets()));
+            updates.add(new RemoveReader(readerId, lastPosition == null ? Collections.emptyMap()
+                    : lastPosition.asImpl().getOwnedSegmentsWithOffsets()));
         });
     }
     


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Tolerate an incomplete Position (partial sets of segments in Position object).

**Purpose of the change**  
Provides a workaround for #3333. **Note**: This is **not** a fix. There is still an issue, this just prevents an exception in the controller process.

**What the code does**  
Avoids throwing an exception.

**How to verify it**  
The system tests should now no longer have issues with the built in streams.
