### PR TITLE
Issue 3484: (SegmentStore) Cleaning up some log messages

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -418,8 +418,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         }
 
         private CacheStatus withUpdatedSize(long sizeDelta) {
-            long newSize = this.size + sizeDelta;
-            assert newSize >= 0 : "given sizeDelta would result in a negative size";
+            long newSize = Math.max(0, this.size + sizeDelta);
             return new CacheStatus(newSize, this.oldestGeneration, this.newestGeneration);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -226,7 +226,9 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
         }
 
         removeFromCache(entries);
-        log.info("{}: Cleared all cache entries ({}).", this.traceObjectId, entries.size());
+        if (entries.size() > 0) {
+            log.debug("{}: Cleared all cache entries ({}).", this.traceObjectId, entries.size());
+        }
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -219,7 +219,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         if (this.durableLog.isOffline()) {
             // Attach a listener to the DurableLog's awaitOnline() Future and initiate the services' startup when that
             // completes successfully.
-            log.info("{}: DurableLog is OFFLINE. Not starting secondary services yet.");
+            log.info("{}: DurableLog is OFFLINE. Not starting secondary services yet.", this.traceObjectId);
             isReady = CompletableFuture.completedFuture(null);
             delayedStart = this.durableLog.awaitOnline()
                     .thenComposeAsync(v -> initializeSecondaryServices(), this.executor);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -206,7 +206,6 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                     if (ex == null) {
                         // We are started and ready to accept requests when DurableLog starts. All other (secondary) services
                         // are not required for accepting new operations and can still start in the background.
-                        log.info("{}: DurableLog Started ({}).", this.traceObjectId, isOffline() ? "OFFLINE" : "Online");
                         notifyStarted();
                     } else {
                         doStop(ex);
@@ -220,6 +219,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         if (this.durableLog.isOffline()) {
             // Attach a listener to the DurableLog's awaitOnline() Future and initiate the services' startup when that
             // completes successfully.
+            log.info("{}: DurableLog is OFFLINE. Not starting secondary services yet.");
             isReady = CompletableFuture.completedFuture(null);
             delayedStart = this.durableLog.awaitOnline()
                     .thenComposeAsync(v -> initializeSecondaryServices(), this.executor);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -256,8 +256,11 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
             count = this.metadataById.size();
         }
 
-        log.info("{}: EvictedStreamSegments Count = {}, Active = {}", this.traceObjectId, evictedSegments.size(), count);
-        this.metrics.segmentCount(count);
+        if (evictedSegments.size() > 0) {
+            log.info("{}: EvictedStreamSegments Count = {}, Active = {}", this.traceObjectId, evictedSegments.size(), count);
+            this.metrics.segmentCount(count);
+        }
+
         return evictedSegments;
     }
 
@@ -274,7 +277,10 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
             count += sm.cleanupAttributes(maximumAttributeCount, adjustedCutoff);
         }
 
-        log.info("{}: EvictedExtendedAttributes Count = {}", this.traceObjectId, count);
+        if (count > 0) {
+            log.info("{}: EvictedExtendedAttributes Count = {}", this.traceObjectId, count);
+        }
+
         return count;
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -91,7 +91,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
         Preconditions.checkArgument(streamSegmentId != ContainerMetadata.NO_STREAM_SEGMENT_ID, "streamSegmentId");
         Preconditions.checkArgument(containerId >= 0, "containerId");
 
-        this.traceObjectId = String.format("StreamSegment[%d]", streamSegmentId);
+        this.traceObjectId = String.format("StreamSegment[%d-%d]", containerId, streamSegmentId);
         this.name = streamSegmentName;
         this.streamSegmentId = streamSegmentId;
         this.containerId = containerId;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -395,7 +395,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                     // But we can (should) only process at most one MetadataCheckpoint per recovery. Any additional
                     // ones are redundant (used just for Truncation purposes) and contain the same information as
                     // if we processed every operation in order, up to them.
-                    log.info("{}: Skipping recovering MetadataCheckpointOperation with SequenceNumber {} because we already have metadata changes.", this.traceObjectId, operation.getSequenceNumber());
+                    log.debug("{}: Skipping MetadataCheckpointOperation with SequenceNumber {} because we already have metadata changes.", this.traceObjectId, operation.getSequenceNumber());
                     return;
                 }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -147,7 +147,6 @@ public class DurableLog extends AbstractService implements OperationLog {
                         .whenComplete((v, ex) -> {
                             if (ex == null) {
                                 // We are done.
-                                log.info("{}: Online.", this.traceObjectId);
                                 notifyDelayedStartComplete(null);
                             } else {
                                 if (Exceptions.unwrap(ex) instanceof DataLogDisabledException) {
@@ -409,7 +408,7 @@ public class DurableLog extends AbstractService implements OperationLog {
     }
 
     private CompletableFuture<Void> queueMetadataCheckpoint() {
-        log.info("{}: MetadataCheckpointOperation queued.", this.traceObjectId);
+        log.debug("{}: Queuing MetadataCheckpointOperation.", this.traceObjectId);
         return this.operationProcessor
                 .process(new MetadataCheckpointOperation())
                 .thenAccept(seqNo -> log.info("{}: MetadataCheckpointOperation durably stored.", this.traceObjectId));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -190,7 +190,9 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             this.indexEntries.clear();
         }
 
-        log.info("{}: Cleared all cache entries ({}).", this.traceObjectId, count);
+        if (count > 0) {
+            log.debug("{}: Cleared all cache entries ({}).", this.traceObjectId, count);
+        }
     }
 
     //endregion
@@ -315,7 +317,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
         this.metadata = newMetadata;
         this.recoveryMode = false;
-        log.info("{}: Exit RecoveryMode.", this.traceObjectId);
+        log.debug("{}: Exit RecoveryMode.", this.traceObjectId);
     }
 
     //endregion


### PR DESCRIPTION
**Change log description**  
- Changed some log messages from INFO to DEBUG.
- Removed duplicated log messages or irrelevant messages (i.e., when it said it didn't do anything).
- Fixed a spurious bug in `CacheManager` that would have caused a stack trace to be logged but with no side effects.

**Purpose of the change**  
Fixes #3484.

**What the code does**  
See Change Log Description above. These are non-functional changes.
These changes were collected while parsing many GBs of logs during recent system test debugging sessions and are meant to reduce noise and improve accuracy.

**How to verify it**  
Non-functional changes. Build must pass.
