### PR TITLE
Issue 3341: Remove many Javadoc warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ project('common') {
             project(':shared:protocol').sourceSets.main.java
         }
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion   
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
         }
         options.addBooleanOption('html5', true)
         options.addBooleanOption("Xdoclint:none", true)
@@ -138,7 +138,7 @@ project('shared:authplugin') {
         title = "Pravega Auth API"
         failOnError = false
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion   
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
         }
         source {
             sourceSets.main.java
@@ -161,7 +161,7 @@ project ('shared:cluster') {
     javadoc {
         exclude 'io/pravega/shared/*'
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion   
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -188,7 +188,7 @@ project ('shared:metrics') {
     javadoc {
         exclude 'io/pravega/shared/*'
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -239,7 +239,7 @@ project('test:testcommon') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -254,7 +254,7 @@ project('segmentstore:contracts') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -272,7 +272,7 @@ project('segmentstore:storage') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -293,7 +293,7 @@ project('segmentstore:storage:impl') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -323,7 +323,7 @@ project ('bindings') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -341,7 +341,7 @@ project('segmentstore:server') {
     }
     javadoc {
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -541,7 +541,7 @@ project('shared:controller-api') {
     javadoc {
         exclude 'io/pravega/controller/*'
         dependencies {
-            compile 'org.projectlombok:lombok:' + lombokVersion            
+            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)

--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,7 @@ project('client') {
         failOnError = false
         exclude "**/impl/**";
         options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:all,-reference", true)
     }
 }
 
@@ -257,7 +258,7 @@ project('segmentstore:contracts') {
         }
         failOnError = false
         options.addBooleanOption('html5', true)
-        options.addStringOption("Xdoclint:none", "-quiet")
+        options.addBooleanOption("Xdoclint:all,-reference", true)
     }
 }
 
@@ -344,7 +345,7 @@ project('segmentstore:server') {
         }
         failOnError = false
         options.addBooleanOption('html5', true)
-        options.addBooleanOption("Xdoclint:none", true)
+        options.addBooleanOption("Xdoclint:all,-reference,-missing", true)
     }
 }
 
@@ -965,7 +966,7 @@ task javadocs(type: Javadoc) {
 
     // Include names of any project that is to be included in the javadoc distribution
     ext.projects = [':client']
-    options.links("http://docs.oracle.com/javase/10/docs/api/", "https://projectlombok.org/api/lombok/");
+    options.links("http://docs.oracle.com/javase/10/docs/api/");
     title = "Pravega API"
     destinationDir = file("${buildDir}/javadocs")
     source = files(projects.collect {
@@ -976,7 +977,7 @@ task javadocs(type: Javadoc) {
     })
     failOnError = true
     exclude "**/impl/**"
-    options.addBooleanOption("Xdoclint:all", true)
+    options.addBooleanOption("Xdoclint:all,-reference", true)
 }
 
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,11 @@ project('common') {
             project(':common').sourceSets.main.java
             project(':shared:protocol').sourceSets.main.java
         }
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -132,10 +137,15 @@ project('shared:authplugin') {
     javadoc {
         title = "Pravega Auth API"
         failOnError = false
-
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
         source {
             sourceSets.main.java
         }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -150,6 +160,12 @@ project ('shared:cluster') {
     }
     javadoc {
         exclude 'io/pravega/shared/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -171,6 +187,12 @@ project ('shared:metrics') {
 
     javadoc {
         exclude 'io/pravega/shared/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -201,6 +223,7 @@ project('client') {
         title = "Pravega Client API"
         failOnError = false
         exclude "**/impl/**";
+        options.addBooleanOption('html5', true)
     }
 }
 
@@ -213,12 +236,28 @@ project('test:testcommon') {
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLogger
     }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
+    }
 }
 
 project('segmentstore:contracts') {
     dependencies {
         compile project(':common')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addStringOption("Xdoclint:none", "-quiet")
     }
 }
 
@@ -229,6 +268,14 @@ project('segmentstore:storage') {
         compile project(':segmentstore:contracts')
         compile project(':shared:metrics')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -242,6 +289,14 @@ project('segmentstore:storage:impl') {
         compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -265,6 +320,14 @@ project ('bindings') {
         testCompile project(':test:testcommon')
         testCompile project(path: ':segmentstore:storage', configuration: 'testRuntime')
     }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
+    }
 }
 
 project('segmentstore:server') {
@@ -274,6 +337,14 @@ project('segmentstore:server') {
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -468,6 +539,12 @@ project('shared:controller-api') {
 
     javadoc {
         exclude 'io/pravega/controller/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -888,7 +965,7 @@ task javadocs(type: Javadoc) {
 
     // Include names of any project that is to be included in the javadoc distribution
     ext.projects = [':client']
-    options.links("http://docs.oracle.com/javase/8/docs/api/");
+    options.links("http://docs.oracle.com/javase/10/docs/api/", "https://projectlombok.org/api/lombok/");
     title = "Pravega API"
     destinationDir = file("${buildDir}/javadocs")
     source = files(projects.collect {
@@ -897,8 +974,9 @@ task javadocs(type: Javadoc) {
     classpath = files(projects.collect {
         project(it).sourceSets.main.output + project(it).sourceSets.main.compileClasspath
     })
-    failOnError = false
+    failOnError = true
     exclude "**/impl/**"
+    options.addBooleanOption("Xdoclint:all", true)
 }
 
 apply plugin: 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ project('common') {
             project(':shared:protocol').sourceSets.main.java
         }
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
+            compile 'org.projectlombok:lombok:' + lombokVersion   
         }
         options.addBooleanOption('html5', true)
         options.addBooleanOption("Xdoclint:none", true)
@@ -138,7 +138,7 @@ project('shared:authplugin') {
         title = "Pravega Auth API"
         failOnError = false
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
+            compile 'org.projectlombok:lombok:' + lombokVersion   
         }
         source {
             sourceSets.main.java
@@ -161,7 +161,7 @@ project ('shared:cluster') {
     javadoc {
         exclude 'io/pravega/shared/*'
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion   
+            compile 'org.projectlombok:lombok:' + lombokVersion   
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -188,7 +188,7 @@ project ('shared:metrics') {
     javadoc {
         exclude 'io/pravega/shared/*'
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -239,7 +239,7 @@ project('test:testcommon') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -254,7 +254,7 @@ project('segmentstore:contracts') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -272,7 +272,7 @@ project('segmentstore:storage') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -293,7 +293,7 @@ project('segmentstore:storage:impl') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -323,7 +323,7 @@ project ('bindings') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -341,7 +341,7 @@ project('segmentstore:server') {
     }
     javadoc {
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)
@@ -541,7 +541,7 @@ project('shared:controller-api') {
     javadoc {
         exclude 'io/pravega/controller/*'
         dependencies {
-            compileOnly 'org.projectlombok:lombok:' + lombokVersion            
+            compile 'org.projectlombok:lombok:' + lombokVersion            
         }
         failOnError = false
         options.addBooleanOption('html5', true)

--- a/client/src/main/java/io/pravega/client/admin/StreamInfo.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamInfo.java
@@ -16,12 +16,12 @@ import lombok.Data;
 /**
  * This class is used to represent Stream information. It currently includes:
  *
- * <ul>
- *  <li> - scope of stream.
- *  <li> - name of stream.
- *  <li> - {@link StreamCut} which represents the current TAIL of the stream.
- *  <li> - {@link StreamCut} which represents the current HEAD of the stream.
- * </ul>
+ *  <ul>
+ *  <li> scope of stream. </li>
+ *  <li> name of stream. </li>
+ *  <li> {@link StreamCut} which represents the current TAIL of the stream. </li>
+ *  <li> {@link StreamCut} which represents the current HEAD of the stream. </li>
+ *  </ul>
  */
 @Beta
 @Data

--- a/client/src/main/java/io/pravega/client/batch/StreamInfo.java
+++ b/client/src/main/java/io/pravega/client/batch/StreamInfo.java
@@ -15,12 +15,12 @@ import lombok.Data;
 
 /**
  * This class is used to represent Stream information. It currently includes:
- *
- *  <li> - scope of stream.
- *  <li> - name of stream.
- *  <li> - {@link StreamCut} which represents the current TAIL of the stream.
- *  <li> - {@link StreamCut} which represents the current HEAD of the stream.
- *
+ *  <ul>
+ *  <li> - scope of stream. </li>
+ *  <li> - name of stream. </li>
+ *  <li> - {@link StreamCut} which represents the current TAIL of the stream. </li>
+ *  <li> - {@link StreamCut} which represents the current HEAD of the stream. </li>
+ *  </ul>
  *  @deprecated This class is deprecated and will be removed in the subsequent releases. Use
  *  {@link io.pravega.client.admin.StreamManager#getStreamInfo(String, String)} to fetch StreamInfo represented
  *  by {@link io.pravega.client.admin.StreamInfo}.

--- a/client/src/main/java/io/pravega/client/byteStream/ByteStreamReader.java
+++ b/client/src/main/java/io/pravega/client/byteStream/ByteStreamReader.java
@@ -29,6 +29,7 @@ public abstract class ByteStreamReader extends InputStream implements Asynchrono
 
     /**
      * Returns the current byte offset in the segment. This call does not block.
+     * @return the current byte offset in the segment.
      */
     public abstract long getOffset();
 
@@ -47,6 +48,7 @@ public abstract class ByteStreamReader extends InputStream implements Asynchrono
      * the end of the stream has been reached and a call to {@link #read(byte[])} will return -1.
      * 
      * @see java.io.InputStream#available()
+     * @return the number of bytes that can be read without blocking.
      */
     @Override
     public abstract int available();
@@ -55,6 +57,7 @@ public abstract class ByteStreamReader extends InputStream implements Asynchrono
      * This make an RPC to the server to fetch the offset at which new bytes would be written. This
      * is the same as the length of the segment (assuming no truncation). This offset can also be
      * passed to {@link #seekToOffset(long)} to only read bytes from this point forward.
+     * @return The tail offset.
      */
     public abstract long fetchTailOffset();
 

--- a/client/src/main/java/io/pravega/client/byteStream/ByteStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/byteStream/ByteStreamWriter.java
@@ -94,6 +94,7 @@ public abstract class ByteStreamWriter extends OutputStream {
      * to the segment in its history. This is the sum total of the bytes written in all calls to
      * {@link #write(byte[])} that have been flushed. It does not include data that was passed to
      * {@link #write(byte[])} but which has not yet been persisted.
+     * @return The tail offset
      */
     public abstract long fetchTailOffset();
     

--- a/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
+++ b/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
@@ -54,11 +54,11 @@ public interface StateSynchronizer<StateT extends Revisioned> extends AutoClosea
      * A function which given a state object populates a list of updates that should be applied.
      * 
      * For example:
-     * <code>
+     * <pre>{@code
      * stateSynchronizer.updateState((state, updates) -> {
      *      updates.addAll(findUpdatesForState(state));
      * });
-     * </code>
+     * }</pre>
      * @param <StateT> The type of state it generates updates for.
      */
     @FunctionalInterface
@@ -69,7 +69,8 @@ public interface StateSynchronizer<StateT extends Revisioned> extends AutoClosea
     /**
      * Similar to {@link UpdateGenerator} but it also returns a result for the caller.
      * For example:
-     * <code>
+     * <pre>
+     * {@code
      * boolean updated = stateSynchronizer.updateState((state, updates) -> {
      *      if (!shouldUpdate(state)) {
      *          return false;
@@ -77,7 +78,8 @@ public interface StateSynchronizer<StateT extends Revisioned> extends AutoClosea
      *      updates.addAll(findUpdatesForState(state));
      *      return true;
      * });
-     * </code>
+     *}
+     * </pre>
      * @param <StateT> The type of state it generates updates for.
      * @param <ReturnT> The type of the result returned.
      */

--- a/client/src/main/java/io/pravega/client/stream/Checkpoint.java
+++ b/client/src/main/java/io/pravega/client/stream/Checkpoint.java
@@ -28,6 +28,7 @@ public interface Checkpoint {
     
     /**
      * Serializes the checkpoint to a compact byte array.
+     * @return A serialized version of this checkpoint.
      */
     ByteBuffer toBytes();
     

--- a/client/src/main/java/io/pravega/client/stream/Position.java
+++ b/client/src/main/java/io/pravega/client/stream/Position.java
@@ -28,6 +28,7 @@ public interface Position {
     
     /**
      * Serializes the position to a compact byte array.
+     * @return A serialized version of this position.
      */
     ByteBuffer toBytes();
     

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -42,6 +42,7 @@ public class StreamConfiguration implements Serializable {
          * Scope is specified on stream creation.
          * @param scope ignored
          * @deprecated Does nothing. 
+         * @return this
          */
         @Deprecated
         public StreamConfigurationBuilder scope(String scope) {
@@ -52,6 +53,7 @@ public class StreamConfiguration implements Serializable {
          * Stream name is specified on stream creation.
          * @param streamName ignored
          * @deprecated Does nothing. 
+         * @return this
          */
         @Deprecated
         public StreamConfigurationBuilder streamName(String streamName) {

--- a/client/src/main/java/io/pravega/client/stream/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamCut.java
@@ -63,6 +63,7 @@ public interface StreamCut extends Serializable {
     
     /**
      * Serializes the cut to a compact byte array.
+     * @return A serialized version of this streamcut.
      */
     ByteBuffer toBytes();
 

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractNotifier.java
@@ -18,7 +18,7 @@ import io.pravega.client.stream.notifications.Observable;
 
 /**
  * AbstractNotifier which is used by all types of Notifiers.
- * @param <T>
+ * @param <T> The type of notification being listened to.
  */
 public abstract class AbstractNotifier<T extends Notification> implements Observable<T> {
 


### PR DESCRIPTION
**Change log description**  
* Fix some issues with Javadocs
* Import Lombok when generating Javadocs to reduce errors
* Suppress minor warnings.

**Purpose of the change**  
Fixes #3341 

**What the code does**  
Removes 95% of out warnings from the `generateJavadoc` target and 100% for the `javadocs` target.

