### PR TITLE
Issue 3533: Fix StreamTransactionMetadataTasks bugs

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -597,7 +597,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
         return commitWriterFuture
                 .thenCompose(commitWriter -> commitWriter.writeEvent(event.getKey(), event));
     }
-    
+
     CompletableFuture<TxnStatus> writeCommitEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
         CommitEvent event = new CommitEvent(scope, stream, epoch);
         return TaskStepsRetryHelper.withRetries(() -> writeCommitEvent(event)
@@ -628,7 +628,6 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     }
 
     private CompletableFuture<Void> notifyTxnCreation(final String scope, final String stream,
-                                 
                                                       final List<Segment> segments, final UUID txnId) {
         return Futures.allOf(segments.stream()
                 .parallel()

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -611,10 +611,10 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
         CommitEvent event = new CommitEvent(scope, stream, epoch);
         return TaskStepsRetryHelper.withRetries(() -> writeCommitEvent(event)
                 .thenAccept(v -> {
-                    log.debug("Transaction {} abort event posted", txnId);
+                    log.debug("Transaction {} commit event posted", txnId);
                 })
                 .exceptionally(ex -> {
-                    log.debug("Transaction {}, failed posting abort event. Retrying...", txnId);
+                    log.debug("Transaction {}, failed posting commit event. Retrying...", txnId);
                     throw new WriteFailedException(ex);
                 }), executor).thenApply(v -> status);
     }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -597,12 +597,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
         return commitWriterFuture
                 .thenCompose(commitWriter -> commitWriter.writeEvent(event.getKey(), event));
     }
-
-    public CompletableFuture<Void> writeAbortEvent(AbortEvent event) {
-        return abortWriterFuture
-                .thenCompose(abortWriter -> abortWriter.writeEvent(event.getKey(), event));
-    }
-
+    
     CompletableFuture<TxnStatus> writeCommitEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
         CommitEvent event = new CommitEvent(scope, stream, epoch);
         return TaskStepsRetryHelper.withRetries(() -> writeCommitEvent(event)
@@ -613,6 +608,11 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
                     log.debug("Transaction {}, failed posting abort event. Retrying...", txnId);
                     throw new WriteFailedException(ex);
                 }), executor).thenApply(v -> status);
+    }
+
+    public CompletableFuture<Void> writeAbortEvent(AbortEvent event) {
+        return abortWriterFuture
+                .thenCompose(abortWriter -> abortWriter.writeEvent(event.getKey(), event));
     }
 
     CompletableFuture<TxnStatus> writeAbortEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
@@ -628,6 +628,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     }
 
     private CompletableFuture<Void> notifyTxnCreation(final String scope, final String stream,
+                                 
                                                       final List<Segment> segments, final UUID txnId) {
         return Futures.allOf(segments.stream()
                 .parallel()

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -166,7 +166,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
      * @param config Controller event processor configuration.
      */
     @Synchronized
-    public Void initializeStreamWriters(final EventStreamClientFactory clientFactory,
+    public void initializeStreamWriters(final EventStreamClientFactory clientFactory,
                                         final ControllerEventProcessorConfig config) {
         if (!commitWriterFuture.isDone()) {
             commitWriterFuture.complete(clientFactory.createEventWriter(
@@ -181,21 +181,15 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
                     EventWriterConfig.builder().build()));
         }
         this.setReady();
-        return null;
     }
 
     @VisibleForTesting
     @Synchronized
-    public Void initializeStreamWriters(final String commitStreamName, final EventStreamWriter<CommitEvent> commitWriter,
-                                        final String abortStreamName, final EventStreamWriter<AbortEvent> abortWriter) {
-        if (!commitWriterFuture.isDone()) {
-            this.commitWriterFuture.complete(commitWriter);
-        }
-        if (!abortWriterFuture.isDone()) {
-            this.abortWriterFuture.complete(abortWriter);
-        }
+    public void initializeStreamWriters(final EventStreamWriter<CommitEvent> commitWriter,
+                                        final EventStreamWriter<AbortEvent> abortWriter) {
+        this.commitWriterFuture.complete(commitWriter);
+        this.abortWriterFuture.complete(abortWriter);
         this.setReady();
-        return null;
     }
 
     /**
@@ -610,13 +604,15 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     CompletableFuture<TxnStatus> writeCommitEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
         CommitEvent event = new CommitEvent(scope, stream, epoch);
         return TaskStepsRetryHelper.withRetries(() -> writeCommitEvent(event)
-                .thenAccept(v -> {
-                    log.debug("Transaction {} commit event posted", txnId);
-                })
-                .exceptionally(ex -> {
-                    log.debug("Transaction {}, failed posting commit event. Retrying...", txnId);
-                    throw new WriteFailedException(ex);
-                }), executor).thenApply(v -> status);
+                .handle((r, e) -> {
+                    if (e != null) {
+                        log.debug("Transaction {}, failed posting commit event. Retrying...", txnId);
+                        throw new WriteFailedException(e);
+                    } else {
+                        log.debug("Transaction {} commit event posted", txnId);
+                        return status;
+                    }
+                }), executor);
     }
 
     public CompletableFuture<Void> writeAbortEvent(AbortEvent event) {
@@ -627,13 +623,15 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     CompletableFuture<TxnStatus> writeAbortEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
         AbortEvent event = new AbortEvent(scope, stream, epoch, txnId);
         return TaskStepsRetryHelper.withRetries(() -> writeAbortEvent(event)
-                .thenAccept(v -> {
-                    log.debug("Transaction {} abort event posted", txnId);
-                    })
-                .exceptionally(ex -> {
-                    log.debug("Transaction {}, failed posting abort event. Retrying...", txnId);
-                    throw new WriteFailedException(ex); 
-                }), executor).thenApply(v -> status);
+                .handle((r, e) -> {
+                    if (e != null) {
+                        log.debug("Transaction {}, failed posting abort event. Retrying...", txnId);
+                        throw new WriteFailedException(e);
+                    } else {
+                        log.debug("Transaction {} abort event posted", txnId);
+                        return status;
+                    }
+                }), executor);
     }
 
     private CompletableFuture<Void> notifyTxnCreation(final String scope, final String stream,

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -133,8 +133,7 @@ public class ControllerClusterListenerTest {
         ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
         StreamTransactionMetadataTasks txnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore,
                 segmentHelper, executor, host.getHostId(), connectionFactory, AuthHelper.getDisabledAuthHelper());
-        txnTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(), "abortStream",
-                new EventStreamWriterMock<>());
+        txnTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
         TxnSweeper txnSweeper = new TxnSweeper(streamStore, txnTasks, 100, executor);
 
         // Create ControllerClusterListener.
@@ -278,8 +277,7 @@ public class ControllerClusterListenerTest {
         doCallRealMethod().when(txnSweeper).isReady();
 
         // Complete txn sweeper initialization by adding event writers.
-        txnTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(), "abortStream",
-                new EventStreamWriterMock<>());
+        txnTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
         txnSweeper.awaitInitialization();
 
         assertTrue(Futures.await(txnSweep, 3000));

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
@@ -109,8 +109,7 @@ public class ControllerEventProcessorTest {
                 segmentHelperMock, executor, "1", connectionFactory, AuthHelper.getDisabledAuthHelper(), requestTracker);
         streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelperMock,
                 executor, "host", connectionFactory, AuthHelper.getDisabledAuthHelper());
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(), "abortStream",
-                new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         // region createStream
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -141,8 +141,7 @@ public class RequestHandlersTest {
         streamMetadataTasks.initializeStreamWriters(clientFactory, Config.SCALE_STREAM_NAME);
         streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, hostStore,
                 segmentHelper, executor, hostId, connectionFactory, AuthHelper.getDisabledAuthHelper());
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(), 
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
         long createTimestamp = System.currentTimeMillis();
 
         // add a host in zk

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -163,8 +163,7 @@ public class ControllerGrpcAuthFocusedTest {
                 EXECUTOR);
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, EXECUTOR));
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         Cluster mockCluster = mock(Cluster.class);
         when(mockCluster.getClusterMembers()).thenReturn(Collections.singleton(new Host("localhost", 9090, null)));

--- a/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
@@ -89,8 +89,7 @@ public class InMemoryControllerServiceImplTest extends ControllerServiceImplTest
                 executorService);
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         Cluster mockCluster = mock(Cluster.class);
         when(mockCluster.getClusterMembers()).thenReturn(Collections.singleton(new Host("localhost", 9090, null)));

--- a/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
@@ -111,8 +111,7 @@ public class ZKControllerServiceImplTest extends ControllerServiceImplTest {
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));
 
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         cluster = new ClusterZKImpl(zkClient, ClusterType.CONTROLLER);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -165,8 +165,7 @@ public class StreamMetadataTasksTest {
                 executor);
         consumer = new ControllerService(streamStorePartialMock, hostStore, streamMetadataTasks,
                 streamTransactionMetadataTasks, segmentHelperMock, executor, null);
-        streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration1 = StreamConfiguration.builder().scalingPolicy(policy1).build();

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -52,7 +52,6 @@ import io.pravega.controller.store.stream.StreamStoreFactory;
 import io.pravega.controller.store.stream.TxnStatus;
 import io.pravega.controller.store.stream.Version;
 import io.pravega.controller.store.stream.VersionedTransactionData;
-import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.TaskStoreFactory;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
@@ -72,7 +71,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -570,13 +568,12 @@ public class StreamTransactionMetadataTasksTest {
                 SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
                 new AuthHelper(this.authEnabled, "secret"));
 
-
         streamStore.createScope(SCOPE).join();
-        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),1L, null, executor).join();
+        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(), 1L, null, executor).join();
         streamStore.setState(SCOPE, STREAM, State.ACTIVE, null, executor).join();
 
         CompletableFuture<Pair<VersionedTransactionData, List<Segment>>> createFuture = txnTasks.createTxn(SCOPE, STREAM, 100L, null);
-        
+
         // create and ping transactions should not wait for writer initialization and complete immediately.
         createFuture.join();
         assertTrue(Futures.await(createFuture));
@@ -586,7 +583,7 @@ public class StreamTransactionMetadataTasksTest {
 
         CompletableFuture<TxnStatus> commitFuture = txnTasks.commitTxn(SCOPE, STREAM, txnId, null);
         assertFalse(commitFuture.isDone());
-        
+
         EventStreamWriterMock<CommitEvent> commitWriter = new EventStreamWriterMock<>();
         EventStreamWriterMock<AbortEvent> abortWriter = new EventStreamWriterMock<>();
 
@@ -606,7 +603,7 @@ public class StreamTransactionMetadataTasksTest {
                 new AuthHelper(this.authEnabled, "secret"));
 
         streamStore.createScope(SCOPE).join();
-        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),1L, null, executor).join();
+        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(), 1L, null, executor).join();
         streamStore.setState(SCOPE, STREAM, State.ACTIVE, null, executor).join();
 
         TestEventStreamWriter<CommitEvent> commitWriter = new TestEventStreamWriter<>();
@@ -617,7 +614,7 @@ public class StreamTransactionMetadataTasksTest {
         UUID txnId = UUID.randomUUID();
         txnTasks.writeAbortEvent(SCOPE, STREAM, 0, txnId, TxnStatus.ABORTING).join();
         Pair<String, AbortEvent> request = abortWriter.requestsReceived.take();
-        assertEquals(request.getKey(), request.getValue().getKey()); 
+        assertEquals(request.getKey(), request.getValue().getKey());
         txnTasks.writeAbortEvent(new AbortEvent(SCOPE, STREAM, 0, txnId)).join();
         Pair<String, AbortEvent> request2 = abortWriter.requestsReceived.take();
         assertEquals(request2.getKey(), request2.getValue().getKey());

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -214,8 +214,7 @@ public class StreamTransactionMetadataTasksTest {
         // Create transaction tasks.
         txnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelperMock,
                 executor, "host", connectionFactory, AuthHelper.getDisabledAuthHelper());
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream",
-                abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         // Create ControllerService.
         consumer = new ControllerService(streamStore, hostStore, streamMetadataTasks, txnTasks,
@@ -256,8 +255,7 @@ public class StreamTransactionMetadataTasksTest {
         txnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelperMock, executor, "host",
                 connectionFactory, AuthHelper.getDisabledAuthHelper());
 
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream",
-                abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         consumer = new ControllerService(streamStore, hostStore, streamMetadataTasks, txnTasks,
                 segmentHelperMock, executor, null);
@@ -273,8 +271,7 @@ public class StreamTransactionMetadataTasksTest {
         @Cleanup
         StreamTransactionMetadataTasks failedTxnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore,
                 segmentHelperMock, executor, "failedHost", connectionFactory, AuthHelper.getDisabledAuthHelper());
-        failedTxnTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(), "abortStream",
-                new EventStreamWriterMock<>());
+        failedTxnTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         // Create 3 transactions from failedHost.
         VersionedTransactionData tx1 = failedTxnTasks.createTxn(SCOPE, STREAM, 10000, null).join().getKey();
@@ -317,7 +314,7 @@ public class StreamTransactionMetadataTasksTest {
                 ex -> ex instanceof IllegalStateException);
 
         // Initialize stream writers.
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream", abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         // Validate that txnTasks is ready.
         assertTrue(txnTasks.isReady());
@@ -384,7 +381,7 @@ public class StreamTransactionMetadataTasksTest {
         // Create transaction tasks.
         txnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore, segmentHelperMock, executor, "host",
                 connectionFactory, AuthHelper.getDisabledAuthHelper());
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream", abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         consumer = new ControllerService(streamStore, hostStore, streamMetadataTasks, txnTasks,
                 segmentHelperMock, executor, null);
@@ -458,8 +455,7 @@ public class StreamTransactionMetadataTasksTest {
         txnTasks = new StreamTransactionMetadataTasks(streamStore, hostStore,
                 SegmentHelperMock.getFailingSegmentHelperMock(), executor, "host", connectionFactory,
                 new AuthHelper(this.authEnabled, "secret"));
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream",
-                abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         // Create ControllerService.
         consumer = new ControllerService(streamStore, hostStore, streamMetadataTasks, txnTasks,
@@ -504,8 +500,7 @@ public class StreamTransactionMetadataTasksTest {
         txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
                 SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
                 new AuthHelper(this.authEnabled, "secret"));
-        txnTasks.initializeStreamWriters("commitStream", commitWriter, "abortStream",
-                abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration1 = StreamConfiguration.builder().scalingPolicy(policy1).build();
@@ -629,7 +624,7 @@ public class StreamTransactionMetadataTasksTest {
         CompletableFuture<TxnStatus> commitFuture = txnTasks.commitTxn(SCOPE, STREAM, txnId, null);
         assertFalse(commitFuture.isDone());
 
-        txnTasks.initializeStreamWriters("", commitWriter, "", abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
         assertTrue(Futures.await(commitFuture));
         UUID txnId2 = txnTasks.createTxn(SCOPE, STREAM, 100L, null).join().getKey().getId();
         assertTrue(Futures.await(txnTasks.abortTxn(SCOPE, STREAM, txnId2, null, null)));
@@ -650,7 +645,7 @@ public class StreamTransactionMetadataTasksTest {
         TestEventStreamWriter<CommitEvent> commitWriter = new TestEventStreamWriter<>();
         TestEventStreamWriter<AbortEvent> abortWriter = new TestEventStreamWriter<>();
 
-        txnTasks.initializeStreamWriters("", commitWriter, "", abortWriter);
+        txnTasks.initializeStreamWriters(commitWriter, abortWriter);
 
         UUID txnId = UUID.randomUUID();
         txnTasks.writeAbortEvent(SCOPE, STREAM, 0, txnId, TxnStatus.ABORTING).join();

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -14,9 +14,11 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.Transaction;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTracker;
@@ -50,6 +52,7 @@ import io.pravega.controller.store.stream.StreamStoreFactory;
 import io.pravega.controller.store.stream.TxnStatus;
 import io.pravega.controller.store.stream.Version;
 import io.pravega.controller.store.stream.VersionedTransactionData;
+import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.TaskStoreFactory;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
@@ -69,6 +72,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -78,6 +82,7 @@ import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -92,6 +97,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -554,6 +560,119 @@ public class StreamTransactionMetadataTasksTest {
         UUID txnId = txn.getKey().getId();
         assertEquals(0, (int) (txnId.getMostSignificantBits() >> 32));
         assertEquals(2, txnId.getLeastSignificantBits());
+    }
+    
+    @Test(timeout = 10000)
+    public void writerInitializationTest() {
+        StreamMetadataStore streamStoreMock = StreamStoreFactory.createZKStore(zkClient, executor);
+
+        txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
+                SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
+                new AuthHelper(this.authEnabled, "secret"));
+
+
+        streamStore.createScope(SCOPE).join();
+        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),1L, null, executor).join();
+        streamStore.setState(SCOPE, STREAM, State.ACTIVE, null, executor).join();
+
+        CompletableFuture<Pair<VersionedTransactionData, List<Segment>>> createFuture = txnTasks.createTxn(SCOPE, STREAM, 100L, null);
+        
+        // create and ping transactions should not wait for writer initialization and complete immediately.
+        createFuture.join();
+        assertTrue(Futures.await(createFuture));
+        UUID txnId = createFuture.join().getKey().getId();
+        CompletableFuture<PingTxnStatus> pingFuture = txnTasks.pingTxn(SCOPE, STREAM, txnId, 100L, null);
+        assertTrue(Futures.await(pingFuture));
+
+        CompletableFuture<TxnStatus> commitFuture = txnTasks.commitTxn(SCOPE, STREAM, txnId, null);
+        assertFalse(commitFuture.isDone());
+        
+        EventStreamWriterMock<CommitEvent> commitWriter = new EventStreamWriterMock<>();
+        EventStreamWriterMock<AbortEvent> abortWriter = new EventStreamWriterMock<>();
+
+        txnTasks.initializeStreamWriters("", commitWriter, "", abortWriter);
+        assertTrue(Futures.await(commitFuture));
+        UUID txnId2 = txnTasks.createTxn(SCOPE, STREAM, 100L, null).join().getKey().getId();
+        assertTrue(Futures.await(txnTasks.abortTxn(SCOPE, STREAM, txnId2, null, null)));
+
+    }
+    
+    @Test(timeout = 10000)
+    public void writerRoutingKeyTest() throws InterruptedException {
+        StreamMetadataStore streamStoreMock = StreamStoreFactory.createZKStore(zkClient, executor);
+
+        txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
+                SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
+                new AuthHelper(this.authEnabled, "secret"));
+
+        streamStore.createScope(SCOPE).join();
+        streamStore.createStream(SCOPE, STREAM, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),1L, null, executor).join();
+        streamStore.setState(SCOPE, STREAM, State.ACTIVE, null, executor).join();
+
+        TestEventStreamWriter<CommitEvent> commitWriter = new TestEventStreamWriter<>();
+        TestEventStreamWriter<AbortEvent> abortWriter = new TestEventStreamWriter<>();
+
+        txnTasks.initializeStreamWriters("", commitWriter, "", abortWriter);
+
+        UUID txnId = UUID.randomUUID();
+        txnTasks.writeAbortEvent(SCOPE, STREAM, 0, txnId, TxnStatus.ABORTING).join();
+        Pair<String, AbortEvent> request = abortWriter.requestsReceived.take();
+        assertEquals(request.getKey(), request.getValue().getKey()); 
+        txnTasks.writeAbortEvent(new AbortEvent(SCOPE, STREAM, 0, txnId)).join();
+        Pair<String, AbortEvent> request2 = abortWriter.requestsReceived.take();
+        assertEquals(request2.getKey(), request2.getValue().getKey());
+        // verify that both use the same key
+        assertEquals(request.getKey(), request2.getKey());
+
+        txnTasks.writeCommitEvent(SCOPE, STREAM, 0, txnId, TxnStatus.COMMITTING).join();
+        Pair<String, CommitEvent> request3 = commitWriter.requestsReceived.take();
+        assertEquals(request3.getKey(), request3.getValue().getKey());
+        txnTasks.writeCommitEvent(new CommitEvent(SCOPE, STREAM, 0)).join();
+        Pair<String, CommitEvent> request4 = commitWriter.requestsReceived.take();
+        assertEquals(request4.getKey(), request4.getValue().getKey());
+        // verify that both use the same key
+        assertEquals(request3.getKey(), request4.getKey());
+    }
+
+    private static class TestEventStreamWriter<T extends ControllerEvent> implements EventStreamWriter<T> {
+        LinkedBlockingQueue<Pair<String, T>> requestsReceived = new LinkedBlockingQueue<>();
+
+        @Override
+        public CompletableFuture<Void> writeEvent(T event) {
+            requestsReceived.offer(new ImmutablePair<>(null, event));
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeEvent(String routingKey, T event) {
+            requestsReceived.offer(new ImmutablePair<>(routingKey, event));
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Transaction<T> beginTxn() {
+            return null;
+        }
+
+        @Override
+        public Transaction<T> getTxn(UUID transactionId) {
+            return null;
+        }
+
+        @Override
+        public EventWriterConfig getConfig() {
+            return null;
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() {
+
+        }
     }
 
     private <T extends ControllerEvent> void createEventProcessor(final String readerGroupName,

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -19,6 +19,7 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTracker;
@@ -35,6 +36,7 @@ import io.pravega.controller.mocks.EventStreamWriterMock;
 import io.pravega.controller.mocks.SegmentHelperMock;
 import io.pravega.controller.server.ControllerService;
 import io.pravega.controller.server.SegmentHelper;
+import io.pravega.controller.server.eventProcessor.ControllerEventProcessorConfig;
 import io.pravega.controller.server.eventProcessor.requesthandlers.AbortRequestHandler;
 import io.pravega.controller.server.eventProcessor.requesthandlers.CommitRequestHandler;
 import io.pravega.controller.server.rpc.auth.AuthHelper;
@@ -70,6 +72,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -105,6 +108,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for StreamTransactionMetadataTasks.
@@ -561,9 +565,50 @@ public class StreamTransactionMetadataTasksTest {
     }
     
     @Test(timeout = 10000)
-    public void writerInitializationTest() {
-        StreamMetadataStore streamStoreMock = StreamStoreFactory.createZKStore(zkClient, executor);
+    public void writerInitializationTest() throws Exception {
+        EventStreamWriterMock<CommitEvent> commitWriter = new EventStreamWriterMock<>();
+        EventStreamWriterMock<AbortEvent> abortWriter = new EventStreamWriterMock<>();
+        StreamMetadataStore streamStoreMock = spy(StreamStoreFactory.createZKStore(zkClient, executor));
 
+        // region close before initialize
+        txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
+                SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
+                new AuthHelper(this.authEnabled, "secret"));
+        CompletableFuture<Void> future = txnTasks.writeCommitEvent(new CommitEvent("scope", "stream", 0));
+        assertFalse(future.isDone());
+
+        txnTasks.close();
+        AssertExtensions.assertFutureThrows("", future, e -> Exceptions.unwrap(e) instanceof CancellationException);
+        // endregion
+
+        // region test initialize writers with client factory
+        txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
+                SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
+                new AuthHelper(this.authEnabled, "secret"));
+
+        future = txnTasks.writeCommitEvent(new CommitEvent("scope", "stream", 0));
+
+        EventStreamClientFactory cfMock = mock(EventStreamClientFactory.class);
+        ControllerEventProcessorConfig eventProcConfigMock = mock(ControllerEventProcessorConfig.class);
+        String commitStream = "commitStream";
+        doAnswer(x -> commitStream).when(eventProcConfigMock).getCommitStreamName();
+        doAnswer(x -> commitWriter).when(cfMock).createEventWriter(eq(commitStream), any(), any());
+        String abortStream = "abortStream";
+        doAnswer(x -> abortStream).when(eventProcConfigMock).getAbortStreamName();
+        doAnswer(x -> abortWriter).when(cfMock).createEventWriter(eq(abortStream), any(), any());
+
+        // future should not have completed as we have not initialized the writers. 
+        assertFalse(future.isDone());
+        
+        // initialize the writers. write future should have completed now. 
+        txnTasks.initializeStreamWriters(cfMock, eventProcConfigMock);
+
+        assertTrue(Futures.await(future));
+
+        txnTasks.close();
+        // endregion
+        
+        // region test method calls and initialize writers with direct writer set up method call
         txnTasks = new StreamTransactionMetadataTasks(streamStoreMock, hostStore,
                 SegmentHelperMock.getSegmentHelperMock(), executor, "host", connectionFactory,
                 new AuthHelper(this.authEnabled, "secret"));
@@ -584,14 +629,10 @@ public class StreamTransactionMetadataTasksTest {
         CompletableFuture<TxnStatus> commitFuture = txnTasks.commitTxn(SCOPE, STREAM, txnId, null);
         assertFalse(commitFuture.isDone());
 
-        EventStreamWriterMock<CommitEvent> commitWriter = new EventStreamWriterMock<>();
-        EventStreamWriterMock<AbortEvent> abortWriter = new EventStreamWriterMock<>();
-
         txnTasks.initializeStreamWriters("", commitWriter, "", abortWriter);
         assertTrue(Futures.await(commitFuture));
         UUID txnId2 = txnTasks.createTxn(SCOPE, STREAM, 100L, null).join().getKey().getId();
         assertTrue(Futures.await(txnTasks.abortTxn(SCOPE, STREAM, txnId2, null, null)));
-
     }
     
     @Test(timeout = 10000)

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -112,8 +112,7 @@ public class TimeoutServiceTest {
         streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, hostStore,
                 SegmentHelperMock.getSegmentHelperMock(), executor, hostId, TimeoutServiceConfig.defaultConfig(),
                 new LinkedBlockingQueue<>(5), connectionFactory, AuthHelper.getDisabledAuthHelper());
-                streamTransactionMetadataTasks.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+                streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         // Create TimeoutService
         timeoutService = (TimerWheelTimeoutService) streamTransactionMetadataTasks.getTimeoutService();
@@ -255,8 +254,7 @@ public class TimeoutServiceTest {
         StreamTransactionMetadataTasks streamTransactionMetadataTasks2 = new StreamTransactionMetadataTasks(streamStore2, hostStore,
                 SegmentHelperMock.getSegmentHelperMock(), executor, "2", TimeoutServiceConfig.defaultConfig(),
                 new LinkedBlockingQueue<>(5), connectionFactory, AuthHelper.getDisabledAuthHelper());
-        streamTransactionMetadataTasks2.initializeStreamWriters("commitStream", new EventStreamWriterMock<>(),
-                "abortStream", new EventStreamWriterMock<>());
+        streamTransactionMetadataTasks2.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
 
         // Create TimeoutService
         TimerWheelTimeoutService timeoutService2 = (TimerWheelTimeoutService) streamTransactionMetadataTasks2.getTimeoutService();

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -9,10 +9,7 @@
  */
 package io.pravega.test.integration;
 
-import io.pravega.common.Exceptions;
-import io.pravega.controller.store.stream.StoreException;
 import io.pravega.segmentstore.contracts.tables.TableStore;
-import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -27,7 +24,6 @@ import io.pravega.client.stream.impl.TxnSegments;
 import io.pravega.test.common.TestUtils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
@@ -35,7 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 /**


### PR DESCRIPTION
**Change log description**  
Fixes couple of issues in stream transaction metadata tasks -
1. Removes unnecessary checkready that results in IllegalState Exception. Replaces it with writer future. 
2. Fixes issue in inconsistent usage of routing key for writing events into commit and abort streams. 

**Purpose of the change**  
Fixes #3533 

**What the code does**  
Earlier streamTransaction metadata tasks class would wait until writers were initialized before doing any operation. The writers are created externally and passed to this class (We will fix that part of it later in a technical debt issue). For now, it doesnt have to do that as `createTxn` and `pingTxn` do not depend on internal stream writer's initialization. They can proceed before initialization happens. 
And commit and abort writers initialization can be wrapped under a promise as a CompletableFuture and the requests can be chained to it. 
So now, even if we receive any requests before writer initialization, we dont throw illegal state exception anymore. We simply return a future which will be completed when the writers are initialized. 

Another issue we fix is where in one of writeCommitEvent methods, the routing key used was incorrect. So to avoid such mistakes, all writeEvents of a type end up calling the same method which does the actual write into the stream using the correct routing key. 

**How to verify it**  
Unit test added. 
