### PR TITLE
Issue 3493: Metric for counting ZK session expirations in the Controller

### DIFF
--- a/controller/src/main/java/io/pravega/controller/metrics/ZookeeperConnectionMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/ZookeeperConnectionMetrics.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.metrics;
+
+import static io.pravega.shared.MetricsNames.CONTROLLER_ZK_SESSION_EXPIRATION;
+import static io.pravega.shared.MetricsNames.globalMetricName;
+
+/**
+ * Class to encapsulate the logic to report Controller metrics related to Zookeeper.
+ */
+public class ZookeeperConnectionMetrics extends AbstractControllerMetrics {
+
+    /**
+     * This method reports a new session expiration event in a Controller instance.
+     */
+    public void reportZKSessionExpiration() {
+        DYNAMIC_LOGGER.incCounterValue(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION), 1);
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
@@ -15,7 +15,7 @@ import static io.pravega.shared.MetricsNames.globalMetricName;
 /**
  * Class to encapsulate the logic to report Controller metrics related to Zookeeper.
  */
-public class ZookeeperConnectionMetrics extends AbstractControllerMetrics {
+public class ZookeeperMetrics extends AbstractControllerMetrics {
 
     /**
      * This method reports a new session expiration event in a Controller instance.

--- a/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
@@ -10,7 +10,6 @@
 package io.pravega.controller.metrics;
 
 import static io.pravega.shared.MetricsNames.CONTROLLER_ZK_SESSION_EXPIRATION;
-import static io.pravega.shared.MetricsNames.globalMetricName;
 
 /**
  * Class to encapsulate the logic to report Controller metrics related to Zookeeper.
@@ -21,6 +20,6 @@ public class ZookeeperMetrics extends AbstractControllerMetrics {
      * This method reports a new session expiration event in a Controller instance.
      */
     public void reportZKSessionExpiration() {
-        DYNAMIC_LOGGER.incCounterValue(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION), 1);
+        DYNAMIC_LOGGER.incCounterValue(CONTROLLER_ZK_SESSION_EXPIRATION, 1);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
@@ -14,7 +14,7 @@ import static io.pravega.shared.MetricsNames.CONTROLLER_ZK_SESSION_EXPIRATION;
 /**
  * Class to encapsulate the logic to report Controller metrics related to Zookeeper.
  */
-public class ZookeeperMetrics extends AbstractControllerMetrics {
+public final class ZookeeperMetrics extends AbstractControllerMetrics {
 
     /**
      * This method reports a new session expiration event in a Controller instance.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -11,7 +11,7 @@ package io.pravega.controller.server;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.LoggerHelpers;
-import io.pravega.controller.metrics.ZookeeperConnectionMetrics;
+import io.pravega.controller.metrics.ZookeeperMetrics;
 import io.pravega.controller.store.client.StoreClient;
 import io.pravega.controller.store.client.StoreClientFactory;
 import io.pravega.controller.store.client.StoreType;
@@ -49,7 +49,7 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
     private final Monitor.Guard hasReachedStarting = new HasReachedState(ServiceState.STARTING);
     private final Monitor.Guard hasReachedPausing = new HasReachedState(ServiceState.PAUSING);
 
-    private final ZookeeperConnectionMetrics zookeeperConnectionMetrics;
+    private final ZookeeperMetrics zookeeperMetrics;
 
     final class HasReachedState extends Monitor.Guard {
         private ServiceState desiredState;
@@ -77,7 +77,7 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
         this.starterFactory = starterFactory;
         this.serviceStopFuture = new CompletableFuture<>();
         this.serviceState = ServiceState.NEW;
-        this.zookeeperConnectionMetrics = new ZookeeperConnectionMetrics();
+        this.zookeeperMetrics = new ZookeeperMetrics();
     }
 
     @Override
@@ -136,7 +136,7 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
                     // Once ZK session expires or once ControllerServiceMain is externally stopped,
                     // stop ControllerServiceStarter.
                     if (sessionExpiryFuture.isDone()) {
-                        zookeeperConnectionMetrics.reportZKSessionExpiration();
+                        zookeeperMetrics.reportZKSessionExpiration();
                         log.info("ZK session expired");
                     }
                 } else {

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.LoggerHelpers;
+import io.pravega.controller.metrics.ZookeeperConnectionMetrics;
 import io.pravega.controller.store.client.StoreClient;
 import io.pravega.controller.store.client.StoreClientFactory;
 import io.pravega.controller.store.client.StoreType;
@@ -48,6 +49,8 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
     private final Monitor.Guard hasReachedStarting = new HasReachedState(ServiceState.STARTING);
     private final Monitor.Guard hasReachedPausing = new HasReachedState(ServiceState.PAUSING);
 
+    private final ZookeeperConnectionMetrics zookeeperConnectionMetrics;
+
     final class HasReachedState extends Monitor.Guard {
         private ServiceState desiredState;
 
@@ -74,6 +77,7 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
         this.starterFactory = starterFactory;
         this.serviceStopFuture = new CompletableFuture<>();
         this.serviceState = ServiceState.NEW;
+        this.zookeeperConnectionMetrics = new ZookeeperConnectionMetrics();
     }
 
     @Override
@@ -132,6 +136,7 @@ public class ControllerServiceMain extends AbstractExecutionThreadService {
                     // Once ZK session expires or once ControllerServiceMain is externally stopped,
                     // stop ControllerServiceStarter.
                     if (sessionExpiryFuture.isDone()) {
+                        zookeeperConnectionMetrics.reportZKSessionExpiration();
                         log.info("ZK session expired");
                     }
                 } else {

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -550,7 +550,7 @@ controller.container.failovers.$containerId.Counter
 
 - Controller Zookeeper session expiration (counter) metrics:
 ```
-controller.zookeeper.session_expiration_global.Counter
+controller.zookeeper.session_expiration.Counter
 ```
 
 # 6. Useful links

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -548,6 +548,11 @@ controller.container.failovers_global.Counter
 controller.container.failovers.$containerId.Counter
 ```
 
+- Controller Zookeeper session expiration (counter) metrics:
+```
+controller.zookeeper.session_expiration_global.Counter
+```
+
 # 6. Useful links
 * [Dropwizard Metrics](https://metrics.dropwizard.io/3.1.0/apidocs)
 * [Statsd_spec](https://github.com/b/statsd_spec)

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -186,6 +186,9 @@ public final class MetricsNames {
     public static final String RETENTION_FREQUENCY = "controller.retention.frequency";   // Per-stream Counter
     public static final String TRUNCATED_SIZE = "controller.retention.truncated_size";   // Per-stream Gauge
 
+    // Zookeeper connectivity metrics
+    public static final String CONTROLLER_ZK_SESSION_EXPIRATION = "controller.zookeeper.session_expiration";  // Counter
+
     // Metric Type Suffix
     public static final String COUNTER_SUFFIX = ".Counter";
     public static final String GAUGE_SUFFIX = ".Gauge";

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -217,14 +217,14 @@ public class ControllerMetricsTest {
      */
     @Test(timeout = 25000)
     public void zookeeperMetricsTest() throws Exception {
-        Counter zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
+        Counter zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(CONTROLLER_ZK_SESSION_EXPIRATION));
         Assert.assertNull(zkSessionExpirationCounter);
         controllerWrapper.forceClientSessionExpiry();
         while (zkSessionExpirationCounter == null) {
             Thread.sleep(100);
-            zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
+            zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(CONTROLLER_ZK_SESSION_EXPIRATION));
         }
-        Assert.assertEquals(zkSessionExpirationCounter.getCount(), 1L);
+        Assert.assertEquals(zkSessionExpirationCounter.count(), 1, 0.1);
     }
 
     private void checkStatsRegisteredValues(int minExpectedValues, String...metricNames) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -49,6 +49,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.pravega.shared.MetricsNames.CONTROLLER_ZK_SESSION_EXPIRATION;
 import static io.pravega.shared.MetricsNames.CREATE_STREAM;
 import static io.pravega.shared.MetricsNames.CREATE_STREAM_LATENCY;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM;
@@ -106,10 +107,12 @@ public class ControllerMetricsTest {
 
         controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
                 false,
+                false,
                 controllerPort,
                 serviceHost,
                 servicePort,
-                containerCount);
+                containerCount,
+                9091);
         controllerWrapper.awaitRunning();
     }
 
@@ -205,6 +208,23 @@ public class ControllerMetricsTest {
 
         checkStatsRegisteredValues(iterations, CREATE_STREAM_LATENCY, SEAL_STREAM_LATENCY, DELETE_STREAM_LATENCY);
         checkStatsRegisteredValues(iterations * iterations, UPDATE_STREAM_LATENCY, TRUNCATE_STREAM_LATENCY);
+    }
+
+    /**
+     * This test verifies that the Controller increments the metric for Zookeeper session expiration events correctly.
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 60000)
+    public void zookeeperMetricsTest() throws Exception {
+        Counter zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
+        Assert.assertNull(zkSessionExpirationCounter);
+        controllerWrapper.forceClientSessionExpiry();
+        while (zkSessionExpirationCounter == null) {
+            Thread.sleep(1000);
+            zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
+        }
+        Assert.assertEquals(zkSessionExpirationCounter.getCount(), 1L);
     }
 
     private void checkStatsRegisteredValues(int minExpectedValues, String...metricNames) {

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -215,13 +215,13 @@ public class ControllerMetricsTest {
      *
      * @throws Exception
      */
-    @Test(timeout = 60000)
+    @Test(timeout = 25000)
     public void zookeeperMetricsTest() throws Exception {
         Counter zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
         Assert.assertNull(zkSessionExpirationCounter);
         controllerWrapper.forceClientSessionExpiry();
         while (zkSessionExpirationCounter == null) {
-            Thread.sleep(1000);
+            Thread.sleep(100);
             zkSessionExpirationCounter = MetricRegistryUtils.getCounter(getCounterMetricName(globalMetricName(CONTROLLER_ZK_SESSION_EXPIRATION)));
         }
         Assert.assertEquals(zkSessionExpirationCounter.getCount(), 1L);


### PR DESCRIPTION
**Change log description**  
Created new metric to keep track of Zookeeper session expirations in the Controller.

**Purpose of the change**  
Fixes #3493.

**What the code does**  
A Zookeeper session expiration may be problematic if not properly handled, and in some cases, could be an indication of an issue in the ZK cluster. To be able of rapidly detecting this kind of situations in a Pravega deployment via a dashboard or alerts, we added a new metric called `controller.zookeeper.session_expiration` to account for the number of session expirations experienced by Controller instances. In turn, a session expiration in the Controller indicates that it is going to perform a graceful restart.

**How to verify it**  
Added a new test to verify that the metric works. All test should be passing as before.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>