### PR TITLE
Issue 2668: Enhancing StreamCut Validation on the client side

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -56,6 +56,7 @@ public interface SegmentOutputStream extends AutoCloseable {
      *
      * Returns a List of all the events that have been passed to write but have not yet been
      * acknowledged as written. The iteration order in the List is from oldest to newest.
+     * @return The List of all the events that have been passed to write but have not yet been acknowledged as written.
      */
     public abstract List<PendingEvent> getUnackedEventsOnSeal();
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -261,6 +261,14 @@ public interface Controller extends AutoCloseable {
     // Controller Apis that are called by writers and readers
 
     /**
+     * API to to verify the stream cut keyspace
+     *
+     * @param streamCut StreamCut
+     * @return True if the keyspace of the given stream cut is valid
+     */
+    CompletableFuture<Boolean> isStreamCutValid(final StreamCut streamCut);
+
+    /**
      * Checks to see if a segment exists and is not sealed.
      * 
      * @param segment The segment to verify.

--- a/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
@@ -30,6 +30,7 @@ public abstract class PositionInternal implements Position {
 
     /**
      * Gets the set of segments currently being read, i.e., ownedSegments set.
+     * @return The set of segments currently being read
      */
     abstract Set<Segment> getOwnedSegments();
 
@@ -42,6 +43,7 @@ public abstract class PositionInternal implements Position {
 
     /**
      * Gets the set of completely read segments.
+     * @return The set of completely read segments.
      */
     abstract Set<Segment> getCompletedSegments();
 
@@ -49,6 +51,7 @@ public abstract class PositionInternal implements Position {
      * Gets the offset for a specified the segment.
      *
      * @param segmentId input segment
+     * @return The offset for a specified the segment.
      */
     abstract Long getOffsetForOwnedSegment(Segment segmentId);
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -211,6 +211,7 @@ public class ReaderGroupState implements Revisioned {
 
     /**
      * Returns the number of segments currently being read from and that are unassigned within the reader group.
+     * @return The number of segments currently being read from and that are unassigned within the reader group.
      */
     @Synchronized
     public int getNumberOfSegments() {

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -46,11 +46,13 @@ public interface KeyVersion extends Serializable {
 
     /**
      * Gets a value representing the internal version inside the Table Segment for this Key.
+     * @return The internal version inside the Table Segment for this Key.
      */
     long getSegmentVersion();
 
     /**
      * Serializes the KeyVersion instance to a compact byte array.
+     * @return The compact byte array of serialized KeyVersion instance.
      */
     ByteBuffer toBytes();
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableEntry.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableEntry.java
@@ -18,11 +18,13 @@ package io.pravega.client.tables.impl;
 public interface TableEntry<KeyT, ValueT> {
     /**
      * The Key.
+     * @return The Key.
      */
     TableKey<KeyT> getKey();
 
     /**
      * The Value.
+     * @return The Value.
      */
     ValueT getValue();
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
@@ -17,11 +17,13 @@ package io.pravega.client.tables.impl;
 public interface TableKey<KeyT> {
     /**
      * The Key.
+     * @return The Key.
      */
     KeyT getKey();
 
     /**
      * The Version. If null, any updates for this Key will be unconditional.
+     * @return The Version.
      */
     KeyVersion getVersion();
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -374,6 +374,12 @@ public class LocalController implements Controller {
     }
 
     @Override
+    public CompletableFuture<StreamSegments> isStreamCutValid(final StreamCut streamCut) {
+        return controller.isStreamCutValid(streamCut)
+                .thenApply(this::isStreamCutValid);
+    }
+
+    @Override
     public void close() {
     }
 


### PR DESCRIPTION
**Change log description**  
enhancement implementation for stream cut validation

**Purpose of the change**  
Fixes #2668 
Also fixes javadoc build warnings

**What the code does**  

- isStreamCutValid API added for utilize the controller implementation to verify key space integrity of the steram cut and make sure there is no key space overlapping at the same time.
- verifies: for the same segment in different cuts, the position (offset) sequence should be consistent 


**How to verify it**  
CleintFactoryTest - to be done