### PR TITLE
Issue 3329:  Remove spurious stacktraces from Kubernetes framework

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -281,7 +281,8 @@ public class K8sClient {
                         throw Exceptions.sneakyThrow(e);
                     }
                 }).exceptionally(t -> {
-                    log.warn("Exception while trying to fetch instance {} of custom resource {}, try to create it.", name, customResourceGroup, t);
+                    log.warn("Exception while trying to fetch instance {} of custom resource {}, try to create it. Details: {}", name,
+                             customResourceGroup, t.getMessage());
                     try {
                         //create object
                         K8AsyncCallback<Object> cb = new K8AsyncCallback<>("createCustomObject");
@@ -453,7 +454,7 @@ public class K8sClient {
                 .retryWhen(t -> {
                     Throwable ex = Exceptions.unwrap(t);
                     if (ex.getCause() instanceof IOException) {
-                        log.warn("Exception while fetching status of pod, will attempt a retry", ex.getMessage());
+                        log.warn("IO Exception while fetching status of pod, will attempt a retry. Details: {}", ex.getMessage());
                         return true;
                     }
                     log.error("Exception while fetching status of pod", ex);

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -453,7 +453,7 @@ public class K8sClient {
                 .retryWhen(t -> {
                     Throwable ex = Exceptions.unwrap(t);
                     if (ex.getCause() instanceof IOException) {
-                        log.warn("Exception while fetching status of pod, will attempt a retry", ex.getCause());
+                        log.warn("Exception while fetching status of pod, will attempt a retry", ex.getMessage());
                         return true;
                     }
                     log.error("Exception while fetching status of pod", ex);

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -71,8 +71,8 @@ import static javax.ws.rs.core.Response.Status.CONFLICT;
 @Slf4j
 public class K8sClient {
 
-    private static final int DEFAULT_TIMEOUT_MINUTES = 5; // timeout of http client.
-    private static final int RETRY_MAX_DELAY_MS = 10_000; // max time between retries to check if pod has completed.
+    private static final int DEFAULT_TIMEOUT_MINUTES = 10; // timeout of http client.
+    private static final int RETRY_MAX_DELAY_MS = 5_000; // max time between retries to check if pod has completed.
     private static final int RETRY_COUNT = 50; // Max duration of a pod is 1 hour.
     private static final int LOG_DOWNLOAD_RETRY_COUNT = 7;
     // Delay before starting to download the logs. The K8s api server responds with error code 400 if immediately requested for log download.

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -76,7 +76,7 @@ public class K8sClient {
     private static final int RETRY_COUNT = 50; // Max duration of a pod is 1 hour.
     private static final int LOG_DOWNLOAD_RETRY_COUNT = 7;
     // Delay before starting to download the logs. The K8s api server responds with error code 400 if immediately request for log download.
-    private static final long LOG_DOWNLOAD_INIT_DELAY_MS = SECONDS.toMillis(15);
+    private static final long LOG_DOWNLOAD_INIT_DELAY_MS = SECONDS.toMillis(20);
     private static final String PRETTY_PRINT = "false";
     private final ApiClient client;
     private final PodLogs logUtility;

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -75,7 +75,7 @@ public class K8sClient {
     private static final int RETRY_MAX_DELAY_MS = 10_000; // max time between retries to check if pod has completed.
     private static final int RETRY_COUNT = 50; // Max duration of a pod is 1 hour.
     private static final int LOG_DOWNLOAD_RETRY_COUNT = 7;
-    // Delay before starting to download the logs. The K8s api server responds with error code 400 if immediately request for log download.
+    // Delay before starting to download the logs. The K8s api server responds with error code 400 if immediately requested for log download.
     private static final long LOG_DOWNLOAD_INIT_DELAY_MS = SECONDS.toMillis(20);
     private static final String PRETTY_PRINT = "false";
     private final ApiClient client;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
@@ -56,15 +56,15 @@ public class BookkeeperK8sService extends AbstractService {
     public boolean isRunning() {
         return k8sClient.getStatusOfPodWithLabel(NAMESPACE, "component", BOOKKEEPER_LABEL)
                         .thenApply(statuses -> statuses.stream()
-                                                      .filter(podStatus -> podStatus.getContainerStatuses()
-                                                                                    .stream()
-                                                                                    .allMatch(st -> st.getState().getRunning() != null))
-                                                      .count())
+                                                       .filter(podStatus -> podStatus.getContainerStatuses()
+                                                                                     .stream()
+                                                                                     .allMatch(st -> st.getState().getRunning() != null))
+                                                       .count())
                         .thenApply(runCount -> runCount >= DEFAULT_BOOKIE_COUNT)
                         .exceptionally(t -> {
-                           log.warn("Exception observed while checking status of pods " + BOOKKEEPER_LABEL, t);
-                           return false;
-                       }).join();
+                            log.warn("Exception observed while checking status of pods {}. Details: {}", BOOKKEEPER_LABEL, t.getMessage());
+                            return false;
+                        }).join();
     }
 
     @Override

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -10,7 +10,6 @@
 package io.pravega.test.system.framework.services.kubernetes;
 
 import com.google.common.collect.ImmutableMap;
-import io.kubernetes.client.models.V1ContainerStateTerminated;
 import io.kubernetes.client.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSourceBuilder;
 import io.kubernetes.client.models.V1Pod;
@@ -23,7 +22,6 @@ import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
 import io.kubernetes.client.models.V1beta1ClusterRoleBindingBuilder;
 import io.kubernetes.client.models.V1beta1RoleRefBuilder;
 import io.kubernetes.client.models.V1beta1SubjectBuilder;
-import io.pravega.common.concurrent.Futures;
 import io.pravega.test.system.framework.TestExecutor;
 import io.pravega.test.system.framework.kubernetes.ClientFactory;
 import io.pravega.test.system.framework.kubernetes.K8sClient;

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaControllerK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaControllerK8sService.java
@@ -58,15 +58,16 @@ public class PravegaControllerK8sService extends AbstractService {
     public boolean isRunning() {
         return k8sClient.getStatusOfPodWithLabel(NAMESPACE, "component", PRAVEGA_CONTROLLER_LABEL)
                         .thenApply(statuses -> statuses.stream()
-                                                      .filter(podStatus -> podStatus.getContainerStatuses()
-                                                                                    .stream()
-                                                                                    .allMatch(st -> st.getState().getRunning() != null))
-                                                      .count())
+                                                       .filter(podStatus -> podStatus.getContainerStatuses()
+                                                                                     .stream()
+                                                                                     .allMatch(st -> st.getState().getRunning() != null))
+                                                       .count())
                         .thenApply(runCount -> runCount >= DEFAULT_CONTROLLER_COUNT)
                         .exceptionally(t -> {
-                           log.warn("Exception observed while checking status of pods " + PRAVEGA_CONTROLLER_LABEL, t);
-                           return false;
-                       }).join();
+                            log.warn("Exception observed while checking status of pods {}. Details: {}", PRAVEGA_CONTROLLER_LABEL,
+                                     t.getMessage());
+                            return false;
+                        }).join();
     }
 
     @Override

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
@@ -62,9 +62,10 @@ public class PravegaSegmentStoreK8sService extends AbstractService {
                                                       .count())
                         .thenApply(runCount -> runCount >= DEFAULT_SEGMENTSTORE_COUNT)
                         .exceptionally(t -> {
-                           log.warn("Exception observed while checking status of pods " + PRAVEGA_SEGMENTSTORE_LABEL, t);
-                           return false;
-                       }).join();
+                            log.warn("Exception observed while checking status of pods {}. Details: {}", PRAVEGA_SEGMENTSTORE_LABEL,
+                                     t.getMessage());
+                            return false;
+                        }).join();
     }
 
     @Override

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -105,7 +105,7 @@ public class ZookeeperK8sService extends AbstractService {
                                                       .count())
                         .thenApply(runCount -> runCount == DEFAULT_INSTANCE_COUNT)
                         .exceptionally(t -> {
-                           log.warn("Exception observed while checking status of pod " + getID(), t);
+                           log.warn("Exception observed while checking status of pod: {}. Details: {} ", getID(), t.getMessage());
                            return false;
                        }).join();
     }


### PR DESCRIPTION
**Change log description**  
- Ensure spurious stack traces are not logged for retry able errors.
- Ensure test logs are preserved across retries during log downloads.
- Wait for log download to complete before starting the next test.

**Purpose of the change**  
Fixes #3329 

**What the code does**  
- Ensure spurious stack traces are not logged for retry able errors.
- Ensure test logs are preserved across retries during log downloads.
- Wait for log download to complete before starting the next test.


**How to verify it**  
All the existing tests should continue to pass.
Update: verified with a system test run on PKS cluster.
