### PR TITLE
Issue 3554: Add Zookeeper environment variable for Controller service definition in Docker Compose Configuration file

### DIFF
--- a/docker/compose/docker-compose-extendeds3.yml
+++ b/docker/compose/docker-compose-extendeds3.yml
@@ -52,10 +52,10 @@ services:
     command: controller
     environment:
       WAIT_FOR: zookeeper:2181
+      ZK_URL: zookeeper:2181
       JAVA_OPTS: |
         -Dcontroller.service.port=9090
         -Dcontroller.service.restPort=10080
-        -Dcontroller.zk.url=zookeeper:2181
         -Dconfig.controller.metricenableCSVReporter=false
         -Xmx512m
         -XX:OnError="kill -9 p%"

--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -52,10 +52,10 @@ services:
     command: controller
     environment:
       WAIT_FOR: zookeeper:2181
+      ZK_URL: zookeeper:2181
       JAVA_OPTS: |
         -Dcontroller.service.port=9090
         -Dcontroller.service.restPort=10080
-        -Dcontroller.zk.url=zookeeper:2181
         -Dconfig.controller.metricenableCSVReporter=false
         -Xmx512m
         -XX:OnError="kill -9 p%"

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -59,10 +59,10 @@ services:
     command: controller
     environment:
       WAIT_FOR: zookeeper:2181
+      ZK_URL: zookeeper:2181
       JAVA_OPTS: |
         -Dcontroller.service.port=9090
         -Dcontroller.service.restPort=10080
-        -Dcontroller.zk.url=zookeeper:2181
         -Dconfig.controller.metricenableCSVReporter=false
         -Xmx512m
         -XX:OnError="kill -9 p%"

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -70,7 +70,6 @@ services:
       JAVA_OPTS: |
         -Dcontroller.service.port=9090
         -Dcontroller.service.restPort=10080
-        -Dcontroller.zk.url=zookeeper:2181
         -Dconfig.controller.metricenableCSVReporter=false
         -Xmx512m
         -XX:OnError="kill -9 p%"

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     command: controller
     environment:
       WAIT_FOR: zookeeper:2181
+      ZK_URL: zookeeper:2181
       JAVA_OPTS: |
         -Dcontroller.service.port=9090
         -Dcontroller.service.restPort=10080


### PR DESCRIPTION
Signed-off-by: Ravi Sharda <ravi.sharda@emc.com>

**Change log description**  
In the Docker Compose configuration file, add ZK_URL as env. variable so that the Controller is linked to the appropriate Zookeeper container. 

**Purpose of the change**  
Fixes #3554. 

**What the code does**  
Adds `ZK_URL` environment variable to the Controller service definition in the Docker Compose application configuration file `docker-compose.yml`.

**How to verify it**  
Here are the steps to verify the fix:

1. Clone Pravega into a VM that has Docker and Docker Compose installed: `git clone https://github.com/pravega/pravega.git`
2. Execute command to navigate to the directory containing the docker-compose.yml file: `cd ./pravega/docker/compose``
3. Execute this command to set an environment variable:  `export HOST_IP=<host-ip>` (where `<host-ip>` is the IP address of the host in which you are deploying Pravega).
4. Execute this command to start the containers: `docker-compose up -d`
5. Verify that the containers are up (check the `state` column): `docker-compose ps`
6. Run a reader/writer client application against Controller URI: `tcp://<host-ip>:9090/`. The client should work correctly with the specified Controller URI. 
7. To be doubly sure, check out the container logs: `docker-compose logs`

