### PR TITLE
Issue 3467: Monitor Pravega pods for restart during a system test run.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -193,8 +193,25 @@ public class K8sClient {
      * @param labelValue Value of the label.
      * @return Future representing the list of pod status.
      */
-    @SneakyThrows(ApiException.class)
     public CompletableFuture<List<V1PodStatus>> getStatusOfPodWithLabel(final String namespace, final String labelName, final String labelValue) {
+        CompletableFuture<V1PodList> future = getPodsWithLabel(namespace, labelName, labelValue);
+        return future
+                .thenApply(v1PodList -> {
+                    List<V1Pod> podList = v1PodList.getItems();
+                    log.debug("{} pod(s) found with label {}={}.", podList.size(), labelName, labelValue);
+                    return podList.stream().map(V1Pod::getStatus).collect(Collectors.toList());
+                });
+    }
+
+    /**
+     * Method to fetch all pods which match a label.
+     * @param namespace Namespace on which the pod(s) reside.
+     * @param labelName Name of the label.
+     * @param labelValue Value of the label.
+     * @return Future representing the list of pod status.
+     */
+    @SneakyThrows(ApiException.class)
+    public CompletableFuture<V1PodList> getPodsWithLabel(String namespace, String labelName, String labelValue) {
         CoreV1Api api = new CoreV1Api();
 
         // Workaround for okhttp issue, tracked by https://github.com/pravega/pravega/issues/3361
@@ -204,12 +221,23 @@ public class K8sClient {
         K8AsyncCallback<V1PodList> callback = new K8AsyncCallback<>("listPods");
         api.listNamespacedPodAsync(namespace, PRETTY_PRINT, null, null, true, labelName + "=" + labelValue, null,
                                    null, null, false, callback);
-        return callback.getFuture()
-                       .thenApply(v1PodList -> {
-                           List<V1Pod> podList = v1PodList.getItems();
-                           log.debug("{} pod(s) found with label {}={}.", podList.size(), labelName, labelValue);
-                           return podList.stream().map(V1Pod::getStatus).collect(Collectors.toList());
-                       });
+        return callback.getFuture();
+    }
+
+    /**
+     * Method to fetch all restarted pods which match a label.
+     * @param namespace Namespace on which the pod(s) reside.
+     * @param labelName Name of the label.
+     * @param labelValue Value of the label.
+     * @return Future representing the list of pod status.
+     */
+    public CompletableFuture<Map<String, V1ContainerStatus>> getRestartedPods(String namespace, String labelName, String labelValue) {
+        return getPodsWithLabel(namespace, labelName, labelValue)
+                     .thenApply(v1PodList -> v1PodList.getItems().stream()
+                                                      .filter(pod -> pod.getStatus().getContainerStatuses().size() != 0 && (pod.getStatus().getContainerStatuses().get(0).getRestartCount() != 0))
+                                                      .collect(Collectors.toMap(pod -> pod.getMetadata().getName(),
+                                                                                // currently this supports only one container per pod.
+                                                                                pod -> pod.getStatus().getContainerStatuses().get(0))));
     }
 
     /**

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -185,7 +185,6 @@ public class K8sClient {
                        });
     }
 
-
     /**
      * Method to fetch the status of all pods which match a label.
      * @param namespace Namespace on which the pod(s) reside.
@@ -194,8 +193,7 @@ public class K8sClient {
      * @return Future representing the list of pod status.
      */
     public CompletableFuture<List<V1PodStatus>> getStatusOfPodWithLabel(final String namespace, final String labelName, final String labelValue) {
-        CompletableFuture<V1PodList> future = getPodsWithLabel(namespace, labelName, labelValue);
-        return future
+        return getPodsWithLabel(namespace, labelName, labelValue)
                 .thenApply(v1PodList -> {
                     List<V1Pod> podList = v1PodList.getItems();
                     log.debug("{} pod(s) found with label {}={}.", podList.size(), labelName, labelValue);

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.test.system.framework.kubernetes;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiCallback;
@@ -208,22 +209,34 @@ public class K8sClient {
      * @param labelValue Value of the label.
      * @return Future representing the list of pod status.
      */
-    @SneakyThrows(ApiException.class)
     public CompletableFuture<V1PodList> getPodsWithLabel(String namespace, String labelName, String labelValue) {
+       return getPodsWithLabels(namespace, ImmutableMap.of(labelName, labelValue));
+    }
+
+    /**
+     * Method to fetch all pods which match a set of labels.
+     * @param namespace Namespace on which the pod(s) reside.
+     * @param labels Name of the label.
+     * @return Future representing the list of pod status.
+     */
+    @SneakyThrows(ApiException.class)
+    public CompletableFuture<V1PodList> getPodsWithLabels(String namespace, Map<String, String> labels) {
         CoreV1Api api = new CoreV1Api();
 
         // Workaround for okhttp issue, tracked by https://github.com/pravega/pravega/issues/3361
         log.debug("Current number of http interceptors {}", api.getApiClient().getHttpClient().networkInterceptors().size());
         api.getApiClient().getHttpClient().networkInterceptors().clear();
 
+        String labelSelector = labels.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining());
         K8AsyncCallback<V1PodList> callback = new K8AsyncCallback<>("listPods");
-        api.listNamespacedPodAsync(namespace, PRETTY_PRINT, null, null, true, labelName + "=" + labelValue, null,
+        api.listNamespacedPodAsync(namespace, PRETTY_PRINT, null, null, true, labelSelector, null,
                                    null, null, false, callback);
         return callback.getFuture();
     }
 
     /**
      * Method to fetch all restarted pods which match a label.
+     * Note: This method currently supports only one container per pod.
      * @param namespace Namespace on which the pod(s) reside.
      * @param labelName Name of the label.
      * @param labelValue Value of the label.
@@ -232,9 +245,9 @@ public class K8sClient {
     public CompletableFuture<Map<String, V1ContainerStatus>> getRestartedPods(String namespace, String labelName, String labelValue) {
         return getPodsWithLabel(namespace, labelName, labelValue)
                      .thenApply(v1PodList -> v1PodList.getItems().stream()
-                                                      .filter(pod -> pod.getStatus().getContainerStatuses().size() != 0 && (pod.getStatus().getContainerStatuses().get(0).getRestartCount() != 0))
+                                                      .filter(pod -> !pod.getStatus().getContainerStatuses().isEmpty() &&
+                                                              (pod.getStatus().getContainerStatuses().get(0).getRestartCount() != 0))
                                                       .collect(Collectors.toMap(pod -> pod.getMetadata().getName(),
-                                                                                // currently this supports only one container per pod.
                                                                                 pod -> pod.getStatus().getContainerStatuses().get(0))));
     }
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -96,8 +96,8 @@ public class K8SequentialExecutor implements TestExecutor {
 
     private void verifyPravegaPodRestart(Map<String, V1ContainerStatus> podStatusBeforeTest, Map<String, V1ContainerStatus> podStatusAfterTest) {
         Map<String, V1ContainerStatus> restartMapFinal = podStatusAfterTest.entrySet().stream()
-                                                                           .filter(e -> podStatusBeforeTest.containsKey(e.getKey())
-                                                                                   && podStatusBeforeTest.get(e.getKey()).getRestartCount() < e.getValue().getRestartCount())
+                                                                           .filter(e -> !podStatusBeforeTest.containsKey(e.getKey()) ||
+                                                                                   podStatusBeforeTest.get(e.getKey()).getRestartCount() < e.getValue().getRestartCount())
                                                                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (restartMapFinal.size() != 0) {
             log.error("Pravega pods have restarted, Details: {}", restartMapFinal);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -96,7 +96,7 @@ public class K8SequentialExecutor implements TestExecutor {
                                                                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (restartMapFinal.size() != 0) {
             log.error("Pravega pods have restarted, Details: {}", restartMapFinal);
-            throw new AssertionError("Failing test due to Pravega pod restart." + restartMapFinal);
+            throw new AssertionError("Failing test due to Pravega pod restart.\n" + restartMapFinal);
         }
     }
 


### PR DESCRIPTION
**Change log description**  
Monitor Pravega pod for restart during every system test run. A pod restart during the test run will fail the corresponding test and log the reason for the pravega pod failure.

**Purpose of the change**  
Fixes #3467 

**What the code does**  
The code now fetches the container Status of Pravega pods during every system test run. Incase the restart count of the Pravega pod is greater than what was observed during the start of the test then the  corresponding test is failed with the details.
Example output while simulating a pod restart  (used `docker kill <containerId>`  to simulate a Pravega pod failure)
```
io.pravega.test.system.PravegaTest > simpleTest FAILED
    java.lang.AssertionError: Failing test due to Pravega pod restart.
{pravega-pravega-controller-6fcf5658c8-7c6t6=class V1ContainerStatus {
        containerID: docker://3d9ad5cde103e5fbffc72a3f410aa49a4f081bf914d84b1ebef53608c9a2e3f7
        lastState: class V1ContainerState {
            running: null
            terminated: class V1ContainerStateTerminated {
                containerID: docker://2b2aed2e0ef4b5c54d9d006ae93314e92876d2b93b8ec9dc38e564d8a86a1d48
                exitCode: 137
                finishedAt: 2019-03-15T04:17:59.000-04:00
                message: null
                reason: Error
                signal: null
                startedAt: 2019-03-15T03:49:18.000-04:00
            }
   restartCount: 5       
   ....   
        state: class V1ContainerState {
            running: class V1ContainerStateRunning {
                startedAt: 2019-03-15T04:18:05.000-04:00
            }
            terminated: null
            waiting: null
        }
    }}
``` 
This also logs the container id, which can be used to fetch the logs from `fluentd` to understand more about the cause of failure.

**How to verify it**  
All the existing tests should continue to pass. 
Verified the behavior by performing `docker kill <containerId>` , which causes K8s to restart the pod causing the test to fail with this error.
