### PR TITLE
Issue 3265: HDFS storage optimization

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.io.IOUtils;
  * <ol>
  * <li> foo_<epoch>: Segment file, owned by a SegmentStore running under epoch "epoch".
  * <li> foo_sealed: A sealed segment.
+ * </ol>
  * <p>
  * When a container fails over and needs to reacquire ownership of a segment, it renames the segment file as foo_<current_epoch>.
  * After creation of the file, the filename is checked again. If there exists any file with higher epoch, the current file is deleted
@@ -67,7 +68,7 @@ import org.apache.hadoop.io.IOUtils;
  * <p>
  */
 @Slf4j
-class HDFSStorage implements SyncStorage {
+public class HDFSStorage implements SyncStorage {
     private static final String PART_SEPARATOR = "_";
     private static final String NAME_FORMAT = "%s" + PART_SEPARATOR + "%s";
     private static final String SEALED = "sealed";
@@ -99,7 +100,7 @@ class HDFSStorage implements SyncStorage {
      *
      * @param config   The configuration to use.
      */
-    HDFSStorage(HDFSStorageConfig config) {
+    public HDFSStorage(HDFSStorageConfig config) {
         Preconditions.checkNotNull(config, "config");
         this.config = config;
         this.closed = new AtomicBoolean(false);

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -259,7 +259,7 @@ public class HDFSStorage implements SyncStorage {
                         throw new StorageNotPrimaryException(handle.getSegmentName());
                     }
                     if (fileEpoch < this.epoch) {
-                        throw new DataCorruptionException(handle.getSegmentName());
+                        throw new DataCorruptionException(handle.getSegmentName(), String.format("Expecting epoch %d, but found epoch %d", this.epoch, fileEpoch));
                     }
                     Path sealedPath = getSealedFilePath(handle.getSegmentName());
                     this.fileSystem.rename(status.getPath(), sealedPath);
@@ -296,7 +296,7 @@ public class HDFSStorage implements SyncStorage {
                         throw new StorageNotPrimaryException(handle.getSegmentName());
                     }
                     if (fileEpoch < this.epoch) {
-                        throw new DataCorruptionException(handle.getSegmentName());
+                        throw new DataCorruptionException(handle.getSegmentName(), String.format("Expecting epoch %d, but found epoch %d", this.epoch, fileEpoch));
                     }
                 }
             } catch (IOException ex) {
@@ -441,7 +441,7 @@ public class HDFSStorage implements SyncStorage {
                     throw new StorageNotPrimaryException(handle.getSegmentName());
                 }
                 if (fileEpoch < this.epoch) {
-                    throw new DataCorruptionException(handle.getSegmentName());
+                    throw new DataCorruptionException(handle.getSegmentName(), String.format("Expecting epoch %d, but found epoch %d", this.epoch, fileEpoch));
                 }
             } catch (IOException ex) {
                 throw HDFSExceptionHelpers.convertException(handle.getSegmentName(), ex);
@@ -635,8 +635,7 @@ public class HDFSStorage implements SyncStorage {
         if (statuses.length > 1) {
             throw new IllegalArgumentException("More than one file");
         }
-
-        return statuses[statuses.length -1];
+        return statuses[0];
     }
 
     /**
@@ -692,16 +691,6 @@ public class HDFSStorage implements SyncStorage {
         } catch (NumberFormatException nfe) {
             throw new FileNameFormatException(fileName, "Could not extract offset or epoch.", nfe);
         }
-    }
-
-    /**
-     * Determines whether the given FileStatus indicates the file is read-only.
-     *
-     * @param fs The FileStatus to check.
-     * @return True or false.
-     */
-    private boolean isReadOnly(FileStatus fs) {
-        return fs.getPermission().getUserAction() == FsAction.READ;
     }
 
     /**

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -394,7 +394,7 @@ public class HDFSStorage implements SyncStorage {
 
         // The writer SHOULD NEVER write to the file with epoch different that this.epoch.
         // If this.epoch is lower than that of file then it means this instance is no longer the owner.
-        // If this.epoch is greater than that of file then it means there is a possble data corruption.
+        // If this.epoch is greater than that of file then it means there is a possible data corruption.
         // In normal conditions, openWrite first renames file to current epoch. So at this point epoch of file should never be lower that this.epoch.
         // Even in this condition write SHOULD NOT write to avoid data corruption.
         // In other words - write ONLY IF this.epoch matches, epoch of the file in file system.
@@ -474,7 +474,7 @@ public class HDFSStorage implements SyncStorage {
             try {
                 Path targetPath = getFilePath(streamSegmentName, this.epoch);
                 FileStatus[] allFileStatuses = findAllStatusForSegment(streamSegmentName, true);
-                FileStatus fileStatus = allFileStatuses[0];
+                FileStatus fileStatus = allFileStatuses[allFileStatuses.length -1];
 
                 // This instance is already owner.
                 if (targetPath.equals(fileStatus.getPath())) {
@@ -493,7 +493,8 @@ public class HDFSStorage implements SyncStorage {
                 try {
                     if (this.fileSystem.rename(fileStatus.getPath(), targetPath)) {
                         // If there is a race during creation and failure there might be zombie stray files, delete them.
-                        for (int i = 1; i < allFileStatuses.length; i++) {
+                        // Do not delete the last file - that is the one that this instance owns!
+                        for (int i = 0; i < allFileStatuses.length-1; i++) {
                             this.fileSystem.delete(allFileStatuses[i].getPath(), true);
                         }
                         return;

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
@@ -387,6 +387,32 @@ public class HDFSStorageTest extends StorageTestBase {
         }
     }
 
+    @Test
+    public void testTruncationNotSupported() throws StreamSegmentException {
+
+        try (val storage = createSyncStorage();) {
+            storage.initialize(11);
+
+            Assert.assertFalse("supportsTruncation should return false", storage.supportsTruncation());
+
+            SegmentHandle handle = storage.create("segment");
+            AssertExtensions.assertThrows(
+                    "truncate should throw UnsupportedOperationException",
+                    () -> storage.truncate(handle, 0),
+                    ex -> ex instanceof UnsupportedOperationException);
+        }
+    }
+
+    @Test
+    public void testStorageNotInitialized() throws StreamSegmentException {
+
+        try (val storage = createSyncStorage();) {
+            AssertExtensions.assertThrows(
+                    "Any operation on unitialized Storage throws IllegalStateException",
+                    () -> storage.create("segment"),
+                    ex -> ex instanceof IllegalStateException);
+        }
+    }
     //endregion
 
     @Override

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTestWithMocks.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTestWithMocks.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.hdfs;
+
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.test.common.AssertExtensions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for HDFSStorage that use mocks.
+ */
+public class HDFSStorageTestWithMocks {
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final FsPermission READWRITE_PERMISSION = new FsPermission(FsAction.READ_WRITE, FsAction.NONE, FsAction.NONE);
+
+    private HDFSStorageConfig adapterConfig;
+    private FileSystem mockFileSystem;
+
+    @Before
+    public void setUp() throws Exception {
+        mockFileSystem = Mockito.mock(FileSystem.class);
+        this.adapterConfig = HDFSStorageConfig
+                .builder()
+                .with(HDFSStorageConfig.REPLICATION, 1)
+                .with(HDFSStorageConfig.URL, String.format("hdfs://localhost:%d/", 1234))
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        mockFileSystem = null;
+    }
+
+    private HDFSStorage createStorage() {
+        return new TestHDFSStorage(mockFileSystem, this.adapterConfig);
+    }
+
+    /**
+     * Tests the case when create has a race with there are multiple files.
+     * Eg.
+     *  Storage with epoch 9, 10 and 11 all race. they all find that segment does not exist
+     *  Storage 9 creates the file seg_0 and renames it.
+     *  Before it can return Storage 10 creates file seg_0 again and renames it.
+     *  Before both can return Storage 11 also starts executing and creates seg_0 again.
+     *  @throws Exception The test can throw exception.
+     */
+    @Test
+    public void testCreateRaceWithZombieFiles() throws Exception {
+        // Two different calls return different data simulating race condition.
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {},
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_10")),
+                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_9")),
+                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_0")),
+                    }
+                );
+        when(mockFileSystem.create(any(), eq(READWRITE_PERMISSION), anyBoolean(), anyInt(), anyShort(), anyLong(), any()))
+                .thenReturn(new FSDataOutputStream(new ByteArrayOutputStream()));
+
+        when(mockFileSystem.rename(any(), any()))
+                .thenReturn(true);
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(11);
+        storage.create("seg");
+        verify(mockFileSystem).rename(new Path("/seg_10"), new Path("/seg_11"));
+        verify(mockFileSystem).delete(new Path("/seg_9"), true);
+        verify(mockFileSystem).delete(new Path("/seg_0"), true);
+    }
+
+    /**
+     * Tests the case when create has a race with there are multiple files.
+     * Eg.
+     *  Storage with epoch 10 and 11 race. They all find that segment does not exist.
+     *  Storage 11 creates the file seg_0 and renames it.
+     *  Before it can return Storage 10 creates file seg_0 again and tries to claim it.
+     *  @throws Exception The test can throw exception.
+     */
+    @Test
+    public void testCreateRaceWithZombieFilesNotPrimary() throws Exception {
+        // Two different calls return different data simulating race condition.
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {},
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_11")),
+                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_0")),
+                }
+        );
+        when(mockFileSystem.create(any(), eq(READWRITE_PERMISSION), anyBoolean(), anyInt(), anyShort(), anyLong(), any()))
+                .thenReturn( new FSDataOutputStream(new ByteArrayOutputStream()));
+
+        when(mockFileSystem.rename(any(), any()))
+                .thenReturn(true);
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(10);
+
+        AssertExtensions.assertThrows("Create should throw StorageNotPrimaryException when file  with higher epoch exists",
+                () -> storage.create("seg"),
+                ex -> ex instanceof StorageNotPrimaryException);
+    }
+
+    /**
+     * Tests the case when create has a race where two segments are trying to create seg_0 file.
+     * Eg.
+     *  Storage with epoch 10 and 11  race. they all find that segment does not exist
+     *  Storage 10 creates the file seg_0. At this point Storage 11 also starts executing and tries to creates seg_0 again.
+     *  It should correctly throw StreamSegmentExistsException
+     *  @throws Exception The test can throw exception.
+     */
+    @Test
+    public void testCreateRaceWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {}
+        );
+        when(mockFileSystem.create(any(), eq(READWRITE_PERMISSION), anyBoolean(), anyInt(), anyShort(), anyLong(), any()))
+                .thenThrow(new FileAlreadyExistsException());
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(11);
+
+        AssertExtensions.assertThrows("create should throw StreamSegmentExistsException",
+                () -> storage.create("seg"),
+                ex -> ex instanceof StreamSegmentExistsException);
+
+    }
+
+
+
+    //region TestHDFSStorage
+    /**
+     * TestHDFSStorage class that uses Mockito mock for file system.
+     **/
+    private static class TestHDFSStorage extends HDFSStorage {
+        FileSystem mockFileSystem;
+        TestHDFSStorage(FileSystem mockFileSystem, HDFSStorageConfig config) {
+            super(config);
+            this.mockFileSystem = mockFileSystem;
+        }
+
+        @Override
+        protected FileSystem openFileSystem(Configuration conf) throws IOException {
+            return mockFileSystem;
+        }
+    }
+    //endregion
+}

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTestWithMocks.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTestWithMocks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,7 +9,9 @@
  */
 package io.pravega.storage.hdfs;
 
+import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.test.common.AssertExtensions;
 import org.apache.hadoop.conf.Configuration;
@@ -18,6 +20,7 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.junit.After;
@@ -35,6 +38,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,8 +46,17 @@ import static org.mockito.Mockito.when;
  * Unit tests for HDFSStorage that use mocks.
  */
 public class HDFSStorageTestWithMocks {
+    private static final String SEG_SEALED_PATH = "/seg_sealed";
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
     private static final FsPermission READWRITE_PERMISSION = new FsPermission(FsAction.READ_WRITE, FsAction.NONE, FsAction.NONE);
+    private static final int HIGHER_EPOCH = 11;
+    private static final int MIDDLE_EPOCH = 10;
+    private static final String MIDDLE_EPOCH_PATH = "/seg_10";
+    private static final String HIGHER_EPOCH_PATH = "/seg_11";
+    private static final String LOWER_EPOCH_PATH = "/seg_9";
+    private static final String ZERO_EPOCH_PATH = "/seg_0";
+    private static final String TEST_SEGMENT_NAME = "seg";
+    private static final String DUMMY_MESSAGE = "dummy exception message";
 
     private HDFSStorageConfig adapterConfig;
     private FileSystem mockFileSystem;
@@ -82,9 +95,9 @@ public class HDFSStorageTestWithMocks {
         when(mockFileSystem.globStatus(any())).thenReturn(
                 new FileStatus[] {},
                 new FileStatus[] {
-                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_10")),
-                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_9")),
-                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_0")),
+                        new FileStatus(0, false, 1, 64, 0, new Path(MIDDLE_EPOCH_PATH)),
+                        new FileStatus(0, false, 1, 64, 0, new Path(LOWER_EPOCH_PATH)),
+                        new FileStatus(0, false, 1, 64, 0, new Path(ZERO_EPOCH_PATH)),
                     }
                 );
         when(mockFileSystem.create(any(), eq(READWRITE_PERMISSION), anyBoolean(), anyInt(), anyShort(), anyLong(), any()))
@@ -94,11 +107,11 @@ public class HDFSStorageTestWithMocks {
                 .thenReturn(true);
 
         HDFSStorage storage = createStorage();
-        storage.initialize(11);
-        storage.create("seg");
-        verify(mockFileSystem).rename(new Path("/seg_10"), new Path("/seg_11"));
-        verify(mockFileSystem).delete(new Path("/seg_9"), true);
-        verify(mockFileSystem).delete(new Path("/seg_0"), true);
+        storage.initialize(HIGHER_EPOCH);
+        storage.create(TEST_SEGMENT_NAME);
+        verify(mockFileSystem).rename(new Path(MIDDLE_EPOCH_PATH), new Path(HIGHER_EPOCH_PATH));
+        verify(mockFileSystem).delete(new Path(LOWER_EPOCH_PATH), true);
+        verify(mockFileSystem).delete(new Path(ZERO_EPOCH_PATH), true);
     }
 
     /**
@@ -115,8 +128,8 @@ public class HDFSStorageTestWithMocks {
         when(mockFileSystem.globStatus(any())).thenReturn(
                 new FileStatus[] {},
                 new FileStatus[] {
-                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_11")),
-                        new FileStatus(0, false, 1, 64, 0, new Path("/seg_0")),
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                        new FileStatus(0, false, 1, 64, 0, new Path(ZERO_EPOCH_PATH)),
                 }
         );
         when(mockFileSystem.create(any(), eq(READWRITE_PERMISSION), anyBoolean(), anyInt(), anyShort(), anyLong(), any()))
@@ -126,10 +139,10 @@ public class HDFSStorageTestWithMocks {
                 .thenReturn(true);
 
         HDFSStorage storage = createStorage();
-        storage.initialize(10);
+        storage.initialize(MIDDLE_EPOCH);
 
         AssertExtensions.assertThrows("Create should throw StorageNotPrimaryException when file  with higher epoch exists",
-                () -> storage.create("seg"),
+                () -> storage.create(TEST_SEGMENT_NAME),
                 ex -> ex instanceof StorageNotPrimaryException);
     }
 
@@ -150,15 +163,278 @@ public class HDFSStorageTestWithMocks {
                 .thenThrow(new FileAlreadyExistsException());
 
         HDFSStorage storage = createStorage();
-        storage.initialize(11);
+        storage.initialize(HIGHER_EPOCH);
 
         AssertExtensions.assertThrows("create should throw StreamSegmentExistsException",
-                () -> storage.create("seg"),
+                () -> storage.create(TEST_SEGMENT_NAME),
                 ex -> ex instanceof StreamSegmentExistsException);
-
     }
 
+    @Test
+    public void testOpenWriteWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
 
+        AssertExtensions.assertThrows("openWrite should correctly throw IOException.",
+                () -> storage.openWrite(TEST_SEGMENT_NAME),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testOpenReadWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+
+        AssertExtensions.assertThrows("openRead should correctly throw IOException.",
+                () -> storage.openRead(TEST_SEGMENT_NAME),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testCreateWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+
+        AssertExtensions.assertThrows("create should correctly throw IOException.",
+                () -> storage.create(TEST_SEGMENT_NAME),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testExistsWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+
+        // should not throw Exception
+        storage.exists(TEST_SEGMENT_NAME);
+    }
+
+    @Test
+    public void testgetStreamSegmentInfoWithException() throws Exception {
+        when(mockFileSystem.globStatus(any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+
+        AssertExtensions.assertThrows(" should correctly throw IOException.",
+                () -> storage.getStreamSegmentInfo(TEST_SEGMENT_NAME),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testUnsealWithException() throws Exception {
+        when(mockFileSystem.rename(any(), any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        AssertExtensions.assertThrows("seal should correctly throw IOException.",
+                () -> storage.unseal(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testSealWithException() throws Exception {
+        when(mockFileSystem.rename(any(), any())).thenThrow(new IOException(DUMMY_MESSAGE));
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+
+        AssertExtensions.assertThrows("seal should correctly throw IOException.",
+                () -> storage.seal(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testDeleteWithException() throws Exception {
+        when(mockFileSystem.delete(any(), anyBoolean())).thenThrow(new IOException(DUMMY_MESSAGE));
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+
+        AssertExtensions.assertThrows("delete should correctly throw IOException.",
+                () -> storage.delete(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testDeleteForPessimisticCaseWithException() throws Exception {
+        when(mockFileSystem.delete(any(), anyBoolean()))
+                .thenThrow(new PathNotFoundException(HIGHER_EPOCH_PATH))
+                .thenThrow(new IOException(HIGHER_EPOCH_PATH));
+
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        AssertExtensions.assertThrows("delete should correctly throw IOException.",
+                () -> storage.delete(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testSealForPessimisticCase() throws Exception {
+        when(mockFileSystem.rename(any(), any()))
+                .thenThrow(new PathNotFoundException(HIGHER_EPOCH_PATH))
+                .thenReturn(true);
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        storage.seal(handle);
+        verify(mockFileSystem, times(2)).rename(new Path(HIGHER_EPOCH_PATH), new Path(SEG_SEALED_PATH));
+    }
+
+    @Test
+    public void testUnsealForPessimisticCase() throws Exception {
+        // First call to rename throws exception, the second call succeeds.
+        when(mockFileSystem.rename(any(), any()))
+                .thenThrow(new PathNotFoundException(SEG_SEALED_PATH))
+                .thenReturn(true);
+
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(SEG_SEALED_PATH)),
+                }
+        );
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        storage.unseal(handle);
+        verify(mockFileSystem, times(2)).rename(new Path(SEG_SEALED_PATH), new Path(HIGHER_EPOCH_PATH));
+    }
+
+    @Test
+    public void testDeleteForPessimisticCase() throws Exception {
+        // First call to rename throws exception, the second call succeeds.
+        when(mockFileSystem.delete(any(), anyBoolean()))
+                .thenThrow(new PathNotFoundException(HIGHER_EPOCH_PATH))
+                .thenReturn(true);
+
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        );
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        storage.delete(handle);
+        verify(mockFileSystem, times(2)).delete(new Path(HIGHER_EPOCH_PATH), true);
+    }
+
+    @Test
+    public void testSealForPessimisticCaseForException() throws Exception {
+        when(mockFileSystem.rename(any(), any()))
+                .thenThrow(new PathNotFoundException(HIGHER_EPOCH_PATH))
+                .thenReturn(true);
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                }
+        ).thenThrow(new IOException(DUMMY_MESSAGE));
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        AssertExtensions.assertThrows("seal should correctly throw IOException.",
+                () -> storage.seal(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testUnsealForPessimisticCaseForException() throws Exception {
+        // First call to rename throws exception, the second call succeeds.
+        when(mockFileSystem.rename(any(), any()))
+                .thenThrow(new PathNotFoundException(SEG_SEALED_PATH))
+                .thenReturn(true);
+
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[] {
+                        new FileStatus(0, false, 1, 64, 0, new Path(SEG_SEALED_PATH)),
+                }
+        ).thenThrow(new IOException(DUMMY_MESSAGE));
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+        SegmentHandle handle = storage.openWrite(TEST_SEGMENT_NAME);
+        AssertExtensions.assertThrows("unseal should correctly throw IOException.",
+                () -> storage.unseal(handle),
+                ex -> ex instanceof IOException && !(ex instanceof StreamSegmentException));
+    }
+
+    @Test
+    public void testIllegalArgumentException() throws Exception {
+
+        when(mockFileSystem.globStatus(any())).thenReturn(
+                new FileStatus[]{
+                        new FileStatus(0, false, 1, 64, 0, new Path(HIGHER_EPOCH_PATH)),
+                        new FileStatus(0, false, 1, 64, 0, new Path(MIDDLE_EPOCH_PATH)),
+                }
+        );
+
+        HDFSStorage storage = createStorage();
+        storage.initialize(HIGHER_EPOCH);
+
+        AssertExtensions.assertThrows("Presence of multiple files correctly results in IllegalArgumentException.",
+                () -> storage.exists(TEST_SEGMENT_NAME),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testFormatException() throws Exception {
+        HDFSStorage storage = createStorage();
+        storage.initialize(MIDDLE_EPOCH);
+
+        String[] malformedStrings = new String[] {
+                "/seg-10",
+                "/seg10",
+                "/seg-abc",
+                "/seg_abc",
+                "/seg_1.0",
+        };
+
+        for (String malformedString : malformedStrings) {
+            when(mockFileSystem.globStatus(any())).thenReturn(
+                    new FileStatus[]{
+                            new FileStatus(0, false, 1, 64, 0, new Path(malformedString)),
+                    }
+            );
+
+            AssertExtensions.assertThrows("Malformed files present",
+                    () -> storage.openWrite(TEST_SEGMENT_NAME),
+                    ex -> ex instanceof IllegalStateException || ex instanceof FileNameFormatException);
+        }
+    }
 
     //region TestHDFSStorage
     /**

--- a/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import io.pravega.segmentstore.contracts.StreamSegmentException;
+
+/**
+ * Indicates that there is a possibility of data corruption.
+ *
+ */
+public class DataCorruptionException extends StreamSegmentException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance of the DataCorruptionException class.
+     *
+     * @param streamSegmentName The name of the segment for which the Storage is no longer primary.
+     */
+    public DataCorruptionException(String streamSegmentName) {
+        this(streamSegmentName, null, null);
+    }
+
+    /**
+     * Creates a new instance of the DataCorruptionException class.
+     *
+     * @param streamSegmentName The name of the segment for which there is a possibility of data corruption.
+     * @param cause             The causing exception.
+     */
+    public DataCorruptionException(String streamSegmentName, Throwable cause) {
+        this(streamSegmentName, null, cause);
+    }
+
+    /**
+     * Creates a new instance of the DataCorruptionException class.
+     *
+     * @param streamSegmentName The name of the segment for which there is a possibility of data corruption.
+     * @param message           The exception message.
+     */
+    public DataCorruptionException(String streamSegmentName, String message) {
+        this(streamSegmentName, message, null);
+    }
+
+    /**
+     * Creates a new instance of the DataCorruptionException class.
+     *
+     * @param streamSegmentName The name of the segment for which there is a possibility of data corruption.
+     * @param cause             The causing exception.
+     * @param message           The exception message.
+     */
+
+    public DataCorruptionException(String streamSegmentName, String message, Throwable cause) {
+        super(streamSegmentName, "The non primary writer detected for this StreamSegment.There is a possibility of data corruption." + (message == null ? "" : " ") + message,
+                cause);
+    }
+}
+

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
@@ -56,7 +56,7 @@ public class DataCorruptionException extends StreamSegmentException {
      */
 
     public DataCorruptionException(String streamSegmentName, String message, Throwable cause) {
-        super(streamSegmentName, "The non primary writer detected for this StreamSegment.There is a possibility of data corruption." + (message == null ? "" : " " + message),
+        super(streamSegmentName, "The non primary writer detected for this StreamSegment. There is a possibility of data corruption." + (message == null ? "" : " " + message),
                 cause);
     }
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataCorruptionException.java
@@ -56,7 +56,7 @@ public class DataCorruptionException extends StreamSegmentException {
      */
 
     public DataCorruptionException(String streamSegmentName, String message, Throwable cause) {
-        super(streamSegmentName, "The non primary writer detected for this StreamSegment.There is a possibility of data corruption." + (message == null ? "" : " ") + message,
+        super(streamSegmentName, "The non primary writer detected for this StreamSegment.There is a possibility of data corruption." + (message == null ? "" : " " + message),
                 cause);
     }
 }


### PR DESCRIPTION
**Change log description**  
Implement fencing optimistically in HDFSStorage.

**Purpose of the change**  
Fixes #3265 

**What the code does**  
- Changes to openWrite to retry until either rename succeeds or file with higher epoch is found or file is found sealed. 
- Any method that takes Handle as parameter makes strong use of the above fact that openWrite returns only after successful rename . What it means is that they can optimistically bypass globStatus for normal case and instead use fixed name and that this will not fail unless ownership has changed.  If the operation fails because the file does not exist (because newer instance rename it) then it makes a directory search pessimistically and retry the operation once. 
- Write operation now never writes to a file if it does not match the current epoch. 
- Note that the HDFSStorage throws StorageNotPrimaryException appropriately if current epoch does not match what is in the file system (in other words it is either stale or there is a possibility of data corruption). 
- There are a couple methods that are not changed as not yet sure doing it optimistically is correct/possible. (Eg. create and concat ) 

**How to verify it**  
All unit tests and system tests should pass.
Performance tests should show increased throughput.

**Summary of Design and its Correctness argument**  
_Need for fencing_
It is possible that during network partition and fail over, multiple segment store instances may concurrently append data to the same segment file. While HDFS provides atomic appends and expects a single writer pattern, it does not actually provide mechanisms to prevent multiple writers from appending data out of sequence and causing eventual data corruption.

_How fencing is implemented_

- The file name used for a segment contains epoch of the owner segment store instance. The format is {segmentname}_{epoch}
- For any operation that modify file/data, the ownership must first be established before proceeding. This is done by simply renaming the existing file with epoch of the new owner. In case of race condition, segment store with highest epoch always wins.
- Segment store should NEVER modify a file with _higher_ epoch and abort any operations with StorageNotPrimaryException.
- Additionally write, seal and unseal should NEVER modify a file with _lower_ epoch also to prevent any possible data corruption. In other words it should always abort the operation with either StorageNotPrimaryException or DataCorruptionException in case the epoch of the file does not _exactly_ match.

_Assumptions_
1.  HDFS FileSystem create, delete and rename operations are atomic. After successful completion of create, file with same name can not be created. After successful completion of rename and delete, the operations that use old file name always fail and operations that use new file name always succeed. 
2. Therefore any new calls to FileSystem.append and  FileSystem.read with old name will always fail. However we can not assume that calls already in fight will fail. 
3. globStatus is eventually consistent. It may return slightly old information but will eventually return new most recent information.
4. Epoch of segment store instances always increase monotonically when new instances are created. 

_Expected Design Invariants/Guarantees and how they are implemented_

1. If file exists then the read should always succeed irrespective of which segment store container owns the file. In short no need to assert ownership before reading.
2. Write, seal, and unseal  operate on a SegmentHandle and therefore they can strongly assume that ownership is already established and file is renamed during earlier call to openWrite. These operations never attempt to establish ownership but only detect the ownership changes. 
3. openWrite first claims ownership by attempting rename existing segment file to epoch of the segment store instance. It retries rename operation until it succeeds or file with higher epoch is detected. This guarantees that on successful return the segment file can not have epoch lower than  epoch of segment store instance.
4. For write to proceed the file with exact epoch must be present in FileSystem. If this is not the case then FileSystem.append fails with file not found exception and operation is aborted with either StorageNotPrimaryException or DataCorruptionException. Therefore a older segment store can never write to file with higher epoch. Note that write does not call globStatus. 
5. The seal operation works similarly and will never seal the file with different epoch. A sealed file is never written to.
6. Immediately after successful segment create, the segment file has the highest epoch. In case of race, create makes best effort to throw StorageNotPrimaryException for segment store instances with lower epoch. In case higher epoch renames file after create returns. The subsequent modifying operations will fail correctly.
8. Delete never deletes files with higher epoch. Delete always succeeds for file with lower or same epoch. In case the newer segment store instance re-creates a deleted file then the epoch of file will be already higher.

**References**  

1. [Core Expectations of a Hadoop Compatible FileSystem]( 
https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/filesystem/introduction.html#Core_Expectations_of_a_Hadoop_Compatible_FileSystem)