### PR TITLE
Issue 3546: Incorrect assertion in MetadataScalability tests

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -182,7 +182,7 @@ public abstract class MetadataScalabilityTest extends AbstractScaleTests {
                          // we will just validate that a non empty value is returned. 
                          return controller.getSuccessors(cut)
                                           .thenAccept(successors -> {
-                                              assertEquals(successors.getSegments().size(), numSegments);
+                                              assertTrue(successors.getSegments().size() > 0);
                                               log.info("Successors for streamcut {} are {}", cut, successors);
                                           });
                      });


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
* Fixes the assertion to be greater than 0.

**Purpose of the change**  
Fixes #3546 

**What the code does**  
Fixes an assertion in `MetadataScalabilityTest` to validate that the number of successor segments is greater than 0.

**How to verify it**  
System test should pass. 