### PR TITLE
Issue 2895: Enable TableStore iterator apis on SegmentHelper.

### DIFF
--- a/client/src/main/java/io/pravega/client/tables/impl/IteratorState.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/IteratorState.java
@@ -9,17 +9,21 @@
  */
 package io.pravega.client.tables.impl;
 
-import java.nio.ByteBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * Defines the state of a resumable iterator.
  */
-interface IteratorState {
+public interface IteratorState {
+
+    IteratorState EMPTY = new IteratorStateImpl(Unpooled.EMPTY_BUFFER);
 
     /**
      * Serializes the IteratorState instance to a compact byte array.
+     * @return byte representation..
      */
-    ByteBuffer toBytes();
+    ByteBuf toBytes();
 
     /**
      * Deserializes the IteratorState from its serialized form obtained from calling {@link #toBytes()}.
@@ -27,7 +31,11 @@ interface IteratorState {
      * @param serializedState A serialized IteratorState.
      * @return The IteratorState object.
      */
-    static IteratorState fromBytes(ByteBuffer serializedState) {
-        throw new UnsupportedOperationException("Not Implemented");
+    static IteratorState fromBytes(ByteBuf serializedState) {
+        if (serializedState == null) {
+            return EMPTY;
+        } else {
+            return new IteratorStateImpl(serializedState);
+        }
     }
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/IteratorStateImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/IteratorStateImpl.java
@@ -9,22 +9,19 @@
  */
 package io.pravega.client.tables.impl;
 
-/**
- * A Table Entry with a Version.
- *
- * @param <KeyT>   Key Type.
- * @param <ValueT> Value Type
- */
-public interface TableEntry<KeyT, ValueT> {
-    /**
-     * The Key.
-     * @return {@link TableKey}
-     */
-    TableKey<KeyT> getKey();
+import io.netty.buffer.ByteBuf;
+import lombok.Data;
 
-    /**
-     * The Value.
-     * @return Value.
-     */
-    ValueT getValue();
+/**
+ * Implementation of {@link KeyVersion}.
+ */
+@Data
+public class IteratorStateImpl implements IteratorState {
+
+    private final ByteBuf token;
+
+    @Override
+    public ByteBuf toBytes() {
+        return token;
+    }
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -20,7 +20,6 @@ public interface KeyVersion extends Serializable {
     /**
      * A special KeyVersion which indicates the Key must not exist when performing Conditional Updates.
      */
-
     KeyVersion NOT_EXISTS = new KeyVersion() {
         private static final long serialVersionUID = 1L;
 
@@ -46,11 +45,13 @@ public interface KeyVersion extends Serializable {
 
     /**
      * Gets a value representing the internal version inside the Table Segment for this Key.
+     * @return Segment version.
      */
     long getSegmentVersion();
 
     /**
      * Serializes the KeyVersion instance to a compact byte array.
+     * @return byte representation.
      */
     ByteBuffer toBytes();
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
@@ -17,11 +17,13 @@ package io.pravega.client.tables.impl;
 public interface TableKey<KeyT> {
     /**
      * The Key.
+     * @return key.
      */
     KeyT getKey();
 
     /**
      * The Version. If null, any updates for this Key will be unconditional.
+     * @return {@link KeyVersion}.
      */
     KeyVersion getVersion();
 }

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -33,7 +33,7 @@ import lombok.Data;
  * @param <KeyT>   Table Key Type.
  * @param <ValueT> Table Value Type.
  */
-interface TableSegment<KeyT, ValueT> extends AutoCloseable {
+public interface TableSegment<KeyT, ValueT> extends AutoCloseable {
 
     /**
      * Inserts or updates an existing Table Entry into this Table Segment.

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -9,16 +9,20 @@
  */
 package io.pravega.controller.server;
 
+import io.netty.buffer.ByteBuf;
 import io.pravega.auth.AuthenticationException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.tables.impl.IteratorState;
+import io.pravega.client.tables.impl.IteratorStateImpl;
 import io.pravega.client.tables.impl.KeyVersion;
 import io.pravega.client.tables.impl.KeyVersionImpl;
 import io.pravega.client.tables.impl.TableEntry;
 import io.pravega.client.tables.impl.TableEntryImpl;
 import io.pravega.client.tables.impl.TableKey;
 import io.pravega.client.tables.impl.TableKeyImpl;
+import io.pravega.client.tables.impl.TableSegment;
 import io.pravega.common.cluster.Host;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.host.HostControllerStore;
@@ -47,13 +51,23 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.pravega.common.Exceptions.unwrap;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getQualifiedStreamSegmentName;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SegmentHelperTest {
 
     private SegmentHelper helper;
+    private final byte[] key0 = "k".getBytes();
+    private final byte[] key1 = "k1".getBytes();
+    private final byte[] key2 = "k2".getBytes();
+    private final byte[] key3 = "k3".getBytes();
+    private final byte[] value = "v".getBytes();
+    private final ByteBuf token1 = wrappedBuffer(new byte[]{0x01});
+    private final ByteBuf token2 = wrappedBuffer(new byte[]{0x02});
 
     @Before
     public void setUp() throws Exception {
@@ -316,23 +330,23 @@ public class SegmentHelperTest {
     @Test
     public void testReadTable() {
         MockConnectionFactory factory = new MockConnectionFactory();
-        List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>("k".getBytes(), KeyVersion.NOT_EXISTS),
-                                                    new TableKeyImpl<>("k1".getBytes(), KeyVersion.NOT_EXISTS));
+        List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>(key0, KeyVersion.NOT_EXISTS),
+                                                    new TableKeyImpl<>(key1, KeyVersion.NOT_EXISTS));
 
-        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>("k".getBytes(), new KeyVersionImpl(10L)), "v".getBytes()),
-                                                                 new TableEntryImpl<>(new TableKeyImpl<>("k1".getBytes(), new KeyVersionImpl(10L)), "v".getBytes()));
-
-        WireCommands.TableEntries resultData = new WireCommands.TableEntries(entries.stream().map(e -> {
-            val k = new WireCommands.TableKey(wrappedBuffer(e.getKey().getKey()), e.getKey().getVersion().getSegmentVersion());
-            val v = new WireCommands.TableValue(wrappedBuffer(e.getValue()));
-            return new AbstractMap.SimpleImmutableEntry<>(k, v);
-        }).collect(Collectors.toList()));
+        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>(key0, new KeyVersionImpl(10L)), value),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>(key1, new KeyVersionImpl(10L)), value));
 
         // On receiving TableKeysRemoved.
         CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", keys, new MockHostControllerStore(),
                                                                                       factory, "", System.nanoTime());
-        factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), resultData));
-        assertEquals(entries, result.join());
+        factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), getTableEntries(entries)));
+        List<TableEntry<byte[], byte[]>> readResult = result.join();
+        assertArrayEquals(key0, readResult.get(0).getKey().getKey());
+        assertEquals(10L, readResult.get(0).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(value, readResult.get(0).getValue());
+        assertArrayEquals(key1, readResult.get(1).getKey().getKey());
+        assertEquals(10L, readResult.get(1).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(value, readResult.get(1).getValue());
 
         // On receiving TableKeyDoesNotExist.
         result = helper.readTable("", "", keys, new MockHostControllerStore(), factory, "", System.nanoTime());
@@ -350,41 +364,176 @@ public class SegmentHelperTest {
         validateNoSuchSegment(factory, futureSupplier);
     }
 
+    @Test
+    public void testReadTableKeys() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+
+        final List<TableKey<byte[]>> keys1 = Arrays.asList(new TableKeyImpl<>(key0, new KeyVersionImpl(2L)),
+                                                           new TableKeyImpl<>(key1, new KeyVersionImpl(10L)));
+
+        final List<TableKey<byte[]>> keys2 = Arrays.asList(new TableKeyImpl<>(key2, new KeyVersionImpl(2L)),
+                                                           new TableKeyImpl<>(key3, new KeyVersionImpl(10L)));
+
+        CompletableFuture<TableSegment.IteratorItem<TableKey<byte[]>>> result = helper.readTableKeys("", "", 3,
+                                                                                                     IteratorState.EMPTY,
+                                                                                                     new MockHostControllerStore(),
+                                                                                                     factory, "", System.nanoTime());
+
+        assertFalse(result.isDone());
+        factory.rp.tableKeysRead(getTableKeysRead(keys1, token1));
+        assertTrue(Futures.await(result));
+        // Validate the results.
+        List<TableKey<byte[]>> iterationResult = result.join().getItems();
+        assertArrayEquals(key0, iterationResult.get(0).getKey());
+        assertEquals(2L, iterationResult.get(0).getVersion().getSegmentVersion());
+        assertArrayEquals(key1, iterationResult.get(1).getKey());
+        assertEquals(10L, iterationResult.get(1).getVersion().getSegmentVersion());
+        assertArrayEquals(token1.array(), result.join().getState().toBytes().array());
+
+        // fetch the next value
+        result = helper.readTableKeys("", "", 3, IteratorState.fromBytes(token1), new MockHostControllerStore(), factory, "",
+                                      System.nanoTime());
+        assertFalse(result.isDone());
+        factory.rp.tableKeysRead(getTableKeysRead(keys2, token2));
+        assertTrue(Futures.await(result));
+        // Validate the results.
+        iterationResult = result.join().getItems();
+        assertArrayEquals(key2, iterationResult.get(0).getKey());
+        assertEquals(2L, iterationResult.get(0).getVersion().getSegmentVersion());
+        assertArrayEquals(key3, iterationResult.get(1).getKey());
+        assertEquals(10L, iterationResult.get(1).getVersion().getSegmentVersion());
+        assertArrayEquals(token2.array(), result.join().getState().toBytes().array());
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTableKeys("", "", 1,
+                                                                                   new IteratorStateImpl(wrappedBuffer(new byte[0])),
+                                                                                   new MockHostControllerStore(),
+                                                                                   factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+        validateNoSuchSegment(factory, futureSupplier);
+    }
+
+    @Test
+    public void testReadTableEntries() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        List<TableEntry<byte[], byte[]>> entries1 = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>(key0,
+                                                                                                          new KeyVersionImpl(10L)), value),
+                                                                  new TableEntryImpl<>(new TableKeyImpl<>(key1, new KeyVersionImpl(10L)),
+                                                                                       value));
+
+        List<TableEntry<byte[], byte[]>> entries2 = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>(key2,
+                                                                                                          new KeyVersionImpl(10L)), value),
+                                                                  new TableEntryImpl<>(new TableKeyImpl<>(key3,
+                                                                                                          new KeyVersionImpl(10L)), value));
+
+        CompletableFuture<TableSegment.IteratorItem<TableEntry<byte[], byte[]>>> result = helper.readTableEntries("", "", 3,
+                                                                                                                  null,
+                                                                                                                  new MockHostControllerStore(),
+                                                                                                                  factory, "", System.nanoTime());
+        assertFalse(result.isDone());
+        factory.rp.tableEntriesRead(getTableEntriesRead(entries1, token1));
+        assertTrue(Futures.await(result));
+        List<TableEntry<byte[], byte[]>> iterationResult = result.join().getItems();
+        assertArrayEquals(key0, iterationResult.get(0).getKey().getKey());
+        assertEquals(10L, iterationResult.get(0).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(value, iterationResult.get(0).getValue());
+        assertArrayEquals(key1, iterationResult.get(1).getKey().getKey());
+        assertEquals(10L, iterationResult.get(1).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(token1.array(), result.join().getState().toBytes().array());
+
+        result = helper.readTableEntries("", "", 3, IteratorState.fromBytes(token1), new MockHostControllerStore(), factory, "",
+                                         System.nanoTime());
+        assertFalse(result.isDone());
+        factory.rp.tableEntriesRead(getTableEntriesRead(entries2, token2));
+        assertTrue(Futures.await(result));
+        iterationResult = result.join().getItems();
+        assertArrayEquals(key2, iterationResult.get(0).getKey().getKey());
+        assertEquals(10L, iterationResult.get(0).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(value, iterationResult.get(0).getValue());
+        assertArrayEquals(key3, iterationResult.get(1).getKey().getKey());
+        assertEquals(10L, iterationResult.get(1).getKey().getVersion().getSegmentVersion());
+        assertArrayEquals(token2.array(), result.join().getState().toBytes().array());
+
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTableEntries("", "", 1,
+                                                                                      new IteratorStateImpl(wrappedBuffer(new byte[0])),
+                                                                                      new MockHostControllerStore(),
+                                                                                      factory, "", System.nanoTime());
+        validateAuthTokenCheckFailed(factory, futureSupplier);
+        validateWrongHost(factory, futureSupplier);
+        validateConnectionDropped(factory, futureSupplier);
+        validateProcessingFailure(factory, futureSupplier);
+        validateNoSuchSegment(factory, futureSupplier);
+    }
+
+    private WireCommands.TableEntries getTableEntries(List<TableEntry<byte[], byte[]>> entries) {
+        return new WireCommands.TableEntries(entries.stream().map(e -> {
+            val k = new WireCommands.TableKey(wrappedBuffer(e.getKey().getKey()), e.getKey().getVersion().getSegmentVersion());
+            val v = new WireCommands.TableValue(wrappedBuffer(e.getValue()));
+            return new AbstractMap.SimpleImmutableEntry<>(k, v);
+        }).collect(Collectors.toList()));
+    }
+
+    private WireCommands.TableKeysRead getTableKeysRead(List<TableKey<byte[]>> keys, ByteBuf continuationToken) {
+        return new WireCommands.TableKeysRead(0L, getQualifiedStreamSegmentName("", "", 0L),
+                                              keys.stream().map(e -> new WireCommands.TableKey(wrappedBuffer(e.getKey()), e.getVersion().getSegmentVersion()))
+                                                  .collect(Collectors.toList()),
+                                              continuationToken);
+    }
+
+    private WireCommands.TableEntriesRead getTableEntriesRead(List<TableEntry<byte[], byte[]>> entries, ByteBuf continuationToken) {
+        return new WireCommands.TableEntriesRead(0L, getQualifiedStreamSegmentName("", "", 0L),
+                                                 getTableEntries(entries), continuationToken);
+    }
+
     private void validateAuthTokenCheckFailed(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
         CompletableFuture<?> future = futureSupplier.get();
         factory.rp.authTokenCheckFailed(new WireCommands.AuthTokenCheckFailed(0, "SomeException"));
         AssertExtensions.assertThrows("", future::join,
-                                      ex -> ex instanceof WireCommandFailedException && ex.getCause() instanceof AuthenticationException);
+                                      t -> {
+                                          Throwable ex = unwrap(t);
+                                          return ex instanceof WireCommandFailedException && ex.getCause() instanceof AuthenticationException;
+                                      });
     }
 
     private void validateNoSuchSegment(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
         CompletableFuture<?> future = futureSupplier.get();
         factory.rp.noSuchSegment(new WireCommands.NoSuchSegment(0, "segment", "SomeException"));
         AssertExtensions.assertThrows("", future::join,
-                                      ex -> ex instanceof WireCommandFailedException &&
-                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.SegmentDoesNotExist));
+                                      t -> {
+                                          Throwable ex = unwrap(t);
+                                          return ex instanceof WireCommandFailedException &&
+                                                  (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.SegmentDoesNotExist);
+                                      });
     }
 
     private void validateWrongHost(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
         CompletableFuture<?> future = futureSupplier.get();
         factory.rp.wrongHost(new WireCommands.WrongHost(0, "segment", "correctHost", "SomeException"));
         AssertExtensions.assertThrows("", future::join,
-                                      ex -> ex instanceof WireCommandFailedException &&
-                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.UnknownHost));
+                                      t -> {
+                                          Throwable ex = unwrap(t);
+                                          return ex instanceof WireCommandFailedException &&
+                                                  (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.UnknownHost);
+                                      });
     }
 
     private void validateConnectionDropped(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
         CompletableFuture<?> future = futureSupplier.get();
         factory.rp.connectionDropped();
         AssertExtensions.assertThrows("", future::join,
-                                      ex -> ex instanceof WireCommandFailedException &&
-                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.ConnectionDropped));
+                                      t -> {
+                                          Throwable ex = unwrap(t);
+                                          return ex instanceof WireCommandFailedException &&
+                                                  (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.ConnectionDropped);
+                                      });
     }
 
     private void validateProcessingFailure(MockConnectionFactory factory, Supplier<CompletableFuture<?>> futureSupplier) {
         CompletableFuture<?> future = futureSupplier.get();
         factory.rp.processingFailure(new RuntimeException());
-        AssertExtensions.assertThrows("", future::join, ex -> ex instanceof RuntimeException);
+        AssertExtensions.assertThrows("", future::join, ex -> unwrap(ex) instanceof RuntimeException);
     }
 
     private static class MockHostControllerStore implements HostControllerStore {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -652,7 +652,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         log.info(readTable.getRequestId(), "Reading from table {}.", readTable);
 
         final List<ArrayView> keys = readTable.getKeys().stream()
-                                              .map(k -> new ByteArraySegment(k.getData().array()))
+                                              .map(k -> getArrayView(k.getData()))
                                               .collect(Collectors.toList());
         tableStore.get(segment, keys, TIMEOUT)
                   .thenAccept(values -> connection.send(new WireCommands.TableRead(readTable.getRequestId(), segment,
@@ -804,7 +804,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         return headerLength + segmentLength + dataLength + continuationTokenLength;
     }
 
-    private ArrayView getArrayView(ByteBuf buf ) {
+    private ArrayView getArrayView(ByteBuf buf) {
         final int length = buf.readableBytes();
         if (buf.hasArray()) {
             return new ByteArraySegment(buf.array(), buf.readerIndex(), length);


### PR DESCRIPTION
**Change log description**  
Enable TableStore iterator apis on the SegmentHelper.

**Purpose of the change**  
Fixes#2895

**What the code does**  
- This PR adds helper methods to enable the controller to access the table store iterator apis.
- It also ensures that the usage of `io.netty.buffer.ByteBuf#array` is used only if the backing array is present. If the backing array is not present (off heap buffer) then the netty api can throw an `UnsupportedOperationException`. Also, the first byte `io.netty.buffer.ByteBuf#array` need not correspond to the first byte of the buffer since the `ByteBuf` can be a slice of other buffer or a pooled Buffer.


**How to verify it**  
All the newly added tests and existing tests should continue to pass.
