### PR TITLE
Issue 3454: File system atomic append

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemBasedLock.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemBasedLock.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implements a mutually exclusive lock by using file system.
+ */
+public class FileSystemBasedLock implements AutoCloseable {
+    private static final long DEFAULT_SLEEP = Duration.of(10, ChronoUnit.MILLIS).toMillis();
+    private static final long DEFAULT_TIMEOUT = Duration.of(1, ChronoUnit.SECONDS).toMillis();
+    private static final long DEFAULT_LEASE_EXPIRATION = Duration.of(10, ChronoUnit.SECONDS).toMillis();
+
+    Path path;
+
+    /**
+     * Creates file system based lock.
+     * @param path Path to use for lock file.
+     * @throws Exception Throws exception.
+     */
+    public FileSystemBasedLock(Path path) throws Exception {
+        this(path, DEFAULT_LEASE_EXPIRATION, DEFAULT_SLEEP, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Creates file system based lock.
+     * @param path Path to use for lock file.
+     * @param leaseDuration Lease expiration timeout.
+     * @param sleep Duartion to wait in mili.
+     * @param timeout Timeout in mili.
+     * @throws Exception Throws exception.
+     */
+    public FileSystemBasedLock(Path path, long leaseDuration, long sleep, long timeout) throws Exception {
+        long startTime = new Date().getTime();
+        this.path = path;
+        boolean done = false;
+        while (!done) {
+            try {
+                Files.createFile(path, PosixFilePermissions.asFileAttribute(FileSystemPermissions.READ_WRITE_PERMISSION));
+                return;
+            } catch (FileAlreadyExistsException ex) {
+                try {
+                    BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+                    if (hasExpired(attributes.creationTime().toMillis(), leaseDuration)) {
+                        Files.deleteIfExists(path);
+                    }
+                } catch (IOException e) {
+                    // The file may be deleted by the time we try to read attributes on it.
+                    if (!(e instanceof NoSuchFileException)) {
+                        throw e;
+                    }
+                }
+            }
+            if (hasExpired(startTime, timeout)) {
+                throw new TimeoutException();
+            }
+            Thread.sleep(sleep);
+        }
+    }
+
+    /**
+     * Determines whether given time interval has expired.
+     * @param startTime Start of interval.
+     * @param duration Duration of interval.
+     * @return
+     */
+    private boolean hasExpired(long startTime, long duration) {
+        return (new Date().getTime() - startTime) > duration;
+    }
+
+    /**
+     * Closes the lock.
+     * @throws Exception
+     */
+
+    @Override
+    public void close() throws Exception {
+        Files.deleteIfExists(path);
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemPermissions.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemPermissions.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+/**
+ * Constants for Posix file Permissions.
+ */
+class FileSystemPermissions {
+    /**
+     * Read permission.
+     */
+    public static final Set<PosixFilePermission> READ_ONLY_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
+
+    /**
+     * Write permission for owner. Read permission for all others.
+     */
+    public static final Set<PosixFilePermission> READ_WRITE_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
+}

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemLockTest.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemLockTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import io.pravega.common.io.FileHelpers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Unit tests for FileSystemBasedLock.
+ */
+public class FileSystemLockTest {
+
+    static final long ONE_HOUR = Duration.of(1, ChronoUnit.HOURS).toMillis();
+    static final long ONE_MILLI = Duration.of(1, ChronoUnit.MILLIS).toMillis();
+    static final long TWO_MILLI = Duration.of(2, ChronoUnit.MILLIS).toMillis();
+    static final long HUNDRED_MILLI = Duration.of(100, ChronoUnit.MILLIS).toMillis();
+
+    private File baseDir = null;
+    private AtomicBoolean inCriticalSection = new AtomicBoolean();
+    private Random rnd = new Random();
+
+    @Before
+    public void setUp() throws Exception {
+        this.baseDir = Files.createTempDirectory("test_nfs").toFile().getAbsoluteFile();
+    }
+
+    @After
+    public void tearDown() {
+        FileHelpers.deleteFileOrDirectory(baseDir);
+        baseDir = null;
+    }
+
+    /**
+     * Test that lock file is created and deleted.
+     * @throws Exception
+     */
+    @Test()
+    public void testBasicLocking() throws Exception {
+        Path lockFilepath = Paths.get(baseDir.getAbsolutePath(), "test1");
+        FileSystemBasedLock lock = new FileSystemBasedLock(lockFilepath);
+        Assert.assertTrue("Lock file should be created after creating lock.", Files.exists(lockFilepath));
+        lock.close();
+        Assert.assertFalse("Lock file should be deleted after close.", Files.exists(lockFilepath));
+        // Calling close multiple times should be okay.
+        lock.close();
+    }
+
+    /**
+     * Create first lock but do not close it.
+     * Try to create second lock with same file, the lock should timeout.
+     * @throws Exception
+     */
+    @Test()
+    public void testConflict() throws Exception {
+        Path lockFilepath = Paths.get(baseDir.getAbsolutePath(), "test1");
+        FileSystemBasedLock lock1 = new FileSystemBasedLock(lockFilepath, ONE_HOUR, ONE_MILLI, TWO_MILLI);
+        Assert.assertTrue("Lock file should be created after creating lock.", Files.exists(lockFilepath));
+        try {
+            FileSystemBasedLock lock2 = new FileSystemBasedLock(lockFilepath, ONE_HOUR, ONE_MILLI, TWO_MILLI);
+            Assert.fail("Exception should be thrown");
+        } catch (TimeoutException ex) {
+            // good exception thrown as expected
+        } finally {
+            Files.delete(lockFilepath);
+        }
+    }
+
+    /**
+     * Create a test lock, but don't close it.
+     * Wait for it to expire.
+     * Create second lock, it should succeed.
+     * @throws Exception
+     */
+    @Test()
+    public void testExpiredLock() throws Exception {
+        Path lockFilepath = Paths.get(baseDir.getAbsolutePath(), "test1");
+        FileSystemBasedLock lock1 = new FileSystemBasedLock(lockFilepath, ONE_MILLI, ONE_MILLI, HUNDRED_MILLI);
+        Assert.assertTrue("Lock file should be created after creating lock.", Files.exists(lockFilepath));
+        Thread.sleep(5);
+        try {
+            // The lock should be expired here.
+            FileSystemBasedLock lock2 = new FileSystemBasedLock(lockFilepath, ONE_MILLI, ONE_MILLI, HUNDRED_MILLI);
+        } finally {
+            Files.deleteIfExists(lockFilepath);
+        }
+    }
+
+    /**
+     * Creates array of futures - each lambda asserts that only one lambda is in critical section.
+     * @throws Exception
+     */
+    @Test()
+    public void testMutualExclusion() throws Exception {
+        Path lockFilepath = Paths.get(baseDir.getAbsolutePath(), "testMutualExclusion");
+        int parallelism = 100;
+        CompletableFuture[] futures = new CompletableFuture[parallelism];
+        inCriticalSection.set(false);
+        for (int i = 0; i < parallelism; i++) {
+            futures[i] = CompletableFuture.runAsync(() -> {
+                try (FileSystemBasedLock lock1 = new FileSystemBasedLock(lockFilepath, ONE_HOUR, ONE_MILLI, ONE_HOUR)) {
+                    Assert.assertFalse("Mutual exclusion failed", inCriticalSection.get());
+                    // Note that code under test i.e locking implementation and aseert is before the use of atomic boolean
+                    inCriticalSection.set(true);
+                    // Sleep some random time, during this time other thread will try to aquire the lock and potentially
+                    // sees inCriticalSection == true if there is a bug in lock.
+                    int limit = rnd.nextInt(5);
+                    for (int j = 0; j < limit; j++) {
+                        Thread.sleep(ONE_MILLI); // wait for random time.
+                    }
+                    inCriticalSection.set(false);
+                } catch (Exception e) {
+                   Assert.fail("Exception thrown:" + e.toString());
+                }
+            });
+        }
+        CompletableFuture.allOf(futures).join();
+    }
+}


### PR DESCRIPTION
**Change log description**  
Implement file system based locking to implement single/exclusive writer pattern. The implementation uses named files as locks. 

**Purpose of the change**  
Fixes #3454 

**What the code does**  
_How the lock works_
- _Acquiring lock_ : While acquiring a lock it uses file system create operation to create a named lock file. The calling thread/process acquires the lock when the file is successfully created. 
- _Releasing  lock_ : For releasing the lock, it uses file system delete operation to delete the named lock file. 
- _Mutual exclusion_: The behavior depends on the atomic nature of underlying file system create call. If the named locked file is already present that means some other thread has already acquired the lock. 
- _Blocking (Waiting) and timeout_: The code sleeps for specified time and retries if it can not acquire the lock. It throws TimeoutException if the lock can not be obtained in specified timeout value. 
- _Handling failure to release locks_: In cases where process acquires the lock but fails to release it ( eg. it crashes ), the lock is reclaimed after specified time. If the previous lock file is found during the creation, then its creation time is checked. If the file was created before threshold time, the lock is considered abandoned and the lock file is deleted.

_How the lock is used_
- All Writes and concat operations for a given segment use lock. The name of the lock is derived from name of the segment by simply appending -lock suffix. 

**Key Assumptions**  
- Create and Delete calls are atomic. 
- The underlying file system correctly throws FileAlreadyExistsException 
- The threshold time (or lease time) on lock is typically order of magnitude bigger than typical clock skew.

**Correctness Argument**  
- The file can not be created twice. Therefore same lock can not be aquired twice.
- The file is not deleted until user of lock releases the lock which means during this time no other caller can acquire the lock. 

**Liveness Argument**  
- In case of crashed caller, the "expired" zombie lock file is deleted by the next caller trying to acquire lock. Crashed writer doesn't halt the system forever and eventually other callers can acquire all the locks previously held by crashed process.
- The caller is blocked until it either acquires the lock or it times out. 

**How to verify it**  
Unit tests should pass.
System tests should pass with Isilon.
