### PR TITLE
Issue 3489: FileSystemStorage should write data synchronously to avoid data loss

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -319,6 +319,7 @@ public class FileSystemStorage implements SyncStorage {
                     totalBytesWritten += bytesWritten;
                     length -= bytesWritten;
                 }
+                channel.force(false);
             }
             FileSystemMetrics.WRITE_LATENCY.reportSuccessEvent(timer.getElapsed());
             FileSystemMetrics.WRITE_BYTES.add(totalBytesWritten);
@@ -377,6 +378,7 @@ public class FileSystemStorage implements SyncStorage {
                 offset += bytesTransferred;
                 length -= bytesTransferred;
             }
+            targetChannel.force(false);
             Files.delete(sourcePath);
             LoggerHelpers.traceLeave(log, "concat", traceId);
             return null;


### PR DESCRIPTION
Call FileChannel.force() at the end of write and concat.

**Change log description** 
Call FileChannel.force() at the end of write and concat.
This prevents data loss if the server crashes before data is written to the disk. Without this the data written is not guaranteed to be written to disk immediately, as data is transferred only to the buffer cache. 

**Purpose of the change**  
Fixes #3489 

**What the code does**  
Call FileChannel.force() at the end of write and concat.

**How to verify it**  
System tests should pass. There is should be no DataCorruptionException in the logs.
