### PR TITLE
Issue 3372: Fix for TLS-related exceptions and test failure - r0.4 port  (#3377)

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -120,15 +120,16 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
         final SslContext sslCtx;
         if (clientConfig.isEnableTls()) {
             try {
-                SslContextBuilder sslCtxFactory = SslContextBuilder.forClient();
+                SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient();
                 if (Strings.isNullOrEmpty(clientConfig.getTrustStore())) {
-                    sslCtxFactory = sslCtxFactory.trustManager(FingerprintTrustManagerFactory
+                    clientSslCtxBuilder = clientSslCtxBuilder.trustManager(FingerprintTrustManagerFactory
                                                       .getInstance(FingerprintTrustManagerFactory.getDefaultAlgorithm()));
+                    log.debug("SslContextBuilder was set to an instance of {}", FingerprintTrustManagerFactory.class);
                 } else {
-                    sslCtxFactory = SslContextBuilder.forClient()
+                    clientSslCtxBuilder = SslContextBuilder.forClient()
                                               .trustManager(new File(clientConfig.getTrustStore()));
                 }
-                sslCtx = sslCtxFactory.build();
+                sslCtx = clientSslCtxBuilder.build();
             } catch (SSLException | NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -124,7 +124,7 @@ public class AutoScaleProcessor {
                 .runAsync(() -> {
                     if (clientFactory.get() == null) {
                         ClientFactory factory = null;
-                        if (configuration.isAuthEnabled()) {
+                        if (configuration.isTlsEnabled()) {
                             factory = ClientFactory.withScope(NameUtils.INTERNAL_SCOPE_NAME,
                                     ClientConfig.builder().controllerURI(configuration.getControllerUri())
                                                 .trustStore(configuration.getTlsCertFile())

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -296,7 +296,8 @@ public class InProcPravegaCluster implements AutoCloseable {
                                          .with(AutoScalerConfig.TOKEN_SIGNING_KEY, "secret")
                                          .with(AutoScalerConfig.AUTH_ENABLED, this.enableAuth)
                                          .with(AutoScalerConfig.TLS_ENABLED, this.enableTls)
-                                         .with(AutoScalerConfig.TLS_CERT_FILE, this.certFile))
+                                         .with(AutoScalerConfig.TLS_CERT_FILE, this.certFile)
+                                         .with(AutoScalerConfig.VALIDATE_HOSTNAME, false))
                 .include(MetricsConfig.builder()
                         .with(MetricsConfig.ENABLE_STATISTICS, enableMetrics));
 


### PR DESCRIPTION
Signed-off-by: Ravi Sharda <ravi.sharda@emc.com>
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Ports PR #3377 to branch `r0.4`
* Fixes a bug in AutoScaleProcessor which led to multiple SSL-related errors.
* The TlsEnabledInProcPravegaClusterTest test now disables automatic checkpoint events to avoid null events being read back.

**Purpose of the change**  
Fixes #3372 

**What the code does**  
See #3377 

**How to verify it**  
See #3377 
