### PR TITLE
Issue 3388: Fix AutoScaleProcessor logging

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -226,15 +226,15 @@ public class AutoScaleProcessor implements AutoCloseable {
     private void writeRequest(AutoScaleEvent event, Runnable successCallback) {
         val writer = this.writer.get();
         if (writer == null) {
-            log.warn("Writer not bootstrapped; unable to post Scale Event ''.", event);
+            log.warn(event.getRequestId(), "Writer not bootstrapped; unable to post Scale Event {}.", event);
         } else {
             writer.writeEvent(event.getKey(), event)
                     .whenComplete((r, e) -> {
                         if (e != null) {
-                            log.error(event.getTimestamp(), "Unable to post Scale Event to RequestStream '{}'.",
+                            log.error(event.getRequestId(), "Unable to post Scale Event to RequestStream '{}'.",
                                     this.configuration.getInternalRequestStream(), e);
                         } else {
-                            log.debug(event.getTimestamp(), "Scale Event posted successfully: ", event);
+                            log.debug(event.getRequestId(), "Scale Event posted successfully: {}.", event);
                             successCallback.run();
                         }
                     });


### PR DESCRIPTION
**Change log description**  
Improved logging of AutoScaleProcessor for better tracking auto-scale events.

**Purpose of the change**  
Fixes #3388.

**What the code does**  
This PR provides a couple fixes on the logging of `AutoScaleProcessor:writeRequest`:
- Use the actual `requestId` field of events in the logs (instead of the timestamp).
- Log the auto-scale events; this was missing before due to the lack of formatting anchors. 

**How to verify it**  
No changes in logic, just logging. All tests should pass as before this PR. 

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
