### PR TITLE
Issue 3433 : Zk garbage collector bug in fetch version update

### DIFF
--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
@@ -105,6 +105,13 @@ public class ZkGarbageCollectorTest {
         Futures.delayedFuture(gcPeriod.plus(delta), executor).join();
         gc2.fetchVersion().join();
         assertEquals(3, gc2.getLatestBatch());
+        
+        // now deliberately set the gc version for gc2 to an older value and call process. 
+        gc2.setVersion(0);
+        gc2.process().join();
+        
+        assertEquals(3, gc2.getVersion());
+        
     }
 
     private void awaitStart(ZKGarbageCollector gc) {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Zk Garbage Collector had a bug where it did not update the version of the batch if it was on old version

**Purpose of the change**  
Fixes #3433 

**What the code does**  
Moves fetchVersion after catching the exception. 

**How to verify it**  
Unit test updated
