### PR TITLE
Issue 3521: Improve verification for SegmentOutputStreamTest.testFailOnClose 

### DIFF
--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -568,7 +568,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         });
         // Verify the order of WireCommands sent.
         inOrder.verify(connection).send(new WireCommands.KeepAlive());
-        // Two invocations of Setup Append are sent, since the first connection try encounters a connection drop.
+        // Two SetupAppend WireCommands are sent since the connection is dropped right after the first KeepAlive WireCommand is sent.
+        // The second SetupAppend WireCommand is sent while trying to re-establish connection.
         inOrder.verify(connection, times(2)).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         // Ensure the pending append is sent over the connection. The exact verification of the append data is performed while setting up
         // the when clause of setting up append.

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -561,13 +561,18 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         //Verify behavior
         AssertExtensions.assertBlocks(() -> {
             output.close();
-        }, () -> {            
+        }, () -> {
+            // close is unblocked once the connection is setup and data is appended on Segment store.
             cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
-            inOrder.verify(connection).send(new WireCommands.KeepAlive());
-            inOrder.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
-            inOrder.verify(connection).sendAsync(Mockito.eq(Collections.singletonList(append)), Mockito.any());
             cf.getProcessor(uri).dataAppended(new WireCommands.DataAppended(output.getRequestId(), cid, 1, 0));
         });
+        // Verify the order of WireCommands sent.
+        inOrder.verify(connection).send(new WireCommands.KeepAlive());
+        // Two invocations of Setup Append are sent, since the first connection try encounters a connection drop.
+        inOrder.verify(connection, times(2)).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
+        // Ensure the pending append is sent over the connection. The exact verification of the append data is performed while setting up
+        // the when clause of setting up append.
+        inOrder.verify(connection).sendAsync(Mockito.anyList(), Mockito.any());
         inOrder.verify(connection).close();
         assertEquals(true, acked.isDone());
         inOrder.verifyNoMoreInteractions();


### PR DESCRIPTION
**Change log description**  
Improve verification for junit test `SegmentOutputStreamTest.testFailOnClose `. Ensure multiple SetupAppend requests are verified.

**Purpose of the change**  
Fixes #3521 

**What the code does**  
Improve the verification of the test to validate that `WireCommands.SetupAppend` is sent twice over the wire.

**How to verify it**  
The tests should continue to pass without transient failures.
