### PR TITLE
Issue 3464: (SegmentStore) Properly calculating StorageWriter acks

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -176,6 +176,17 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
                 });
     }
 
+    @Override
+    public String toString() {
+        return String.format(
+                "[%d: %s] Count = %d, LastOffset = %s, LUSN = %d",
+                this.connector.getMetadata().getId(),
+                this.connector.getMetadata().getName(),
+                this.aggregator.size(),
+                this.lastAddedOffset,
+                getLowestUncommittedSequenceNumber());
+    }
+
     //endregion
 
     //region Helpers
@@ -469,6 +480,10 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
             }
 
             return true;
+        }
+
+        synchronized int size() {
+            return this.appendOffsets.size();
         }
 
         @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AckCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AckCalculator.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.writer;
 
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.server.WriterSegmentProcessor;
+import io.pravega.segmentstore.server.logs.operations.Operation;
 
 /**
  * Helper class that calculates Ack Sequence Numbers based on input information from OperationProcessors.
@@ -31,9 +32,10 @@ class AckCalculator {
     /**
      * Determines the largest Sequence Number that can be safely truncated from the Writer's Data Source. All operations
      * up to, and including the one for this Sequence Number have been successfully committed to External Storage.
-     * <p>
+     *
      * The Sequence Number we acknowledge has the property that all operations up to, and including it, have been
      * committed to Storage.
+     *
      * This can only be calculated by looking at all the active SegmentAggregators and picking the Lowest Uncommitted
      * Sequence Number (LUSN) among all of those Aggregators that have any outstanding data. The LUSN for each aggregator
      * has the property that, within the context of that Aggregator alone, all Operations that have a Sequence Number (SN)
@@ -41,10 +43,16 @@ class AckCalculator {
      * all the active SegmentAggregators will give us the highest SN that can be safely truncated out of the OperationLog.
      * Note that LUSN still points to an uncommitted Operation, so we need to subtract 1 from it to obtain the highest SN
      * that can be truncated up to (and including).
+     *
      * If we have no active Aggregators, then we have committed all operations that were passed to us, so we can
      * safely truncate up to LastReadSequenceNumber.
      *
-     * @param processors The Processors to inspect for commit status.
+     * As opposed from {@link #getLowestUncommittedSequenceNumber}, this method should be called for
+     * {@link WriterSegmentProcessor} instances that deal with different Segments.
+     *
+     * @param processors The {@link WriterSegmentProcessor} to inspect for commit status.
+     * @param <T> {@link WriterSegmentProcessor} type.
+     * @return The Highest Committed Sequence Number.
      */
     <T extends WriterSegmentProcessor> long getHighestCommittedSequenceNumber(Iterable<T> processors) {
         long lowestUncommittedSeqNo = Long.MAX_VALUE;
@@ -61,5 +69,32 @@ class AckCalculator {
 
         lowestUncommittedSeqNo = Math.min(lowestUncommittedSeqNo, this.state.getLastReadSequenceNumber());
         return lowestUncommittedSeqNo;
+    }
+
+    /**
+     * Determines the lowest Sequence Number across the given {@link WriterSegmentProcessor} instances that has not
+     * yet been committed to Storage.
+     * <p>
+     * As opposed from {@link #getHighestCommittedSequenceNumber}, this method should be called for
+     * {@link WriterSegmentProcessor} instances that deal with the same Segment.
+     *
+     * @param processors The {@link WriterSegmentProcessor} to inspect.
+     * @param <T>        {@link WriterSegmentProcessor} type.
+     * @return The Lowest Uncommited Sequence Number.
+     */
+    <T extends WriterSegmentProcessor> long getLowestUncommittedSequenceNumber(Iterable<T> processors) {
+        // We need to find the lowest value across all processors that have uncommitted data.
+        long result = Long.MAX_VALUE;
+        for (WriterSegmentProcessor p : processors) {
+            // If a processor has uncommitted data, its LUSN will be a positive number. Otherwise it means it is up-to-date.
+            long sn = p.getLowestUncommittedSequenceNumber();
+            if (sn >= 0 && sn < result) {
+                result = sn;
+            }
+        }
+
+        // If at least one processor has uncommitted data, return the smallest LUSN among them. Otherwise report that
+        // everything is up-to date.
+        return result == Long.MAX_VALUE ? Operation.NO_SEQUENCE_NUMBER : result;
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -228,7 +228,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
     @Override
     public String toString() {
         return String.format(
-                "[%d: %s] Count = %d, LastOffset = %s, LUSN = %d LastFlush = %ds",
+                "[%d: %s] Count = %d, LastOffset = %s, LUSN = %d, LastFlush = %ds",
                 this.metadata.getId(),
                 this.metadata.getName(),
                 this.operations.size(),

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -543,7 +543,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     /**
      * Wraps a collection of WriterSegmentProcessors, including the main Segment Aggregator.
      */
-    private static class ProcessorCollection implements WriterSegmentProcessor {
+    private class ProcessorCollection implements WriterSegmentProcessor {
         private final SegmentAggregator aggregator;
         private final List<WriterSegmentProcessor> processors;
 
@@ -594,11 +594,9 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
 
         @Override
         public long getLowestUncommittedSequenceNumber() {
-            // We collect the lowest value across all processors.
-            return this.processors.stream()
-                                  .mapToLong(WriterSegmentProcessor::getLowestUncommittedSequenceNumber)
-                                  .min()
-                                  .orElse(Operation.NO_SEQUENCE_NUMBER);
+            return this.processors.size() == 1
+                    ? this.processors.get(0).getLowestUncommittedSequenceNumber()
+                    : StorageWriter.this.ackCalculator.getLowestUncommittedSequenceNumber(this.processors);
         }
 
         @Override


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `StorageWriter` where it wasn't correctly calculating the ack sequence number for Table Segments.

**Purpose of the change**  
Fixes #3464.

**What the code does**  
- For Table Segments, there are two types of processors: `SegmentAggregator` (that moves data to Tier2) and `WriterTableProcessor` (which indexes table updates)
- When determining the Sequence Number (SN) that's appropriate to truncate Tier 1 at, for each Table Segment, it needs to get the minimum of the SNs that have not yet been processed. 
- If a particular processor is fully caught up, it returns a special value `Operation.NO_SEQUENCE_NUMBER`, which also happens to be negative, hence smaller than any real SN.
- The current code was confused about this and if the Table Processor was ahead of the Segment Aggregator (and fully caught up), it would incorrectly report that both were fully caught up. As such, the Storage Writer would potentially truncate more from Tier 1 than has been moved to Tier 2, which would cause data loss (corruption) upon recovery.
- This was fixed so that the min-calculation ignores fully-caught-up processors and only returns that special value if ALL processors are fully caught up.

**How to verify it**  
New unit test added to test corner case.
System test must pass (1744 did).
