### PR TITLE
Issue 3358: Fix stack overflow error caused by okhttp used by kubernetes-java client.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -196,6 +196,11 @@ public class K8sClient {
     @SneakyThrows(ApiException.class)
     public CompletableFuture<List<V1PodStatus>> getStatusOfPodWithLabel(final String namespace, final String labelName, final String labelValue) {
         CoreV1Api api = new CoreV1Api();
+
+        // Workaround based on okhttp issue https://github.com/square/okhttp/issues/2300
+        log.debug("Current number of http interceptors {}", api.getApiClient().getHttpClient().networkInterceptors().size());
+        api.getApiClient().getHttpClient().networkInterceptors().clear();
+
         K8AsyncCallback<V1PodList> callback = new K8AsyncCallback<>("listPods");
         api.listNamespacedPodAsync(namespace, PRETTY_PRINT, null, null, true, labelName + "=" + labelValue, null,
                                    null, null, false, callback);

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -197,7 +197,7 @@ public class K8sClient {
     public CompletableFuture<List<V1PodStatus>> getStatusOfPodWithLabel(final String namespace, final String labelName, final String labelValue) {
         CoreV1Api api = new CoreV1Api();
 
-        // Workaround based on okhttp issue https://github.com/square/okhttp/issues/2300
+        // Workaround for okhttp issue, tracked by https://github.com/pravega/pravega/issues/3361
         log.debug("Current number of http interceptors {}", api.getApiClient().getHttpClient().networkInterceptors().size());
         api.getApiClient().getHttpClient().networkInterceptors().clear();
 


### PR DESCRIPTION
**Change log description**  
Ensure networkInterceptors are cleared before invoking `io.kubernetes.client.apis.CoreV1Api#listNamespacedPodAsync`.

**Purpose of the change**  
Fixes #3358

**What the code does**  
The stack overflow error is due to `com.squareup.okhttp.OkHttpClient#networkInterceptors` being repeatedly added during the invocation of `CoreV1Api#listNamespacedPodAsync` .
This adds a workaround to ensure we clear the network interceptors before invoking the `listNamespacedPodAsync` . This workaround can be removed once this issue is resolved in the kubernetes-client /okhttp library.

**How to verify it**  
Verified that the tests run on the K8s cluster.
