### PR TITLE
Issue 3342: Increase the read timeout to avoid test failure 

### DIFF
--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -57,7 +57,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
     // Note: Strictly speaking, this test is really an "integration test" and is a little
     // time consuming. For now, its intended to run as a unit test, but it could be moved
     // to an integration test suite if and when necessary.
-    @Test(timeout = 50000)
+    @Test(timeout = 200000)
     public void testWriteAndReadEventWhenConfigurationIsProper() throws ExecutionException,
             InterruptedException, ReinitializationRequiredException {
 

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -115,7 +115,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
 
         // Keeping the read timeout large so that there is ample time for reading the event even in
         // case of abnormal delays in test environments.
-        EventRead<String> event = reader.readNextEvent(50000);
+        EventRead<String> event = reader.readNextEvent(150000);
         String readMessage = event.getEvent();
         log.debug("Read event '{}", readMessage);
         assertEquals(message, readMessage);


### PR DESCRIPTION
Signed-off-by: Ravi Sharda <ravi.sharda@emc.com>

**Change log description**  
Increase read timeouts (tripled) to avoid test failures under abnormal delays in build/test environments. 

**Purpose of the change**  
Fixes #3342. 

**What the code does**  
Increases the read timeout. 

**How to verify it**  
Tests in TlsEnabledInProcPravegaClusterTest pass consistently.