### PR TITLE
Issue 3446: Update path to ZK release in BK Dockerfile

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -27,7 +27,7 @@ RUN wget http://central.maven.org/maven2/org/apache/bookkeeper/bookkeeper-server
 &&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bookkeeper
 
 # zookeeper-3.5.3-beta.tar.gz is actually not compressed even though it is published as .tar.gz, so not using -z flag to untar
-RUN wget http://www.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
+RUN wget http://http://archive.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
 &&  tar xvf zookeeper-$ZOOKEEPER_VERSION.tar.gz \
 &&  mv zookeeper-$ZOOKEEPER_VERSION /opt/zookeeper
 

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -27,7 +27,7 @@ RUN wget http://central.maven.org/maven2/org/apache/bookkeeper/bookkeeper-server
 &&  mv bookkeeper-server-$BOOKKEEPER_VERSION /opt/bookkeeper
 
 # zookeeper-3.5.3-beta.tar.gz is actually not compressed even though it is published as .tar.gz, so not using -z flag to untar
-RUN wget http://http://archive.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
+RUN wget http://archive.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz \
 &&  tar xvf zookeeper-$ZOOKEEPER_VERSION.tar.gz \
 &&  mv zookeeper-$ZOOKEEPER_VERSION /opt/zookeeper
 


### PR DESCRIPTION
**Change log description**  
* Updates the URL to fetch the ZooKeeper release in the BookKeeper Dockerfile to use the Apache archive.

**Purpose of the change**  
Fixes #3446 

**What the code does**  
Updates the ZooKeeper release path in the BookKeeper Dockerfile (`docker/bookkeeper/Dockerfile`)  to use the Apache archive. Note that this is change in the `r0.4` branch.

**How to verify it**  
`./gradlew buildBookkeeperImage`