### PR TITLE
Issue 3471: MetadataScalability test does future.await which can incorrectly declare test successful 

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -138,7 +138,7 @@ public class MetadataScalabilityTest extends AbstractScaleTests {
                                                      });
                                 }), executorService);
 
-        CompletableFuture<Void> result = scaleFuture
+        scaleFuture
                 .thenCompose(r -> {
                     // try SCALES_TO_PERFORM randomly generated stream cuts and truncate stream at those 
                     // stream cuts. 
@@ -172,8 +172,6 @@ public class MetadataScalabilityTest extends AbstractScaleTests {
                                                      });
                                 });
                     }, executorService);
-                });
-
-        Futures.await(result);
+                }).join();
     }
 }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
 MetadataScalability test uses futures.await to wait for all scale and truncation to complete.
This means even if there is a failure during scale or truncation, the test will declare it success.

**Purpose of the change**  
Fixes #3471 

**What the code does**  
Uses `future.join` instead of `Futures.await`

**How to verify it**  
System test should pass
