### PR TITLE
Issue #3344: (Watermarking) Add server side support for watermarking

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -58,4 +58,11 @@ public interface SegmentOutputStream extends AutoCloseable {
      * acknowledged as written. The iteration order in the List is from oldest to newest.
      */
     public abstract List<PendingEvent> getUnackedEventsOnSeal();
+    
+    /**
+     * This returns the write offset of a segment that was most recently observed from an Ack.
+     * This may not be the same as the current write offset. 
+     * If no acks have been observed on this segment it returns -1. 
+     */
+    public abstract long getLastObservedWriteOffset();
 }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -129,13 +129,13 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 return inflight.size();
             }
         }
-        
+
         private long getLastSegmentLength() {
             synchronized (lock) {
                 return segmentLength;
             }
         }
-        
+
         private void noteSegmentLength(long newLength) {
             synchronized (lock) {
                 segmentLength = Math.max(segmentLength, newLength);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -105,6 +105,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         private final ConcurrentSkipListMap<Long, PendingEvent> inflight = new ConcurrentSkipListMap<>();
         @GuardedBy("lock")
         private long eventNumber = 0;
+        @GuardedBy("lock")
+        private long segmentLength = -1;
         private final ReusableFutureLatch<ClientConnection> setupConnection = new ReusableFutureLatch<>();
         private final ReusableLatch waitingInflight = new ReusableLatch(true);
         private final AtomicBoolean needSuccessors = new AtomicBoolean();
@@ -125,6 +127,18 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         private int getNumInflight() {
             synchronized (lock) {
                 return inflight.size();
+            }
+        }
+        
+        private long getLastSegmentLength() {
+            synchronized (lock) {
+                return segmentLength;
+            }
+        }
+        
+        private void noteSegmentLength(long newLength) {
+            synchronized (lock) {
+                segmentLength = Math.max(segmentLength, newLength);
             }
         }
 
@@ -331,6 +345,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             try {
                 checkAckLevels(ackLevel, previousAckLevel);
                 ackUpTo(ackLevel);
+                state.noteSegmentLength(dataAppended.getCurrentSegmentWriteOffset());
             } catch (Exception e) {
                 failConnection(e);
             }
@@ -582,4 +597,11 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             return Collections.unmodifiableList(state.getAllInflightEvents());
         }
     }
+
+    @Override
+    public long getLastObservedWriteOffset() {
+        return state.getLastSegmentLength();
+    }
+    
+    
 }

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -45,7 +45,7 @@ public class EventWriterConfig implements Serializable {
      * it affects all transactions.
      */
     private final long transactionTimeoutTime;
-       
+
     /**
      * Automatically invoke {@link EventStreamWriter#noteTime(long)} passing
      * {@link System#currentTimeMillis()} on a regular interval.
@@ -58,7 +58,6 @@ public class EventWriterConfig implements Serializable {
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
         private long transactionTimeoutTime = 30 * 1000 - 1;
-        private long timestampAggrigationTimeout = 120 * 1000;
         private boolean automaticallyNoteTime = false; 
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -177,8 +177,8 @@ public class SegmentSelector {
     }
 
     @Synchronized
-    public List<SegmentOutputStream> getWriters() {
-        return new ArrayList<>(writers.values());
+    public Map<Segment, SegmentOutputStream> getWriters() {
+        return new HashMap<>(writers);
     }
 
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -201,6 +201,15 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
             return segment.getScopedName();
         }
 
+        @Override
+        public long getLastObservedWriteOffset() {
+            long result = 0;
+            for (PendingEvent value : unacked) {
+                result += value.getData().capacity();
+            }
+            return result;
+        }
+
     }
 
     @NotThreadSafe
@@ -245,6 +254,11 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         @Override
         public String getSegmentName() {
             return segment.getScopedName();
+        }
+
+        @Override
+        public long getLastObservedWriteOffset() {
+            return -1;
         }
 
     }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -239,4 +239,9 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     public void sealSegment() {
         //Nothing to do
     }
+
+    @Override
+    public long getLastObservedWriteOffset() {
+        return fetchCurrentSegmentLength();
+    }
 }

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/MergeStreamSegmentResult.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/MergeStreamSegmentResult.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.contracts;
+
+import java.util.Map;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class MergeStreamSegmentResult {
+
+    /**
+     * The new length of the target segment after the merge.
+     * This should be equal to the prior segment length plus {@link #getMergedDataLength()}
+     * 
+     * @return The length of the target segment.
+     */
+    private final long targetSegmentLength;
+    
+    /**
+     * Gets a value indicating the amount of data merged into the StreamSegment. 
+     * This should be the same as the size of the source segment.
+     *
+     * @return full readable length of the stream segment, including inaccessible bytes before the start offset
+     */
+    private final long mergedDataLength;
+    
+    /**
+     * Gets a read-only Map of AttributeId-Values of the source Segment.
+     *
+     * @return The source segment attributes
+     */
+    private final Map<UUID, Long> attributes;
+    
+}

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -26,44 +26,53 @@ import java.util.concurrent.CompletableFuture;
  * * To delete an Attribute, set its value to Attributes.NULL_ATTRIBUTE_VALUE.
  */
 public interface StreamSegmentStore {
+    
     /**
-     * Appends a range of bytes at the end of a StreamSegment and atomically updates the given attributes. The byte range
-     * will be appended as a contiguous block, however there is no guarantee of ordering between different calls to this
-     * method.
+     * Appends a range of bytes at the end of a StreamSegment and atomically updates the given
+     * attributes. The byte range will be appended as a contiguous block, however there is no
+     * guarantee of ordering between different calls to this method.
      *
      * @param streamSegmentName The name of the StreamSegment to append to.
      * @param data              The data to add.
-     * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
-     *                          See Notes about AttributeUpdates in the interface Javadoc.
+     * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which
+     *                          indicates no updates). See Notes about AttributeUpdates in the interface Javadoc.
      * @param timeout           Timeout for the operation
-     * @return A CompletableFuture that, will completed normally, if the add was added. If the
-     * operation failed, the future will be failed with the causing exception.
-     * @throws NullPointerException     If any of the arguments are null, except attributeUpdates.
+     * @return A CompletableFuture that, when completed normally, will indicate the append completed
+     *         successfully and contains the new length of the segment. If the operation failed, the
+     *         future will be failed with the causing exception. (NOTE: the length is not
+     *         necessarily the same as offset immediately following the data because the append may
+     *         have been batched together with others internally.)
+     * @throws NullPointerException If any of the arguments are null, except attributeUpdates.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't
-     *                                  check if the StreamSegment does not exist - that exception will be set in the
-     *                                  returned CompletableFuture).
+     *                                  check if the StreamSegment does not exist - that exception 
+     *                                  will be set in the returned CompletableFuture).
      */
-    CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout);
+    CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout);
 
     /**
-     * Appends a range of bytes at the end of a StreamSegment an atomically updates the given attributes, but only if the
-     * current length of the StreamSegment equals a certain value. The byte range will be appended as a contiguous block.
-     * This method guarantees ordering (among subsequent calls).
+     * Appends a range of bytes at the end of a StreamSegment an atomically updates the given
+     * attributes, but only if the current length of the StreamSegment equals a certain value. The
+     * byte range will be appended as a contiguous block. This method guarantees ordering (among
+     * subsequent calls).
      *
      * @param streamSegmentName The name of the StreamSegment to append to.
-     * @param offset            The offset at which to append. If the current length of the StreamSegment does not equal
-     *                          this value, the operation will fail with a BadOffsetException.
+     * @param offset            The offset at which to append. If the current length of the StreamSegment does
+     *                          not equal this value, the operation will fail with a BadOffsetException.
      * @param data              The data to add.
-     * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
-     *                          See Notes about AttributeUpdates in the interface Javadoc.
+     * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which
+     *                          indicates no updates). See Notes about AttributeUpdates in the interface Javadoc.
      * @param timeout           Timeout for the operation
-     * @return A CompletableFuture that, when completed normally, will indicate the append completed successfully.
-     * If the operation failed, the future will be failed with the causing exception.
-     * @throws NullPointerException     If any of the arguments are null, except attributeUpdates.
-     * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't check if the StreamSegment
-     *                                  does not exist - that exception will be set in the returned CompletableFuture).
+     * @return A CompletableFuture that, when completed normally, will indicate the append completed
+     *         successfully and contains the new length of the segment. If the operation failed, the
+     *         future will be failed with the causing exception. (NOTE: the length is not
+     *         necessarily the same as offset immediately following the data because the append may
+     *         have been batched together with others internally.)
+     * @throws NullPointerException If any of the arguments are null, except attributeUpdates.
+     * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't
+     *                                  check if the StreamSegment does not exist - that exception
+     *                                  will be set in the returned CompletableFuture).
      */
-    CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout);
+    CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout);
 
     /**
      * Performs an attribute update operation on the given Segment.
@@ -151,11 +160,11 @@ public interface StreamSegmentStore {
      * @param targetSegmentName The name of the StreamSegment to merge into.
      * @param sourceSegmentName The name of the StreamSegment to merge.
      * @param timeout           Timeout for the operation.
-     * @return A CompletableFuture that, when completed normally, will contain a SegmentProperties instance with the last known
-     * state of the source Segment. If the operation failed, the future will be failed with the causing exception.
+     * @return A CompletableFuture that, when completed normally, will contain a MergeStreamSegmentResult instance with information about the 
+     * source and target Segments. If the operation failed, the future will be failed with the causing exception.
      * @throws IllegalArgumentException If any of the arguments are invalid.
      */
-    CompletableFuture<SegmentProperties> mergeStreamSegment(String targetSegmentName, String sourceSegmentName, Duration timeout);
+    CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetSegmentName, String sourceSegmentName, Duration timeout);
 
     /**
      * Seals a StreamSegment for modifications.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -192,9 +192,9 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         long traceId = LoggerHelpers.traceEnter(log, "storeAppend", append);
         Timer timer = new Timer();
         storeAppend(append)
-                .whenComplete((v, e) -> {
-                    handleAppendResult(append, e, timer);
-                    LoggerHelpers.traceLeave(log, "storeAppend", traceId, v, e);
+                .whenComplete((length, e) -> {
+                    handleAppendResult(append, length, e, timer);
+                    LoggerHelpers.traceLeave(log, "storeAppend", traceId, append, e);
                 })
                 .whenComplete((v, e) -> append.getData().release());
     }
@@ -235,7 +235,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         }
     }
 
-    private CompletableFuture<Void> storeAppend(Append append) {
+    private CompletableFuture<Long> storeAppend(Append append) {
         long lastEventNumber;
         synchronized (lock) {
             lastEventNumber = latestEventNumbers.get(Pair.of(append.getSegment(), append.getWriterId()));
@@ -254,7 +254,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         }
     }
 
-    private void handleAppendResult(final Append append, Throwable exception, Timer elapsedTimer) {
+    private void handleAppendResult(final Append append, Long newWriteOffset, Throwable exception, Timer elapsedTimer) {
         boolean success = exception == null;
         try {
             boolean conditionalFailed = !success && (Exceptions.unwrap(exception) instanceof BadOffsetException);
@@ -268,7 +268,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
 
             if (success) {
                 final DataAppended dataAppendedAck = new DataAppended(append.getRequestId(), append.getWriterId(), append.getEventNumber(),
-                        previousEventNumber);
+                        previousEventNumber, newWriteOffset);
                 log.trace("Sending DataAppended : {}", dataAppendedAck);
                 connection.send(dataAppendedAck);
             } else {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -27,10 +27,10 @@ import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
 import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.ContainerNotFoundException;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
-import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentMergedException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
@@ -455,15 +455,24 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         log.info(mergeSegments.getRequestId(), "Merging Segments {} ", mergeSegments);
         segmentStore.mergeStreamSegment(mergeSegments.getTarget(), mergeSegments.getSource(), TIMEOUT)
-                    .thenAccept(txnProp -> {
-                        recordStatForTransaction(txnProp, mergeSegments.getTarget());
-                        connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(), mergeSegments.getTarget(), mergeSegments.getSource()));
+                    .thenAccept(mergeResult -> {
+                        recordStatForTransaction(mergeResult, mergeSegments.getTarget());
+                        connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
+                                                                        mergeSegments.getTarget(),
+                                                                        mergeSegments.getSource(),
+                                                                        mergeResult.getTargetSegmentLength()));
                     })
                     .exceptionally(e -> {
                         if (Exceptions.unwrap(e) instanceof StreamSegmentMergedException) {
                             log.info(mergeSegments.getRequestId(), "Stream segment is already merged '{}'.",
                                     mergeSegments.getSource());
-                            connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(), mergeSegments.getTarget(), mergeSegments.getSource()));
+                            segmentStore.getStreamSegmentInfo(mergeSegments.getTarget(), TIMEOUT)
+                                        .thenAccept(properties -> {
+                                            connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
+                                                                                            mergeSegments.getTarget(),
+                                                                                            mergeSegments.getSource(),
+                                                                                            properties.getLength()));
+                                        });
                             return null;
                         } else {
                             return handleException(mergeSegments.getRequestId(), mergeSegments.getSource(), operation, e);
@@ -602,7 +611,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         tableStore.merge(mergeTableSegments.getTarget(), mergeTableSegments.getSource(), TIMEOUT)
                   .thenRun(() -> connection.send(new WireCommands.SegmentsMerged(mergeTableSegments.getRequestId(),
                                                                                  mergeTableSegments.getTarget(),
-                                                                                 mergeTableSegments.getSource())))
+                                                                                 mergeTableSegments.getSource(), -1)))
                   .exceptionally(e -> handleException(mergeTableSegments.getRequestId(), mergeTableSegments.getSource(), operation, e));
     }
 
@@ -967,19 +976,19 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         return null;
     }
 
-    private void recordStatForTransaction(SegmentProperties sourceInfo, String targetSegmentName) {
+    private void recordStatForTransaction(MergeStreamSegmentResult mergeResult, String targetSegmentName) {
         try {
-            if (sourceInfo != null &&
-                    sourceInfo.getAttributes().containsKey(Attributes.CREATION_TIME) &&
-                            sourceInfo.getAttributes().containsKey(Attributes.EVENT_COUNT)) {
-                long creationTime = sourceInfo.getAttributes().get(Attributes.CREATION_TIME);
-                int numOfEvents = sourceInfo.getAttributes().get(Attributes.EVENT_COUNT).intValue();
-                long len = sourceInfo.getLength();
+            if (mergeResult != null &&
+                    mergeResult.getAttributes().containsKey(Attributes.CREATION_TIME) &&
+                            mergeResult.getAttributes().containsKey(Attributes.EVENT_COUNT)) {
+                long creationTime = mergeResult.getAttributes().get(Attributes.CREATION_TIME);
+                int numOfEvents = mergeResult.getAttributes().get(Attributes.EVENT_COUNT).intValue();
+                long len = mergeResult.getMergedDataLength();
                 statsRecorder.merge(targetSegmentName, len, numOfEvents, creationTime);
             }
         } catch (Exception ex) {
             // gobble up any errors from stat recording so we do not affect rest of the flow.
-            log.error("exception while computing stats while merging txn {}", sourceInfo.getName(), ex);
+            log.error("exception while computing stats while merging txn into {}", targetSegmentName, ex);
         }
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -14,6 +14,7 @@ import io.netty.buffer.ByteBuf;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.HashedArray;
 import io.pravega.segmentstore.contracts.Attributes;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
@@ -298,7 +299,7 @@ public class PravegaRequestProcessorTest {
         // so createSegmentStats may record 1 or 2 createSegment operation here.
     }
 
-    @Test(timeout = 20000)
+    @Test//(timeout = 20000)
     public void testTransaction() throws Exception {
         String streamSegmentName = "scope/stream/testTxn";
         UUID txnid = UUID.randomUUID();
@@ -324,7 +325,7 @@ public class PravegaRequestProcessorTest {
             return t instanceof WireCommands.StreamSegmentInfo && ((WireCommands.StreamSegmentInfo) t).exists();
         }));
         processor.mergeSegments(new WireCommands.MergeSegments(requestId, streamSegmentName, transactionName, ""));
-        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, -1));
+        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, 2));
         processor.getStreamSegmentInfo(new WireCommands.GetStreamSegmentInfo(requestId, transactionName, ""));
         order.verify(connection)
                 .send(new WireCommands.NoSuchSegment(requestId, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid), "", -1L));
@@ -360,7 +361,7 @@ public class PravegaRequestProcessorTest {
         store.sealStreamSegment(txnName, Duration.ZERO).join();
 
         processor.mergeSegments(new WireCommands.MergeSegments(requestId, streamSegmentName, transactionName, ""));
-        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, -1));
+        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, 4));
         processor.getStreamSegmentInfo(new WireCommands.GetStreamSegmentInfo(requestId, transactionName, ""));
         order.verify(connection)
                 .send(new WireCommands.NoSuchSegment(requestId, StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid), "", -1L));
@@ -394,7 +395,7 @@ public class PravegaRequestProcessorTest {
         processor.createSegment(new WireCommands.CreateSegment(requestId, transactionName, WireCommands.CreateSegment.NO_SCALE, 0, ""));
         order.verify(connection).send(new WireCommands.SegmentCreated(requestId, transactionName));
         processor.mergeSegments(new WireCommands.MergeSegments(requestId, streamSegmentName, transactionName, ""));
-        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, -1));
+        order.verify(connection).send(new WireCommands.SegmentsMerged(requestId, streamSegmentName, transactionName, 0));
 
         txnid = UUID.randomUUID();
         transactionName = StreamSegmentNameUtils.getTransactionNameFromId(streamSegmentName, txnid);
@@ -425,7 +426,7 @@ public class PravegaRequestProcessorTest {
                 anyString(), any());
 
         //test txn segment merge
-        CompletableFuture<SegmentProperties> txnFuture = CompletableFuture.completedFuture(createSegmentProperty(streamSegmentName, txnId));
+        CompletableFuture<MergeStreamSegmentResult> txnFuture = CompletableFuture.completedFuture(createMergeStreamSegmentResult(streamSegmentName, txnId));
         doReturn(txnFuture).when(store).mergeStreamSegment(anyString(), anyString(), any());
         SegmentStatsRecorder recorderMock = mock(SegmentStatsRecorder.class);
         PravegaRequestProcessor processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, recorderMock,
@@ -438,6 +439,13 @@ public class PravegaRequestProcessorTest {
         verify(recorderMock).merge(streamSegmentName, 100L, 10, (long) streamSegmentName.hashCode());
     }
 
+    private MergeStreamSegmentResult createMergeStreamSegmentResult(String streamSegmentName, UUID txnId) {
+        Map<UUID, Long> attributes = new HashMap<>();
+        attributes.put(Attributes.EVENT_COUNT, 10L);
+        attributes.put(Attributes.CREATION_TIME, (long) streamSegmentName.hashCode());
+        return new MergeStreamSegmentResult(100, 100, attributes);
+    }
+    
     private SegmentProperties createSegmentProperty(String streamSegmentName, UUID txnId) {
 
         Map<UUID, Long> attributes = new HashMap<>();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
@@ -18,6 +18,7 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.Services;
 import io.pravega.common.util.Retry;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
@@ -151,12 +152,12 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     }
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         return unsupported("append");
     }
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         return unsupported("append");
     }
 
@@ -176,7 +177,7 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
+    public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
         return unsupported("mergeStreamSegment");
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -25,6 +25,7 @@ import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentMergedException;
@@ -340,7 +341,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     //region StreamSegmentStore Implementation
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         ensureRunning();
 
         TimeoutTimer timer = new TimeoutTimer(timeout);
@@ -349,12 +350,14 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         return this.metadataStore.getOrAssignSegmentId(streamSegmentName, timer.getRemaining(),
                 streamSegmentId -> {
                     StreamSegmentAppendOperation operation = new StreamSegmentAppendOperation(streamSegmentId, data, attributeUpdates);
-                    return processAttributeUpdaterOperation(operation, timer);
+                    return processAttributeUpdaterOperation(operation, timer).thenApply(v -> {
+                        return operation.getLastStreamSegmentOffset();
+                    });
                 });
     }
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         ensureRunning();
 
         TimeoutTimer timer = new TimeoutTimer(timeout);
@@ -363,7 +366,9 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         return this.metadataStore.getOrAssignSegmentId(streamSegmentName, timer.getRemaining(),
                 streamSegmentId -> {
                     StreamSegmentAppendOperation operation = new StreamSegmentAppendOperation(streamSegmentId, offset, data, attributeUpdates);
-                    return processAttributeUpdaterOperation(operation, timer);
+                    return processAttributeUpdaterOperation(operation, timer).thenApply(v -> {
+                        return operation.getLastStreamSegmentOffset();
+                    });
                 });
     }
 
@@ -460,7 +465,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
+    public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
         ensureRunning();
 
         logRequest("mergeStreamSegment", targetStreamSegment, sourceStreamSegment);
@@ -476,7 +481,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                 .getOrAssignSegmentId(targetStreamSegment, timer.getRemaining(),
                         targetSegmentId -> this.metadataStore.getOrAssignSegmentId(sourceStreamSegment, timer.getRemaining(),
                                 sourceSegmentId -> mergeStreamSegment(targetSegmentId, sourceSegmentId, timer)))
-                .handleAsync((sp, ex) -> {
+                .handleAsync((msr, ex) -> {
                     if (ex == null || Exceptions.unwrap(ex) instanceof StreamSegmentMergedException) {
                         // No exception or segment was already merged. Need to clear SegmentInfo for source.
                         // We can do this asynchronously and not wait on it.
@@ -485,7 +490,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
 
                     if (ex == null) {
                         // Everything is good. Return the result.
-                        return sp;
+                        return msr;
                     } else {
                         // Re-throw the exception to the caller in this case.
                         throw new CompletionException(ex);
@@ -493,35 +498,44 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                 }, this.executor);
     }
 
-    private CompletableFuture<SegmentProperties> mergeStreamSegment(long targetSegmentId, long sourceSegmentId, TimeoutTimer timer) {
+    private CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(long targetSegmentId, long sourceSegmentId, TimeoutTimer timer) {
         // Get a reference to the source segment's metadata now, before the merge. It may not be accessible afterwards.
         SegmentMetadata sourceMetadata = this.metadata.getStreamSegmentMetadata(sourceSegmentId);
 
-        CompletableFuture<Void> result = trySealStreamSegment(sourceMetadata, timer.getRemaining());
+        CompletableFuture<Void> sealResult = trySealStreamSegment(sourceMetadata, timer.getRemaining());
         if (sourceMetadata.getLength() == 0) {
             // Source is empty. We may be able to skip the merge altogether and simply delete the segment. But we can only
             // be certain of this if the source is also sealed, otherwise it's possible it may still have outstanding
             // writes in the pipeline. As such, we cannot pipeline the two operations, and must wait for the seal to finish first.
-            result = result.thenComposeAsync(v -> {
+            return sealResult.thenComposeAsync(v -> {
                 // Seal is done. The DurableLog guarantees that the metadata is now updated with all operations up
                 // to and including the seal, so if there were any writes outstanding before, they should now be reflected in it.
                 if (sourceMetadata.getLength() == 0) {
                     // Source is still empty after sealing - OK to delete.
                     log.debug("{}: Deleting empty source segment instead of merging {}.", this.traceObjectId, sourceMetadata.getName());
-                    return deleteStreamSegment(sourceMetadata.getName(), timer.getRemaining());
+                    return deleteStreamSegment(sourceMetadata.getName(), timer.getRemaining()).thenApply(v2 -> {
+                        return new MergeStreamSegmentResult(this.metadata.getStreamSegmentMetadata(targetSegmentId).getLength(),
+                                                            sourceMetadata.getLength(), sourceMetadata.getAttributes());
+                    });
                 } else {
                     // Source now has some data - we must merge the two.
-                    return this.durableLog.add(new MergeSegmentOperation(targetSegmentId, sourceSegmentId), timer.getRemaining());
+                    MergeSegmentOperation operation = new MergeSegmentOperation(targetSegmentId, sourceSegmentId);
+                    return this.durableLog.add(operation, timer.getRemaining()).thenApply(v2 -> {
+                        return new MergeStreamSegmentResult(operation.getStreamSegmentOffset() + operation.getLength(),
+                                                            operation.getLength(), sourceMetadata.getAttributes());
+                    });
                 }
             }, this.executor);
         } else {
             // Source is not empty, so we cannot delete. Make use of the DurableLog's pipelining abilities by queueing up
             // the Merge right after the Seal.
-            result = CompletableFuture.allOf(result,
-                    this.durableLog.add(new MergeSegmentOperation(targetSegmentId, sourceSegmentId), timer.getRemaining()));
+            MergeSegmentOperation operation = new MergeSegmentOperation(targetSegmentId, sourceSegmentId);
+            return CompletableFuture.allOf(sealResult,
+                                           this.durableLog.add(operation, timer.getRemaining())).thenApply(v2 -> {
+                                               return new MergeStreamSegmentResult(operation.getStreamSegmentOffset() + operation.getLength(),
+                                                                                   operation.getLength(), sourceMetadata.getAttributes());
+                                           });
         }
-
-        return result.thenApply(v -> sourceMetadata.getSnapshot());
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageOperation.java
@@ -61,8 +61,9 @@ public abstract class StorageOperation extends Operation implements SegmentOpera
     public abstract long getLength();
 
     /**
-     * Gets a value indicating the Offset within the StreamSegment of the last byte that this operation applies (i.e., ending offset).
-     * @return The Offset within the StreamSegment of the last byte that this operation applies.
+     * Gets a value indicating the Offset within the StreamSegment following the last byte that this operation applies 
+     * (i.e., the next write's offset).
+     * @return The Offset within the StreamSegment following the last byte that this operation applies.
      */
     public long getLastStreamSegmentOffset() {
         return getStreamSegmentOffset() + getLength();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStore.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.mocks;
 
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -32,17 +33,17 @@ public class SynchronousStreamSegmentStore implements StreamSegmentStore {
     private final StreamSegmentStore impl;
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates,
+    public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates,
                                           Duration timeout) {
-        CompletableFuture<Void> result = impl.append(streamSegmentName, data, attributeUpdates, timeout);
+        CompletableFuture<Long> result = impl.append(streamSegmentName, data, attributeUpdates, timeout);
         Futures.await(result);
         return result;
     }
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data,
+    public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data,
                                           Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
-        CompletableFuture<Void> result = impl.append(streamSegmentName, offset, data, attributeUpdates, timeout);
+        CompletableFuture<Long> result = impl.append(streamSegmentName, offset, data, attributeUpdates, timeout);
         Futures.await(result);
         return result;
     }
@@ -84,8 +85,8 @@ public class SynchronousStreamSegmentStore implements StreamSegmentStore {
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
-        CompletableFuture<SegmentProperties> result = impl.mergeStreamSegment(targetStreamSegment, sourceStreamSegment, timeout);
+    public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
+        CompletableFuture<MergeStreamSegmentResult> result = impl.mergeStreamSegment(targetStreamSegment, sourceStreamSegment, timeout);
         Futures.await(result);
         return result;
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.server.store;
 
 import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -45,7 +46,7 @@ public class StreamSegmentService extends SegmentContainerCollection implements 
     //region StreamSegmentStore Implementation
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         return invoke(
                 streamSegmentName,
                 container -> container.append(streamSegmentName, data, attributeUpdates, timeout),
@@ -53,7 +54,7 @@ public class StreamSegmentService extends SegmentContainerCollection implements 
     }
 
     @Override
-    public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+    public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
         return invoke(
                 streamSegmentName,
                 container -> container.append(streamSegmentName, offset, data, attributeUpdates, timeout),
@@ -101,7 +102,7 @@ public class StreamSegmentService extends SegmentContainerCollection implements 
     }
 
     @Override
-    public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
+    public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
         return invoke(
                 sourceStreamSegment,
                 container -> container.mergeStreamSegment(targetStreamSegment, sourceStreamSegment, timeout),

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -16,6 +16,7 @@ import io.pravega.common.concurrent.Services;
 import io.pravega.common.util.ReusableLatch;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.ContainerNotFoundException;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
@@ -334,12 +335,12 @@ public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
         //region Unimplemented methods
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             return null;
         }
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             return null;
         }
 
@@ -369,7 +370,7 @@ public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
+        public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetStreamSegment, String sourceStreamSegment, Duration timeout) {
             return null;
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -391,7 +391,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                 lengths.put(segmentName, lengths.getOrDefault(segmentName, 0L) + appendData.length);
                 recordAppend(segmentName, appendData, segmentContents);
 
-                result.add(store -> store.append(segmentName, appendData, createAttributeUpdates(), TIMEOUT));
+                result.add(store -> Futures.toVoid(store.append(segmentName, appendData, createAttributeUpdates(), TIMEOUT)));
             }
 
             // Add the rest of the attribute updates.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -17,6 +17,7 @@ import io.pravega.common.util.AsyncIterator;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.HashedArray;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
@@ -944,12 +945,12 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             throw new UnsupportedOperationException("Not Expected");
         }
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             throw new UnsupportedOperationException("Not Expected");
         }
 
@@ -974,7 +975,7 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public CompletableFuture<SegmentProperties> mergeStreamSegment(String targetSegmentName, String sourceSegmentName, Duration timeout) {
+        public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String targetSegmentName, String sourceSegmentName, Duration timeout) {
             throw new UnsupportedOperationException("Not Expected");
         }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -700,15 +700,16 @@ public final class WireCommands {
             out.writeLong(eventNumber);
             out.writeLong(previousEventNumber);
             out.writeLong(requestId);
+            out.writeLong(currentSegmentWriteOffset);
         }
 
         public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
-            long offset = in.readLong();
+            long eventNumber = in.readLong();
             long previousEventNumber = in.available() >= Long.BYTES ? in.readLong() : -1L;
             long requestId = in.available() >= Long.BYTES ? in.readLong() : -1L;
             long currentSegmentWriteOffset = in.available() >= Long.BYTES ? in.readLong() : -1L;
-            return new DataAppended(requestId, writerId, offset, previousEventNumber, currentSegmentWriteOffset);
+            return new DataAppended(requestId, writerId, eventNumber, previousEventNumber, currentSegmentWriteOffset);
         }
         
         @Override

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -180,6 +180,40 @@ public class WireCommandsTest {
             out.writeLong(eventNumber);
         }
     }
+    
+    @Data
+    public static final class DataAppendedV3 implements WireCommand {
+        final WireCommandType type = WireCommandType.DATA_APPENDED;
+        final UUID writerId;
+        final long eventNumber;
+        final long previousEventNumber;
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(writerId.getMostSignificantBits());
+            out.writeLong(writerId.getLeastSignificantBits());
+            out.writeLong(eventNumber);
+            out.writeLong(previousEventNumber);
+        }
+    }
+    
+    @Data
+    public static final class DataAppendedV4 implements WireCommand {
+        final WireCommandType type = WireCommandType.DATA_APPENDED;
+        final long requestId;
+        final UUID writerId;
+        final long eventNumber;
+        final long previousEventNumber;
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(writerId.getMostSignificantBits());
+            out.writeLong(writerId.getLeastSignificantBits());
+            out.writeLong(eventNumber);
+            out.writeLong(previousEventNumber);
+            out.writeLong(requestId);
+        }
+    }
 
     @Test
     public void testDataAppended() throws IOException {
@@ -187,11 +221,21 @@ public class WireCommandsTest {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         DataAppendedV2 commandV2 = new DataAppendedV2(uuid, l);
         commandV2.writeFields(new DataOutputStream(bout));
-        testCommandFromByteArray(bout.toByteArray(), new WireCommands.DataAppended(-1L, uuid, l, -1, l));
+        testCommandFromByteArray(bout.toByteArray(), new WireCommands.DataAppended(-1L, uuid, l, -1, -1));
 
+        bout = new ByteArrayOutputStream();
+        DataAppendedV3 commandV3 = new DataAppendedV3(uuid, l, 2);
+        commandV3.writeFields(new DataOutputStream(bout));
+        testCommandFromByteArray(bout.toByteArray(), new WireCommands.DataAppended(-1L, uuid, l, 2L, -1));
+        
+        bout = new ByteArrayOutputStream();
+        DataAppendedV4 commandV4 = new DataAppendedV4(4, uuid, l, 3);
+        commandV4.writeFields(new DataOutputStream(bout));
+        testCommandFromByteArray(bout.toByteArray(), new WireCommands.DataAppended(4L, uuid, l, 3L, -1));
+        
         // Test that we are able to encode and decode the current response
         // to append data correctly.
-        testCommand(new WireCommands.DataAppended(l, uuid, l, Long.MIN_VALUE, -l));
+        testCommand(new WireCommands.DataAppended(1, uuid, l, Long.MIN_VALUE, -l));
     }
 
     /*

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
@@ -17,6 +17,7 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.ArrayView;
 import io.pravega.common.util.AsyncIterator;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
@@ -142,7 +143,7 @@ class InProcessMockClientAdapter extends ClientAdapterBase {
         }
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             if (this.segments.contains(streamSegmentName)) {
                 return CompletableFuture.completedFuture(null);
             } else {
@@ -151,7 +152,7 @@ class InProcessMockClientAdapter extends ClientAdapterBase {
         }
 
         @Override
-        public CompletableFuture<Void> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+        public CompletableFuture<Long> append(String streamSegmentName, long offset, byte[] data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
             return append(streamSegmentName, data, attributeUpdates, timeout);
         }
 
@@ -180,7 +181,7 @@ class InProcessMockClientAdapter extends ClientAdapterBase {
         }
 
         @Override
-        public CompletableFuture<SegmentProperties> mergeStreamSegment(String target, String source, Duration timeout) {
+        public CompletableFuture<MergeStreamSegmentResult> mergeStreamSegment(String target, String source, Duration timeout) {
             throw new UnsupportedOperationException("mergeStreamSegment");
         }
 

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
@@ -185,7 +185,7 @@ class SegmentStoreAdapter extends StoreAdapter {
         ensureRunning();
         ArrayView s = event.getSerialization();
         byte[] payload = s.arrayOffset() == 0 ? s.array() : Arrays.copyOfRange(s.array(), s.arrayOffset(), s.getLength());
-        return this.streamSegmentStore.append(streamName, payload, null, timeout)
+        return Futures.toVoid(this.streamSegmentStore.append(streamName, payload, null, timeout))
                                       .exceptionally(ex -> attemptReconcile(ex, streamName, timeout));
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -121,7 +121,7 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
         @Cleanup
         ClientFactoryImpl clientFactory = new ClientFactoryImpl("test", controller, connectionFactory);
         @Cleanup
-        TransactionalEventStreamWriter<String> test = clientFactory.createTransactionalEventWriter("writer","test", new UTF8StringSerializer(),
+        TransactionalEventStreamWriter<String> test = clientFactory.createTransactionalEventWriter("writer", "test", new UTF8StringSerializer(),
                 EventWriterConfig.builder().transactionTimeoutTime(10000).build());
         Transaction<String> transaction1 = test.beginTxn();
         transaction1.writeEvent("0", "txntest1");


### PR DESCRIPTION
**NOTE: This is merging to the Watermarking branch not master.**

**Change log description**  
* Add server side support and new wirecommands needed for watermarking
* Add plumbing on the client to get the offsets where they are needed.

**Purpose of the change**  
Sub item of #3344

**What the code does**  
Changes appends and segment merges to return the length of the segment after the data has been appended. This will be collected by the writer and passed to the controller when time is noted.

**How to verify it**  
Not yet ready for end-to-end testing as client impl is not complete.
