### PR TITLE
Issue 3104: Clean up gradle properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -829,7 +829,7 @@ project('test:system') {
         if(ext.getProperty('awsExecution').toString().equals("true")) {
             commandLine './aws/preTestScript.sh'
             args "$aws_access_key", "$aws_secret_key", "$aws_region", "$aws_key_name", "$cred_path", "$config_path", "$pravega_org", "$pravega_branch"
-        } else {
+        } else if (project.hasProperty('CLUSTER_NAME')) {
             commandLine "./preTestScript.sh"
             args "$CLUSTER_NAME", "$MASTER", "$NUM_SLAVES"
         }
@@ -904,8 +904,10 @@ project('test:system') {
     }
 
     task collectSystemTestLogsFromAws(type: Exec) {
-        commandLine './aws/postTestScript.sh'
-        args "$aws_access_key", "$aws_secret_key", "$aws_region", "$aws_key_name", "$cred_path", "$config_path", "$pravega_org", "$pravega_branch", "$travis_commit"
+        if (project.hasProperty('aws_secret_key')) {
+            commandLine './aws/postTestScript.sh'
+            args "$aws_access_key", "$aws_secret_key", "$aws_region", "$aws_key_name", "$cred_path", "$config_path", "$pravega_org", "$pravega_branch", "$travis_commit"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,29 +58,6 @@ pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 
 # Pravega Signing Key
-signing.keyId=05949AF6
+signing.keyId=
 # This will be defaulted to ~/.gnupg/secring.gpg if not provided as a command line property
 signing.secretKeyRingFile=
-
-#Default values for cluster name, master IP and number of slaves in the cluster.
-#To override this use -PCLUSTER_NAME=<> -PMASTER=<> -PNUM_SLAVES=<> while running gradle task
-CLUSTER_NAME=ant-man
-MASTER=127.0.0.1
-NUM_SLAVES=3
-
-#Default host,user path values for pravega.io server
-#To override this use -Phostname=<> -PMASTER=<> -Pusername=<> while running gradle task
-hostname=0.0.0.0
-username=root
-
-#Default config values for system test execution on AWS
-#To override this use -Paws_access_key=<> and so on... while running gradle task `startSystemTestsWithDocker`
-aws_access_key=null
-aws_secret_key=null
-aws_region=us-east-2
-aws_key_name=aws-key-pair
-cred_path=/home/ubuntu
-config_path=/home/ubuntu
-pravega_org=pravega
-pravega_branch=master
-travis_commit=0


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Updates gradle.properties to remove properties related tests that are needed only when running system tests.

**Purpose of the change**  
Fixes #3104 

**What the code does**  
There is no code change. This pull request is removing a bunch of gradle properties from the `gradle.properties` file, which are specific to running tests and can be passed via command line.

Although I have removed those properties altogether (and posted them to the wiki), it would also be fine to leave them without any parameters. I removed because I felt that they are cluttering the properties file unnecessarily.

**How to verify it**  
There is no functional change, but it should build regularly.
