### PR TITLE
Issue-217: Clean the unnecessary ConnectionFactory creation

### DIFF
--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -14,7 +14,7 @@ import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.impl.BatchClientFactoryImpl;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.Serializer;
@@ -22,7 +22,6 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import lombok.val;
 
 /**
  * Please note this is an experimental API.
@@ -43,10 +42,10 @@ public interface BatchClientFactory extends AutoCloseable {
      *
      * @param scope The scope of the stream.
      * @param config Configuration for the client.
+     * @param connectionFactory Connection for the client.
      * @return Instance of BatchClientFactory implementation.
      */
-    static BatchClientFactory withScope(String scope, ClientConfig config) {
-        val connectionFactory = new ConnectionFactoryImpl(config);
+    static BatchClientFactory withScope(String scope, ClientConfig config, ConnectionFactory connectionFactory) {
         ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
                            connectionFactory.getInternalExecutor());
         return new BatchClientFactoryImpl(controller, connectionFactory);

--- a/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
@@ -36,7 +36,6 @@ public interface ByteStreamClientFactory extends AutoCloseable {
      * @return Instance of ByteStreamClientFactory implementation.
      */
     static ByteStreamClientFactory withScope(String scope, ClientConfig config, ConnectionFactory connectionFactory) {
-        /* val connectionFactory = new ConnectionFactoryImpl(config); */
         ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
                            connectionFactory.getInternalExecutor());
         return new ByteStreamClientImpl(scope, controller, connectionFactory);

--- a/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
@@ -13,10 +13,9 @@ import com.google.common.annotations.Beta;
 import io.pravega.client.byteStream.ByteStreamReader;
 import io.pravega.client.byteStream.ByteStreamWriter;
 import io.pravega.client.byteStream.impl.ByteStreamClientImpl;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import lombok.val;
 
 /**
  * Used to create Writers and Readers operating on a Byte Stream.
@@ -33,10 +32,11 @@ public interface ByteStreamClientFactory extends AutoCloseable {
      *
      * @param scope The scope string.
      * @param config Configuration for the client.
+     * @param connectionFactory Connection for the client.
      * @return Instance of ByteStreamClientFactory implementation.
      */
-    static ByteStreamClientFactory withScope(String scope, ClientConfig config) {
-        val connectionFactory = new ConnectionFactoryImpl(config);
+    static ByteStreamClientFactory withScope(String scope, ClientConfig config, ConnectionFactory connectionFactory) {
+        /* val connectionFactory = new ConnectionFactoryImpl(config); */
         ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
                            connectionFactory.getInternalExecutor());
         return new ByteStreamClientImpl(scope, controller, connectionFactory);
@@ -44,7 +44,7 @@ public interface ByteStreamClientFactory extends AutoCloseable {
 
     /**
      * Creates a new ByteStreamReader on the specified stream initialized to offset 0.
-     * 
+     *
      * @param streamName the stream to read from.
      * @return A new ByteStreamReader
      */

--- a/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
+++ b/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
@@ -9,7 +9,7 @@
  */
 package io.pravega.client;
 
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.Revisioned;
 import io.pravega.client.state.RevisionedStreamClient;
@@ -20,7 +20,6 @@ import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
-import lombok.val;
 
 /**
  * Used to create StateSynchronizer and RevisionedStreamClient objects which allow for 
@@ -33,10 +32,10 @@ public interface SynchronizerClientFactory extends AutoCloseable {
      *
      * @param scope The scope string.
      * @param config Configuration for the client.
+     * @param connectionFactory Connection for the client.
      * @return Instance of ClientFactory implementation.
      */
-    static SynchronizerClientFactory withScope(String scope, ClientConfig config) {
-        val connectionFactory = new ConnectionFactoryImpl(config);
+    static SynchronizerClientFactory withScope(String scope, ClientConfig config, ConnectionFactory connectionFactory) {
         return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
                 connectionFactory.getInternalExecutor()), connectionFactory);
     }

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -12,11 +12,12 @@ package io.pravega.client.admin;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
+
 import java.net.URI;
 
 /**
@@ -29,10 +30,11 @@ public interface ReaderGroupManager extends AutoCloseable {
      *
      * @param scope The Scope string.
      * @param controllerUri The Controller URI.
+     * @param connectionFactory The Connection for the client.
      * @return Instance of Stream Manager implementation.
      */
-    public static ReaderGroupManager withScope(String scope, URI controllerUri) {
-        return withScope(scope, ClientConfig.builder().controllerURI(controllerUri).build());
+    public static ReaderGroupManager withScope(String scope, URI controllerUri, ConnectionFactory connectionFactory) {
+        return withScope(scope, ClientConfig.builder().controllerURI(controllerUri).build(), connectionFactory);
     }
 
     /**
@@ -40,10 +42,11 @@ public interface ReaderGroupManager extends AutoCloseable {
      *
      * @param scope The Scope string.
      * @param clientConfig Configuration for the client.
+     * @param connectionFactory The Connection for the client.
      * @return Instance of Stream Manager implementation.
      */
-    public static ReaderGroupManager withScope(String scope, ClientConfig clientConfig) {
-        return new ReaderGroupManagerImpl(scope, clientConfig, new ConnectionFactoryImpl(clientConfig));
+    public static ReaderGroupManager withScope(String scope, ClientConfig clientConfig, ConnectionFactory connectionFactory) {
+        return new ReaderGroupManagerImpl(scope, clientConfig, connectionFactory);
     }
 
     /**

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -17,6 +17,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
@@ -104,8 +106,9 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
                     .disableAutomaticCheckpoints()
                     .build();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
         readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
 
         @Cleanup

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -105,7 +105,7 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
                     .stream(Stream.of(scope, streamName))
                     .disableAutomaticCheckpoints()
                     .build();
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
@@ -13,6 +13,8 @@ import com.google.common.base.Preconditions;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.segment.impl.NoSuchEventException;
 import io.pravega.client.stream.EventPointer;
 import io.pravega.client.stream.EventRead;
@@ -151,11 +153,12 @@ class ClientReader implements StoreReader, AutoCloseable {
         StreamReader(String streamName) {
             this.readerGroup = UUID.randomUUID().toString().replace("-", "");
             this.readerId = UUID.randomUUID().toString().replace("-", "");
-            try (ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(ClientAdapterBase.SCOPE,
-                    ClientConfig.builder().controllerURI(ClientReader.this.controllerUri)
-                            .trustStore("../../config/cert.pem")
-                            .credentials(new DefaultCredentials("1111_aaaa", "admin"))
-                            .validateHostName(false).build())) {
+            ClientConfig clientConfig = ClientConfig.builder().controllerURI(ClientReader.this.controllerUri)
+                    .trustStore("../../config/cert.pem")
+                    .credentials(new DefaultCredentials("1111_aaaa", "admin"))
+                    .validateHostName(false).build();
+            ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+            try (ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(ClientAdapterBase.SCOPE, clientConfig, connectionFactory)) {
                 readerGroupManager.createReaderGroup(this.readerGroup, ReaderGroupConfig.builder()
                                                                                         .stream(Stream.of(ClientAdapterBase.SCOPE, streamName))
                                                                                         .build());

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
@@ -149,6 +149,7 @@ class ClientReader implements StoreReader, AutoCloseable {
         private boolean closed;
         @GuardedBy("this")
         private EventStreamReader<byte[]> reader;
+        private final ConnectionFactory connectionFactory;
 
         StreamReader(String streamName) {
             this.readerGroup = UUID.randomUUID().toString().replace("-", "");
@@ -157,7 +158,7 @@ class ClientReader implements StoreReader, AutoCloseable {
                     .trustStore("../../config/cert.pem")
                     .credentials(new DefaultCredentials("1111_aaaa", "admin"))
                     .validateHostName(false).build();
-            ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+            this.connectionFactory = new ConnectionFactoryImpl(clientConfig);
             try (ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(ClientAdapterBase.SCOPE, clientConfig, connectionFactory)) {
                 readerGroupManager.createReaderGroup(this.readerGroup, ReaderGroupConfig.builder()
                                                                                         .stream(Stream.of(ClientAdapterBase.SCOPE, streamName))
@@ -179,6 +180,9 @@ class ClientReader implements StoreReader, AutoCloseable {
             }
             if (r != null) {
                 r.close();
+            }
+            if (this.connectionFactory != null) {
+                this.connectionFactory.close();
             }
         }
 

--- a/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
@@ -190,7 +190,7 @@ public final class SetupUtils {
         Preconditions.checkState(this.started.get(), "Services not yet started");
         Preconditions.checkNotNull(streamName);
 
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
         final String readerGroup = "testReaderGroup" + scope + streamName;
         readerGroupManager.createReaderGroup(
                 readerGroup,

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -165,6 +165,7 @@ public class BatchClientTest {
         createTestStreamWithEvents(clientFactory);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+	@Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
@@ -190,6 +191,7 @@ public class BatchClientTest {
         createTestStreamWithEvents(clientFactory);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+	@Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -128,6 +128,7 @@ public class BatchClientTest {
         createTestStreamWithEvents(clientFactory);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -165,7 +165,7 @@ public class BatchClientTest {
         createTestStreamWithEvents(clientFactory);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
-	@Cleanup
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
@@ -191,7 +191,7 @@ public class BatchClientTest {
         createTestStreamWithEvents(clientFactory);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
-	@Cleanup
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -19,6 +19,8 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.batch.impl.SegmentRangeImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -124,8 +126,11 @@ public class BatchClientTest {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
         createTestStreamWithEvents(clientFactory);
+
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
 
         // List out all the segments in the stream.
         ArrayList<SegmentRange> segments = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), null, null).getIterator());
@@ -157,8 +162,11 @@ public class BatchClientTest {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
         createTestStreamWithEvents(clientFactory);
+
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
 
         // 1. Create a StreamCut after 2 events(offset = 2 * 30 = 60).
         StreamCut streamCut60L = new StreamCutImpl(Stream.of(SCOPE, STREAM), ImmutableMap.of(new Segment(SCOPE, STREAM, 0), 60L));
@@ -179,8 +187,11 @@ public class BatchClientTest {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
         createTestStreamWithEvents(clientFactory);
+
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
 
         // 1. Fetch Segments.
         ArrayList<SegmentRange> segmentsPostTruncation = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -133,6 +133,7 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(3)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
 
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
@@ -188,6 +189,7 @@ public class BoundedStreamReaderTest {
         StreamCut streamCut = getStreamCut(STREAM1, 30L, 0);
 
         // 3. Create a ReaderGroup where the lower and upper bound are the same.
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
@@ -232,6 +234,7 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(5)).get();
 
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
@@ -289,6 +292,7 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(3)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
 
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -131,8 +133,9 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(3)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
         groupManager.createReaderGroup("group", ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints()
                 .stream(Stream.of(SCOPE, STREAM1),
@@ -185,8 +188,9 @@ public class BoundedStreamReaderTest {
         StreamCut streamCut = getStreamCut(STREAM1, 30L, 0);
 
         // 3. Create a ReaderGroup where the lower and upper bound are the same.
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
         groupManager.createReaderGroup("group", ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints()
                 .stream(Stream.of(SCOPE, STREAM1), streamCut, streamCut)
@@ -228,8 +232,9 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(5)).get();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
 
         ReaderGroupConfig readerGroupCfg1 = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
                 .stream(Stream.of(SCOPE, STREAM1),
@@ -284,8 +289,9 @@ public class BoundedStreamReaderTest {
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(3)).get();
         writer1.writeEvent(keyGenerator.get(), getEventData.apply(4)).get();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
         StreamCut offset30SC = getStreamCut(STREAM3, 30L, 0); // Streamcut pointing to event 2.
         StreamCut offset60SC = getStreamCut(STREAM3, 60L, 0);
         groupManager.createReaderGroup("group", ReaderGroupConfig

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -154,6 +154,7 @@ public class ControllerMetricsTest {
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder()
                                                                                                        .controllerURI(controllerURI)
                                                                                                        .build());
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -15,6 +15,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
@@ -152,8 +154,9 @@ public class ControllerMetricsTest {
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder()
                                                                                                        .controllerURI(controllerURI)
                                                                                                        .build());
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
 
         for (int i = 0; i < iterations; i++) {
             final String iterationStreamName = streamName + i;

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -272,9 +272,12 @@ public class ControllerRestApiTest {
         final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
         final String reader1 = RandomStringUtils.randomAlphanumeric(10);
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
+
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         try (ClientFactoryImpl clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor));
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope,
-                     ClientConfig.builder().controllerURI(controllerUri).build())) {
+                     clientConfig, connectionFactory)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder()
                                                                                     .stream(Stream.of(testScope, testStream1))
                                                                                     .stream(Stream.of(testScope, testStream2))

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -274,8 +274,8 @@ public class ControllerRestApiTest {
         final String reader2 = RandomStringUtils.randomAlphanumeric(10);
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
-        try (ClientFactoryImpl clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor));
+        try (ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+             ClientFactoryImpl clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor));
              ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope,
                      clientConfig, connectionFactory)) {
             readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder()

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -14,6 +14,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -133,10 +135,10 @@ public class MultiReadersEndToEndTest {
 
         final String readerGroupName = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10).toLowerCase();
 
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(SETUP_UTILS.getControllerUri()).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SETUP_UTILS.getScope(),
-                                    ClientConfig.builder()
-                                                .controllerURI(SETUP_UTILS.getControllerUri()).build());
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SETUP_UTILS.getScope(), clientConfig, connectionFactory);
         ReaderGroupConfig.ReaderGroupConfigBuilder builder = ReaderGroupConfig.builder();
         streamNames.forEach(s -> builder.stream(Stream.of(SETUP_UTILS.getScope(), s)));
         readerGroupManager.createReaderGroup(readerGroupName, builder.build());

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -136,6 +136,7 @@ public class MultiReadersEndToEndTest {
         final String readerGroupName = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10).toLowerCase();
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(SETUP_UTILS.getControllerUri()).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SETUP_UTILS.getScope(), clientConfig, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
@@ -121,6 +121,7 @@ public class ReaderGroupStreamCutUpdateTest {
                                                                .stream(Stream.of(scope, stream))
                                                                .automaticCheckpointIntervalMillis(checkpointingIntervalMs)
                                                                .build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -119,9 +121,9 @@ public class ReaderGroupStreamCutUpdateTest {
                                                                .stream(Stream.of(scope, stream))
                                                                .automaticCheckpointIntervalMillis(checkpointingIntervalMs)
                                                                .build();
-
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
         readerGroupManager.createReaderGroup(readerGroupName, readerGroupConfig);
         ReaderGroup readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
         @Cleanup

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -105,6 +105,7 @@ public class StreamRecreationTest {
         @Cleanup
         StreamManager streamManager = StreamManager.create(controllerURI);
         streamManager.createScope(myScope);
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(myScope, controllerURI, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -103,8 +105,9 @@ public class StreamRecreationTest {
         @Cleanup
         StreamManager streamManager = StreamManager.create(controllerURI);
         streamManager.createScope(myScope);
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(myScope, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(myScope, controllerURI, connectionFactory);
         final ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
                                                                      .stream(Stream.of(myScope, myStream))
                                                                      .build();

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
@@ -123,7 +123,7 @@ public class StreamSeekTest {
         @Cleanup
         EventStreamWriter<String> writer1 = clientFactory.createEventWriter(STREAM1, serializer,
                 EventWriterConfig.builder().build());
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
@@ -12,6 +12,8 @@ package io.pravega.test.integration;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -122,8 +124,9 @@ public class StreamSeekTest {
         EventStreamWriter<String> writer1 = clientFactory.createEventWriter(STREAM1, serializer,
                 EventWriterConfig.builder().build());
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
         groupManager.createReaderGroup("group", ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, STREAM1)).stream(Stream.of(SCOPE, STREAM2)).build());
         @Cleanup

--- a/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
@@ -116,6 +116,7 @@ public class UnreadBytesTest {
                 EventWriterConfig.builder().build());
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes", clientConfig, connectionFactory);
@@ -178,6 +179,7 @@ public class UnreadBytesTest {
         writer.writeEvent("0", "data of size 30").get();
 
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes", clientConfig, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
@@ -113,8 +115,10 @@ public class UnreadBytesTest {
         EventStreamWriter<String> writer = clientFactory.createEventWriter("unreadbytes", new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
 
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes",  ClientConfig.builder().controllerURI(controllerUri).build());
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes", clientConfig, connectionFactory);
         groupManager.createReaderGroup("group", ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream("unreadbytes/unreadbytes").build());
         @Cleanup
         ReaderGroup readerGroup = groupManager.getReaderGroup("group");
@@ -173,8 +177,10 @@ public class UnreadBytesTest {
         writer.writeEvent("0", "data of size 30").get();
         writer.writeEvent("0", "data of size 30").get();
 
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes",  ClientConfig.builder().controllerURI(controllerUri).build());
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope("unreadbytes", clientConfig, connectionFactory);
         //create a bounded reader group.
         groupManager.createReaderGroup("group", ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints().stream("unreadbytes/unreadbytes", StreamCut.UNBOUNDED,

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.checkerframework.checker.units.qual.C;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -186,8 +186,9 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(3)).join();
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(4)).join();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(group, ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(1000)
                 .stream(stream)
@@ -240,8 +241,9 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(3)).join();
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(4)).join();
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(group, ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(1000)
                 .stream(stream)
@@ -323,8 +325,9 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         //6. Write events to Segment 1.
         writer.writeEvent(keyGenerator.apply("0.9"), getEventData.apply(1));
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(group, ReaderGroupConfig
                 .builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(1000)
                 .stream(stream)

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.units.qual.C;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -186,6 +187,7 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(3)).join();
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(4)).join();
 
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
@@ -240,7 +242,7 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(2)).join();
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(3)).join();
         writer.writeEvent(randomKeyGenerator.get(), getEventData.apply(4)).join();
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
@@ -324,7 +326,7 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent(keyGenerator.apply("0.3"), getEventData.apply(3));
         //6. Write events to Segment 1.
         writer.writeEvent(keyGenerator.apply("0.9"), getEventData.apply(1));
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -391,8 +391,9 @@ public class EndToEndTruncationTest {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
                 ClientConfig.builder().controllerURI(controllerURI).build());
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
         groupManager.createReaderGroup(readerGroupName, ReaderGroupConfig.builder().disableAutomaticCheckpoints()
                                                                          .stream(scope + "/" + streamName)
                                                                          .build());
@@ -440,8 +441,9 @@ public class EndToEndTruncationTest {
         StreamConfiguration streamConf = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(parallelism)).build();
         @Cleanup
         StreamManager streamManager = StreamManager.create(controllerURI);
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder().controllerURI(controllerURI).build());
         streamManager.createScope(scope);
@@ -583,8 +585,9 @@ public class EndToEndTruncationTest {
         writeEvents(clientFactory, streamName, totalEvents);
 
         // Instantiate readers to consume from Stream.
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
         groupManager.createReaderGroup(readerGroup, ReaderGroupConfig.builder().stream(Stream.of(scope, streamName)).build());
         final List<CompletableFuture<Integer>> futures = readEvents(clientFactory, readerGroup, parallelism);
 

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -391,6 +391,7 @@ public class EndToEndTruncationTest {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
                 ClientConfig.builder().controllerURI(controllerURI).build());
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
@@ -441,6 +442,7 @@ public class EndToEndTruncationTest {
         StreamConfiguration streamConf = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(parallelism)).build();
         @Cleanup
         StreamManager streamManager = StreamManager.create(controllerURI);
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);
@@ -585,6 +587,7 @@ public class EndToEndTruncationTest {
         writeEvents(clientFactory, streamName, totalEvents);
 
         // Instantiate readers to consume from Stream.
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, controllerURI, connectionFactory);

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -120,10 +120,10 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
         @Cleanup
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, controller);
         @Cleanup
-        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig);
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig, connectionFactory);
         log.info("Invoking batchClientSimpleTest test with Controller URI: {}", controllerURI);
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints()
                                                                       .stream(SCOPE + "/" + STREAM).build());
         ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -14,6 +14,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -127,7 +129,9 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
         createScopeAndStream(SCOPE, STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", SCOPE);
         clientFactory = new ClientFactoryImpl(SCOPE, controller);
-        readerGroupManager = ReaderGroupManager.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(SCOPE, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -33,6 +33,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
@@ -130,6 +132,7 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
         log.info("Scope passed to client factory {}", SCOPE);
         clientFactory = new ClientFactoryImpl(SCOPE, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(SCOPE, clientConfig, connectionFactory);
     }

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
@@ -270,9 +272,10 @@ public class ControllerRestApiTest extends AbstractSystemTest {
         Controller controller = new ControllerImpl(ControllerImplConfig.builder()
                                      .clientConfig(ClientConfig.builder().controllerURI(controllerUri).build())
                                      .build(), executor);
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
         try (ClientFactoryImpl clientFactory = new ClientFactoryImpl(testScope, controller);
-             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope,
-                     ClientConfig.builder().controllerURI(controllerUri).build())) {
+             ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope, clientConfig, connectionFactory)) {
             final ReaderGroupConfig config = ReaderGroupConfig.builder()
                                                        .stream(Stream.of(testScope, testStream1))
                                                        .stream(Stream.of(testScope, testStream2))

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -111,7 +113,9 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,  ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
@@ -114,6 +115,7 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -110,7 +112,9 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -60,6 +60,7 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
     private ClientFactoryImpl clientFactory;
     private ReaderGroupManager readerGroupManager;
     private StreamManager streamManager;
+    private ConnectionFactory connectionFactory;
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
@@ -113,7 +114,7 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
@@ -125,6 +126,7 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
         testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close(); //close the clientFactory/connectionFactory.
+        connectionFactory.close();
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
         //scale the controller and segmentStore back to 1 instance.

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
@@ -156,7 +158,9 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
 
         log.info("Invoking reader with controller URI: {}", controllerUri);
         final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerUri).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
         groupManager.createReaderGroup(readerGroup,
                 ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream(Stream.of(scope, stream)).build());
 

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -159,6 +159,7 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
         log.info("Invoking reader with controller URI: {}", controllerUri);
         final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
         groupManager.createReaderGroup(readerGroup,

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -116,7 +116,7 @@ public class OffsetTruncationTest extends AbstractReadWriteTest {
         log.info("Invoking offsetTruncationTest test with Controller URI: {}", controllerURI);
 
         @Cleanup
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM)).build());
         @Cleanup
         ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -134,6 +134,7 @@ public class PravegaTest extends AbstractReadWriteTest {
         }
         log.info("Invoking Reader test.");
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(STREAM_SCOPE, clientConfig, connectionFactory);
         groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().stream(Stream.of(STREAM_SCOPE, STREAM_NAME)).build());

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -24,7 +24,6 @@ import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -24,6 +24,7 @@ import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.JavaSerializer;
@@ -133,7 +134,9 @@ public class PravegaTest extends AbstractReadWriteTest {
             writer.flush();
         }
         log.info("Invoking Reader test.");
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(STREAM_SCOPE, ClientConfig.builder().controllerURI(controllerUri).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(STREAM_SCOPE, clientConfig, connectionFactory);
         groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().stream(Stream.of(STREAM_SCOPE, STREAM_NAME)).build());
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -14,6 +14,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -111,7 +113,9 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -63,6 +63,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
     private ClientFactoryImpl clientFactory;
     private ReaderGroupManager readerGroupManager;
     private StreamManager streamManager;
+    private ConnectionFactory connectionFactory;
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
@@ -114,7 +115,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
@@ -126,6 +127,7 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
         testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
+        connectionFactory.close();
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
         //scale the controller and segmentStore back to 1 instance.

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -68,6 +68,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
     private ClientFactoryImpl clientFactory;
     private ReaderGroupManager readerGroupManager;
     private StreamManager streamManager;
+    private ConnectionFactory connectionFactory;
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
@@ -119,7 +120,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
@@ -131,6 +132,7 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
+        connectionFactory.close();
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
         //scale the controller and segmentStore back to 1 instance.

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -14,6 +14,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -116,8 +118,9 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -123,6 +123,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
 
         //2.1 Create a reader group.
         log.info("Creating Reader group : {}", READER_GROUP_NAME);
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -9,8 +9,11 @@
  */
 package io.pravega.test.system;
 
+import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
@@ -120,8 +123,9 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
 
         //2.1 Create a reader group.
         log.info("Creating Reader group : {}", READER_GROUP_NAME);
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerUri).build());
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerUri, connectionFactory);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         //2.2 Create readers.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -63,6 +63,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
     private ClientFactoryImpl clientFactory;
     private ReaderGroupManager readerGroupManager;
     private StreamManager streamManager;
+    private ConnectionFactory connectionFactory;
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
@@ -115,7 +116,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
@@ -127,6 +128,7 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close();
+        connectionFactory.close();
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
         //scale the controller and segmentStore back to 1 instance.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -112,8 +114,9 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
         log.info("Scope passed to client factory {}", scope);
 
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -67,6 +67,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
     private ClientFactoryImpl clientFactory;
     private ReaderGroupManager readerGroupManager;
     private StreamManager streamManager;
+    private ConnectionFactory connectionFactory;
 
     @Environment
     public static void initialize() throws MarathonException, ExecutionException {
@@ -120,7 +121,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
         readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
@@ -132,6 +133,7 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         testState.cancelAllPendingWork();
         streamManager.close();
         clientFactory.close(); //close the clientFactory/connectionFactory.
+        connectionFactory.close();
         readerGroupManager.close();
         ExecutorServiceHelpers.shutdown(executorService, controllerExecutorService);
         //scale the controller and segmentStore back to 1 instance.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -117,8 +119,9 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
         createScopeAndStream(scope, SCALE_STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerURIDirect).build();
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig, connectionFactory);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.checkerframework.checker.units.qual.C;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.units.qual.C;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -98,6 +99,7 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     @After
     public void tearDown() {
         ExecutorServiceHelpers.shutdown(readerExecutor);
+
     }
 
     @Test
@@ -106,7 +108,7 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         StreamManager streamManager = StreamManager.create(controllerURI);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_1));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_1, STREAM, streamConfig));
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_1, controllerURI, connectionFactory);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME,
@@ -161,7 +163,7 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         StreamManager streamManager = StreamManager.create(controllerURI);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_2));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_2, STREAM, streamConfig));
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_2, controllerURI, connectionFactory);

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
@@ -105,8 +107,8 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_1));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_1, STREAM, streamConfig));
 
-        @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_1, controllerURI);
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_1, controllerURI, connectionFactory);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME,
                 ReaderGroupConfig.builder().stream(io.pravega.client.stream.Stream.of(SCOPE_1, STREAM)).build());
         @Cleanup
@@ -160,8 +162,9 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_2));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_2, STREAM, streamConfig));
 
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_2, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_2, controllerURI, connectionFactory);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME,
                                              ReaderGroupConfig.builder()
                                                               .stream(io.pravega.client.stream.Stream.of(SCOPE_2, STREAM))

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -123,7 +123,7 @@ public class RetentionTest extends AbstractSystemTest {
         Exceptions.handleInterrupted(() -> Thread.sleep(5 * 60 * 1000));
 
         //create a reader
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, STREAM)).build());
         EventStreamReader<String> reader = clientFactory.createReader(UUID.randomUUID().toString(),
                 READER_GROUP,

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -137,7 +137,7 @@ public class StreamCutsTest extends AbstractReadWriteTest {
     public void streamCutsTest() {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURI).build());
-
+        @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -13,6 +13,8 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.ReaderConfig;
@@ -135,8 +137,10 @@ public class StreamCutsTest extends AbstractReadWriteTest {
     public void streamCutsTest() {
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURI).build());
+
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(controllerURI).build());
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerURI, connectionFactory);
         readerGroupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder()
                                                                             .stream(Stream.of(SCOPE, STREAM_ONE))
                                                                             .stream(Stream.of(SCOPE, STREAM_TWO)).build());


### PR DESCRIPTION
Signed-off-by: huide9 <huide9@gmail.com>

**Change log description**  
Clean the unnecessary ConnectionFactory instance creation; modify the integration test case to apply testing for the changed code. 

**Purpose of the change**  
A step towards resolving #217: connection pooling  - reduce the connection instance creation. 

**What the code does**  
Replace `new ConnectionFactoryImpl()` with input instance which created by StreamManager and other management class, such as EventStreamClientFactory.
*new instance creation removed from: 
- BatchClientFactory,
- ByteStreamClientFactory, 
- SynchronizerClientFactory 
- ReaderGroumanager. 
- The integration test case calls.

**How to verify it**  
integration tests - gradlew test:integration:build