### PR TITLE
Issue 3398: Fix a bug that makes auth configuration item required for TLS-enabled standalone mode

### DIFF
--- a/config/standalone-config.properties
+++ b/config/standalone-config.properties
@@ -41,6 +41,9 @@
 # Password associated with the default user
 #singlenode.passwd=1111_aaaa
 
+# Password file for default password handler
+#singlenode.passwdFile=../config/passwd
+
 # Whether to enable TLS for segmentstore and controller.
 # Valid values: 'true' or 'false'
 # Default value: false
@@ -48,9 +51,6 @@
 
 # Location of server's key file for TLS communication.
 #singlenode.keyFile=../config/key.pem
-
-# Password file for default password handler
-#singlenode.passwdFile=../config/passwd
 
 # Location of server's certificate file for TLS communication.
 #singlenode.certFile=../config/cert.pem

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -144,8 +144,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                             && !Strings.isNullOrEmpty(this.certFile)
                             && !Strings.isNullOrEmpty(this.jksKeyFile)
                             && !Strings.isNullOrEmpty(this.jksTrustFile)
-                            && !Strings.isNullOrEmpty(this.keyPasswordFile)
-                            && !Strings.isNullOrEmpty(this.passwdFile)),
+                            && !Strings.isNullOrEmpty(this.keyPasswordFile)),
                     "TLS enabled, but not all parameters set");
 
             if (this.isInMemStorage) {


### PR DESCRIPTION
**Change log description**  
Fix a bug that makes auth-related configuration item ``singlenode.passwdFile`` mandatory for TLS. 

**Purpose of the change**  
Fixes #3398 

**What the code does**  
* Modifies the pre-conditions related to TLS parameters in `InProcPravegaCluster` class
* Changes the order of properties in `standalone-config.properties` file, to bring the auth-related config near auth-related config items

**How to verify it**  
1. Configure standalone server to communicate using SSL/TLS. To do so, edit the TLS-related properties in ``standalone-config.properties`` as shown below:
   
   ```
   singlenode.enableTls=true
   singlenode.keyFile=../config/key.pem
   singlenode.certFile=../config/cert.pem
   singlenode.keyStoreJKS=../config/standalone.keystore.jks
   singlenode.keyStoreJKSPasswordFile=../config/standalone.keystore.jks.passwd
   singlenode.trustStoreJKS=../config/standalone.truststore.jks
   ```
2. Ensure that the server's certificate is trusted. If you run ``/gradlew startStandalone`` without it, you'll encounter the following error:

```
Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
        at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:397)
        at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:302)
        at sun.security.validator.Validator.validate(Validator.java:260)
        at sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManager
```
 To ensure the server's certificate is trusted, import it into the JVM's truststore. I used the following commands to do so (in Linux) with the provided certificate file "cert.pem":
   * `cd /path/to/pravega/config`
   * Convert the 'cert.pem' file to DER format: `openssl x509 -in cert.pem -inform pem -out cert.der -outform der`
   * Import the certificate into the local JVM's trust store:
   `sudo keytool -importcert -alias local-CA -keystore /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts  -file cert.der` (using the default password 'changeit')
3. Run Pravega standalone mode using command ``./gradlew startStandalone``. 
4. Verify that controller REST API is returning response over SSL/TLS:  
    ```
     curl -v -k https://104.215.152.115:9091/v1/scopes
    ```
    ``-v`` is to avoid hostname verification, since we are using the provided certificate 
    which isn't assigned to your hostname. You can find details about curl's options [here](https://curl.haxx.se/docs/manpage.html).
5. Run reader/writer apps against the standalone server to verify it is responding appropriately to read/write requests. To do so, in the ClientConfig, set the following:

   ```
   ClientConfig clientConfig = ClientConfig.builder()
                .controllerURI(...)
                .trustStore("/path/to/cert.pem")
                .validateHostName(false)
                .build();
   ```
   Everything else should be the same as other reader/writer apps. 
   