### PR TITLE
Issue 3372: Fix for TLS-related exceptions and test failure 

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -120,16 +120,16 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
         final SslContext sslCtx;
         if (clientConfig.isEnableTls()) {
             try {
-                SslContextBuilder sslCtxFactory = SslContextBuilder.forClient();
+                SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient();
                 if (Strings.isNullOrEmpty(clientConfig.getTrustStore())) {
-                    sslCtxFactory = sslCtxFactory.trustManager(FingerprintTrustManagerFactory
+                    clientSslCtxBuilder = clientSslCtxBuilder.trustManager(FingerprintTrustManagerFactory
                                                       .getInstance(FingerprintTrustManagerFactory.getDefaultAlgorithm()));
-                    log.warn("Done setting the sslCtxFactory to FingerprintTrustManagerFactory");
+                    log.debug("SslContextBuilder was set to an instance of {}", FingerprintTrustManagerFactory.class);
                 } else {
-                    sslCtxFactory = SslContextBuilder.forClient()
+                    clientSslCtxBuilder = SslContextBuilder.forClient()
                                               .trustManager(new File(clientConfig.getTrustStore()));
                 }
-                sslCtx = sslCtxFactory.build();
+                sslCtx = clientSslCtxBuilder.build();
             } catch (SSLException | NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -124,6 +124,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                 if (Strings.isNullOrEmpty(clientConfig.getTrustStore())) {
                     sslCtxFactory = sslCtxFactory.trustManager(FingerprintTrustManagerFactory
                                                       .getInstance(FingerprintTrustManagerFactory.getDefaultAlgorithm()));
+                    log.warn("Done setting the sslCtxFactory to FingerprintTrustManagerFactory");
                 } else {
                     sslCtxFactory = SslContextBuilder.forClient()
                                               .trustManager(new File(clientConfig.getTrustStore()));

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -157,7 +157,7 @@ public class AutoScaleProcessor implements AutoCloseable {
     }
 
     private static EventStreamClientFactory createFactory(AutoScalerConfig configuration) {
-        if (configuration.isAuthEnabled()) {
+        if (configuration.isTlsEnabled()) {
             return EventStreamClientFactory.withScope(NameUtils.INTERNAL_SCOPE_NAME,
                     ClientConfig.builder().controllerURI(configuration.getControllerUri())
                                 .trustStore(configuration.getTlsCertFile())

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -296,7 +296,8 @@ public class InProcPravegaCluster implements AutoCloseable {
                                          .with(AutoScalerConfig.TOKEN_SIGNING_KEY, "secret")
                                          .with(AutoScalerConfig.AUTH_ENABLED, this.enableAuth)
                                          .with(AutoScalerConfig.TLS_ENABLED, this.enableTls)
-                                         .with(AutoScalerConfig.TLS_CERT_FILE, this.certFile))
+                                         .with(AutoScalerConfig.TLS_CERT_FILE, this.certFile)
+                                         .with(AutoScalerConfig.VALIDATE_HOSTNAME, false))
                 .include(MetricsConfig.builder()
                         .with(MetricsConfig.ENABLE_STATISTICS, enableMetrics));
 

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -104,6 +104,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
         String readerGroup = UUID.randomUUID().toString().replace("-", "");
         ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
                     .stream(Stream.of(scope, streamName))
+                    .disableAutomaticCheckpoints()
                     .build();
 
         @Cleanup
@@ -117,15 +118,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
 
         // Keeping the read timeout large so that there is ample time for reading the event even in
         // case of abnormal delays in test environments.
-        long readTimeOut = 10000;
-
-        EventRead<String> event = reader.readNextEvent(readTimeOut);
-        if (event.isCheckpoint()) {
-            log.info("Encountered a checkpoint event. Reading next event again.");
-            event = reader.readNextEvent(readTimeOut);
-        }
-
-        String readMessage = event.getEvent();
+        String readMessage = reader.readNextEvent(10000).getEvent();
         log.info("Done reading event [{}]", readMessage);
 
         assertEquals(message, readMessage);

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -28,7 +28,6 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.EventRead;
 
 import java.net.URI;
 import java.util.UUID;

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -57,7 +57,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
     // Note: Strictly speaking, this test is really an "integration test" and is a little
     // time consuming. For now, its intended to run as a unit test, but it could be moved
     // to an integration test suite if and when necessary.
-    @Test(timeout = 200000)
+    @Test(timeout = 50000)
     public void testWriteAndReadEventWhenConfigurationIsProper() throws ExecutionException,
             InterruptedException, ReinitializationRequiredException {
 
@@ -115,7 +115,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
 
         // Keeping the read timeout large so that there is ample time for reading the event even in
         // case of abnormal delays in test environments.
-        EventRead<String> event = reader.readNextEvent(150000);
+        EventRead<String> event = reader.readNextEvent(50000);
         String readMessage = event.getEvent();
         log.debug("Read event '{}", readMessage);
         assertEquals(message, readMessage);

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -9,6 +9,10 @@
  */
 package io.pravega.local;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
@@ -30,16 +34,13 @@ import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import io.pravega.common.Timer;
 import lombok.Cleanup;
-
 import lombok.extern.slf4j.Slf4j;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for TLS enabled standalone cluster.

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import io.pravega.common.Timer;
 import lombok.Cleanup;
 
 import lombok.extern.slf4j.Slf4j;
@@ -115,9 +116,17 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
 
         // Keeping the read timeout large so that there is ample time for reading the event even in
         // case of abnormal delays in test environments.
-        EventRead<String> event = reader.readNextEvent(50000);
+        long readTimeOut = 10000;
+
+        EventRead<String> event = reader.readNextEvent(readTimeOut);
+        if (event.isCheckpoint()) {
+            log.info("Encountered a checkpoint event. Reading next event again.");
+            event = reader.readNextEvent(readTimeOut);
+        }
+
         String readMessage = event.getEvent();
-        log.debug("Read event '{}", readMessage);
+        log.info("Done reading event [{}]", readMessage);
+
         assertEquals(message, readMessage);
     }
 

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -21,7 +21,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
@@ -69,7 +68,6 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
 
         ClientConfig clientConfig = ClientConfig.builder()
                 .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
                 .trustStore("../config/cert.pem")
                 .validateHostName(false)
                 .build();


### PR DESCRIPTION
**Change log description**  
Fix TLS-related bugs in code that was causing exceptions to be thrown and logged. Also resolve the root cause behind the flakiness of TlsEnabledInProcPravegaClusterTest test. 

**Purpose of the change**  
Fixes #3372. 

**What the code does**  
* Fixes a bug in AutoScaleProcessor which led to multiple SSL-related errors. 
* The TlsEnabledInProcPravegaClusterTest test now checks for whether an event is a checkpoint event, before making a test assertion about the contents of the event. 

**How to verify it**  
* Run TlsEnabledInProcPravegaClusterTest in a loop to check that the test runs successfully over several runs.
* Standalone mode works properly with TLS enabled configuration
