### PR TITLE
Issue 3404: Unit tests: Controller tests use large number of connections 

### DIFF
--- a/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
@@ -56,5 +56,6 @@ public class MockConnectionFactoryImpl implements ConnectionFactory {
 
     @Override
     public void close() {
+        executor.shutdown();
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
@@ -56,6 +56,6 @@ public class MockConnectionFactoryImpl implements ConnectionFactory {
 
     @Override
     public void close() {
-        executor.shutdown();
+        ExecutorServiceHelpers.shutdown(executor);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -47,13 +47,15 @@ public abstract class PingTest {
     private RESTServerConfig serverConfig;
     private RESTServer restServer;
     private Client client;
-
+    private ConnectionFactoryImpl connectionFactory;
+    
     @Before
     public void setup() throws Exception {
         ControllerService mockControllerService = mock(ControllerService.class);
         serverConfig = getServerConfig();
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
         restServer = new RESTServer(null, mockControllerService, null, serverConfig,
-                new ConnectionFactoryImpl(ClientConfig.builder().build()));
+                connectionFactory);
         restServer.startAsync();
         restServer.awaitRunning();
         client = createJerseyClient();
@@ -69,6 +71,7 @@ public abstract class PingTest {
         client.close();
         restServer.stopAsync();
         restServer.awaitTerminated();
+        connectionFactory.close();
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -188,8 +188,8 @@ public class StreamMetaDataAuthFocusedTests {
         serverConfig = RESTServerConfigImpl.builder().host("localhost").port(TestUtils.getAvailableListenPort()).build();
         LocalController controller = new LocalController(mockControllerService, false, "");
         connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
-                                                                                        .controllerURI(URI.create("tcp://localhost"))
-                                                                                        .build());
+                                                                  .controllerURI(URI.create("tcp://localhost"))
+                                                                  .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
                 connectionFactory);
         restServer.startAsync();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -126,6 +126,9 @@ public class StreamMetaDataAuthFocusedTests {
     @SuppressWarnings("checkstyle:StaticVariableName")
     private static File passwordHandlerInputFile;
 
+    @SuppressWarnings("checkstyle:StaticVariableName")
+    private static ConnectionFactoryImpl connectionFactory;
+    
     // We want to ensure that the tests in this class are run one after another (in no particular sequence), as we
     // are using a shared server (for execution efficiency). We use this in setup and teardown method initiazers
     // for ensuring the desired behavior.
@@ -184,10 +187,11 @@ public class StreamMetaDataAuthFocusedTests {
         mockControllerService = mock(ControllerService.class);
         serverConfig = RESTServerConfigImpl.builder().host("localhost").port(TestUtils.getAvailableListenPort()).build();
         LocalController controller = new LocalController(mockControllerService, false, "");
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                                        .controllerURI(URI.create("tcp://localhost"))
+                                                                                        .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                new ConnectionFactoryImpl(ClientConfig.builder()
-                        .controllerURI(URI.create("tcp://localhost"))
-                        .build()));
+                connectionFactory);
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();
@@ -206,6 +210,7 @@ public class StreamMetaDataAuthFocusedTests {
         if (passwordHandlerInputFile != null) {
             passwordHandlerInputFile.delete();
         }
+        connectionFactory.close();
     }
 
     @Before

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -97,7 +97,8 @@ public class StreamMetaDataTests {
 
     private RESTServerConfig serverConfig;
     private RESTServer restServer;
-
+    private ConnectionFactoryImpl connectionFactory;
+    
     private final String stream1 = "stream1";
     private final String stream2 = "stream2";
     private final String stream3 = "stream3";
@@ -146,10 +147,11 @@ public class StreamMetaDataTests {
         mockControllerService = mock(ControllerService.class);
         serverConfig = RESTServerConfigImpl.builder().host("localhost").port(TestUtils.getAvailableListenPort()).build();
         LocalController controller = new LocalController(mockControllerService, false, "");
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                                        .controllerURI(URI.create("tcp://localhost"))
+                                                                                        .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                new ConnectionFactoryImpl(ClientConfig.builder()
-                                                      .controllerURI(URI.create("tcp://localhost"))
-                                                      .build()));
+                connectionFactory);
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();
@@ -215,6 +217,7 @@ public class StreamMetaDataTests {
         client.close();
         restServer.stopAsync();
         restServer.awaitTerminated();
+        connectionFactory.close();
     }
 
     /**

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -562,11 +562,12 @@ public class SegmentHelperTest {
     private class MockConnectionFactory implements ConnectionFactory {
         @Getter
         private ReplyProcessor rp;
-
+        private ClientConnection connection;
+        
         @Override
         public CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri endpoint, ReplyProcessor rp) {
             this.rp = rp;
-            ClientConnection connection = new MockConnection(rp);
+            connection = new MockConnection(rp);
             return CompletableFuture.completedFuture(connection);
         }
 
@@ -577,7 +578,7 @@ public class SegmentHelperTest {
 
         @Override
         public void close() {
-
+            connection.close();
         }
     }
 

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -578,7 +578,9 @@ public class SegmentHelperTest {
 
         @Override
         public void close() {
-            connection.close();
+            if (connection != null) {
+                connection.close();
+            }
         }
     }
 

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -67,20 +67,21 @@ public class ControllerServiceTest {
 
     private final StreamMetadataStore streamStore = StreamStoreFactory.createInMemoryStore(executor);
 
-    private final StreamMetadataTasks streamMetadataTasks;
-    private final StreamTransactionMetadataTasks streamTransactionMetadataTasks;
-    private final ConnectionFactoryImpl connectionFactory;
-    private final ControllerService consumer;
+    private StreamMetadataTasks streamMetadataTasks;
+    private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
+    private ConnectionFactoryImpl connectionFactory;
+    private ControllerService consumer;
 
-    private final CuratorFramework zkClient;
-    private final TestingServer zkServer;
+    private CuratorFramework zkClient;
+    private TestingServer zkServer;
 
     private long startTs;
     private long scaleTs;
 
     private RequestTracker requestTracker = new RequestTracker(true);
-
-    public ControllerServiceTest() throws Exception {
+    
+    @Before
+    public void setup() throws Exception {
         zkServer = new TestingServerStarter().start();
         zkServer.start();
         zkClient = CuratorFrameworkFactory.newClient(zkServer.getConnectString(),
@@ -99,10 +100,6 @@ public class ControllerServiceTest {
 
         consumer = new ControllerService(streamStore, hostStore, streamMetadataTasks, streamTransactionMetadataTasks,
                 new SegmentHelper(), executor, null);
-    }
-
-    @Before
-    public void setup() throws ExecutionException, InterruptedException {
 
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final ScalingPolicy policy2 = ScalingPolicy.fixed(3);

--- a/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
@@ -61,7 +61,8 @@ public class InMemoryControllerServiceImplTest extends ControllerServiceImplTest
     private StreamMetadataStore streamStore;
     private SegmentHelper segmentHelper;
     private RequestTracker requestTracker;
-
+    private ConnectionFactoryImpl connectionFactory;
+    
     @Override
     public void setup() throws Exception {
         executorService = ExecutorServiceHelpers.newScheduledThreadPool(20, "testpool");
@@ -72,7 +73,7 @@ public class InMemoryControllerServiceImplTest extends ControllerServiceImplTest
         segmentHelper = SegmentHelperMock.getSegmentHelperMock();
         requestTracker = new RequestTracker(true);
 
-        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
                                                                                         .controllerURI(URI.create("tcp://localhost"))
                                                                                         .build());
         streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, hostStore, taskMetadataStore, segmentHelper,
@@ -108,5 +109,7 @@ public class InMemoryControllerServiceImplTest extends ControllerServiceImplTest
         if (streamTransactionMetadataTasks != null) {
             streamTransactionMetadataTasks.close();
         }
+        
+        connectionFactory.close();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
@@ -72,6 +72,7 @@ public class ZKControllerServiceImplTest extends ControllerServiceImplTest {
     private ScheduledExecutorService executorService;
     private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
     private Cluster cluster;
+    private ConnectionFactoryImpl connectionFactory;
 
     @Override
     public void setup() throws Exception {
@@ -95,7 +96,7 @@ public class ZKControllerServiceImplTest extends ControllerServiceImplTest {
         BucketStore bucketStore = StreamStoreFactory.createZKBucketStore(zkClient, executorService);
         segmentHelper = SegmentHelperMock.getSegmentHelperMock();
 
-        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
         streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, hostStore, taskMetadataStore, segmentHelper,
                 executorService, "host", connectionFactory, AuthHelper.getDisabledAuthHelper(), requestTracker);
         streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelper,
@@ -142,6 +143,7 @@ public class ZKControllerServiceImplTest extends ControllerServiceImplTest {
         storeClient.close();
         zkClient.close();
         zkServer.close();
+        connectionFactory.close();
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.task.Stream;
 
 import io.pravega.client.ClientConfig;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
@@ -74,7 +75,8 @@ public class IntermittentCnxnFailureTest {
 
     private SegmentHelper segmentHelperMock;
     private RequestTracker requestTracker = new RequestTracker(true);
-
+    private ConnectionFactory connectionFactory;
+    
     @Before
     public void setup() throws Exception {
         zkServer = new TestingServerStarter().start();
@@ -93,7 +95,7 @@ public class IntermittentCnxnFailureTest {
         doReturn(Controller.NodeUri.newBuilder().setEndpoint("localhost").setPort(Config.SERVICE_PORT).build()).when(segmentHelperMock).getSegmentUri(
                 anyString(), anyString(), anyInt(), any());
 
-        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
         streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, hostStore, taskMetadataStore, segmentHelperMock,
                 executor, "host", connectionFactory, AuthHelper.getDisabledAuthHelper(), requestTracker);
 
@@ -112,6 +114,7 @@ public class IntermittentCnxnFailureTest {
         streamTransactionMetadataTasks.close();
         zkClient.close();
         zkServer.close();
+        connectionFactory.close();
         ExecutorServiceHelpers.shutdown(executor);
     }
 

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -83,21 +83,23 @@ public class TaskTest {
     private final StreamConfiguration configuration1 = StreamConfiguration.builder().scalingPolicy(policy1).build();
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
 
-    private final StreamMetadataStore streamStore;
+    private StreamMetadataStore streamStore;
 
     private final HostControllerStore hostStore = HostStoreFactory.createInMemoryStore(HostMonitorConfigImpl.dummyConfig());
 
-    private final TaskMetadataStore taskMetadataStore;
+    private TaskMetadataStore taskMetadataStore;
 
-    private final TestingServer zkServer;
+    private TestingServer zkServer;
 
-    private final StreamMetadataTasks streamMetadataTasks;
-    private final SegmentHelper segmentHelperMock;
-    private final CuratorFramework cli;
+    private StreamMetadataTasks streamMetadataTasks;
+    private SegmentHelper segmentHelperMock;
+    private CuratorFramework cli;
     private Map<Long, Map.Entry<Double, Double>> segmentsCreated;
     private final RequestTracker requestTracker = new RequestTracker(true);
-
-    public TaskTest() throws Exception {
+    private ConnectionFactoryImpl connectionFactory;
+    
+    @Before
+    public void setUp() throws Exception {
         zkServer = new TestingServerStarter().start();
         zkServer.start();
 
@@ -108,15 +110,13 @@ public class TaskTest {
 
         segmentHelperMock = SegmentHelperMock.getSegmentHelperMock();
 
+        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                  .controllerURI(URI.create("tcp://localhost"))
+                                                                  .build());
         streamMetadataTasks = new StreamMetadataTasks(streamStore, StreamStoreFactory.createInMemoryBucketStore(), hostStore, taskMetadataStore, segmentHelperMock,
-                executor, HOSTNAME, new ConnectionFactoryImpl(ClientConfig.builder()
-                                                                          .controllerURI(URI.create("tcp://localhost"))
-                                                                          .build()),
+                executor, HOSTNAME, connectionFactory,
                 AuthHelper.getDisabledAuthHelper(), requestTracker);
-    }
 
-    @Before
-    public void setUp() throws ExecutionException, InterruptedException {
         final String stream2 = "stream2";
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final ScalingPolicy policy2 = ScalingPolicy.fixed(3);
@@ -173,6 +173,7 @@ public class TaskTest {
         zkServer.stop();
         zkServer.close();
         ExecutorServiceHelpers.shutdown(executor);
+        connectionFactory.close();
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Closing connection factory at the end of the tests. 

**Purpose of the change**  
Fixes #3404 

**What the code does**  
Closes ConnectionFactory at the end of tests

**How to verify it**  
No more "too many open files" while running unit tests locally. 