### PR TITLE
Issue 3465: Fix Segment comparision check in CommandEncoder.

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -84,7 +84,7 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
             Append append = (Append) msg;
             Session session = setupSegments.get(append.segment);
             validateAppend(append, session);
-            if (append.segment != segmentBeingAppendedTo) {
+            if (!append.segment.equals(segmentBeingAppendedTo)) {
                 breakFromAppend(out);
             }
             if (bytesLeftInBlock == 0) {


### PR DESCRIPTION
**Change log description**  
Fix Segment comparison check in CommandEncoder to use String.equals()

**Purpose of the change**  
Fixes #3465 

**What the code does**  
Fix Segment comparison check in CommandEncoder to use String.equals(). This check is used to decide to break out from an AppendBlock.

**How to verify it**  
All the existing tests should continue to pass.