### PR TITLE
Issue 3532: User called workflow completion checks should be tighter and include state as well

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -40,6 +40,7 @@ import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.VersionedMetadata;
 import io.pravega.controller.store.stream.records.EpochRecord;
+import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.RetentionSet;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
@@ -571,6 +572,8 @@ public class StreamMetadataTasks extends TaskBase {
                 streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor);
         CompletableFuture<State> stateFuture =
                 streamMetadataStore.getState(scope, stream, true, context, executor);
+        CompletableFuture<EpochTransitionRecord> etrFuture =
+                streamMetadataStore.getEpochTransition(scope, stream, context, executor).thenApply(VersionedMetadata::getObject);
         return CompletableFuture.allOf(stateFuture, activeEpochFuture)
                         .handle((r, ex) -> {
                             ScaleStatusResponse.Builder response = ScaleStatusResponse.newBuilder();
@@ -585,6 +588,7 @@ public class StreamMetadataTasks extends TaskBase {
                             } else {
                                 EpochRecord activeEpoch = activeEpochFuture.join();
                                 State state = stateFuture.join();
+                                EpochTransitionRecord etr = etrFuture.join();
                                 if (epoch > activeEpoch.getEpoch()) {
                                     response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
                                 } else if (activeEpoch.getEpoch() == epoch || activeEpoch.getReferenceEpoch() == epoch) {
@@ -592,7 +596,8 @@ public class StreamMetadataTasks extends TaskBase {
                                 } else {
                                     // active epoch == scale epoch + 1 but the state is scaling, the previous workflow 
                                     // has not completed.
-                                    if (epoch + 1 == activeEpoch.getReferenceEpoch() && state.equals(State.SCALING)) {
+                                    if (epoch + 1 == activeEpoch.getReferenceEpoch() && state.equals(State.SCALING) &&
+                                            (etr.equals(EpochTransitionRecord.EMPTY) || etr.getNewEpoch() == activeEpoch.getEpoch())) {
                                         response.setStatus(ScaleStatusResponse.ScaleStatus.IN_PROGRESS);
                                     } else {
                                         response.setStatus(ScaleStatusResponse.ScaleStatus.SUCCESS);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -216,7 +216,7 @@ public class StreamMetadataTasks extends TaskBase {
                                     State state = stateFuture.join();
                                     StreamConfigurationRecord configProperty = configPropertyFuture.join();
 
-                                    // if property is updating and doesnt match our request, its a subsequent update
+                                    // if property is updating and doesn't match our request, it's a subsequent update
                                     if (configProperty.isUpdating()) {
                                         return !configProperty.getStreamConfiguration().equals(newConfig);
                                     } else {
@@ -412,7 +412,7 @@ public class StreamMetadataTasks extends TaskBase {
                                     State state = stateFuture.join();
                                     StreamTruncationRecord truncationRecord = configPropertyFuture.join();
 
-                                    // if property is updating and doesnt match our request, its a subsequent update
+                                    // if property is updating and doesn't match our request, it's a subsequent update
                                     if (truncationRecord.isUpdating()) {
                                         return !truncationRecord.getStreamCut().equals(streamCut);
                                     } else {
@@ -513,7 +513,7 @@ public class StreamMetadataTasks extends TaskBase {
     /**
      * Helper method to perform scale operation against an scale request.
      * This method posts a request in the request stream and then starts the scale operation while
-     * tracking its progress. Eventually, after scale completion, it sends a response to the caller.
+     * tracking it's progress. Eventually, after scale completion, it sends a response to the caller.
      *
      * @param scope          scope.
      * @param stream         stream name.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -38,6 +38,9 @@ import io.pravega.controller.store.stream.Segment;
 import io.pravega.controller.store.stream.State;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.VersionedMetadata;
+import io.pravega.controller.store.stream.records.EpochRecord;
+import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.RetentionSet;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
@@ -531,31 +534,35 @@ public class StreamMetadataTasks extends TaskBase {
      */
     public CompletableFuture<ScaleStatusResponse> checkScale(String scope, String stream, int epoch,
                                                                         OperationContext context) {
-        return streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor)
-                        .handle((activeEpoch, ex) -> {
-                            ScaleStatusResponse.Builder response = ScaleStatusResponse.newBuilder();
-
-                            if (ex != null) {
-                                Throwable e = Exceptions.unwrap(ex);
-                                if (e instanceof StoreException.DataNotFoundException) {
-                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
+        CompletableFuture<EpochTransitionRecord> epochTransitionFuture = streamMetadataStore.getEpochTransition(scope, stream, context, executor)
+                                                                                                         .thenApply(VersionedMetadata::getObject);
+        CompletableFuture<EpochRecord> activeEpochFuture = streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor);
+        return CompletableFuture.allOf(epochTransitionFuture, activeEpochFuture)
+                            .handle((r, ex) -> {
+                                ScaleStatusResponse.Builder response = ScaleStatusResponse.newBuilder();
+    
+                                if (ex != null) {
+                                    Throwable e = Exceptions.unwrap(ex);
+                                    if (e instanceof StoreException.DataNotFoundException) {
+                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
+                                    } else {
+                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INTERNAL_ERROR);
+                                    }
                                 } else {
-                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INTERNAL_ERROR);
+                                    EpochRecord activeEpoch = activeEpochFuture.join();
+                                    EpochTransitionRecord epochTransitionRecord = epochTransitionFuture.join(); 
+                                    if (epoch > activeEpoch.getEpoch()) {
+                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
+                                    } else if (activeEpoch.getEpoch() == epoch || activeEpoch.getReferenceEpoch() == epoch ||
+                                            (epochTransitionRecord.getNewEpoch() == activeEpoch.getEpoch() && activeEpoch.getReferenceEpoch() == epoch + 1)) {
+                                        response.setStatus(ScaleStatusResponse.ScaleStatus.IN_PROGRESS);
+                                    } else {
+                                        response.setStatus(ScaleStatusResponse.ScaleStatus.SUCCESS);
+                                    }
                                 }
-                            } else {
-                                Preconditions.checkNotNull(activeEpoch);
-
-                                if (epoch > activeEpoch.getEpoch()) {
-                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
-                                } else if (activeEpoch.getEpoch() == epoch || activeEpoch.getReferenceEpoch() == epoch) {
-                                    response.setStatus(ScaleStatusResponse.ScaleStatus.IN_PROGRESS);
-                                } else {
-                                    response.setStatus(ScaleStatusResponse.ScaleStatus.SUCCESS);
-                                }
-                            }
-
-                            return response.build();
-                        });
+    
+                                return response.build();
+                            });
     }
 
     public CompletableFuture<Void> writeEvent(ControllerEvent event) {

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -40,10 +40,11 @@ import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.VersionedMetadata;
 import io.pravega.controller.store.stream.records.EpochRecord;
-import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.RetentionSet;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
+import io.pravega.controller.store.stream.records.StreamTruncationRecord;
 import io.pravega.controller.store.task.Resource;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
@@ -204,9 +205,25 @@ public class StreamMetadataTasks extends TaskBase {
                              .thenAccept(isDone::set), executor);
     }
 
-    private CompletableFuture<Boolean> isUpdated(String scope, String stream, StreamConfiguration newConfig, OperationContext context) {
-        return streamMetadataStore.getConfigurationRecord(scope, stream, context, executor)
-                .thenApply(configProperty -> !configProperty.getObject().isUpdating() || !configProperty.getObject().getStreamConfiguration().equals(newConfig));
+    @VisibleForTesting
+    CompletableFuture<Boolean> isUpdated(String scope, String stream, StreamConfiguration newConfig, OperationContext context) {
+        CompletableFuture<State> stateFuture = streamMetadataStore.getState(scope, stream, true, context, executor);
+        CompletableFuture<StreamConfigurationRecord> configPropertyFuture
+                = streamMetadataStore.getConfigurationRecord(scope, stream, context, executor).thenApply(VersionedMetadata::getObject);
+        return CompletableFuture.allOf(stateFuture, configPropertyFuture)
+                                .thenApply(v -> {
+                                    State state = stateFuture.join();
+                                    StreamConfigurationRecord configProperty = configPropertyFuture.join();
+
+                                    // if property is updating and doesnt match our request, its a subsequent update
+                                    if (configProperty.isUpdating()) {
+                                        return !configProperty.getStreamConfiguration().equals(newConfig);
+                                    } else {
+                                        // if update-barrier is not updating, then update is complete if property matches our expectation 
+                                        // and state is not updating 
+                                        return !(configProperty.getStreamConfiguration().equals(newConfig) && state.equals(State.UPDATING));
+                                    }
+                                });
     }
 
     /**
@@ -384,9 +401,25 @@ public class StreamMetadataTasks extends TaskBase {
                 });
     }
 
-    private CompletableFuture<Boolean> isTruncated(String scope, String stream, Map<Long, Long> streamCut, OperationContext context) {
-        return streamMetadataStore.getTruncationRecord(scope, stream, context, executor)
-                .thenApply(truncationProp -> !truncationProp.getObject().isUpdating() || !truncationProp.getObject().getStreamCut().equals(streamCut));
+    @VisibleForTesting
+    CompletableFuture<Boolean> isTruncated(String scope, String stream, Map<Long, Long> streamCut, OperationContext context) {
+        CompletableFuture<State> stateFuture = streamMetadataStore.getState(scope, stream, true, context, executor);
+        CompletableFuture<StreamTruncationRecord> configPropertyFuture
+                = streamMetadataStore.getTruncationRecord(scope, stream, context, executor).thenApply(VersionedMetadata::getObject);
+        return CompletableFuture.allOf(stateFuture, configPropertyFuture)
+                                .thenApply(v -> {
+                                    State state = stateFuture.join();
+                                    StreamTruncationRecord truncationRecord = configPropertyFuture.join();
+
+                                    // if property is updating and doesnt match our request, its a subsequent update
+                                    if (truncationRecord.isUpdating()) {
+                                        return !truncationRecord.getStreamCut().equals(streamCut);
+                                    } else {
+                                        // if truncate-barrier is not updating, then truncate is complete if property matches our expectation 
+                                        // and state is not updating 
+                                        return !(truncationRecord.getStreamCut().equals(streamCut) && state.equals(State.TRUNCATING));
+                                    }
+                                });
     }
 
     /**
@@ -534,33 +567,38 @@ public class StreamMetadataTasks extends TaskBase {
      */
     public CompletableFuture<ScaleStatusResponse> checkScale(String scope, String stream, int epoch,
                                                                         OperationContext context) {
-        CompletableFuture<EpochTransitionRecord> epochTransitionFuture = streamMetadataStore.getEpochTransition(scope, stream, context, executor)
-                                                                                                         .thenApply(VersionedMetadata::getObject);
-        CompletableFuture<EpochRecord> activeEpochFuture = streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor);
-        return CompletableFuture.allOf(epochTransitionFuture, activeEpochFuture)
-                            .handle((r, ex) -> {
-                                ScaleStatusResponse.Builder response = ScaleStatusResponse.newBuilder();
-    
-                                if (ex != null) {
-                                    Throwable e = Exceptions.unwrap(ex);
-                                    if (e instanceof StoreException.DataNotFoundException) {
-                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
-                                    } else {
-                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INTERNAL_ERROR);
-                                    }
+        CompletableFuture<EpochRecord> activeEpochFuture =
+                streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor);
+        CompletableFuture<State> stateFuture =
+                streamMetadataStore.getState(scope, stream, true, context, executor);
+        return CompletableFuture.allOf(stateFuture, activeEpochFuture)
+                        .handle((r, ex) -> {
+                            ScaleStatusResponse.Builder response = ScaleStatusResponse.newBuilder();
+
+                            if (ex != null) {
+                                Throwable e = Exceptions.unwrap(ex);
+                                if (e instanceof StoreException.DataNotFoundException) {
+                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
                                 } else {
-                                    EpochRecord activeEpoch = activeEpochFuture.join();
-                                    EpochTransitionRecord epochTransitionRecord = epochTransitionFuture.join(); 
-                                    if (epoch > activeEpoch.getEpoch()) {
-                                        response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
-                                    } else if (activeEpoch.getEpoch() == epoch || activeEpoch.getReferenceEpoch() == epoch ||
-                                            (epochTransitionRecord.getNewEpoch() == activeEpoch.getEpoch() && activeEpoch.getReferenceEpoch() == epoch + 1)) {
+                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INTERNAL_ERROR);
+                                }
+                            } else {
+                                EpochRecord activeEpoch = activeEpochFuture.join();
+                                State state = stateFuture.join();
+                                if (epoch > activeEpoch.getEpoch()) {
+                                    response.setStatus(ScaleStatusResponse.ScaleStatus.INVALID_INPUT);
+                                } else if (activeEpoch.getEpoch() == epoch || activeEpoch.getReferenceEpoch() == epoch) {
+                                    response.setStatus(ScaleStatusResponse.ScaleStatus.IN_PROGRESS);
+                                } else {
+                                    // active epoch == scale epoch + 1 but the state is scaling, the previous workflow 
+                                    // has not completed.
+                                    if (epoch + 1 == activeEpoch.getReferenceEpoch() && state.equals(State.SCALING)) {
                                         response.setStatus(ScaleStatusResponse.ScaleStatus.IN_PROGRESS);
                                     } else {
                                         response.setStatus(ScaleStatusResponse.ScaleStatus.SUCCESS);
                                     }
                                 }
-    
+                            }
                                 return response.build();
                             });
     }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1160,6 +1160,19 @@ public class StreamMetadataTasksTest {
 
         scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
         assertEquals(Controller.ScaleStatusResponse.ScaleStatus.SUCCESS, scaleStatusResult.getStatus());
+
+        // start another scale
+        scaleOpResult = streamMetadataTasks.manualScale(SCOPE, test, Collections.singletonList(StreamSegmentNameUtils.computeSegmentId(1, 1)),
+                newRanges, 30, null).get();
+        assertEquals(ScaleStreamStatus.STARTED, scaleOpResult.getStatus());
+        streamStorePartialMock.setState(SCOPE, test, State.SCALING, null, executor).join();
+
+        // even now we should get success for epoch 0 
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.SUCCESS, scaleStatusResult.getStatus());
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 1, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
         // endregion
     }
     

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -82,10 +82,12 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.Getter;
@@ -106,9 +108,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
 public class StreamMetadataTasksTest {
 
@@ -1070,26 +1070,6 @@ public class StreamMetadataTasksTest {
 
         scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 5, null).get();
         assertEquals(Controller.ScaleStatusResponse.ScaleStatus.INVALID_INPUT, scaleStatusResult.getStatus());
-        
-        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
-        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
-
-        // perform scale steps and check scale after each step
-        VersionedMetadata<EpochTransitionRecord> etr = streamStorePartialMock.getEpochTransition(SCOPE, "test", null, executor).join();
-        streamStorePartialMock.scaleCreateNewEpochs(SCOPE, "test", etr, null, executor).join();
-
-        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
-        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
-
-        streamStorePartialMock.scaleSegmentsSealed(SCOPE, "test", Collections.singletonMap(0L, 0L), etr, null, executor).join();
-
-        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
-        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
-
-        streamStorePartialMock.completeScale(SCOPE, "test", etr, null, executor).join();
-
-        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
-        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.SUCCESS, scaleStatusResult.getStatus());
     }
 
     @Test(timeout = 30000)
@@ -1137,6 +1117,142 @@ public class StreamMetadataTasksTest {
                              && AssertExtensions.nearlyEquals(x.getValue().getValue(), 1.0, 0)));
     }
 
+    @Test(timeout = 10000)
+    public void checkScaleCompleteTest() throws ExecutionException, InterruptedException {
+        final ScalingPolicy policy = ScalingPolicy.fixed(1);
+
+        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
+
+        String test = "testCheckScale";
+        streamStorePartialMock.createStream(SCOPE, test, configuration, System.currentTimeMillis(), null, executor).get();
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).get();
+        List<Map.Entry<Double, Double>> newRanges = Collections.singletonList(new AbstractMap.SimpleEntry<>(0.0, 1.0));
+        streamMetadataTasks.setRequestEventWriter(new EventStreamWriterMock<>());
+        
+        // region scale
+        ScaleResponse scaleOpResult = streamMetadataTasks.manualScale(SCOPE, test, Collections.singletonList(0L),
+                newRanges, 30, null).get();
+        assertEquals(ScaleStreamStatus.STARTED, scaleOpResult.getStatus());
+
+        streamStorePartialMock.setState(SCOPE, test, State.SCALING, null, executor).join();
+        
+        Controller.ScaleStatusResponse scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        // perform scale steps and check scale after each step
+        VersionedMetadata<EpochTransitionRecord> etr = streamStorePartialMock.getEpochTransition(SCOPE, test, null, executor).join();
+        streamStorePartialMock.scaleCreateNewEpochs(SCOPE, test, etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        streamStorePartialMock.scaleSegmentsSealed(SCOPE, test, Collections.singletonMap(0L, 0L), etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        streamStorePartialMock.completeScale(SCOPE, test, etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, test, 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.SUCCESS, scaleStatusResult.getStatus());
+        // endregion
+    }
+    
+    @Test(timeout = 10000)
+    public void checkUpdateCompleteTest() throws ExecutionException, InterruptedException {
+        final ScalingPolicy policy = ScalingPolicy.fixed(1);
+
+        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
+
+        String test = "testUpdate";
+        streamStorePartialMock.createStream(SCOPE, test, configuration, System.currentTimeMillis(), null, executor).get();
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).get();
+        streamMetadataTasks.setRequestEventWriter(new EventStreamWriterMock<>());
+        // region update
+        
+        final StreamConfiguration configuration2 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(2)).build();
+
+        streamMetadataTasks.updateStream(SCOPE, test, configuration2, null);
+        // wait till configuration is updated
+        Supplier<Boolean> configUpdated = () -> !streamStorePartialMock.getConfigurationRecord(SCOPE, test, null, executor).join().getObject().isUpdating();
+        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+
+        streamStorePartialMock.setState(SCOPE, test, State.UPDATING, null, executor).join();
+
+        assertFalse(streamMetadataTasks.isUpdated(SCOPE, test, configuration2, null).get());
+
+        VersionedMetadata<StreamConfigurationRecord> configurationRecord = streamStorePartialMock.getConfigurationRecord(SCOPE, test, null, executor).join();
+        assertTrue(configurationRecord.getObject().isUpdating());
+        streamStorePartialMock.completeUpdateConfiguration(SCOPE, test, configurationRecord, null, executor);
+
+        assertFalse(streamMetadataTasks.isUpdated(SCOPE, test, configuration2, null).get());
+
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).join();
+        assertTrue(streamMetadataTasks.isUpdated(SCOPE, test, configuration2, null).get());
+
+        // start next update with different configuration. 
+        final StreamConfiguration configuration3 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        streamMetadataTasks.updateStream(SCOPE, test, configuration3, null);
+        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+
+        streamStorePartialMock.setState(SCOPE, test, State.UPDATING, null, executor).join();
+        // we should still get complete for previous configuration we attempted to update
+        assertTrue(streamMetadataTasks.isUpdated(SCOPE, test, configuration2, null).get());
+        
+        assertFalse(streamMetadataTasks.isUpdated(SCOPE, test, configuration3, null).get());
+        // end region
+    }
+    
+    @Test(timeout = 10000)
+    public void checkTruncateCompleteTest() throws ExecutionException, InterruptedException {
+        final ScalingPolicy policy = ScalingPolicy.fixed(1);
+
+        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
+
+        String test = "testTruncate";
+        streamStorePartialMock.createStream(SCOPE, test, configuration, System.currentTimeMillis(), null, executor).get();
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).get();
+        streamMetadataTasks.setRequestEventWriter(new EventStreamWriterMock<>());
+        
+        // region truncate
+        Map<Long, Long> map = Collections.singletonMap(0L, 1L);
+        streamMetadataTasks.truncateStream(SCOPE, test, map, null);
+        // wait till configuration is updated
+        Supplier<Boolean> truncationStarted = () -> !streamStorePartialMock.getTruncationRecord(SCOPE, test, null, executor).join().getObject().isUpdating();
+        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+
+        streamStorePartialMock.setState(SCOPE, test, State.TRUNCATING, null, executor).join();
+
+        assertFalse(streamMetadataTasks.isTruncated(SCOPE, test, map, null).get());
+
+        VersionedMetadata<StreamTruncationRecord> truncationRecord = streamStorePartialMock.getTruncationRecord(SCOPE, test, null, executor).join();
+        assertTrue(truncationRecord.getObject().isUpdating());
+        streamStorePartialMock.completeTruncation(SCOPE, test, truncationRecord, null, executor);
+
+        assertFalse(streamMetadataTasks.isTruncated(SCOPE, test, map, null).get());
+
+        streamStorePartialMock.setState(SCOPE, test, State.ACTIVE, null, executor).join();
+        assertTrue(streamMetadataTasks.isTruncated(SCOPE, test, map, null).get());
+
+        // start next update with different configuration. 
+        Map<Long, Long> map2 = Collections.singletonMap(0L, 10L);
+
+        streamMetadataTasks.truncateStream(SCOPE, test, map2, null);
+        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+
+        streamStorePartialMock.setState(SCOPE, test, State.TRUNCATING, null, executor).join();
+        
+        // we should still get complete for previous configuration we attempted to update
+        assertTrue(streamMetadataTasks.isTruncated(SCOPE, test, map, null).get());
+        assertFalse(streamMetadataTasks.isTruncated(SCOPE, test, map2, null).get());
+        // end region
+    }
+    
     private CompletableFuture<Void> processEvent(WriterMock requestEventWriter) throws InterruptedException {
         return Retry.withExpBackoff(100, 10, 5, 1000)
                 .retryingOn(TaskExceptions.StartException.class)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1193,7 +1193,7 @@ public class StreamMetadataTasksTest {
         streamMetadataTasks.updateStream(SCOPE, test, configuration2, null);
         // wait till configuration is updated
         Supplier<Boolean> configUpdated = () -> !streamStorePartialMock.getConfigurationRecord(SCOPE, test, null, executor).join().getObject().isUpdating();
-        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor), executor).join();
 
         streamStorePartialMock.setState(SCOPE, test, State.UPDATING, null, executor).join();
 
@@ -1211,7 +1211,7 @@ public class StreamMetadataTasksTest {
         // start next update with different configuration. 
         final StreamConfiguration configuration3 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
         streamMetadataTasks.updateStream(SCOPE, test, configuration3, null);
-        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+        Futures.loop(configUpdated, () -> Futures.delayedFuture(Duration.ofMillis(100), executor), executor).join();
 
         streamStorePartialMock.setState(SCOPE, test, State.UPDATING, null, executor).join();
         // we should still get complete for previous configuration we attempted to update
@@ -1237,7 +1237,7 @@ public class StreamMetadataTasksTest {
         streamMetadataTasks.truncateStream(SCOPE, test, map, null);
         // wait till configuration is updated
         Supplier<Boolean> truncationStarted = () -> !streamStorePartialMock.getTruncationRecord(SCOPE, test, null, executor).join().getObject().isUpdating();
-        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor), executor).join();
 
         streamStorePartialMock.setState(SCOPE, test, State.TRUNCATING, null, executor).join();
 
@@ -1256,7 +1256,7 @@ public class StreamMetadataTasksTest {
         Map<Long, Long> map2 = Collections.singletonMap(0L, 10L);
 
         streamMetadataTasks.truncateStream(SCOPE, test, map2, null);
-        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor),executor).join();
+        Futures.loop(truncationStarted, () -> Futures.delayedFuture(Duration.ofMillis(100), executor), executor).join();
 
         streamStorePartialMock.setState(SCOPE, test, State.TRUNCATING, null, executor).join();
         

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1070,6 +1070,26 @@ public class StreamMetadataTasksTest {
 
         scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 5, null).get();
         assertEquals(Controller.ScaleStatusResponse.ScaleStatus.INVALID_INPUT, scaleStatusResult.getStatus());
+        
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        // perform scale steps and check scale after each step
+        VersionedMetadata<EpochTransitionRecord> etr = streamStorePartialMock.getEpochTransition(SCOPE, "test", null, executor).join();
+        streamStorePartialMock.scaleCreateNewEpochs(SCOPE, "test", etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        streamStorePartialMock.scaleSegmentsSealed(SCOPE, "test", Collections.singletonMap(0L, 0L), etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.IN_PROGRESS, scaleStatusResult.getStatus());
+
+        streamStorePartialMock.completeScale(SCOPE, "test", etr, null, executor).join();
+
+        scaleStatusResult = streamMetadataTasks.checkScale(SCOPE, "test", 0, null).get();
+        assertEquals(Controller.ScaleStatusResponse.ScaleStatus.SUCCESS, scaleStatusResult.getStatus());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**
Fixes the cause for sporadic System test failure for ScopesAndStreamManagementTest where we send update followed by seal and if update is complete but state is not updated, then seal fails and test fails. 
So we need to have stricter checks and only declare workflow complete once the state has been reset. 

**Purpose of the change**
Fixes #3532

**What the code does**

For each of the externally submitted workflows, it now says workflow is complete only after the state is also reset. For check scale, `isUpdated` and `isTruncated` until the final step of workflow (state is reset) is performed we will continue to return in-progress. 

CheckScaleDone:
Original condition: 

```
if (activeEpoch.referenceEpoch == checkScaleEpoch) return `inProgress`.
```

now new condition is:

```
if (activeEpoch.referenceEpoch == checkScaleEpoch ||
(checkScaleEpoch == activeEpoch.referenceEpoch + 1 // indicates metadata updated && 
state =SCALING // indicates exact match for our requested check scale)) return `inprogress`
```

Note: if we want even tighter check we can include ETR as well. Otherwise, when next scale starts, etr is updated and state is set to SCALING and until active epoch is updated, we will continue to get Inprogress for previous scale. I have included the ETR check as well. where if 
epoch + 1 == activeEpoch && state == scaling then we check the epoch transition record and if it is either empty or matches our previous scale then return inprogress. 

`IsTruncated`:
old condition: 

```
truncationProp.streamCut == truncationCut && !truncationProp.isUpdating ==>inProgress
```

new condition: 

```
1. truncationProp.isUpdating 
    !truncationProp.streamcut.equals(ourStreamCut) ==> done 
     else ==> InProgress
2. !truncationProp.isUpdating 
    truncationProp.streamCut == ourStreamCut && state == TRUNCATING // if truncation record is updated but state is not reset ==> InProgress
    else ==> done
```

`IsUpdated`:
```
old condition: ConfigProp.config == newConfig && !configProp.isUpdating ==> inProgress
```

new condition:
```
1. configProp.isUpdating 
    !configProp.config.equals(ourConfig) ==> done 
     else ==> InProgress
2. !configProp.isUpdating 
    configProp.config == ourConfig && state == UPDATING // if config record is updated but state is not reset ==> InProgress
    else ==> done
```

**How to verify it**
Unit test added.