### PR TITLE
Issue 3341: Fix build errors and warnings in `common`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,13 @@ project('common') {
             project(':common').sourceSets.main.java
             project(':shared:protocol').sourceSets.main.java
         }
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
+
 }
 
 def withoutLogger = { exclude group: 'org.slf4j', module: 'slf4j-log4j12'
@@ -132,10 +138,15 @@ project('shared:authplugin') {
     javadoc {
         title = "Pravega Auth API"
         failOnError = false
-
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
         source {
             sourceSets.main.java
         }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -150,6 +161,12 @@ project ('shared:cluster') {
     }
     javadoc {
         exclude 'io/pravega/shared/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion   
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -171,6 +188,12 @@ project ('shared:metrics') {
 
     javadoc {
         exclude 'io/pravega/shared/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -201,6 +224,8 @@ project('client') {
         title = "Pravega Client API"
         failOnError = false
         exclude "**/impl/**";
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:all,-reference", true)
     }
 }
 
@@ -213,12 +238,28 @@ project('test:testcommon') {
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLogger
     }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
+    }
 }
 
 project('segmentstore:contracts') {
     dependencies {
         compile project(':common')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:all,-reference", true)
     }
 }
 
@@ -229,6 +270,14 @@ project('segmentstore:storage') {
         compile project(':segmentstore:contracts')
         compile project(':shared:metrics')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -242,6 +291,14 @@ project('segmentstore:storage:impl') {
         compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -265,6 +322,14 @@ project ('bindings') {
         testCompile project(':test:testcommon')
         testCompile project(path: ':segmentstore:storage', configuration: 'testRuntime')
     }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
+    }
 }
 
 project('segmentstore:server') {
@@ -274,6 +339,14 @@ project('segmentstore:server') {
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
         testCompile project(':test:testcommon')
+    }
+    javadoc {
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:all,-reference,-missing", true)
     }
 }
 
@@ -468,6 +541,12 @@ project('shared:controller-api') {
 
     javadoc {
         exclude 'io/pravega/controller/*'
+        dependencies {
+            compile 'org.projectlombok:lombok:' + lombokVersion            
+        }
+        failOnError = false
+        options.addBooleanOption('html5', true)
+        options.addBooleanOption("Xdoclint:none", true)
     }
 }
 
@@ -888,7 +967,7 @@ task javadocs(type: Javadoc) {
 
     // Include names of any project that is to be included in the javadoc distribution
     ext.projects = [':client']
-    options.links("http://docs.oracle.com/javase/8/docs/api/");
+    options.links("http://docs.oracle.com/javase/10/docs/api/");
     title = "Pravega API"
     destinationDir = file("${buildDir}/javadocs")
     source = files(projects.collect {
@@ -897,8 +976,9 @@ task javadocs(type: Javadoc) {
     classpath = files(projects.collect {
         project(it).sourceSets.main.output + project(it).sourceSets.main.compileClasspath
     })
-    failOnError = false
+    failOnError = true
     exclude "**/impl/**"
+    options.addBooleanOption("Xdoclint:all,-reference", true)
 }
 
 apply plugin: 'distribution'

--- a/common/src/main/java/io/pravega/common/concurrent/MultiKeySequentialProcessor.java
+++ b/common/src/main/java/io/pravega/common/concurrent/MultiKeySequentialProcessor.java
@@ -63,6 +63,7 @@ public class MultiKeySequentialProcessor<KeyType> implements AutoCloseable {
 
     /**
      * Gets the number of concurrent tasks currently executing.
+     * @return current task count
      */
     @VisibleForTesting
     public int getCurrentTaskCount() {

--- a/common/src/main/java/io/pravega/common/io/serialization/RandomAccessOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RandomAccessOutputStream.java
@@ -55,6 +55,7 @@ public interface RandomAccessOutputStream {
 
     /**
      * Gets a value indicating the size of this OutputStream.
+     * @return size of this OutputStream
      */
     int size();
 }

--- a/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
@@ -52,8 +52,8 @@ import java.util.Map;
  * * Are incremental on top of the previous ones, can be added on the fly, and can be used to make format changes
  * without breaking backward or forward compatibility.
  * * Older code will read as many revisions as it knows about, so even if newer code encodes B revisions, older code that
- * only knows about A < B revisions will only read the first A revisions, ignoring the rest. Similarly, newer code that
- * knows about B revisions will be able to handle A < B revisions by reading as much as is available.
+ * only knows about A &lt; B revisions will only read the first A revisions, ignoring the rest. Similarly, newer code that
+ * knows about B revisions will be able to handle A &lt; B revisions by reading as much as is available.
  * ** It is the responsibility of the calling code to fill-in-the-blanks for newly added fields in revisions &gt; A.
  * * Once published, the format for a Version-Revision should never change, otherwise existing (older) code will not be
  * able to process that serialization.
@@ -416,7 +416,7 @@ public abstract class VersionedSerializer<T> {
      * deserialization and we only need to update its state.
      *
      * Example:
-     * * <pre>
+     * <pre>
      * {@code
      * class Segment { ... }
      *
@@ -424,10 +424,10 @@ public abstract class VersionedSerializer<T> {
      *    // This is the version we'll be serializing now. We have already introduced read support for Version 1, but
      *    // we cannot write into Version 1 until we know that all deployed code knows how to read it. In order to guarantee
      *    // a successful upgrade when changing Versions, all existing code needs to know how to read the new version.
-     *    @Override
+     *    {@Override}
      *    protected byte getWriteVersion() { return 0; }
      *
-     *    @Override
+     *    {@Override}
      *    protected void declareVersions() {
      *      // We define all supported versions and their revisions here.
      *      version(0).revision(0, this::write00, this::read00)
@@ -475,7 +475,7 @@ public abstract class VersionedSerializer<T> {
      *
      * Example:
      * <pre>
-     *
+     * {@code
      * class Attribute {
      *    private final Long value;
      *    private final Long lastUsed;
@@ -500,7 +500,7 @@ public abstract class VersionedSerializer<T> {
      *
      *    private void read00(RevisionDataInput input, Attribute.AttributeBuilder target) throws IOException { ... }
      * }
-     *
+     * }
      * </pre>
      *
      * @param <TargetType> Type of the object to serialize from.
@@ -611,7 +611,7 @@ public abstract class VersionedSerializer<T> {
      * }
      *
      * class BaseTypeSerializer extends VersionedSerializer.MultiType<BaseType> {
-     *    @Override
+     *    {@Override}
      *    protected void declareSerializers(Builder b) {
      *        // Declare sub-serializers here. IDs must be unique, non-changeable (during refactoring) and not necessarily
      *        // sequential or contiguous.

--- a/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
+++ b/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
@@ -48,6 +48,7 @@ public class ProcessStarter {
      * Creates a new instance of the ProcessStarter class.
      *
      * @param target The Class to start. This class must have a static main() method defined in it.
+     * @return ProcessStarter
      */
     public static ProcessStarter forClass(Class<?> target) {
         return new ProcessStarter(target);

--- a/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
+++ b/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
@@ -30,7 +30,7 @@ import java.util.Comparator;
  *
  * For example:
  * - Consider any two Longs L1 and L2.
- * - Let S1 be the result of {@link BitConverter#writeUnsignedLong) when applied to L1, and S2 the result when applied to L2.
+ * - Let S1 be the result of {@link BitConverter#writeUnsignedLong} when applied to L1, and S2 the result when applied to L2.
  * - Then {@link Long#compare} applied to (L1, L2) is equal to {@link ByteArrayComparator#compare} applied to (S1, S2).
  * - This equality would not hold should L1 and L2 be serialized using {@link BitConverter#writeLong} or if we used plain
  * (signed) byte comparison internall.


### PR DESCRIPTION
**Change log description**  
Fix annoying build warnings/errors during the javadoc compilation for "common"

**Purpose of the change**  
fixed 18 errors and 4 warnings
fixes #3341

**What the code does**  
java 8 has more strict xlint rule, follow the rule add necessary information in java comments

**How to verify it**  
cd pravega
./gradlew common:build

** Note ** 
the changes depend on build.gradle changes in PR#3359; it's not merged at the moment so the file build.gradle is also attached. 