### PR TITLE
Issue 3470: (SegmentStore) Increasing max number of active segments.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -24,10 +24,10 @@ public class ContainerConfig {
 
     public static final int MINIMUM_SEGMENT_METADATA_EXPIRATION_SECONDS = 60; // Minimum possible value for segmentExpiration
     public static final Property<Integer> SEGMENT_METADATA_EXPIRATION_SECONDS = Property.named("segmentMetadataExpirationSeconds",
-            5 * MINIMUM_SEGMENT_METADATA_EXPIRATION_SECONDS);
+            MINIMUM_SEGMENT_METADATA_EXPIRATION_SECONDS);
     public static final Property<Integer> METADATA_STORE_INIT_TIMEOUT_SECONDS = Property.named("metadataStoreInitTimeoutSeconds", 30);
     public static final Property<Integer> MAX_ACTIVE_SEGMENT_COUNT = Property.named("maxActiveSegmentCount", 10000);
-    public static final Property<Integer> MAX_CONCURRENT_SEGMENT_EVICTION_COUNT = Property.named("maxConcurrentSegmentEvictionCount", 250);
+    public static final Property<Integer> MAX_CONCURRENT_SEGMENT_EVICTION_COUNT = Property.named("maxConcurrentSegmentEvictionCount", 2500);
     public static final Property<Integer> MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT = Property.named("maxCachedExtendedAttributeCount", 4096);
     private static final String COMPONENT_CODE = "containers";
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -26,7 +26,7 @@ public class ContainerConfig {
     public static final Property<Integer> SEGMENT_METADATA_EXPIRATION_SECONDS = Property.named("segmentMetadataExpirationSeconds",
             MINIMUM_SEGMENT_METADATA_EXPIRATION_SECONDS);
     public static final Property<Integer> METADATA_STORE_INIT_TIMEOUT_SECONDS = Property.named("metadataStoreInitTimeoutSeconds", 30);
-    public static final Property<Integer> MAX_ACTIVE_SEGMENT_COUNT = Property.named("maxActiveSegmentCount", 10000);
+    public static final Property<Integer> MAX_ACTIVE_SEGMENT_COUNT = Property.named("maxActiveSegmentCount", 25000);
     public static final Property<Integer> MAX_CONCURRENT_SEGMENT_EVICTION_COUNT = Property.named("maxConcurrentSegmentEvictionCount", 2500);
     public static final Property<Integer> MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT = Property.named("maxCachedExtendedAttributeCount", 4096);
     private static final String COMPONENT_CODE = "containers";


### PR DESCRIPTION
**Change log description**  
- Increased the max number of active segments to 25000 (from 10000).
- Increased the max number of segments to be flushed at once to 2500 (from 250).
- Decreased the min amount of time to keep segments in memory that do not have an operation pointing at them to 1 minute (from 5 minutes).

**Purpose of the change**  
Fixes #3470.

**What the code does**  
- Changed configuration to accommodate more demanding system tests that cycle through a large number of segments at once.

**How to verify it**  
Unit tests must pass.
System tests must pass (or not have any trace of `TooManyActiveSegmentsException`). Two such runs executed so far.
