### PR TITLE
Issue 3462: Fix Segmentstore's Kubernetes bootstrapping

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -22,6 +22,10 @@ k8() {
         retval=$( curl --cacert ${cacert} -H "Authorization: Bearer ${bearer}" https://kubernetes.default.svc/api/v1/namespaces/${namespace}/${resource_type}/${resource_name} 2> /dev/null | jq -rM "${jsonpath}" 2> /dev/null )
     fi
 
+    if [ "$retval" == "null" ]; then
+        retval=""
+    fi
+
     echo "$retval"
 }
 


### PR DESCRIPTION
**Change log description**  
- Replace "null" return values with "" (empty string) to consider the value as invalid and keep the process in the retry loop.
- Refactor how the external service endpoint is obtained to reduce duplicated code.

**Purpose of the change**  
Fix #3462 

**What the code does**  
Updates the `init_kubernetes.sh` file.

**How to verify it**  
@jkhalack will be able to test the change in an environment where this error can be easily reproduced. 

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>