### PR TITLE
Issue 3422: BucketStore.getBucket must return a positive bucket number

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
@@ -82,7 +82,8 @@ public interface BucketStore {
 
     static int getBucket(String scope, String stream, int bucketCount) {
         String scopedStreamName = getScopedStreamName(scope, stream);
-        return Math.abs(scopedStreamName.hashCode()) % bucketCount;
+        int hash = scopedStreamName.hashCode();
+        return hash == Integer.MIN_VALUE ? 0 : Math.abs(hash) % bucketCount;
     }
 
     static String getScopedStreamName(String scope, String stream) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
@@ -82,7 +82,7 @@ public interface BucketStore {
 
     static int getBucket(String scope, String stream, int bucketCount) {
         String scopedStreamName = getScopedStreamName(scope, stream);
-        return scopedStreamName.hashCode() % bucketCount;
+        return Math.abs(scopedStreamName.hashCode()) % bucketCount;
     }
 
     static String getScopedStreamName(String scope, String stream) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
@@ -82,8 +82,7 @@ public interface BucketStore {
 
     static int getBucket(String scope, String stream, int bucketCount) {
         String scopedStreamName = getScopedStreamName(scope, stream);
-        int hash = scopedStreamName.hashCode();
-        return hash == Integer.MIN_VALUE ? 0 : Math.abs(hash) % bucketCount;
+        return (scopedStreamName.hashCode() & 0x7fffffff) % bucketCount;
     }
 
     static String getScopedStreamName(String scope, String stream) {

--- a/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
@@ -112,7 +112,7 @@ public abstract class BucketServiceTest {
         bucketStore.addStreamToBucketStore(BucketStore.ServiceType.RetentionService, scope, streamName, executor).join();
 
         // verify that at least one of the buckets got the notification
-        int bucketId = stream.getScopedName().hashCode() % 3;
+        int bucketId = BucketStore.getBucket(scope, streamName, 3);
         Set<String> streams = bucketStore.getStreamsForBucket(BucketStore.ServiceType.RetentionService, bucketId, executor).join();
         
         BucketService bucketService = bucketServices.get(bucketId);

--- a/controller/src/test/java/io/pravega/controller/server/bucket/ZkStoreRetentionTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/ZkStoreRetentionTest.java
@@ -114,7 +114,7 @@ public class ZkStoreRetentionTest extends BucketServiceTest {
         // verify that at least one of the buckets got the notification
         Map<Integer, BucketService> bucketServices = service.getBucketServices();
 
-        int bucketId = stream.getScopedName().hashCode() % 3;
+        int bucketId = BucketStore.getBucket(scope, streamName, 3);
         BucketService bucketService = bucketServices.get(bucketId);
         AtomicBoolean added = new AtomicBoolean(false);
         RetryHelper.loopWithDelay(() -> !added.get(), () -> CompletableFuture.completedFuture(null)


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
 * Changes the logic in `BucketStore.getBucket` to handle negative hash codes.

**Purpose of the change**  
Fixes #3422 

**What the code does**  
Bucket store is changed to absolute value of java.hashcode() method

**How to verify it**  
(Optional: steps to verify that the changes are effective)
