### PR TITLE
Issue 3515: ControllerFailover test case is incorrect and stale 

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -12,14 +12,13 @@ package io.pravega.test.system;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.ControllerImpl;
 import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.impl.StreamSegments;
-import io.pravega.client.stream.impl.TxnSegments;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.Utils;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +61,7 @@ public class ControllerFailoverTest extends AbstractSystemTest {
     public static void initialize() throws MarathonException, ExecutionException {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
-        URI controllerUri = startPravegaControllerInstances(zkUri, 2);
+        URI controllerUri = startPravegaControllerInstances(zkUri, 1);
         ensureSegmentStoreRunning(zkUri, controllerUri);
     }
 
@@ -93,12 +91,10 @@ public class ControllerFailoverTest extends AbstractSystemTest {
     public void failoverTest() throws InterruptedException, ExecutionException {
         String scope = "testFailoverScope" + RandomStringUtils.randomAlphabetic(5);
         String stream = "testFailoverStream" + RandomStringUtils.randomAlphabetic(5);
-        int initialSegments = 2;
+        int initialSegments = 1;
         List<Long> segmentsToSeal = Collections.singletonList(0L);
         Map<Double, Double> newRangesToCreate = new HashMap<>();
-        newRangesToCreate.put(0.0, 0.25);
-        newRangesToCreate.put(0.25, 0.5);
-        long lease = 29000;
+        newRangesToCreate.put(0.0, 1.0);
 
         // Connect with first controller instance.
         final Controller controller1 = new ControllerImpl(
@@ -115,14 +111,15 @@ public class ControllerFailoverTest extends AbstractSystemTest {
 
         long txnCreationTimestamp = System.nanoTime();
         StreamImpl stream1 = new StreamImpl(scope, stream);
-        TxnSegments txnSegments = controller1.createTransaction(
-                stream1, lease).join();
-        log.info("Transaction {} created successfully, beginTime={}", txnSegments.getTxnId(), txnCreationTimestamp);
 
         // Initiate scale operation. It will block until ongoing transaction is complete.
         controller1.startScale(stream1, segmentsToSeal, newRangesToCreate).join();
-        
+
         // Now stop the controller instance executing scale operation.
+        Futures.getAndHandleExceptions(controllerService1.scaleService(0), ExecutionException::new);
+        log.info("Successfully stopped one instance of controller service");
+
+        // restart controller service
         Futures.getAndHandleExceptions(controllerService1.scaleService(1), ExecutionException::new);
         log.info("Successfully stopped one instance of controller service");
 
@@ -141,33 +138,25 @@ public class ControllerFailoverTest extends AbstractSystemTest {
                                     .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
                                     .build(), executorService);
 
-        // Fetch status of transaction.
-        log.info("Fetching status of transaction {}, time elapsed since its creation={}",
-                txnSegments.getTxnId(), System.nanoTime() - txnCreationTimestamp);
-        Transaction.Status status = controller2.checkTransactionStatus(stream1,
-                txnSegments.getTxnId()).join();
-        log.info("Transaction {} status={}", txnSegments.getTxnId(), status);
-
-        if (status == Transaction.Status.OPEN) {
-            // Abort the ongoing transaction.
-            log.info("Trying to abort transaction {}, by sending request to controller at {}", txnSegments.getTxnId(),
-                    controllerURIDirect);
-            controller2.abortTransaction(stream1, txnSegments.getTxnId()).join();
+        // Note: if scale does not complete within desired time, test will timeout.
+        boolean scaleStatus = controller2.checkScaleStatus(stream1, 0).join();
+        while (!scaleStatus) {
+            scaleStatus = controller2.checkScaleStatus(stream1, 0).join();
+            Thread.sleep(30000);
         }
 
-        // Note: if scale does not complete within desired time, test will timeout. 
-        AtomicBoolean scaleDone = new AtomicBoolean(false);
-        Futures.loop(() -> !scaleDone.get(), 
-                () -> Futures.delayedFuture(() -> controller2.checkScaleStatus(stream1, 0)
-                                                             .thenAccept(scaleDone::set), 3000, executorService), 
-                executorService).join();
+        segmentsToSeal = Collections.singletonList(StreamSegmentNameUtils.computeSegmentId(1, 1));
 
-        // Ensure that the stream has 3 segments now.
+        newRangesToCreate = new HashMap<>();
+        newRangesToCreate.put(0.0, 0.5);
+        newRangesToCreate.put(0.5, 1.0);
+
+        controller2.scaleStream(stream1, segmentsToSeal, newRangesToCreate, executorService).getFuture().join();
+
         log.info("Checking whether scale operation succeeded by fetching current segments");
         StreamSegments streamSegments = controller2.getCurrentSegments(scope, stream).join();
         log.info("Current segment count=", streamSegments.getSegments().size());
-        Assert.assertEquals(initialSegments - segmentsToSeal.size() + newRangesToCreate.size(),
-                streamSegments.getSegments().size());
+        Assert.assertEquals(2, streamSegments.getSegments().size());
     }
 
     private void createStream(Controller controller, String scope, String stream, ScalingPolicy scalingPolicy) {

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -120,12 +120,7 @@ public class ControllerFailoverTest extends AbstractSystemTest {
 
         // Initiate scale operation. It will block until ongoing transaction is complete.
         controller1.startScale(stream1, segmentsToSeal, newRangesToCreate).join();
-
-        // Ensure that scale is not yet done.
-        boolean scaleStatus = controller1.checkScaleStatus(stream1, 0).join();
-        log.info("Status of scale operation isDone={}", scaleStatus);
-        Assert.assertTrue(!scaleStatus);
-
+        
         // Now stop the controller instance executing scale operation.
         Futures.getAndHandleExceptions(controllerService1.scaleService(1), ExecutionException::new);
         log.info("Successfully stopped one instance of controller service");
@@ -161,6 +156,8 @@ public class ControllerFailoverTest extends AbstractSystemTest {
 
         // Scale operation should now complete on the second controller instance.
         // Note: if scale does not complete within desired time, test will timeout. 
+        // Ensure that scale is not yet done.
+        boolean scaleStatus = controller1.checkScaleStatus(stream1, 0).join();
         while (!scaleStatus) {
             scaleStatus = controller2.checkScaleStatus(stream1, 0).join();
             Thread.sleep(30000);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -154,14 +155,12 @@ public class ControllerFailoverTest extends AbstractSystemTest {
             controller2.abortTransaction(stream1, txnSegments.getTxnId()).join();
         }
 
-        // Scale operation should now complete on the second controller instance.
         // Note: if scale does not complete within desired time, test will timeout. 
-        // Ensure that scale is not yet done.
-        boolean scaleStatus = controller1.checkScaleStatus(stream1, 0).join();
-        while (!scaleStatus) {
-            scaleStatus = controller2.checkScaleStatus(stream1, 0).join();
-            Thread.sleep(30000);
-        }
+        AtomicBoolean scaleDone = new AtomicBoolean(false);
+        Futures.loop(() -> !scaleDone.get(), 
+                () -> Futures.delayedFuture(() -> controller2.checkScaleStatus(stream1, 0)
+                                                             .thenAccept(scaleDone::set), 3000, executorService), 
+                executorService).join();
 
         // Ensure that the stream has 3 segments now.
         log.info("Checking whether scale operation succeeded by fetching current segments");


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
* Refactors the test case to validate that scaling happens after stopping and restarting the controller.

**Purpose of the change**  
Fixes #3515 

**What the code does**  
 Controller failover test is stale. It was written at a time when scale waited for transactions on old epochs which was no longer the case with rolling transactions.
The test creates a transaction and then initiates a scale and expects the scale to stall.
it checks once if the scale is complete or not. And then goes on to invoke a controller failover.

So there are two problems here -
1.     assumption that the scale would wait on transaction.
    This had been passing merely by luck as when we check isScaleDone in the test, the scale is not complete. But there is nothing preventing the scale to complete.
2.    the test starts with 2 controller instances. There is nothing that tells this test which controller is running the scale. So reducing number of controller instances has no guarantee that the scale processing for the said stream actually fails over.

We have removed the incorrect scale check. To make the test meaningful (but not deterministic, we stop a controller and restart it. We verify that the scale operation is able to complete despite the restart.

**How to verify it**  
System test should consistently pass
