### PR TITLE
Issue 3479: Increase client throttling limit

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -70,8 +70,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     //region Members
 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
-    private static final int HIGH_WATER_MARK = 128 * 10 * 1024;
-    private static final int LOW_WATER_MARK = 64 * 10 * 1024;
+    private static final int HIGH_WATER_MARK = 640 * 1024; // 640KB
+    private static final int LOW_WATER_MARK = 320 * 1024;  // 320KB
     private static final String EMPTY_STACK_TRACE = "";
     private final StreamSegmentStore store;
     private final ServerConnection connection;

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -70,8 +70,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     //region Members
 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
-    private static final int HIGH_WATER_MARK = 128 * 1024;
-    private static final int LOW_WATER_MARK = 64 * 1024;
+    private static final int HIGH_WATER_MARK = 128 * 10 * 1024;
+    private static final int LOW_WATER_MARK = 64 * 10 * 1024;
     private static final String EMPTY_STACK_TRACE = "";
     private final StreamSegmentStore store;
     private final ServerConnection connection;


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**  
  * increased the throttling limit by a factor of ~~10~~ 5 to ensure the clients are not blocked 

**Purpose of the change**  
To address the issue https://github.com/pravega/pravega/issues/3479

**What the code does**  
Increased the throttling configuration setting in `AppendProcessor`  

**How to verify it**  
test by writing more/frequent data with/without the fix and observe the write throughput difference
