### PR TITLE
Issue 3457: Fix for the ControllerRestApiTest.restApiTests test failure

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -540,8 +540,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                     streamsList.forEach((stream, config) -> {
 
                         try {
-                            if (restAuthHelper.isAuthorized(getAuthorizationHeader(),
-                                    AuthResourceRepresentation.ofStreamInScope(scopeName, stream),
+                            if (restAuthHelper.isAuthorized(authHeader, AuthResourceRepresentation.ofStreamInScope(scopeName, stream),
                                     principal, READ)) {
                                 // If internal streams are requested select only the ones that have the special stream names
                                 // otherwise display the regular user created streams.


### PR DESCRIPTION
Signed-off-by: Ravi Sharda <ravi.sharda@emc.com>

**Change log description**  

An HTTP status code `500` indicating `Internal Server Error` was encountered inside the integration test `ControllerRestApiTest.restApiTests`, upon invocation of the REST endpoint for listing streams: `/v1/scopes/<scope-name>/streams`. 

The error was due to a bug in the REST API controller method `StreamMetadataResourceImpl.listStreams()`, where the `Authorization` request header was being retrieved outside the HTTP request scope. This was causing the following exception: 

```
2019-03-13 12:59:56,798 118249 [controllerpool-1] WARN  i.p.c.s.r.r.StreamMetadataResourceImpl - listStreams for k3tQfG7LPO failed with exception: {}
    java.util.concurrent.CompletionException: java.lang.IllegalStateException: Not inside a request scope.
    	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
    	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
```

**Purpose of the change**  
Fixes #3457.

**What the code does**  

Inside the `StreamMetadataResourceImpl.listStreams()` method, we now reuse the cached authorization HTTP header values inside the `forEach` loop later in the method where the request scope is not accessible. 

**How to verify it**  
All of the tests should pass. 

I also tested manually by invoking the list streams endpoint for different users with different permissions assigned to them. The specific manual test cases were: 

1. Verify that the privileged user with acl `*,READ_UPDATE` is able to list all streams under any given scope. 
2. Verify that a user with acl `org.example.myscope,READ;org.example.myscope/*,READ` is able to:
    * List streams under scope `org.example.myscope`
    * See all streams under the scope in the result, when listing streams
3. Verify that a user with acl `org.example.myscope,READ;org.example.myscope/mystream2,READ` is able to:
   * List streams under scope `org.example.myscope`
   * Upon listing streams in that scope, sees only `mystream2` in the result. 