### PR TITLE
Issue 3393: Add javadocs stage to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ jobs:
       after_success:
            - bash <(curl -s https://codecov.io/bash) -t ccceafaf-7c60-4a02-9165-480174b535a2
 
+    - stage: javadocs
+      install: echo "Building javadocs"
+      script: ./gradlew javadocs
+
     - stage: snapshot
       if: branch = master AND NOT (type = pull_request)
       env:


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Adds a stage to the Travis configuration to build Javadocs.

**Purpose of the change**  
Fixes #3393 

**What the code does**  
There is no code change. It adds to the Travis configuration to build Javadocs and verify that the build isn't broken.

**How to verify it**  
It should be triggered on every build.
