### PR TITLE
Issue 3547 : Ensure the key version is set to NOT_EXISTS if the key is not present.

### DIFF
--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -45,6 +45,11 @@ public interface KeyVersion extends Serializable {
     };
 
     /**
+     * A special KeyVersion which indicates that no versioning is required.
+     */
+    KeyVersion NO_VERSION = new KeyVersionImpl(Long.MIN_VALUE);
+
+    /**
      * Gets a value representing the internal version inside the Table Segment for this Key.
      * @return Segment version.
      */

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -69,11 +69,11 @@ public class KeyVersionImpl implements KeyVersion {
         }
 
         private void read00(RevisionDataInput revisionDataInput, KeyVersionBuilder builder) throws IOException {
-            builder.segmentVersion(revisionDataInput.readCompactLong());
+            builder.segmentVersion(revisionDataInput.readLong());
         }
 
         private void write00(KeyVersionImpl version, RevisionDataOutput revisionDataOutput) throws IOException {
-            revisionDataOutput.writeCompactLong(version.getSegmentVersion());
+            revisionDataOutput.writeLong(version.getSegmentVersion());
         }
     }
 

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
@@ -30,8 +30,16 @@ public class KeyVersionTest {
     }
 
     @Test
-    public void testUnboundedStreamCutSerialization() throws Exception {
+    public void testNotExistsKeySerialization() throws Exception {
         KeyVersion kv = KeyVersion.NOT_EXISTS;
+        assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
+        byte[] buf = serialize(kv);
+        assertEquals(kv, deSerializeKeyVersion(buf));
+    }
+
+    @Test
+    public void testNoVersionKeySerialization() throws Exception {
+        KeyVersion kv = KeyVersion.NO_VERSION;
         assertEquals(kv, KeyVersion.fromBytes(kv.toBytes()));
         byte[] buf = serialize(kv);
         assertEquals(kv, deSerializeKeyVersion(buf));

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -863,8 +863,7 @@ public class SegmentHelper {
      * @param scope               Stream scope.
      * @param stream              Stream name.
      * @param keys                List of {@link TableKey}s to be removed. Only if all the elements in the list has version as
-     *                            {@link KeyVersion#NO_VERSION} then an unconditional update/removal is performed. Else an atomic
-     *                            conditional
+     *                            {@link KeyVersion#NO_VERSION} then an unconditional update/removal is performed. Else an atomic conditional
      *                            update (removal) is performed.
      * @param hostControllerStore Host controller store.
      * @param clientCF            Client connection factory.

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -959,10 +959,8 @@ public class SegmentHelper {
      * @param delegationToken     The token to be presented to the segmentstore.
      * @param clientRequestId     Request id.
      * @return A CompletableFuture that, when completed normally, will contain a list of {@link TableEntry} with
-     * a value corresponding to the latest version. If the operation failed, the future will be failed with the
-     * causing exception. If the exception can be retried then the future will be failed with
-     * {@link WireCommandFailedException}.
-     * Note: TableKeyDoesNotExist is not thrown by the readTable Command.
+     * a value corresponding to the latest version. The version will be set to {@link KeyVersion#NOT_EXISTS} if the
+     * key does not exist. If the operation failed, the future will be failed with the causing exception.
      */
     public CompletableFuture<List<TableEntry<byte[], byte[]>>> readTable(final String scope,
                                                                          final String stream,

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -1089,12 +1089,6 @@ public class SegmentHelper {
             }
 
             @Override
-            public void tableKeyDoesNotExist(WireCommands.TableKeyDoesNotExist tableKeyDoesNotExist) {
-                log.warn(requestId, "readTableKeys request for {} tableSegment failed with TableKeyDoesNotExist.", qualifiedName);
-                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyDoesNotExist));
-            }
-
-            @Override
             public void processingFailure(Exception error) {
                 log.error(requestId, "readTableKeys {} failed", qualifiedName, error);
                 result.completeExceptionally(error);
@@ -1177,12 +1171,6 @@ public class SegmentHelper {
                                             return new TableEntryImpl<>(tableKey, getArray(e.getValue().getData()));
                                         }).collect(Collectors.toList());
                 result.complete(new TableSegment.IteratorItem<>(state, entries));
-            }
-
-            @Override
-            public void tableKeyDoesNotExist(WireCommands.TableKeyDoesNotExist tableKeyDoesNotExist) {
-                log.warn(requestId, "readTableEntries request for {} tableSegment failed with TableKeyDoesNotExist.", qualifiedName);
-                result.completeExceptionally(new WireCommandFailedException(type, WireCommandFailedException.Reason.TableKeyDoesNotExist));
             }
 
             @Override

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -330,32 +330,25 @@ public class SegmentHelperTest {
     @Test
     public void testReadTable() {
         MockConnectionFactory factory = new MockConnectionFactory();
-        List<TableKey<byte[]>> keys = Arrays.asList(new TableKeyImpl<>(key0, KeyVersion.NOT_EXISTS),
-                                                    new TableKeyImpl<>(key1, KeyVersion.NOT_EXISTS));
+        List<TableKey<byte[]>> keysToBeRead = Arrays.asList(new TableKeyImpl<>(key0, KeyVersion.NO_VERSION),
+                                                    new TableKeyImpl<>(key1, KeyVersion.NO_VERSION));
 
-        List<TableEntry<byte[], byte[]>> entries = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>(key0, new KeyVersionImpl(10L)), value),
-                                                                 new TableEntryImpl<>(new TableKeyImpl<>(key1, new KeyVersionImpl(10L)), value));
+        List<TableEntry<byte[], byte[]>> reponseFromSegmentStore = Arrays.asList(new TableEntryImpl<>(new TableKeyImpl<>(key0,
+                                                                                                              new KeyVersionImpl(10L)), value),
+                                                                 new TableEntryImpl<>(new TableKeyImpl<>(key1, KeyVersion.NOT_EXISTS), value));
 
-        // On receiving TableKeysRemoved.
-        CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", keys, new MockHostControllerStore(),
+        CompletableFuture<List<TableEntry<byte[], byte[]>>> result = helper.readTable("", "", keysToBeRead, new MockHostControllerStore(),
                                                                                       factory, "", System.nanoTime());
-        factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), getTableEntries(entries)));
+        factory.rp.tableRead(new WireCommands.TableRead(0, getQualifiedStreamSegmentName("", "", 0L), getTableEntries(reponseFromSegmentStore)));
         List<TableEntry<byte[], byte[]>> readResult = result.join();
         assertArrayEquals(key0, readResult.get(0).getKey().getKey());
         assertEquals(10L, readResult.get(0).getKey().getVersion().getSegmentVersion());
         assertArrayEquals(value, readResult.get(0).getValue());
         assertArrayEquals(key1, readResult.get(1).getKey().getKey());
-        assertEquals(10L, readResult.get(1).getKey().getVersion().getSegmentVersion());
+        assertEquals(KeyVersion.NOT_EXISTS, readResult.get(1).getKey().getVersion());
         assertArrayEquals(value, readResult.get(1).getValue());
 
-        // On receiving TableKeyDoesNotExist.
-        result = helper.readTable("", "", keys, new MockHostControllerStore(), factory, "", System.nanoTime());
-        factory.rp.tableKeyDoesNotExist(new WireCommands.TableKeyDoesNotExist(0, getQualifiedStreamSegmentName("", "", 0L), ""));
-        AssertExtensions.assertThrows("", result::join,
-                                      ex -> ex instanceof WireCommandFailedException &&
-                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableKeyDoesNotExist));
-
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTable("", "", keys, new MockHostControllerStore(),
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.readTable("", "", keysToBeRead, new MockHostControllerStore(),
                                                                                factory, "", System.nanoTime());
         validateAuthTokenCheckFailed(factory, futureSupplier);
         validateWrongHost(factory, futureSupplier);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -872,7 +872,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                              if (resultTableEntry == null) { // no entry for key at index i.
                                  ArrayView k = inputKeys.get(i); // key for which the read result was null.
                                  val keyWireCommand = new WireCommands.TableKey(wrappedBuffer(k.array(), k.arrayOffset(), k.getLength()),
-                                                                                TableKey.NO_VERSION);
+                                                                                TableKey.NOT_EXISTS);
                                  return new AbstractMap.SimpleImmutableEntry<>(keyWireCommand, WireCommands.TableValue.EMPTY);
                              } else {
                                  TableEntry te = resultEntries.get(i);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -797,10 +797,12 @@ public class PravegaRequestProcessorTest {
         WireCommands.TableKey key = new WireCommands.TableKey(wrappedBuffer(entry.getKey().getKey().array()), TableKey.NO_VERSION);
         processor.readTable(new WireCommands.ReadTable(2, tableSegmentName, "", singletonList(key)));
 
-        // expected result is Key with an empty TableValue.
+        // expected result is Key (with key with version as NOT_EXISTS) and an empty TableValue.)
+        WireCommands.TableKey keyResponse = new WireCommands.TableKey(wrappedBuffer(entry.getKey().getKey().array()),
+                                                                      WireCommands.TableKey.NOT_EXISTS);
         order.verify(connection).send(new WireCommands.TableRead(2, tableSegmentName,
                                                                  new WireCommands.TableEntries(
-                                                                         singletonList(new AbstractMap.SimpleImmutableEntry<>(key, WireCommands.TableValue.EMPTY)))));
+                                                                         singletonList(new AbstractMap.SimpleImmutableEntry<>(keyResponse, WireCommands.TableValue.EMPTY)))));
         recorderMockOrder.verify(recorderMock).getKeys(eq(tableSegmentName), eq(1), any());
 
         // Update a value to a key.


### PR DESCRIPTION
**Change log description**  
* If the key does not exist during the readTable Operation then the resulting TableEntry should have a version corresponding to `io.pravega.segmentstore.contracts.tables.TableKey#NOT_EXISTS`

**Purpose of the change**  
Fixes #3547 

**What the code does**  
- When a `readTable` operation is performed on the TableStore and if the key does not exist then the resulting TableEntry will have a zero length value and the key version should be TableKey#NOT_EXISTS.
-  Since`TableStore`  does not throw `KeyNotExistsException` for `TableStore#get` , the `SegmentHelper#readTableupdated ` has been updated.

 **How to verify it**  
All the existing and newly added tests should continue to pass.
