### PR TITLE
Issue 3412: Table Segment Metrics

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -105,7 +105,8 @@ public final class ServiceStarter {
 
         TokenVerifierImpl tokenVerifier = new TokenVerifierImpl(builderConfig.getConfig(AutoScalerConfig::builder));
         this.listener = new PravegaConnectionListener(this.serviceConfig.isEnableTls(), this.serviceConfig.getListeningIPAddress(),
-                                                      this.serviceConfig.getListeningPort(), service, tableStoreService, autoScaleMonitor.getRecorder(),
+                                                      this.serviceConfig.getListeningPort(), service, tableStoreService,
+                                                      autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(),
                                                       tokenVerifier, this.serviceConfig.getCertFile(), this.serviceConfig.getKeyFile(),
                                                       this.serviceConfig.isReplyWithStackTraceOnError());
         this.listener.startListening();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -36,6 +36,7 @@ import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.shared.protocol.netty.AppendDecoder;
 import io.pravega.shared.protocol.netty.CommandDecoder;
 import io.pravega.shared.protocol.netty.CommandEncoder;
@@ -63,6 +64,7 @@ public final class PravegaConnectionListener implements AutoCloseable {
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private final SegmentStatsRecorder statsRecorder;
+    private final TableSegmentStatsRecorder tableStatsRecorder;
     private final boolean replyWithStackTraceOnError;
 
     //endregion
@@ -79,7 +81,8 @@ public final class PravegaConnectionListener implements AutoCloseable {
      */
     @VisibleForTesting
     public PravegaConnectionListener(boolean ssl, int port, StreamSegmentStore streamSegmentStore, TableStore tableStore) {
-        this(ssl, "localhost", port, streamSegmentStore, tableStore, SegmentStatsRecorder.noOp(), new PassingTokenVerifier(), null, null, true);
+        this(ssl, "localhost", port, streamSegmentStore, tableStore, SegmentStatsRecorder.noOp(), TableSegmentStatsRecorder.noOp(),
+                new PassingTokenVerifier(), null, null, true);
     }
 
     /**
@@ -89,21 +92,23 @@ public final class PravegaConnectionListener implements AutoCloseable {
      * @param port               The port to listen on.
      * @param streamSegmentStore The SegmentStore to delegate all requests to.
      * @param tableStore         The TableStore to delegate all requests to.
-     * @param statsRecorder      (Optional) A StatsRecorder for Metrics.
+     * @param statsRecorder      (Optional) A StatsRecorder for Metrics for Stream Segments.
+     * @param tableStatsRecorder (Optional) A Table StatsRecorder for Metrics for Table Segments.
      * @param tokenVerifier      The object to verify delegation token.
      * @param certFile           Path to the certificate file to be used for TLS.
      * @param keyFile            Path to be key file to be used for TLS.
      * @param replyWithStackTraceOnError Whether to send a server-side exceptions to the client in error messages.
      */
     public PravegaConnectionListener(boolean ssl, String host, int port, StreamSegmentStore streamSegmentStore, TableStore tableStore,
-                                     SegmentStatsRecorder statsRecorder, DelegationTokenVerifier tokenVerifier,
-                                     String certFile, String keyFile, boolean replyWithStackTraceOnError) {
+                                     SegmentStatsRecorder statsRecorder, TableSegmentStatsRecorder tableStatsRecorder,
+                                     DelegationTokenVerifier tokenVerifier, String certFile, String keyFile, boolean replyWithStackTraceOnError) {
         this.ssl = ssl;
         this.host = Exceptions.checkNotNullOrEmpty(host, "host");
         this.port = port;
         this.store = Preconditions.checkNotNull(streamSegmentStore, "streamSegmentStore");
         this.tableStore = Preconditions.checkNotNull(tableStore, "tableStore");
         this.statsRecorder = Preconditions.checkNotNull(statsRecorder, "statsRecorder");
+        this.tableStatsRecorder = Preconditions.checkNotNull(tableStatsRecorder, "tableStatsRecorder");
         this.certFile = certFile;
         this.keyFile = keyFile;
         InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
@@ -153,7 +158,6 @@ public final class PravegaConnectionListener implements AutoCloseable {
                      p.addLast(handler);
                  }
                  ServerConnectionInboundHandler lsh = new ServerConnectionInboundHandler();
-                 // p.addLast(new LoggingHandler(LogLevel.INFO));
                  p.addLast(new ExceptionLoggingHandler(ch.remoteAddress().toString()),
                          new CommandEncoder(null),
                          new LengthFieldBasedFrameDecoder(MAX_WIRECOMMAND_SIZE, 4, 4),
@@ -162,7 +166,7 @@ public final class PravegaConnectionListener implements AutoCloseable {
                          lsh);
                  lsh.setRequestProcessor(new AppendProcessor(store,
                          lsh,
-                         new PravegaRequestProcessor(store, tableStore, lsh, statsRecorder, tokenVerifier, replyWithStackTraceOnError),
+                         new PravegaRequestProcessor(store, tableStore, lsh, statsRecorder, tableStatsRecorder, tokenVerifier, replyWithStackTraceOnError),
                          statsRecorder,
                          tokenVerifier,
                          replyWithStackTraceOnError));

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -556,10 +556,10 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         log.info(createTableSegment.getRequestId(), "Creating table segment {}.", createTableSegment);
         val timer = new Timer();
         tableStore.createSegment(createTableSegment.getSegment(), TIMEOUT)
-                .thenAccept(v -> {
-                    connection.send(new SegmentCreated(createTableSegment.getRequestId(), createTableSegment.getSegment()));
-                    this.tableStatsRecorder.createTableSegment(createTableSegment.getSegment(), timer.getElapsed());
-                })
+                  .thenAccept(v -> {
+                      connection.send(new SegmentCreated(createTableSegment.getRequestId(), createTableSegment.getSegment()));
+                      this.tableStatsRecorder.createTableSegment(createTableSegment.getSegment(), timer.getElapsed());
+                  })
                   .exceptionally(e -> handleException(createTableSegment.getRequestId(), createTableSegment.getSegment(), operation, e));
     }
 
@@ -575,10 +575,10 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         log.info(deleteTableSegment.getRequestId(), "Deleting table segment {}.", deleteTableSegment);
         val timer = new Timer();
         tableStore.deleteSegment(segment, deleteTableSegment.isMustBeEmpty(), TIMEOUT)
-                .thenRun(() -> {
-                    connection.send(new SegmentDeleted(deleteTableSegment.getRequestId(), segment));
-                    this.tableStatsRecorder.deleteTableSegment(segment, timer.getElapsed());
-                })
+                  .thenRun(() -> {
+                      connection.send(new SegmentDeleted(deleteTableSegment.getRequestId(), segment));
+                      this.tableStatsRecorder.deleteTableSegment(segment, timer.getElapsed());
+                  })
                   .exceptionally(e -> handleException(deleteTableSegment.getRequestId(), segment, operation, e));
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
@@ -50,6 +50,7 @@ public class AutoScaleMonitor implements AutoCloseable {
     @Override
     public void close() {
         this.statsRecorder.close();
+        this.tableSegmentStatsRecorder.close();
         this.processor.close();
         ExecutorServiceHelpers.shutdown(this.executor);
     }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
@@ -27,25 +27,29 @@ public class AutoScaleMonitor implements AutoCloseable {
     private final ScheduledExecutorService executor;
     private final AutoScaleProcessor processor;
     @Getter
-    private final SegmentStatsRecorder recorder;
+    private final SegmentStatsRecorder statsRecorder;
+    @Getter
+    private final TableSegmentStatsRecorder tableSegmentStatsRecorder;
 
     @VisibleForTesting
     public AutoScaleMonitor(@NonNull StreamSegmentStore store, @NonNull EventStreamClientFactory clientFactory,
                             @NonNull AutoScalerConfig configuration) {
         this.executor = ExecutorServiceHelpers.newScheduledThreadPool(configuration.getThreadPoolSize(), "auto-scaler");
         this.processor = new AutoScaleProcessor(configuration, clientFactory, this.executor);
-        this.recorder = new SegmentStatsRecorderImpl(this.processor, store, this.executor);
+        this.statsRecorder = new SegmentStatsRecorderImpl(this.processor, store, this.executor);
+        this.tableSegmentStatsRecorder = new TableSegmentStatsRecorderImpl();
     }
 
     public AutoScaleMonitor(@NonNull StreamSegmentStore store, @NonNull AutoScalerConfig configuration) {
         this.executor = ExecutorServiceHelpers.newScheduledThreadPool(configuration.getThreadPoolSize(), "auto-scaler");
         this.processor = new AutoScaleProcessor(configuration, this.executor);
-        this.recorder = new SegmentStatsRecorderImpl(this.processor, store, this.executor);
+        this.statsRecorder = new SegmentStatsRecorderImpl(this.processor, store, this.executor);
+        this.tableSegmentStatsRecorder = new TableSegmentStatsRecorderImpl();
     }
 
     @Override
     public void close() {
-        this.recorder.close();
+        this.statsRecorder.close();
         this.processor.close();
         ExecutorServiceHelpers.shutdown(this.executor);
     }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorder.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorder.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.stat;
+
+import java.time.Duration;
+
+/**
+ * Defines a Stat Recorder for Table Segments.
+ */
+public interface TableSegmentStatsRecorder extends AutoCloseable {
+    /**
+     * Notifies a Table Segment has been created.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param elapsed          Elapsed time.
+     */
+    void createTableSegment(String tableSegmentName, Duration elapsed);
+
+    /**
+     * Notifies a Table Segment has been deleted.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param elapsed          Elapsed time.
+     */
+    void deleteTableSegment(String tableSegmentName, Duration elapsed);
+
+    /**
+     * Notifies a set of Entries has been updated.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param entryCount       Number of entries updated.
+     * @param conditional      Whether the update is conditional.
+     * @param elapsed          Elapsed time.
+     */
+    void updateEntries(String tableSegmentName, int entryCount, boolean conditional, Duration elapsed);
+
+    /**
+     * Notifies a set of Keys has been removed.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param keyCount         Number of keys removed.
+     * @param conditional      Whether the removal is conditional.
+     * @param elapsed          Elapsed time.
+     */
+    void removeKeys(String tableSegmentName, int keyCount, boolean conditional, Duration elapsed);
+
+    /**
+     * Notifies a set of Keys have been retrieved.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param keyCount         Number of keys retrieved.
+     * @param elapsed          Elapsed time.
+     */
+    void getKeys(String tableSegmentName, int keyCount, Duration elapsed);
+
+    /**
+     * Notifies a Table Key iteration completed.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param resultCount      Number of Keys in the iteration result.
+     * @param elapsed          Elapsed time.
+     */
+    void iterateKeys(String tableSegmentName, int resultCount, Duration elapsed);
+
+    /**
+     * Notifies a Table Entry iteration completed.
+     *
+     * @param tableSegmentName Table Segment Name.
+     * @param resultCount      Number of Entries in the iteration result.
+     * @param elapsed          Elapsed time.
+     */
+    void iterateEntries(String tableSegmentName, int resultCount, Duration elapsed);
+
+    @Override
+    void close();
+
+    //region NoOp
+
+    /**
+     * Creates a new {@link TableSegmentStatsRecorder} instance that does not do anything.
+     */
+    static TableSegmentStatsRecorder noOp() {
+        return new TableSegmentStatsRecorder() {
+            @Override
+            public void createTableSegment(String tableSegmentName, Duration elapsed) {
+            }
+
+            @Override
+            public void deleteTableSegment(String tableSegmentName, Duration elapsed) {
+            }
+
+            @Override
+            public void updateEntries(String tableSegmentName, int entryCount, boolean conditional, Duration elapsed) {
+            }
+
+            @Override
+            public void removeKeys(String tableSegmentName, int keyCount, boolean conditional, Duration elapsed) {
+            }
+
+            @Override
+            public void getKeys(String tableSegmentName, int keyCount, Duration elapsed) {
+            }
+
+            @Override
+            public void iterateKeys(String tableSegmentName, int resultCount, Duration elapsed) {
+            }
+
+            @Override
+            public void iterateEntries(String tableSegmentName, int resultCount, Duration elapsed) {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    //endregion
+}

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
@@ -18,6 +18,9 @@ import java.time.Duration;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+/**
+ * Implementation for {@link TableSegmentStatsRecorder}.
+ */
 public class TableSegmentStatsRecorderImpl implements TableSegmentStatsRecorder {
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
     @Getter(AccessLevel.PROTECTED)
@@ -38,21 +41,20 @@ public class TableSegmentStatsRecorderImpl implements TableSegmentStatsRecorder 
     private final OpStatsLogger iterateKeys = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS_LATENCY);
     @Getter(AccessLevel.PROTECTED)
     private final OpStatsLogger iterateEntries = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES_LATENCY);
-
     @Getter(AccessLevel.PROTECTED)
     private final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
 
     @Override
     public void close() {
-        this.createSegment.close();
-        this.deleteSegment.close();
-        this.updateConditional.close();
-        this.updateUnconditional.close();
-        this.removeConditional.close();
-        this.removeUnconditional.close();
-        this.getKeys.close();
-        this.iterateKeys.close();
-        this.iterateEntries.close();
+        getCreateSegment().close();
+        getDeleteSegment().close();
+        getUpdateConditional().close();
+        getUpdateUnconditional().close();
+        getRemoveConditional().close();
+        getRemoveUnconditional().close();
+        getGetKeys().close();
+        getIterateKeys().close();
+        getIterateEntries().close();
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.stat;
+
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.metrics.DynamicLogger;
+import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.OpStatsLogger;
+import io.pravega.shared.metrics.StatsLogger;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public class TableSegmentStatsRecorderImpl implements TableSegmentStatsRecorder {
+    private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("segmentstore");
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger createSegment = STATS_LOGGER.createStats(MetricsNames.SEGMENT_CREATE_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger deleteSegment = STATS_LOGGER.createStats(MetricsNames.SEGMENT_DELETE_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger updateConditional = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger updateUnconditional = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_UPDATE_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger removeConditional = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger removeUnconditional = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_REMOVE_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger getKeys = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_GET_KEYS_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger iterateKeys = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS_LATENCY);
+    @Getter(AccessLevel.PROTECTED)
+    private final OpStatsLogger iterateEntries = STATS_LOGGER.createStats(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES_LATENCY);
+
+    @Getter(AccessLevel.PROTECTED)
+    private final DynamicLogger dynamicLogger = MetricsProvider.getDynamicLogger();
+
+    @Override
+    public void close() {
+        this.createSegment.close();
+        this.deleteSegment.close();
+        this.updateConditional.close();
+        this.updateUnconditional.close();
+        this.removeConditional.close();
+        this.removeUnconditional.close();
+        this.getKeys.close();
+        this.iterateKeys.close();
+        this.iterateEntries.close();
+    }
+
+    @Override
+    public void createTableSegment(String tableSegmentName, Duration elapsed) {
+        getCreateSegment().reportSuccessEvent(elapsed);
+    }
+
+    @Override
+    public void deleteTableSegment(String tableSegmentName, Duration elapsed) {
+        getDeleteSegment().reportSuccessEvent(elapsed);
+        getDynamicLogger().freezeCounters(
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, tableSegmentName),
+                MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, tableSegmentName));
+    }
+
+    @Override
+    public void updateEntries(String tableSegmentName, int entryCount, boolean conditional, Duration elapsed) {
+        choose(conditional, getUpdateConditional(), getUpdateUnconditional()).reportSuccessEvent(elapsed);
+        String countMetric = choose(conditional, MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, MetricsNames.TABLE_SEGMENT_UPDATE);
+        getDynamicLogger().incCounterValue(MetricsNames.globalMetricName(countMetric), entryCount);
+        getDynamicLogger().incCounterValue(MetricsNames.nameFromSegment(countMetric, tableSegmentName), entryCount);
+    }
+
+    @Override
+    public void removeKeys(String tableSegmentName, int keyCount, boolean conditional, Duration elapsed) {
+        choose(conditional, getRemoveConditional(), getRemoveUnconditional()).reportSuccessEvent(elapsed);
+        String countMetric = choose(conditional, MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, MetricsNames.TABLE_SEGMENT_REMOVE);
+        getDynamicLogger().incCounterValue(MetricsNames.globalMetricName(countMetric), keyCount);
+        getDynamicLogger().incCounterValue(MetricsNames.nameFromSegment(countMetric, tableSegmentName), keyCount);
+    }
+
+    @Override
+    public void getKeys(String tableSegmentName, int keyCount, Duration elapsed) {
+        getGetKeys().reportSuccessEvent(elapsed);
+        getDynamicLogger().incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_GET), keyCount);
+        getDynamicLogger().incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, tableSegmentName), keyCount);
+    }
+
+    @Override
+    public void iterateKeys(String tableSegmentName, int resultCount, Duration elapsed) {
+        getIterateKeys().reportSuccessEvent(elapsed);
+        getDynamicLogger().incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS), resultCount);
+        getDynamicLogger().incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, tableSegmentName), resultCount);
+    }
+
+    @Override
+    public void iterateEntries(String tableSegmentName, int resultCount, Duration elapsed) {
+        getIterateEntries().reportSuccessEvent(elapsed);
+        getDynamicLogger().incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES), resultCount);
+        getDynamicLogger().incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, tableSegmentName), resultCount);
+    }
+
+    private <T> T choose(boolean conditional, T whenConditional, T whenUnconditional) {
+        return conditional ? whenConditional : whenUnconditional;
+    }
+}

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
@@ -36,7 +36,7 @@ public class TableSegmentStatsRecorderImpl implements TableSegmentStatsRecorder 
     @Getter(AccessLevel.PACKAGE)
     private final OpStatsLogger removeUnconditional = createLogger(MetricsNames.TABLE_SEGMENT_REMOVE_LATENCY);
     @Getter(AccessLevel.PACKAGE)
-    private final OpStatsLogger getKeys = createLogger(MetricsNames.TABLE_SEGMENT_GET_KEYS_LATENCY);
+    private final OpStatsLogger getKeys = createLogger(MetricsNames.TABLE_SEGMENT_GET_LATENCY);
     @Getter(AccessLevel.PACKAGE)
     private final OpStatsLogger iterateKeys = createLogger(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS_LATENCY);
     @Getter(AccessLevel.PACKAGE)

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.server.host.handler;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.shared.protocol.netty.WireCommands;
 import org.junit.After;
 import org.junit.Before;
@@ -30,7 +31,7 @@ public class PravegaRequestProcessorAuthFailedTest {
         StreamSegmentStore store = mock(StreamSegmentStore.class);
         connection = mock(ServerConnection.class);
         processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, SegmentStatsRecorder.noOp(),
-                (resource, token, expectedLevel) -> false, false);
+                TableSegmentStatsRecorder.noOp(), (resource, token, expectedLevel) -> false, false);
     }
 
     @After

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -28,6 +28,7 @@ import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.segmentstore.server.mocks.SynchronousStreamSegmentStore;
 import io.pravega.segmentstore.server.reading.ReadResultEntryBase;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
@@ -277,7 +278,8 @@ public class PravegaRequestProcessorTest {
         ServerConnection connection = mock(ServerConnection.class);
         InOrder order = inOrder(connection);
         val recorderMock = mock(SegmentStatsRecorder.class);
-        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, recorderMock, new PassingTokenVerifier(), false);
+        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, recorderMock,
+                TableSegmentStatsRecorder.noOp(), new PassingTokenVerifier(), false);
 
         // Execute and Verify createSegment/getStreamSegmentInfo calling stack is executed as design.
         processor.createSegment(new WireCommands.CreateSegment(1, streamSegmentName, WireCommands.CreateSegment.NO_SCALE, 0, ""));
@@ -421,7 +423,8 @@ public class PravegaRequestProcessorTest {
         CompletableFuture<SegmentProperties> txnFuture = CompletableFuture.completedFuture(createSegmentProperty(streamSegmentName, txnId));
         doReturn(txnFuture).when(store).mergeStreamSegment(anyString(), anyString(), any());
         SegmentStatsRecorder recorderMock = mock(SegmentStatsRecorder.class);
-        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, recorderMock, new PassingTokenVerifier(), false);
+        PravegaRequestProcessor processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, recorderMock,
+                TableSegmentStatsRecorder.noOp(), new PassingTokenVerifier(), false);
 
         processor.createSegment(new WireCommands.CreateSegment(0, streamSegmentName, WireCommands.CreateSegment.NO_SCALE, 0, ""));
         String transactionName = StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnId);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
@@ -13,12 +13,8 @@ import io.pravega.shared.MetricsNames;
 import io.pravega.shared.metrics.DynamicLogger;
 import io.pravega.shared.metrics.OpStatsLogger;
 import java.time.Duration;
-import java.util.ArrayList;
-import lombok.AccessLevel;
 import lombok.Cleanup;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.Test;
 
@@ -47,95 +43,66 @@ public class TableSegmentStatsRecorderTest {
 
         // Create Segment.
         r.createTableSegment(SEGMENT_NAME, ELAPSED);
-        verify(r.createSegment).reportSuccessEvent(ELAPSED);
+        verify(r.getCreateSegment()).reportSuccessEvent(ELAPSED);
 
         // Delete Segment.
         r.deleteTableSegment(SEGMENT_NAME, ELAPSED);
-        verify(r.deleteSegment).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).freezeCounters(TO_FREEZE);
+        verify(r.getDeleteSegment()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).freezeCounters(TO_FREEZE);
 
         // Unconditional update.
         r.updateEntries(SEGMENT_NAME, 2, false, ELAPSED);
-        verify(r.updateUnconditional).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE), 2);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE, SEGMENT_NAME), 2);
+        verify(r.getUpdateUnconditional()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE), 2);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE, SEGMENT_NAME), 2);
 
         // Conditional update.
         r.updateEntries(SEGMENT_NAME, 3, true, ELAPSED);
-        verify(r.updateConditional).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL), 3);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, SEGMENT_NAME), 3);
+        verify(r.getUpdateConditional()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL), 3);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, SEGMENT_NAME), 3);
 
         // Unconditional removal.
         r.removeKeys(SEGMENT_NAME, 4, false, ELAPSED);
-        verify(r.removeUnconditional).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE), 4);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE, SEGMENT_NAME), 4);
+        verify(r.getRemoveUnconditional()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE), 4);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE, SEGMENT_NAME), 4);
 
         // Conditional removal.
         r.removeKeys(SEGMENT_NAME, 5, true, ELAPSED);
-        verify(r.removeConditional).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL), 5);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, SEGMENT_NAME), 5);
+        verify(r.getRemoveConditional()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL), 5);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, SEGMENT_NAME), 5);
 
         // Get Keys.
         r.getKeys(SEGMENT_NAME, 6, ELAPSED);
-        verify(r.getKeys).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_GET), 6);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, SEGMENT_NAME), 6);
+        verify(r.getGetKeys()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_GET), 6);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, SEGMENT_NAME), 6);
 
         // Iterate Keys.
         r.iterateKeys(SEGMENT_NAME, 7, ELAPSED);
-        verify(r.iterateKeys).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS), 7);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, SEGMENT_NAME), 7);
+        verify(r.getIterateKeys()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS), 7);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, SEGMENT_NAME), 7);
 
         // Iterate Entries.
         r.iterateEntries(SEGMENT_NAME, 8, ELAPSED);
-        verify(r.iterateEntries).reportSuccessEvent(ELAPSED);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES), 8);
-        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, SEGMENT_NAME), 8);
+        verify(r.getIterateEntries()).reportSuccessEvent(ELAPSED);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES), 8);
+        verify(r.getDynamicLogger()).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, SEGMENT_NAME), 8);
     }
 
     @RequiredArgsConstructor
     private static class TestRecorder extends TableSegmentStatsRecorderImpl {
-        @Getter(AccessLevel.PROTECTED)
-        final OpStatsLogger createSegment = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger deleteSegment = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger updateConditional = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger updateUnconditional = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger removeConditional = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger removeUnconditional = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger getKeys = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger iterateKeys = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final OpStatsLogger iterateEntries = mock(OpStatsLogger.class);
-        @Getter(AccessLevel.PROTECTED)
-        private final DynamicLogger dynamicLogger = mock(DynamicLogger.class);
+        @Override
+        protected OpStatsLogger createLogger(String name) {
+            return mock(OpStatsLogger.class);
+        }
 
         @Override
-        @SneakyThrows
-        public void close() {
-            super.close();
-
-            // Validate that the loggers are properly closed.
-            val candidates = new ArrayList<OpStatsLogger>();
-            for (val field : this.getClass().getDeclaredFields()) {
-                if (field.getType().isAssignableFrom(OpStatsLogger.class)) {
-                    candidates.add((OpStatsLogger) field.get(this));
-                }
-            }
-
-            for (val l : candidates) {
-                verify(l).close();
-            }
+        protected DynamicLogger createDynamicLogger() {
+            return mock(DynamicLogger.class);
         }
     }
 }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.stat;
+
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.metrics.DynamicLogger;
+import io.pravega.shared.metrics.OpStatsLogger;
+import java.time.Duration;
+import java.util.ArrayList;
+import lombok.AccessLevel;
+import lombok.Cleanup;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link TableSegmentStatsRecorderImpl} class.
+ */
+public class TableSegmentStatsRecorderTest {
+    private static final String SEGMENT_NAME = "TableSegment";
+    private static final Duration ELAPSED = Duration.ofMillis(123456);
+    private static final String[] TO_FREEZE = new String[]{
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, SEGMENT_NAME),
+            MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, SEGMENT_NAME)};
+
+    @Test
+    public void testCreateSegment() {
+        @Cleanup
+        val r = new TestRecorder();
+
+        // Create Segment.
+        r.createTableSegment(SEGMENT_NAME, ELAPSED);
+        verify(r.createSegment).reportSuccessEvent(ELAPSED);
+
+        // Delete Segment.
+        r.deleteTableSegment(SEGMENT_NAME, ELAPSED);
+        verify(r.deleteSegment).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).freezeCounters(TO_FREEZE);
+
+        // Unconditional update.
+        r.updateEntries(SEGMENT_NAME, 2, false, ELAPSED);
+        verify(r.updateUnconditional).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE), 2);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE, SEGMENT_NAME), 2);
+
+        // Conditional update.
+        r.updateEntries(SEGMENT_NAME, 3, true, ELAPSED);
+        verify(r.updateConditional).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL), 3);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_UPDATE_CONDITIONAL, SEGMENT_NAME), 3);
+
+        // Unconditional removal.
+        r.removeKeys(SEGMENT_NAME, 4, false, ELAPSED);
+        verify(r.removeUnconditional).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE), 4);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE, SEGMENT_NAME), 4);
+
+        // Conditional removal.
+        r.removeKeys(SEGMENT_NAME, 5, true, ELAPSED);
+        verify(r.removeConditional).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL), 5);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_REMOVE_CONDITIONAL, SEGMENT_NAME), 5);
+
+        // Get Keys.
+        r.getKeys(SEGMENT_NAME, 6, ELAPSED);
+        verify(r.getKeys).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_GET), 6);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_GET, SEGMENT_NAME), 6);
+
+        // Iterate Keys.
+        r.iterateKeys(SEGMENT_NAME, 7, ELAPSED);
+        verify(r.iterateKeys).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS), 7);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_KEYS, SEGMENT_NAME), 7);
+
+        // Iterate Entries.
+        r.iterateEntries(SEGMENT_NAME, 8, ELAPSED);
+        verify(r.iterateEntries).reportSuccessEvent(ELAPSED);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.globalMetricName(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES), 8);
+        verify(r.dynamicLogger).incCounterValue(MetricsNames.nameFromSegment(MetricsNames.TABLE_SEGMENT_ITERATE_ENTRIES, SEGMENT_NAME), 8);
+    }
+
+    @RequiredArgsConstructor
+    private static class TestRecorder extends TableSegmentStatsRecorderImpl {
+        @Getter(AccessLevel.PROTECTED)
+        final OpStatsLogger createSegment = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger deleteSegment = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger updateConditional = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger updateUnconditional = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger removeConditional = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger removeUnconditional = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger getKeys = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger iterateKeys = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final OpStatsLogger iterateEntries = mock(OpStatsLogger.class);
+        @Getter(AccessLevel.PROTECTED)
+        private final DynamicLogger dynamicLogger = mock(DynamicLogger.class);
+
+        @Override
+        @SneakyThrows
+        public void close() {
+            super.close();
+
+            // Validate that the loggers are properly closed.
+            val candidates = new ArrayList<OpStatsLogger>();
+            for (val field : this.getClass().getDeclaredFields()) {
+                if (field.getType().isAssignableFrom(OpStatsLogger.class)) {
+                    candidates.add((OpStatsLogger) field.get(this));
+                }
+            }
+
+            for (val l : candidates) {
+                verify(l).close();
+            }
+        }
+    }
+}

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -56,11 +56,29 @@ public final class MetricsNames {
     // Metrics in Segment Store Service
     // Segment-related stats
     public static final String SEGMENT_CREATE_LATENCY = "segmentstore.segment.create_latency_ms"; // Histogram
+    public static final String SEGMENT_DELETE_LATENCY = "segmentstore.segment.delete_latency_ms"; // Histogram
     public static final String SEGMENT_READ_LATENCY = "segmentstore.segment.read_latency_ms";     // Histogram
     public static final String SEGMENT_WRITE_LATENCY = "segmentstore.segment.write_latency_ms";   // Histogram
     public static final String SEGMENT_READ_BYTES = "segmentstore.segment.read_bytes";            // Counter and Per-segment Counter
     public static final String SEGMENT_WRITE_BYTES = "segmentstore.segment.write_bytes";          // Counter and Per-segment Counter
     public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment.write_events";        // Counter and Per-segment Counter
+
+    // Table Segment stats
+    public static final String TABLE_SEGMENT_UPDATE_LATENCY = "segmentstore.tablesegment.update_latency_ms";
+    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.update_conditional_latency_ms";
+    public static final String TABLE_SEGMENT_REMOVE_LATENCY = "segmentstore.tablesegment.remove_latency_ms";
+    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.remove_conditional_latency_ms";
+    public static final String TABLE_SEGMENT_GET_KEYS_LATENCY = "segmentstore.tablesegment.get_latency_ms";
+    public static final String TABLE_SEGMENT_ITERATE_KEYS_LATENCY = "segmentstore.tablesegment.iterate_keys_latency_ms";
+    public static final String TABLE_SEGMENT_ITERATE_ENTRIES_LATENCY = "segmentstore.tablesegment.iterate_entries_latency_ms";
+
+    public static final String TABLE_SEGMENT_UPDATE = "segmentstore.tablesegment.update_entries";
+    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL = "segmentstore.tablesegment.update_entries_conditional";
+    public static final String TABLE_SEGMENT_REMOVE = "segmentstore.tablesegment.remove_keys";
+    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL = "segmentstore.tablesegment.remove_keys_conditional";
+    public static final String TABLE_SEGMENT_GET = "segmentstore.tablesegment.get_keys";
+    public static final String TABLE_SEGMENT_ITERATE_KEYS = "segmentstore.tablesegment.iterate_keys";
+    public static final String TABLE_SEGMENT_ITERATE_ENTRIES = "segmentstore.tablesegment.iterate_entries";
 
     // Storage stats
     public static final String STORAGE_READ_LATENCY = "segmentstore.storage.read_latency_ms";   // Histogram

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -64,21 +64,21 @@ public final class MetricsNames {
     public static final String SEGMENT_WRITE_EVENTS = "segmentstore.segment.write_events";        // Counter and Per-segment Counter
 
     // Table Segment stats
-    public static final String TABLE_SEGMENT_UPDATE_LATENCY = "segmentstore.tablesegment.update_latency_ms";
-    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.update_conditional_latency_ms";
-    public static final String TABLE_SEGMENT_REMOVE_LATENCY = "segmentstore.tablesegment.remove_latency_ms";
-    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.remove_conditional_latency_ms";
-    public static final String TABLE_SEGMENT_GET_KEYS_LATENCY = "segmentstore.tablesegment.get_latency_ms";
-    public static final String TABLE_SEGMENT_ITERATE_KEYS_LATENCY = "segmentstore.tablesegment.iterate_keys_latency_ms";
-    public static final String TABLE_SEGMENT_ITERATE_ENTRIES_LATENCY = "segmentstore.tablesegment.iterate_entries_latency_ms";
+    public static final String TABLE_SEGMENT_UPDATE_LATENCY = "segmentstore.tablesegment.update_latency_ms";                         // Histogram
+    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.update_conditional_latency_ms"; // Histogram
+    public static final String TABLE_SEGMENT_REMOVE_LATENCY = "segmentstore.tablesegment.remove_latency_ms";                         // Histogram
+    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL_LATENCY = "segmentstore.tablesegment.remove_conditional_latency_ms"; // Histogram
+    public static final String TABLE_SEGMENT_GET_LATENCY = "segmentstore.tablesegment.get_latency_ms";                               // Histogram
+    public static final String TABLE_SEGMENT_ITERATE_KEYS_LATENCY = "segmentstore.tablesegment.iterate_keys_latency_ms";             // Histogram
+    public static final String TABLE_SEGMENT_ITERATE_ENTRIES_LATENCY = "segmentstore.tablesegment.iterate_entries_latency_ms";       // Histogram
 
-    public static final String TABLE_SEGMENT_UPDATE = "segmentstore.tablesegment.update_entries";
-    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL = "segmentstore.tablesegment.update_entries_conditional";
-    public static final String TABLE_SEGMENT_REMOVE = "segmentstore.tablesegment.remove_keys";
-    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL = "segmentstore.tablesegment.remove_keys_conditional";
-    public static final String TABLE_SEGMENT_GET = "segmentstore.tablesegment.get_keys";
-    public static final String TABLE_SEGMENT_ITERATE_KEYS = "segmentstore.tablesegment.iterate_keys";
-    public static final String TABLE_SEGMENT_ITERATE_ENTRIES = "segmentstore.tablesegment.iterate_entries";
+    public static final String TABLE_SEGMENT_UPDATE = "segmentstore.tablesegment.update";                         // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_UPDATE_CONDITIONAL = "segmentstore.tablesegment.update_conditional"; // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_REMOVE = "segmentstore.tablesegment.remove";                         // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_REMOVE_CONDITIONAL = "segmentstore.tablesegment.remove_conditional"; // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_GET = "segmentstore.tablesegment.get";                               // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_ITERATE_KEYS = "segmentstore.tablesegment.iterate_keys";             // Counter and Per-segment Counter
+    public static final String TABLE_SEGMENT_ITERATE_ENTRIES = "segmentstore.tablesegment.iterate_entries";       // Counter and Per-segment Counter
 
     // Storage stats
     public static final String STORAGE_READ_LATENCY = "segmentstore.storage.read_latency_ms";   // Histogram

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
@@ -38,6 +38,17 @@ public interface DynamicLogger {
     void freezeCounter(String name);
 
     /**
+     * Notifies that the counters will not be updated.
+     *
+     * @param names the names of counters
+     */
+    default void freezeCounters(String... names) {
+        for (String name : names) {
+            freezeCounter(name);
+        }
+    }
+
+    /**
      * Report gauge value.
      *
      * @param <T>   the type of value

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleDownTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleDownTest.java
@@ -22,9 +22,8 @@ import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.host.stat.AutoScaleMonitor;
-import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
@@ -68,11 +67,10 @@ public class EndToEndAutoScaleDownTest {
                                     .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0)
                                     .with(AutoScalerConfig.CACHE_CLEANUP_IN_SECONDS, 5)
                                     .with(AutoScalerConfig.CACHE_EXPIRY_IN_SECONDS, 30).build());
-            SegmentStatsRecorder statsRecorder = autoScaleMonitor.getRecorder();
 
             @Cleanup
             PravegaConnectionListener server = new PravegaConnectionListener(false, "localhost", 12345, store, tableStore,
-                    statsRecorder, null, null, null, true);
+                    autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null, true);
             server.startListening();
             controllerWrapper.awaitRunning();
             controllerWrapper.getControllerService().createScope("test").get();

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpTest.java
@@ -24,9 +24,8 @@ import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.host.stat.AutoScaleMonitor;
-import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
@@ -65,11 +64,10 @@ public class EndToEndAutoScaleUpTest {
             AutoScaleMonitor autoScaleMonitor = new AutoScaleMonitor(store, internalCF,
                     AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
                                     .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0).build());
-            SegmentStatsRecorder statsRecorder = autoScaleMonitor.getRecorder();
 
             @Cleanup
             PravegaConnectionListener server = new PravegaConnectionListener(false, "localhost", 12345, store, tableStore,
-                                                                             statsRecorder, null, null, null, true);
+                    autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null, true);
             server.startListening();
 
             controllerWrapper.awaitRunning();

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
@@ -34,9 +34,8 @@ import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.host.stat.AutoScaleMonitor;
-import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
@@ -85,11 +84,10 @@ public class EndToEndAutoScaleUpWithTxnTest {
                     internalCF,
                     AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
                                     .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0).build());
-            SegmentStatsRecorder statsRecorder = autoScaleMonitor.getRecorder();
 
             @Cleanup
             PravegaConnectionListener server = new PravegaConnectionListener(false, "localhost", 12345, store, tableStore,
-                    statsRecorder, null, null, null, true);
+                    autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null, true);
             server.startListening();
 
             controllerWrapper.awaitRunning();

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -105,7 +105,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
         monitor = new AutoScaleMonitor(store, AutoScalerConfig.builder().build());
 
         this.server = new PravegaConnectionListener(false, "localhost", servicePort, store, mock(TableStore.class),
-                monitor.getRecorder(), new PassingTokenVerifier(), null, null, true);
+                monitor.getStatsRecorder(), monitor.getTableSegmentStatsRecorder(), new PassingTokenVerifier(), null, null, true);
         this.server.startListening();
 
         // 3. Start Pravega Controller service

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadFromDeletedStreamTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadFromDeletedStreamTest.java
@@ -22,6 +22,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.AssertExtensions;
@@ -48,7 +49,7 @@ public class ReadFromDeletedStreamTest {
 
         @Cleanup
         PravegaConnectionListener server = new PravegaConnectionListener(false, "localhost", 12345, store, mock(TableStore.class),
-                SegmentStatsRecorder.noOp(), null, null, null, true);
+                SegmentStatsRecorder.noOp(), TableSegmentStatsRecorder.noOp(), null, null, null, true);
         server.startListening();
 
         streamManager.createScope("test");

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -30,6 +30,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
+import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
@@ -74,7 +75,7 @@ public class EndToEndStatsTest {
         statsRecorder = new TestStatsRecorder();
 
         server = new PravegaConnectionListener(false, "localhost", servicePort, store, tableStore,
-                statsRecorder, null, null, null, true);
+                statsRecorder, TableSegmentStatsRecorder.noOp(), null, null, null, true);
         server.startListening();
 
         controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),


### PR DESCRIPTION
**Change log description**  
- Added metrics for all Table Segment Operations in PravegaRequestProcessor.

**Purpose of the change**  
Fixes #3412.

**What the code does**  
- Tracking elapsed time for table segment creation and deletion
- Tracking number of entries added and elapsed time for updates/conditional updates.
- Tracking number of keys removed and elapsed time for removals/conditional removals.
- Tracking number of items returned and elapsed time for retrievals and iterators.

**How to verify it**  
Unit tests must pass.