### PR TITLE
Issue 3379: Remove workaround of deleting pvc after scaling down Bookkeeper.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
@@ -94,20 +94,7 @@ public class BookkeeperK8sService extends AbstractService {
                                       currentControllerCount, currentSegmentStoreCount);
                             if (currentBookkeeperCount != newInstanceCount) {
                                 return deployPravegaUsingOperator(zkUri, currentControllerCount, currentSegmentStoreCount, newInstanceCount)
-                                        .thenCompose(v -> k8sClient.waitUntilPodIsRunning(NAMESPACE, "component", BOOKKEEPER_LABEL, newInstanceCount))
-                                        .thenRun(() -> {
-                                            if (currentBookkeeperCount > newInstanceCount) {
-                                                // we are scaling down bookkepeer instances.
-                                                // delete pvc is a workaround for issue pravega/pravega-operator/issues/100
-                                                int bookieIndex = currentBookkeeperCount - 1;
-                                                while (bookieIndex > newInstanceCount - 1) {
-                                                    log.debug("delete Persistent Volume claims for bookie {}", bookieIndex);
-                                                    k8sClient.deletePVC(NAMESPACE, "journal-pravega-bookie-" + bookieIndex);
-                                                    k8sClient.deletePVC(NAMESPACE, "ledger-pravega-bookie-" + bookieIndex);
-                                                    bookieIndex--;
-                                                }
-                                            }
-                                        });
+                                        .thenCompose(v -> k8sClient.waitUntilPodIsRunning(NAMESPACE, "component", BOOKKEEPER_LABEL, newInstanceCount));
                             } else {
                                 return CompletableFuture.completedFuture(null);
                             }


### PR DESCRIPTION
**Change log description**  
Remove workaround of manually deleting pvc after scaling down Bookkeeper.

**Purpose of the change**  
Fixes #3379 

**What the code does**  
Remove the workaround in BookkeeperK8sService.java of deleting pvc incase of Bookkeeper scale down.
pravega-operator `0.3.0-rc3` has the fix for automatically deleting the pvc.

**How to verify it**  
Verified that the system test BookieFailoverTest works fine.
