### PR TITLE
Issue 3487: Make Docker images configurable for K8 system tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -801,13 +801,16 @@ project('test:system') {
 
         ext.repoUrl = project.hasProperty("repoUrl") ? project.repoUrl : ""
         systemProperty "execType", "KUBERNETES"
-        systemProperty "pravegaOperatorVersion", System.getProperty("pravegaOperatorVersion", "latest") // default value is "latest"
+        systemProperty "pravegaOperatorImage", System.getProperty("pravegaOperatorImage", "pravega/pravega-operator:latest")
+        systemProperty "zookeeperOperatorImage", System.getProperty("zookeeperOperatorImage", "pravega/zookeeper-operator:latest")
         // The below properties are used to to specify the pravega docker image properties
         // e.g: private-docker-repo/pravega-prefix/pravega:version
         if (System.getProperty("dockerRegistryUrl") != null) { // docker images are pulled from dockerhub if dockerRegistryUrl is not specified.
             systemProperty "dockerRegistryUrl", System.getProperty("dockerRegistryUrl") + "/"
         }
         systemProperty "imagePrefix", System.getProperty("imagePrefix", "pravega")  // the default value of imagePrefix is pravega.
+        systemProperty "pravegaImageName", System.getProperty("pravegaImageName", "pravega") // pravega image name
+        systemProperty "bookkeeperImageName", System.getProperty("bookkeeperImageName", "bookkeeper") // bookkeeper image name
         systemProperty "imageVersion", System.getProperty("imageVersion") // pravega version.
         // bookkeeper version defaults to pravega version.
         systemProperty "pravegaBookkeeperVersion", System.getProperty("pravegaBookkeeperVersion", System.getProperty("imageVersion"))

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -72,12 +72,12 @@ public abstract class AbstractService implements Service {
     static final String PRAVEGA_SEGMENTSTORE_LABEL = "pravega-segmentstore";
     static final String BOOKKEEPER_LABEL = "bookie";
     static final String PRAVEGA_ID = "pravega";
+    static final String ZOOKEEPER_OPERATOR_IMAGE = System.getProperty("zookeeperOperatorImage", "pravega/zookeeper-operator:latest");
     static final String IMAGE_PULL_POLICY = System.getProperty("imagePullPolicy", "Always");
     private static final String DOCKER_REGISTRY =  System.getProperty("dockerRegistryUrl", "");
     private static final String PRAVEGA_VERSION = System.getProperty("imageVersion", "latest");
     private static final String PRAVEGA_BOOKKEEPER_VERSION = System.getProperty("pravegaBookkeeperVersion", PRAVEGA_VERSION);
     private static final String PRAVEGA_OPERATOR_IMAGE = System.getProperty("pravegaOperatorImage", "pravega/pravega-operator:latest");
-    static final String ZOOKEEPER_OPERATOR_IMAGE = System.getProperty("zookeeperOperatorImage", "pravega/zookeeper-operator:latest");
     private static final String PREFIX = System.getProperty("imagePrefix", "pravega");
     private static final String PRAVEGA_IMAGE_NAME = System.getProperty("pravegaImageName", "pravega");
     private static final String BOOKKEEPER_IMAGE_NAME = System.getProperty("bookkeeperImageName", "bookkeeper");

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -222,7 +222,7 @@ public abstract class AbstractService implements Service {
                                   .withScope("Namespaced")
                                   .withVersion(CUSTOM_RESOURCE_VERSION_PRAVEGA)
                                   .withNewSubresources()
-                                                     .withStatus(new V1beta1CustomResourceDefinitionStatus())
+                                  .withStatus(new V1beta1CustomResourceDefinitionStatus())
                                   .endSubresources()
                                   .build())
                 .build();

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -31,6 +31,7 @@ import io.kubernetes.client.models.V1beta1CustomResourceDefinition;
 import io.kubernetes.client.models.V1beta1CustomResourceDefinitionBuilder;
 import io.kubernetes.client.models.V1beta1CustomResourceDefinitionNamesBuilder;
 import io.kubernetes.client.models.V1beta1CustomResourceDefinitionSpecBuilder;
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionStatus;
 import io.kubernetes.client.models.V1beta1PolicyRuleBuilder;
 import io.kubernetes.client.models.V1beta1RoleRefBuilder;
 import io.kubernetes.client.models.V1beta1SubjectBuilder;
@@ -161,6 +162,9 @@ public class ZookeeperK8sService extends AbstractService {
                                                      .build())
                                   .withScope("Namespaced")
                                   .withVersion(CUSTOM_RESOURCE_VERSION)
+                                  .withNewSubresources()
+                                                    .withStatus(new V1beta1CustomResourceDefinitionStatus())
+                                  .endSubresources()
                                   .build())
                 .build();
 
@@ -193,7 +197,7 @@ public class ZookeeperK8sService extends AbstractService {
 
     private V1Deployment getDeployment() {
         V1Container container = new V1ContainerBuilder().withName("zookeeper-operator")
-                                                        .withImage("pravega/zookeeper-operator:latest")
+                                                        .withImage(ZOOKEEPER_OPERATOR_IMAGE)
                                                         .withPorts(new V1ContainerPortBuilder().withContainerPort(60000).build())
                                                         .withCommand("zookeeper-operator")
                                                         .withImagePullPolicy(IMAGE_PULL_POLICY)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -163,7 +163,7 @@ public class ZookeeperK8sService extends AbstractService {
                                   .withScope("Namespaced")
                                   .withVersion(CUSTOM_RESOURCE_VERSION)
                                   .withNewSubresources()
-                                                    .withStatus(new V1beta1CustomResourceDefinitionStatus())
+                                                     .withStatus(new V1beta1CustomResourceDefinitionStatus())
                                   .endSubresources()
                                   .build())
                 .build();

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -163,7 +163,7 @@ public class ZookeeperK8sService extends AbstractService {
                                   .withScope("Namespaced")
                                   .withVersion(CUSTOM_RESOURCE_VERSION)
                                   .withNewSubresources()
-                                                     .withStatus(new V1beta1CustomResourceDefinitionStatus())
+                                  .withStatus(new V1beta1CustomResourceDefinitionStatus())
                                   .endSubresources()
                                   .build())
                 .build();


### PR DESCRIPTION
**Change log description**  
- Add ability to configure Docker images for Pravega operator, Zookeeper operator, Pravega, and BookKeeper
- Fix Zookeeper and Pravega CRD by adding the new Status subresource ([ref](https://github.com/pravega/pravega-operator/blob/0.3.0/deploy/crd.yaml#L26) and [ref](https://github.com/pravega/zookeeper-operator/blob/0.2.1/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml#L36))
- Fix "bookeeper" typo

**Purpose of the change**  
Fix #3487 

**What the code does**  
Updates `build.gradle` and K8-based testing classes.

**How to verify it**  
Start a K8-based system tests with custom images with the following arguments:
```
./gradlew startK8SystemTests -DimageVersion=0.5.0 -DpravegaImageName=pravega2 -DbookkeeperImageName=bookeeper2 -DpravegaOperatorImage=user/pravega-operator:tag -DzookeeperOperatorImage=user/zookeeper-operator:tag
```

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>