### PR TITLE
Issue 3363: Install musl compatibility library for glibc programs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -996,6 +996,7 @@ class DockerBuildTask extends Exec {
     DockerBuildTask() {
         executable project.dockerExecutable
         args "build"
+        args "--pull"
         args "-t", "${->baseTag}:${project.version}"
         args "-t", "${->baseTag}:latest"
         args "${->dockerDir}"

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -12,7 +12,7 @@ FROM openjdk:8-jre-alpine
 RUN apk add --update \
     rpcbind \
     nfs-utils \
-    libc6-compat \
+    gcompat \
     python \
     jq \
     curl \


### PR DESCRIPTION
**Change log description**  
Alpine images have recently switched from glibc to musl, making non-musl compatible libraries like RocksDB to suddenly fail. This PR installs the `gcompat` Alpine package to provide support for non-musl compatible libraries. Also, it removes the `libc6-compat` package as it is not needed anymore. `libc6-compat` provided support for musl libraries to run in a glibc environment.

This PR also makes sure that the base image is always up to date before building Pravega and BookKeeper images.

**Purpose of the change**  
Fix #3363 

**What the code does**  
Updates Pravega Dockerfile to install the new package and build.gradle to make sure base images are always up to date.

**How to verify it**  
Tests should pass.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>