### PR TITLE
Issue 3391: Log the build JVM version during pravega build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
@@ -10,6 +12,9 @@
  */
 // Apply the java plugin to add support for Java
 buildscript {
+
+    // log the current JVM version.
+    println "Build JVM Version is : " + Jvm.current()
     repositories {
         jcenter()
         maven {
@@ -72,8 +77,8 @@ allprojects {
 
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
-            sourceCompatibility = "8"
-            targetCompatibility = "8"
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
     }


### PR DESCRIPTION
**Change log description**  
Ensure that during a build the jvm version is logged and use the constants for specify the sourcecompatability and targetcompatability.

**Purpose of the change**  
Fixes #3391 

**What the code does**  
Pravega docker containers can fail with `Caused by: java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;` if we build pravega on JDK 9+ (with source and target as 1.8) and run on jre8. The docker containers for Pravega are configured to used openjre:8 and hence will face `java.lang.NoSuchMethodError`.

We are observing this error sporadically on our jenkins build system and this change would help to confirm the JVM version used during the build.

```
gradle build output:
> Configure project :
Build JVM Version is : 1.8.0_201 (Oracle Corporation 25.201-b09)

```

**How to verify it**  
No Changes to functionality, all the tests should continue to pass.
