### PR TITLE
Issue 3550 resolution proposal

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/Serializer.java
+++ b/client/src/main/java/io/pravega/client/stream/Serializer.java
@@ -24,7 +24,7 @@ public interface Serializer<T> {
     /**
      * The maximum event size, in bytes.
      */
-    int MAX_EVENT_SIZE = 1024 * 1024;
+    int MAX_EVENT_SIZE = 1024 * 1024 + 8;
 
     /**
      * Serializes the given event.


### PR DESCRIPTION
**Change log description**  
Allow max event size payload = 1MB

**Purpose of the change**  
Fixes #3550
Pravega v0.4.0 brakes the compatibility. It was possible to write events with size up to 1MB (including this value). Since v0.4.0 the upper limit is 8 bytes less due to the additional headers introduced to distinguish byte streams and event streams. 

**What the code does**  
Change the max event size to 1MB + 8 bytes

**How to verify it**  
Try to write an event with payload size = 1MB