### PR TITLE
Issue 3495: Split metadata scalability test into two separate tests

### DIFF
--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -139,7 +139,7 @@ public final class Config {
     private static final Property<String> PROPERTY_TLS_TRUST_STORE = Property.named("auth.tlsTrustStore", "");
     private static final Property<String> PROPERTY_TLS_KEY_FILE = Property.named("auth.tlsKeyFile", "");
     private static final Property<String> PROPERTY_TOKEN_SIGNING_KEY = Property.named("auth.tokenSigningKey", "");
-    private static final Property<String> PROPERTY_ZK_URL = Property.named("zk.url", "localhost:2121");
+    private static final Property<String> PROPERTY_ZK_URL = Property.named("zk.url", "localhost:2181");
     private static final Property<Integer> PROPERTY_ZK_RETRY_MILLIS = Property.named("zk.retryIntervalMillis", 5000);
     private static final Property<Integer> PROPERTY_ZK_MAX_RETRY_COUNT = Property.named("maxRetries", 5);
     private static final Property<Integer> PROPERTY_ZK_SESSION_TIMEOUT_MILLIS = Property.named("sessionTimeoutMillis", 10000);

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.shared.segment.StreamSegmentNameUtils;
+import io.pravega.test.system.framework.SystemTestRunner;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * This test creates a stream with 10k segments and then rapidly scales it 10 times.
+ * Then it performs truncation a random number of times.
+ */
+@Slf4j
+@RunWith(SystemTestRunner.class)
+public class MetadataScalabilityLargeNumSegmentsTest extends MetadataScalabilityTest {
+    private static final String STREAM_NAME = "metadataScalabilitySegments";
+    private static final int NUM_SEGMENTS = 10000;
+    private static final StreamConfiguration CONFIG = StreamConfiguration.builder()
+                                                                         .scalingPolicy(ScalingPolicy.fixed(NUM_SEGMENTS)).build();
+    private static final int SCALES_TO_PERFORM = 10;
+    
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @Override
+    String getStreamName() {
+        return STREAM_NAME;
+    }
+
+    @Override
+    StreamConfiguration getStreamConfig() {
+        return CONFIG;
+    }
+    
+    @Override
+    int getScalesToPerform() {
+        return SCALES_TO_PERFORM;
+    }
+
+    /**
+     * Chooses one segment out of the current segments and selects its matching range as the input for next scale.
+     * @param sortedCurrentSegments sorted current segments
+     * @return scale input for next scale
+     */
+    Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
+        int i = counter.incrementAndGet();
+        List<Long> segmentsToSeal = sortedCurrentSegments.stream()
+                                          .filter(x -> i - 1 == StreamSegmentNameUtils.getSegmentNumber(x.getSegmentId()) % NUM_SEGMENTS)
+                                          .map(Segment::getSegmentId).collect(Collectors.toList());
+        Map<Double, Double> newRanges = new HashMap<>();
+        double delta = 1.0 / NUM_SEGMENTS;
+        newRanges.put(delta * (i - 1), delta * i);
+
+        return new ImmutablePair<>(segmentsToSeal, newRanges);
+    }
+
+    @Test
+    public void largeNumSegmentsScalability() {
+        testState = new TestState(false);
+
+        ControllerImpl controller = getController();
+
+        List<List<Segment>> listOfEpochs = scale(controller);
+        // TODO: uncomment truncation as part of #3478
+        // truncation(controller, listOfEpochs);
+        sealAndDeleteStream(controller);
+    }
+}

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.test.system.framework.SystemTestRunner;
+import lombok.Synchronized;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This test creates a stream with 10 segments and then rapidly scales it 1010 times.
+ * Then it performs truncation a random number of times.
+ */
+@Slf4j
+@RunWith(SystemTestRunner.class)
+public class MetadataScalabilityLargeScalesTest extends MetadataScalabilityTest {
+    private static final String STREAM_NAME = "metadataScalabilityScale";
+    private static final int NUM_SEGMENTS = 10;
+    private static final StreamConfiguration CONFIG = StreamConfiguration.builder()
+                                                                         .scalingPolicy(ScalingPolicy.fixed(NUM_SEGMENTS)).build();
+    private static final int SCALES_TO_PERFORM = 1010;
+    
+    private final Map<Double, Double> newRanges = new HashMap<>();
+    
+    @Override
+    String getStreamName() {
+        return STREAM_NAME;
+    }
+
+    @Override
+    StreamConfiguration getStreamConfig() {
+        return CONFIG;
+    }
+
+    @Override
+    int getScalesToPerform() {
+        return SCALES_TO_PERFORM;
+    }
+
+    /**
+     * Scale all the segments in the current epoch and replace them with new identical 10 segments. 
+     * @param sortedCurrentSegments segments in current epoch
+     * @return scale input for next scale to perform
+     */
+    Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
+        return new ImmutablePair<>(getSegmentsToSeal(sortedCurrentSegments), getNewRanges());     
+    }
+    
+    private List<Long> getSegmentsToSeal(ArrayList<Segment> sorted) {
+        return sorted.stream()
+                     .map(Segment::getSegmentId).collect(Collectors.toList());
+    }
+
+    @Synchronized
+    private Map<Double, Double> getNewRanges() {
+        if (newRanges.isEmpty()) {
+            double delta = 1.0 / NUM_SEGMENTS;
+            for (int i = 0; i < NUM_SEGMENTS; i++) {
+                double low = delta * i;
+                double high = i == NUM_SEGMENTS - 1 ? 1.0 : delta * (i + 1);
+
+                newRanges.put(low, high);
+            }
+        }
+        return newRanges;
+    }
+    
+    @Test
+    public void largeNumScalesScalability() {
+        testState = new TestState(false);
+
+        ControllerImpl controller = getController();
+
+        List<List<Segment>> listOfEpochs = scale(controller);
+        truncation(controller, listOfEpochs);
+        sealAndDeleteStream(controller);
+    }
+}

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -46,8 +46,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
@@ -156,16 +156,16 @@ public abstract class MetadataScalabilityTest extends AbstractScaleTests {
              indexes.add(new AtomicInteger(1));
          }
          Futures.loop(() -> indexes.stream().allMatch(x -> x.get() < scalesToPerform - 1), () -> {
-            // We randomly generate a stream cut in each iteration of this loop. A valid stream
-            // cut in this scenario contains for each position i in [0, numSegments -1], a segment
-            // from one of the scale epochs of the stream. For each position i, we randomly
-            // choose an epoch and pick the segment at position i. It increments the epoch
-            // index accordingly (indexes list) so that in the next iteration it chooses a later
-            // epoch for the same i.
-            //
-            // Because the segment in position i always contain the range [d * (i-1), d * i],
-            // where d = 1 / (number of segments), the stream cut is guaranteed to cover
-            // the entire key space. 
+             // We randomly generate a stream cut in each iteration of this loop. A valid stream
+             // cut in this scenario contains for each position i in [0, numSegments -1], a segment
+             // from one of the scale epochs of the stream. For each position i, we randomly
+             // choose an epoch and pick the segment at position i. It increments the epoch
+             // index accordingly (indexes list) so that in the next iteration it chooses a later
+             // epoch for the same i.
+             //
+             // Because the segment in position i always contain the range [d * (i-1), d * i],
+             // where d = 1 / (number of segments), the stream cut is guaranteed to cover
+             // the entire key space. 
              Map<Segment, Long> map = new HashMap<>();
              for (int i = 0; i < numSegments; i++) {
                  AtomicInteger index = indexes.get(i);

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -11,7 +11,6 @@ package io.pravega.test.system;
 
 import com.google.common.collect.Lists;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
@@ -25,10 +24,10 @@ import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
@@ -47,22 +46,21 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-/**
- * This test creates a stream with 10k segments and then rapidly scales it 1010 times.
- * Then it performs truncation a random number (less than 1010) of times. 
- */
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
 @Slf4j
 @RunWith(SystemTestRunner.class)
-public class MetadataScalabilityTest extends AbstractScaleTests {
-    private static final String STREAM_NAME = "metadataScalability";
-    private static final int NUM_SEGMENTS = 10000;
-    private static final StreamConfiguration CONFIG = StreamConfiguration.builder()
-                                                                         .scalingPolicy(ScalingPolicy.fixed(NUM_SEGMENTS)).build();
-    private static final int SCALES_TO_PERFORM = 1010;
-
+/**
+ * Base class for scalability tests. This class takes a stream name and number of segments and scales to perform and then 
+ * performs that many scales. The scale input is supplied by derived class. 
+ * Then we perform truncation arbitrary number of times but the moment any truncation stream cut contains a segment from latest epoch, 
+ * the test concludes. Post which we seal and delete the stream. 
+ */
+public abstract class MetadataScalabilityTest extends AbstractScaleTests {
     @Rule
     public Timeout globalTimeout = Timeout.seconds(60 * 60);
-
+    private final String streamName = getStreamName();
     private final ScheduledExecutorService scaleExecutorService = Executors.newScheduledThreadPool(5);
 
     @Environment
@@ -89,7 +87,7 @@ public class MetadataScalabilityTest extends AbstractScaleTests {
         log.debug("create scope status {}", createScopeStatus);
 
         //create a stream
-        Boolean createStreamStatus = controller.createStream(SCOPE, STREAM_NAME, CONFIG).get();
+        Boolean createStreamStatus = controller.createStream(SCOPE, getStreamName(), getStreamConfig()).get();
         log.debug("create stream status for scale up stream {}", createStreamStatus);
     }
 
@@ -101,35 +99,37 @@ public class MetadataScalabilityTest extends AbstractScaleTests {
         ExecutorServiceHelpers.shutdown(executorService, scaleExecutorService);
     }
 
-    @Test
-    public void scalability() {
-        testState = new TestState(false);
+    abstract StreamConfiguration getStreamConfig();
 
-        ControllerImpl controller = getController();
+    abstract String getStreamName();
+
+    abstract int getScalesToPerform();
+
+    abstract Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments);
+
+    List<List<Segment>> scale(ControllerImpl controller) {
+        int numSegments = getStreamConfig().getScalingPolicy().getMinNumSegments();
+        int scalesToPerform = getScalesToPerform();
 
         // manually scale the stream SCALES_TO_PERFORM times
-        Stream stream = new StreamImpl(SCOPE, STREAM_NAME);
+        Stream stream = new StreamImpl(SCOPE, getStreamName());
         AtomicInteger counter = new AtomicInteger(0);
         List<List<Segment>> listOfEpochs = new LinkedList<>();
 
-        CompletableFuture<Void> scaleFuture = Futures.loop(() -> counter.incrementAndGet() <= SCALES_TO_PERFORM,
-                () -> controller.getCurrentSegments(SCOPE, STREAM_NAME)
+        CompletableFuture<Void> scaleFuture = Futures.loop(() -> counter.incrementAndGet() <= scalesToPerform,
+                () -> controller.getCurrentSegments(SCOPE, streamName)
                                 .thenCompose(segments -> {
-                                    Map<Double, Double> newRanges = new HashMap<>();
-                                    double delta = 1.0 / NUM_SEGMENTS;
-                                    newRanges.put(delta * (counter.get() - 1), delta * counter.get());
-
                                     ArrayList<Segment> sorted = Lists.newArrayList(segments.getSegments().stream()
                                                                                            .sorted(Comparator.comparingInt(x ->
-                                                                                                   StreamSegmentNameUtils.getSegmentNumber(x.getSegmentId()) % NUM_SEGMENTS))
+                                                                                                   StreamSegmentNameUtils.getSegmentNumber(x.getSegmentId()) % numSegments))
                                                                                            .collect(Collectors.toList()));
-                                    log.info("found segments in epoch = {}", sorted);
                                     listOfEpochs.add(sorted);
-                                    // note: with SCALES_TO_PERFORM < NUM_SEGMENTS, we can use the segment number as the index
+                                    // note: with SCALES_TO_PERFORM < numSegments, we can use the segment number as the index
                                     // into the range map
-                                    List<Long> segmentsToSeal = sorted.stream()
-                                                                      .filter(x -> counter.get() - 1 == StreamSegmentNameUtils.getSegmentNumber(x.getSegmentId()) % NUM_SEGMENTS)
-                                                                      .map(Segment::getSegmentId).collect(Collectors.toList());
+                                    Pair<List<Long>, Map<Double, Double>> scaleInput = getScaleInput(sorted);
+                                    List<Long> segmentsToSeal = scaleInput.getKey();
+                                    Map<Double, Double> newRanges = scaleInput.getValue();
+
                                     return controller.scaleStream(stream, segmentsToSeal, newRanges, executorService)
                                                      .getFuture()
                                                      .thenAccept(scaleStatus -> {
@@ -138,40 +138,59 @@ public class MetadataScalabilityTest extends AbstractScaleTests {
                                                      });
                                 }), executorService);
 
-        scaleFuture
-                .thenCompose(r -> {
-                    // try SCALES_TO_PERFORM randomly generated stream cuts and truncate stream at those 
-                    // stream cuts. 
-                    List<AtomicInteger> indexes = new LinkedList<>();
-                    Random rand = new Random();
-                    for (int i = 0; i < NUM_SEGMENTS; i++) {
-                        indexes.add(new AtomicInteger(1));
-                    }
-                    return Futures.loop(() -> indexes.stream().allMatch(x -> x.get() < SCALES_TO_PERFORM - 1), () -> {
-                        // randomly generate a stream cut. 
-                        // Note: From epoch 1 till epoch SCALES_TO_PERFORM each epoch is made up of 10k segments
-                        // and the range is statically partitioned evenly. 
-                        // So a random, correct streamcut would be choosing NUM_SEGMENTS disjoint segments from NUM_SEGMENTS random epochs. 
-                        Map<Segment, Long> map = new HashMap<>();
-                        for (int i = 0; i < NUM_SEGMENTS; i++) {
-                            AtomicInteger index = indexes.get(i);
-                            index.set(index.get() + rand.nextInt(SCALES_TO_PERFORM - index.get()));
-                            map.put(listOfEpochs.get(index.get()).get(i), 0L);
-                        }
+        scaleFuture.join();
+        
+        return listOfEpochs;
+    }
+     
+     void truncation(ControllerImpl controller, List<List<Segment>> listOfEpochs) {
+         int numSegments = getStreamConfig().getScalingPolicy().getMinNumSegments();
+         int scalesToPerform = getScalesToPerform();
+         Stream stream = new StreamImpl(SCOPE, getStreamName());
 
-                        StreamCut cut = new StreamCutImpl(stream, map);
-                        log.info("truncating stream at {}", map);
-                        return controller.truncateStream(SCOPE, STREAM_NAME, cut).
-                                thenCompose(truncated -> {
-                                    log.info("stream truncated successfully at {}", cut);
-                                    assert truncated;
-                                    // we will just validate that a non empty value is returned. 
-                                    return controller.getSuccessors(cut)
-                                                     .thenAccept(successors -> {
-                                                         log.info("Successors for streamcut {} are {}", cut, successors);
-                                                     });
-                                });
-                    }, executorService);
-                }).join();
+         // try SCALES_TO_PERFORM randomly generated stream cuts and truncate stream at those 
+         // stream cuts. 
+         List<AtomicInteger> indexes = new LinkedList<>();
+         Random rand = new Random();
+         for (int i = 0; i < numSegments; i++) {
+             indexes.add(new AtomicInteger(1));
+         }
+         Futures.loop(() -> indexes.stream().allMatch(x -> x.get() < scalesToPerform - 1), () -> {
+            // We randomly generate a stream cut in each iteration of this loop. A valid stream
+            // cut in this scenario contains for each position i in [0, numSegments -1], a segment
+            // from one of the scale epochs of the stream. For each position i, we randomly
+            // choose an epoch and pick the segment at position i. It increments the epoch
+            // index accordingly (indexes list) so that in the next iteration it chooses a later
+            // epoch for the same i.
+            //
+            // Because the segment in position i always contain the range [d * (i-1), d * i],
+            // where d = 1 / (number of segments), the stream cut is guaranteed to cover
+            // the entire key space. 
+             Map<Segment, Long> map = new HashMap<>();
+             for (int i = 0; i < numSegments; i++) {
+                 AtomicInteger index = indexes.get(i);
+                 index.set(index.get() + rand.nextInt(scalesToPerform - index.get()));
+                 map.put(listOfEpochs.get(index.get()).get(i), 0L);
+             }
+
+             StreamCut cut = new StreamCutImpl(stream, map);
+             log.info("truncating stream at {}", map);
+             return controller.truncateStream(SCOPE, streamName, cut).
+                     thenCompose(truncated -> {
+                         log.info("stream truncated successfully at {}", cut);
+                         assertTrue(truncated);
+                         // we will just validate that a non empty value is returned. 
+                         return controller.getSuccessors(cut)
+                                          .thenAccept(successors -> {
+                                              assertEquals(successors.getSegments().size(), numSegments);
+                                              log.info("Successors for streamcut {} are {}", cut, successors);
+                                          });
+                     });
+         }, executorService).join();
+     }
+    
+    void sealAndDeleteStream(ControllerImpl controller) {
+        controller.sealStream(SCOPE, streamName).join();
+        controller.deleteStream(SCOPE, streamName).join();
     }
 }


### PR DESCRIPTION
**Change log description**  
Split metadata scalability test into two separate tests so that they are individually not resource hungry and test intended scenarios. 

**Purpose of the change**  
Fixes #3495

**What the code does**  
1. Metadata operations on stream with large number of segments like scale and truncate
2. Metadata operation on stream with large number of epochs (perform 1000s of scales) and then truncate. 

One additional change of config file having incorrect default zookeeper port is fixed. 

PS: running truncation on large stream has a huge memory footprint because we loop over all segments in streamcut and that actually reads epoch record from cache and deserializes it for each segment. so that happens 10k times and puts a huge memory pressure on controller. I have fixed that issue as part of issue 3478. Will include truncation related changes for large stream in that branch.

This large epoch record

**How to verify it**  
System test should pass
