### PR TITLE
Issue 3411: Improve permissions required for Controller gRPC API 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
@@ -108,7 +108,7 @@ public class PasswordAuthHandler implements AuthHandler {
      *                     by this instance.
      */
     @VisibleForTesting
-    public void initialize(String passwordFile) {
+    void initialize(String passwordFile) {
         loadPasswordFile(passwordFile);
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.server.rpc.auth;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -97,6 +98,18 @@ public class PasswordAuthHandler implements AuthHandler {
             throw new CompletionException(new AuthenticationException(userName));
         }
         return authorizeForUser(userMap.get(userName), resource);
+    }
+
+    /**
+     * This method exists expressly for unit testing purposes. It loads the contents of the specified
+     * {@code passwordFile} into this object.
+     *
+     * @param passwordFile the file with a list of users, their encrypted passwords and their ACLs that is to be used
+     *                     by this instance.
+     */
+    @VisibleForTesting
+    public void initialize(String passwordFile) {
+        loadPasswordFile(passwordFile);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -170,7 +170,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         log.info("getCurrentSegments called for stream {}/{}.", request.getScope(), request.getStream());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(request.getScope(), request.getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.getCurrentSegments(request.getScope(), request.getStream())
                                        .thenApply(segmentRanges -> SegmentRanges.newBuilder()
                                                                                 .addAllSegmentRanges(segmentRanges)
@@ -186,7 +186,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.getSegmentsAtHead(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream())
                                        .thenApply(segments -> {
@@ -257,7 +257,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 request.getStreamInfo().getStream());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.checkScale(request.getStreamInfo().getScope(), request.getStreamInfo().getStream(),
                         request.getEpoch()), responseObserver);
     }
@@ -370,7 +370,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 request.getStreamInfo().getStream(), request.getTxnId());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.checkTransactionStatus(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
                         request.getTxnId()),

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -170,7 +170,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         log.info("getCurrentSegments called for stream {}/{}.", request.getScope(), request.getStream());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(request.getScope(), request.getStream()),
-                AuthHandler.Permissions.READ),
+                AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> controllerService.getCurrentSegments(request.getScope(), request.getStream())
                                        .thenApply(segmentRanges -> SegmentRanges.newBuilder()
                                                                                 .addAllSegmentRanges(segmentRanges)

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -268,7 +268,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 request.getStreamInfo().getStream(), request.getSegmentId());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.getURI(request),
                 responseObserver);
     }
@@ -281,7 +281,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.isSegmentValid(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
                         request.getSegmentId())
@@ -296,7 +296,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
+                AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.isStreamCutValid(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
                         request.getCutMap())
@@ -356,7 +356,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 request.getStreamInfo().getStream(), request.getTxnId());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ),
+                AuthHandler.Permissions.READ_UPDATE),
                delegationToken  -> controllerService.pingTransaction(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
                         request.getTxnId(),

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -186,7 +186,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream()),
-                AuthHandler.Permissions.READ),
+                AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> controllerService.getSegmentsAtHead(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream())
                                        .thenApply(segments -> {

--- a/controller/src/test/java/io/pravega/controller/auth/AuthFileUtils.java
+++ b/controller/src/test/java/io/pravega/controller/auth/AuthFileUtils.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.auth;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+public class AuthFileUtils {
+
+    public static String credentialsAndAclAsString(String username, String password, String acl) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(username)
+                && !Strings.isNullOrEmpty(password)
+                && acl != null
+                && !acl.startsWith(":"));
+
+        // This will return a string that looks like this:"<username>:<pasword>:acl\n"
+        return String.format("%s:%s:%s%n", username, password, acl);
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -9,8 +9,6 @@
  */
 package io.pravega.controller.rest.v1;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.ServerBuilder;
 import io.pravega.client.ClientConfig;
@@ -66,6 +64,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static io.pravega.controller.auth.AuthFileUtils.credentialsAndAclAsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -564,16 +563,6 @@ public class StreamMetaDataAuthFocusedTests {
     //endregion
 
     //region Private methods
-
-    private static String credentialsAndAclAsString(String username, String password, String acl) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(username)
-                && !Strings.isNullOrEmpty(password)
-                && acl != null
-                && !acl.startsWith(":"));
-
-        // This will return a string that looks like this:"<username>:<pasword>:acl\n"
-        return String.format("%s:%s:%s%n", username, password, acl);
-    }
 
     private boolean createScopes(List<String> scopeNames, String username, String password) {
         boolean result = true;

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -186,6 +186,10 @@ public class ControllerGrpcAuthFocusedTest {
         ((PasswordAuthHandler) authHandler).initialize(AUTH_FILE.getAbsolutePath());
 
         String uniqueServerName = String.format("Test server name: %s", getClass());
+
+        // Using a builder that creates a server for servicing in-process requests.
+        // Also, using a direct executor which executes app code directly in transport thread. See
+        // https://grpc.io/grpc-java/javadoc/io/grpc/inprocess/InProcessServerBuilder.html for more information.
         grpcServer = InProcessServerBuilder.forName(uniqueServerName)
                 .addService(ServerInterceptors.intercept(controllerServiceImplBase,
                         new PravegaInterceptor(authHandler)))
@@ -203,7 +207,6 @@ public class ControllerGrpcAuthFocusedTest {
         if (streamTransactionMetadataTasks != null) {
             streamTransactionMetadataTasks.close();
         }
-
         inProcessChannel.shutdownNow();
         grpcServer.shutdownNow();
     }
@@ -382,7 +385,6 @@ public class ControllerGrpcAuthFocusedTest {
         return response.getTxnId();
     }
 
-
     private SegmentId segmentId(String scope, String stream, long segmentId) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(scope, "stream");
@@ -391,7 +393,6 @@ public class ControllerGrpcAuthFocusedTest {
                 .setSegmentId(segmentId)
                 .build();
     }
-
 
     private ControllerServiceBlockingStub prepareCallStub(String username, String password) {
         Exceptions.checkNotNullOrEmpty(username, "username");
@@ -408,7 +409,6 @@ public class ControllerGrpcAuthFocusedTest {
         }
         return stub;
     }
-
 
     private ScalingPolicy prepareFromFixedScaleTypePolicy(int numSegments) {
         return ScalingPolicy.newBuilder()
@@ -434,7 +434,6 @@ public class ControllerGrpcAuthFocusedTest {
         createScopeAndStream(scope, streamConfig);
     }
 
-
     private void createScopeAndStream(String scope, StreamConfig streamConfig) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Preconditions.checkNotNull(streamConfig, "streamConfig");
@@ -444,9 +443,6 @@ public class ControllerGrpcAuthFocusedTest {
         stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scope).build());
         stub.createStream(streamConfig);
     }
-
-
-
 
     private static File createAuthFile() {
         try {
@@ -480,5 +476,3 @@ public class ControllerGrpcAuthFocusedTest {
         private final static String SCOPE1_STREAM2_READ = "authSc1Str2readonly";
     }
 }
-
-

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -1,0 +1,478 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.rpc.auth;
+
+import com.google.common.base.Preconditions;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.ServerInterceptors;
+import io.grpc.StatusRuntimeException;
+import io.grpc.auth.MoreCallCredentials;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.pravega.auth.AuthHandler;
+import io.pravega.client.ClientConfig;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.stream.impl.Credentials;
+import io.pravega.client.stream.impl.DefaultCredentials;
+import io.pravega.client.stream.impl.PravegaCredentialsWrapper;
+import io.pravega.common.Exceptions;
+import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.Host;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.tracing.RequestTracker;
+import io.pravega.controller.mocks.ControllerEventStreamWriterMock;
+import io.pravega.controller.mocks.EventStreamWriterMock;
+import io.pravega.controller.mocks.SegmentHelperMock;
+import io.pravega.controller.server.ControllerService;
+import io.pravega.controller.server.SegmentHelper;
+import io.pravega.controller.server.eventProcessor.requesthandlers.*;
+import io.pravega.controller.server.rpc.grpc.v1.ControllerServiceImpl;
+import io.pravega.controller.store.host.HostControllerStore;
+import io.pravega.controller.store.host.HostStoreFactory;
+import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
+import io.pravega.controller.store.stream.BucketStore;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import io.pravega.controller.store.task.TaskMetadataStore;
+import io.pravega.controller.store.task.TaskStoreFactory;
+import io.pravega.controller.stream.api.grpc.v1.Controller;
+import io.pravega.controller.stream.api.grpc.v1.Controller.NodeUri;
+import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentId;
+import io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.ScalingPolicy;
+import io.pravega.controller.stream.api.grpc.v1.Controller.StreamConfig;
+import io.pravega.controller.stream.api.grpc.v1.Controller.StreamInfo;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateScopeStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.TxnId;
+import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc;
+import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc.ControllerServiceBlockingStub;
+import io.pravega.controller.task.Stream.StreamMetadataTasks;
+import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static io.pravega.controller.auth.AuthFileUtils.credentialsAndAclAsString;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The tests in this class are intended to perform verification of authorization logic in ControllerServiceImpl (the
+ * service implementation of the Controller gRPC interface).
+ */
+public class ControllerGrpcAuthFocusedTest {
+
+    private StreamMetadataTasks streamMetadataTasks;
+    private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
+    private Server grpcServer;
+    private ManagedChannel inProcessChannel;
+
+    /**
+     * We share these two members for all of the tests in this class, for efficiency reasons
+     */
+    private static ScheduledExecutorService executorService;
+    private static File authFile = null;
+
+    private static String DEFAULT_PASSWORD = "1111_aaaa";
+
+    /**
+     * This rule makes sure that the tests in this class run in 10 seconds or less.
+     */
+    @Rule
+    public final Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+
+    /**
+     * This rule is used later to expect both the exception class and the message.
+     */
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @BeforeClass
+    public static void classSetup() throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
+        authFile = createAuthFile();
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(20,
+                MethodHandles.lookup().lookupClass() + "-pool");
+    }
+
+    @AfterClass
+    public static void classTearDown() {
+        if (authFile != null && authFile.exists()) {
+            authFile.delete();
+        }
+        ExecutorServiceHelpers.shutdown(executorService);
+    }
+
+    @Before
+    public void setup() throws IOException {
+        TaskMetadataStore taskMetadataStore = TaskStoreFactory.createInMemoryStore(executorService);
+        HostControllerStore hostStore = HostStoreFactory.createInMemoryStore(HostMonitorConfigImpl.dummyConfig());
+        StreamMetadataStore streamStore = StreamStoreFactory.createInMemoryStore(executorService);
+        BucketStore bucketStore = StreamStoreFactory.createInMemoryBucketStore();
+        SegmentHelper segmentHelper = SegmentHelperMock.getSegmentHelperMock();
+        RequestTracker requestTracker = new RequestTracker(true);
+
+        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(
+                ClientConfig.builder()
+                        .controllerURI(URI.create("tcp://localhost"))
+                        .credentials(new DefaultCredentials(DEFAULT_PASSWORD, UserNames.ADMIN))
+                        .build());
+
+        AuthHelper authHelper = new AuthHelper(true, "secret");
+
+        streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, hostStore, taskMetadataStore, segmentHelper,
+                executorService, "host", connectionFactory, authHelper, requestTracker);
+
+        streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelper,
+                executorService, "host", connectionFactory, authHelper);
+
+        StreamRequestHandler streamRequestHandler = new StreamRequestHandler(new AutoScaleTask(streamMetadataTasks, streamStore, executorService),
+                new ScaleOperationTask(streamMetadataTasks, streamStore, executorService),
+                new UpdateStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
+                new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executorService),
+                new DeleteStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
+                new TruncateStreamTask(streamMetadataTasks, streamStore, executorService),
+                streamStore,
+                executorService);
+
+        streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));
+        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
+                "abortStream", new EventStreamWriterMock<>());
+
+        Cluster mockCluster = mock(Cluster.class);
+        when(mockCluster.getClusterMembers()).thenReturn(Collections.singleton(new Host("localhost", 9090, null)));
+
+        ControllerServiceGrpc.ControllerServiceImplBase controllerServiceImplBase = new ControllerServiceImpl(
+                new ControllerService(streamStore,
+                                      hostStore,
+                                      streamMetadataTasks,
+                                      streamTransactionMetadataTasks,
+                                      new SegmentHelper(),
+                                      executorService,
+                                      mockCluster),
+                authHelper,
+                requestTracker,
+                true,
+                2);
+
+        AuthHandler authHandler = new PasswordAuthHandler();
+        ((PasswordAuthHandler) authHandler).initialize(authFile.getAbsolutePath());
+
+        String uniqueServerName = String.format("Test server name: %s", getClass());
+        grpcServer = InProcessServerBuilder.forName(uniqueServerName)
+                .addService(ServerInterceptors.intercept(controllerServiceImplBase,
+                        new PravegaInterceptor(authHandler)))
+                .directExecutor()
+                .build()
+                .start();
+        inProcessChannel = InProcessChannelBuilder.forName(uniqueServerName).directExecutor().build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (streamMetadataTasks != null) {
+            streamMetadataTasks.close();
+        }
+        if (streamTransactionMetadataTasks != null) {
+            streamTransactionMetadataTasks.close();
+        }
+
+        inProcessChannel.shutdownNow();
+        grpcServer.shutdownNow();
+    }
+
+    @Test
+    public void createScopeSucceedsForPrivilegedUser() {
+        //Arrange
+        ControllerServiceGrpc.ControllerServiceBlockingStub blockingStub =
+                prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
+
+        //Act
+        CreateScopeStatus status = blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
+
+        //Verify
+        assertEquals(CreateScopeStatus.Status.SUCCESS, status.getStatus());
+    }
+
+    @Test
+    public void createScopeFailsForUnauthorizedUser() {
+        //Arrange
+        ControllerServiceGrpc.ControllerServiceBlockingStub blockingStub =
+                prepareCallStub(UserNames.SCOPE_READER, DEFAULT_PASSWORD);
+
+        //Verify
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("UNAUTHENTICATED");
+
+        //Act
+        blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
+    }
+
+    @Test
+    public void createScopeFailsForNonExistentUser() {
+        //Arrange
+        ControllerServiceBlockingStub blockingStub =
+                prepareCallStub("whatever", "whatever");
+
+        //Verify
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("UNAUTHENTICATED");
+
+        //Act
+        blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
+    }
+
+    @Test
+    public void getUriSucceedsForPrivilegedUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+
+        //Arrange
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
+
+        //Act
+        NodeUri nodeUri1 = stub.getURI(segmentId(scope, stream, 0));
+        NodeUri nodeUri2 = stub.getURI(segmentId(scope, stream, 1));
+
+        //Verify
+        assertEquals("localhost", nodeUri1.getEndpoint());
+        assertEquals(12345, nodeUri1.getPort());
+        assertEquals("localhost", nodeUri2.getEndpoint());
+        assertEquals(12345, nodeUri2.getPort());
+    }
+
+    @Test
+    public void getUriFailsForNonExistentUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+
+        //Arrange
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub("nonexistentuser", "whatever");
+
+        //Verify
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("UNAUTHENTICATED");
+
+        //Act
+        NodeUri nodeUri1 = stub.getURI(segmentId(scope, stream, 0));
+    }
+
+    @Test
+    public void isSegmentValidSucceedsForAuthorizedUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM1_READ, DEFAULT_PASSWORD);
+
+        assertTrue(stub.isSegmentValid(segmentId(scope, stream, 0)).getResponse());
+        assertFalse(stub.isSegmentValid(segmentId(scope, stream, 3)).getResponse());
+    }
+
+    @Test
+    public void isSegmentValidFailsForUnauthorizedUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+
+        //Note that the user has READ access to scope1/stream2, not scope1/stream1.
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM2_READ, DEFAULT_PASSWORD);
+
+        //Set the expected exception
+        thrown.expect(StatusRuntimeException.class);
+        //thrown.expectMessage();
+        thrown.expectMessage("UNAUTHENTICATED");
+
+        stub.isSegmentValid(segmentId(scope, stream, 0));
+    }
+
+    @Test
+    public void pingTransactionSucceedsForAuthorizedUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+        TxnId transactionId = createTransaction(StreamInfo.newBuilder().setScope(scope).setStream(stream).build(), 2000);
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM1_READUPDATE, DEFAULT_PASSWORD);
+
+        PingTxnStatus status = stub.pingTransaction(Controller.PingTxnRequest.newBuilder()
+                    .setStreamInfo(StreamInfo.newBuilder().setScope(scope).setStream(stream).build())
+                    .setTxnId(transactionId)
+                    .setLease(1000)
+                    .build());
+        assertEquals(PingTxnStatus.Status.OK, status.getStatus());
+    }
+
+    @Test
+    public void pingTransactionFailsForUnAuthorizedUser() {
+        String scope = "scope1";
+        String stream = "stream1";
+
+        createScopeAndStream(scope, stream, prepareFromFixedScaleTypePolicy(2));
+        TxnId transactionId = createTransaction(StreamInfo.newBuilder().setScope(scope).setStream(stream).build(), 2000);
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM1_READ, DEFAULT_PASSWORD);
+
+        //Set the expected exception
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("UNAUTHENTICATED: Authentication failed");
+
+        PingTxnStatus status = stub.pingTransaction(Controller.PingTxnRequest.newBuilder()
+                .setStreamInfo(StreamInfo.newBuilder().setScope(scope).setStream(stream).build())
+                .setTxnId(transactionId)
+                .setLease(1000)
+                .build());
+    }
+
+    //region Private methods
+
+    private static TxnId decode(UUID txnId) {
+        Preconditions.checkNotNull(txnId, "txnId");
+        return Controller.TxnId.newBuilder()
+                .setHighBits(txnId.getMostSignificantBits())
+                .setLowBits(txnId.getLeastSignificantBits())
+                .build();
+    }
+
+    private TxnId createTransaction(StreamInfo streamInfo, int lease) {
+        Preconditions.checkNotNull(streamInfo, "streamInfo");
+        return createTransaction(UserNames.ADMIN, DEFAULT_PASSWORD, streamInfo, lease);
+    }
+
+    private TxnId createTransaction(String username, String password, StreamInfo streamInfo, int lease) {
+        Exceptions.checkNotNullOrEmpty(username, "username");
+        Exceptions.checkNotNullOrEmpty(password, "password");
+        Preconditions.checkNotNull(streamInfo, "streamInfo");
+        Controller.CreateTxnRequest request = Controller.CreateTxnRequest.newBuilder()
+                .setStreamInfo(streamInfo)
+                .setLease(lease)
+                .build();
+
+        Controller.CreateTxnResponse response = prepareCallStub(username, password).createTransaction(request);
+        return response.getTxnId();
+    }
+
+
+    private SegmentId segmentId(String scope, String stream, long segmentId) {
+        Exceptions.checkNotNullOrEmpty(scope, "scope");
+        Exceptions.checkNotNullOrEmpty(scope, "stream");
+        return SegmentId.newBuilder()
+                .setStreamInfo(StreamInfo.newBuilder().setScope(scope).setStream(stream).build())
+                .setSegmentId(segmentId)
+                .build();
+    }
+
+
+    private ControllerServiceBlockingStub prepareCallStub(String username, String password) {
+        Exceptions.checkNotNullOrEmpty(username, "username");
+        Exceptions.checkNotNullOrEmpty(password, "password");
+
+        ControllerServiceBlockingStub stub =
+                ControllerServiceGrpc.newBlockingStub(inProcessChannel);
+
+        // Set call credentials
+        Credentials credentials = new DefaultCredentials(password, username);
+        if (credentials != null) {
+            PravegaCredentialsWrapper wrapper = new PravegaCredentialsWrapper(credentials);
+            stub = stub.withCallCredentials(MoreCallCredentials.from(wrapper));
+        }
+        return stub;
+    }
+
+
+    private ScalingPolicy prepareFromFixedScaleTypePolicy(int numSegments) {
+        return ScalingPolicy.newBuilder()
+                .setScaleType(Controller.ScalingPolicy.ScalingPolicyType.FIXED_NUM_SEGMENTS)
+                .setTargetRate(0)
+                .setScaleFactor(0)
+                .setMinNumSegments(numSegments)
+                .build();
+    }
+
+    private void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {
+        Exceptions.checkNotNullOrEmpty(scope, "scope");
+        Exceptions.checkNotNullOrEmpty(scope, "stream");
+        Preconditions.checkNotNull(scalingPolicy, "scalingPolicy");
+
+        StreamConfig streamConfig = StreamConfig.newBuilder()
+                .setStreamInfo(Controller.StreamInfo.newBuilder()
+                        .setScope(scope)
+                        .setStream(stream)
+                        .build())
+                .setScalingPolicy(scalingPolicy)
+                .build();
+        createScopeAndStream(scope, streamConfig);
+    }
+
+
+    private void createScopeAndStream(String scope, StreamConfig streamConfig) {
+        Exceptions.checkNotNullOrEmpty(scope, "scope");
+        Preconditions.checkNotNull(streamConfig, "streamConfig");
+
+        ControllerServiceBlockingStub stub =
+                prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
+        stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scope).build());
+        stub.createStream(streamConfig);
+    }
+
+
+
+
+    private static File createAuthFile() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        File result = File.createTempFile("auth_file", ".txt");
+        StrongPasswordProcessor passwordEncryptor = StrongPasswordProcessor.builder().build();
+
+        try (FileWriter writer = new FileWriter(result.getAbsolutePath())) {
+            String defaultPassword = passwordEncryptor.encryptPassword("1111_aaaa");
+            writer.write(credentialsAndAclAsString(UserNames.ADMIN,  defaultPassword, "*,READ_UPDATE;"));
+            writer.write(credentialsAndAclAsString(UserNames.SCOPE_READER, defaultPassword, "/,READ"));
+            writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READUPDATE, defaultPassword, "scope1/stream1,READ_UPDATE"));
+            writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READ, defaultPassword, "scope1/stream1,READ"));
+            writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM2_READ, defaultPassword, "scope1/stream2,READ"));
+        }
+        return result;
+    }
+
+    //endregion
+
+    /**
+     * Holds username strings for use in the parent class.
+     */
+    private static class UserNames {
+        private static String ADMIN = "admin";
+        private static String SCOPE_READER = "scopereader";
+        private static String SCOPE1_STREAM1_READUPDATE = "authSc1Str1";
+        private static String SCOPE1_STREAM1_READ = "authSc1Str1readonly";
+        private static String SCOPE1_STREAM2_READ = "authSc1Str2readonly";
+    }
+}
+
+


### PR DESCRIPTION
**Change log description**  

Some of the operations of the Controller gRPC interface require a higher permission level `READ_UPDATE`, even though they are read operations and do not modify the state of the resource. And then, there is one operation that does modify the state, but only requires `READ` permission. 

**Purpose of the change**  
Fixes #3411. 

**What the code does**  

The code fixes the permissions required for the operations listed below. We continue to use the same serial numbers (S.No.) as mentioned in the issue so that it is easier for readers to keep track of the changes. 

|S.No.| Action |	Resource String for Auth (in this PR)  | Required Permission - "OLD" | Required Permission - "NEW"| gRPC method (in ``ControllerServiceImpl``) | REST controller method (in ``StreamMetadataResourceImpl``| 
|:--:|:-----------|:---------------:|:---------------:|:---------------:|:---------------:|:----------------------|
|21.| Check scale status | ``<scope-name>/<stream-name>`` | READ_UPDATE | READ | ``checkScale``|-|
|22.| Get URI for segment | ``<scope-name>/<stream-name>`` | READ_UPDATE | READ | ``getURI``|-|
|23.| Is Segment valid | ``<scope-name>/<stream-name>`` | READ_UPDATE | READ | ``isSegmentValid``|-|
|24.| Is stream cut valid | ``<scope-name>/<stream-name>`` | READ_UPDATE | READ | ``isStreamCutValid``|-|
|28.| Ping transaction | ``<scope-name>/<stream-name>`` | READ | READ_UPDATE | ``pingTransaction``|-|
|29.| Check transaction state | ``<scope-name>/<stream-name>`` | READ_UPDATE | READ | ``checkTransactionState``|-|  

Also, a new test class `ControllerGrpcAuthFocusedTest` has been added for verifying authorization logic of the Controller gRPC service implementation `ControllerServiceImpl`.

**Note:**
* The permission required for `Get delegation token`/`getDelegationToken` has been left as-is (`READ_UPDATE`) as the operation is state-mutative.
* The permission required for `List current stream segments`/`getCurrentSegments()` and `List stream segments`/`getSegments()` have been left as-is (`READ_UPDATE`) as the operations use the permission to create a delegation token for downstream processing.

**How to verify it**  

All tests should pass. 

For convenience, I also create a temporary test suite comprising of a subset of test classes as shown below, for verifying code when there are any auth-related changes in the controller interfaces:

```java
import io.pravega.controller.rest.v1.SecureStreamMetaDataTests;
import io.pravega.controller.rest.v1.StreamMetaDataAuthFocusedTests;
import io.pravega.controller.rest.v1.StreamMetaDataTests;
import io.pravega.controller.rest.v1.UserSecureStreamMetaDataTests;
import io.pravega.controller.server.v1.InMemoryControllerServiceImplTest;
import io.pravega.controller.server.v1.ZKControllerServiceImplTest;
import org.junit.runner.RunWith;
import org.junit.runners.Suite;

@RunWith(Suite.class)
@Suite.SuiteClasses({
        StreamMetaDataAuthFocusedTests.class,
        StreamMetaDataTests.class,
        SecureStreamMetaDataTests.class,
        UserSecureStreamMetaDataTests.class,
        InMemoryControllerServiceImplTest.class,
        ZKControllerServiceImplTest.class,
        RESTAuthHelperTest.class,
        PravegaAuthManagerTest.class,
        ControllerGrpcAuthFocusedTest.class
})

// Run this class on your IDE to execute the test classes in the suite. 
public class AuthTestSuite {
}
```