### PR TITLE
Issue 3458: Controller Metrics Config Fix

### DIFF
--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -110,8 +110,7 @@ public final class Config {
     public static final MetricsConfig METRICS_CONFIG;
     public static final GRPCServerConfig GRPC_SERVER_CONFIG;
 
-    private static final String METRICS_PATH = "controller.metrics";
-    private static final String METRICS_PREFIX_REPLACEMENT = MetricsConfig.COMPONENT_CODE;
+    private static final String METRICS_PATH = "controller.metrics.";
 
 
     //endregion
@@ -307,7 +306,7 @@ public final class Config {
         for (val e : p.entrySet()) {
             String key = (String) e.getKey();
             if (key.startsWith(METRICS_PATH)) {
-                builder.with(Property.named(key.replaceFirst(METRICS_PATH, METRICS_PREFIX_REPLACEMENT)), e.getValue());
+                builder.with(Property.named(key.substring(METRICS_PATH.length())), e.getValue());
             }
         }
 

--- a/controller/src/test/java/io/pravega/controller/util/ConfigTest.java
+++ b/controller/src/test/java/io/pravega/controller/util/ConfigTest.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.util;
 
 import io.pravega.controller.server.rpc.grpc.GRPCServerConfig;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,5 +50,11 @@ public class ConfigTest {
         Assert.assertEquals(9090, grpcServerConfig.getPort());
         Assert.assertEquals(9090, (int) grpcServerConfig.getPublishedRPCPort().orElse(12345));
         Assert.assertFalse(grpcServerConfig.getPublishedRPCHost().isPresent());
+    }
+
+    @Test
+    public void testMetricsConfig() {
+        val mc = Config.METRICS_CONFIG;
+        Assert.assertEquals("no-host", mc.getStatsDHost());
     }
 }

--- a/controller/src/test/resources/controller.config.properties
+++ b/controller/src/test/resources/controller.config.properties
@@ -46,3 +46,4 @@ controller.transaction.maxLeaseValue=30000
 #controller.transaction.ttlHours=
 controller.scale.streamName=_requeststream
 #controller.scale.readerGroup=scaleGroup
+controller.metrics.statsDHost=no-host


### PR DESCRIPTION
**Change log description**  
Fixing `Config.java#createMetricsConfig` to not prefix metrics-related config values with "metrics" - that is already done by the `MetricsConfig` builder.

**Purpose of the change**  
Fixes #3458.

**What the code does**  
Instead of replacing `controllermetrics.` with `metrics.` it simply removes `controller.metrics.` from the property name. The `MetricsConfig.builder()` will take care of the prefix.

**How to verify it**  
New unit test to verify metrics config for controller.
