### PR TITLE
Issue 3551: Version number changed in the hyperlinks in the documents 

### DIFF
--- a/documentation/src/docs/basic-reader-and-writer.md
+++ b/documentation/src/docs/basic-reader-and-writer.md
@@ -11,10 +11,10 @@ You may obtain a copy of the License at
 
 Lets examine how to build Pravega applications. The simplest kind of Pravega application uses a Reader to read from a Stream or a
 Writer that writes to a Stream. A simple sample application of both can be
-found in the [Pravega samples repository](https://github.com/pravega/pravega-samples/blob/v0.4.0/pravega-client-examples/README.md) (`HelloWorldReader` and  `HelloWorldWriter`) applications. These samples give a sense on how a Java application could use the Pravega's Java Client Library to access Pravega functionality.
+found in the [Pravega samples repository](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md) (`HelloWorldReader` and  `HelloWorldWriter`) applications. These samples give a sense on how a Java application could use the Pravega's Java Client Library to access Pravega functionality.
 
 Instructions for running the sample applications can be found in the [Pravega
-Samples](https://github.com/pravega/pravega-samples/blob/v0.4.0/pravega-client-examples/README.md). Get familiar with the [Pravega Concepts](http://pravega.io/docs/latest/pravega-concepts/)
+Samples](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md). Get familiar with the [Pravega Concepts](http://pravega.io/docs/latest/pravega-concepts/)
 before executing the sample applications.
 
 ## HelloWorldWriter

--- a/documentation/src/docs/state-synchronizer.md
+++ b/documentation/src/docs/state-synchronizer.md
@@ -19,7 +19,7 @@ we explore with this document.
 
 Instructions for running the sample applications can be found in the[ Pravega
 Samples
-readme](https://github.com/pravega/pravega-samples/blob/v0.4.0/pravega-client-examples/README.md).
+readme](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md).
 
 You really should be familiar with Pravega Concepts (see [Pravega
 Concepts](pravega-concepts.md)) before continuing reading this page.
@@ -44,7 +44,7 @@ concurrently read and write the shared state in a consistent fashion. 
 Before we dive into the details about how to use State Synchronizer, let's take
 a quick look at an example application that uses State Synchronizer.  We have
 provided a simple yet illustrative example of using State
-Synchronizer [here.](https://github.com/pravega/pravega-samples/tree/v0.4.0/pravega-client-examples/src/main/java/io/pravega/example/statesynchronizer)
+Synchronizer [here.](https://github.com/pravega/pravega-samples/tree/v0.5.0/pravega-client-examples/src/main/java/io/pravega/example/statesynchronizer)
 
 The example uses State Synchronizer to build an implementation of Java's Map
 data structure called SharedMap.  We use that primitive SharedMap data structure

--- a/documentation/src/docs/streamcuts.md
+++ b/documentation/src/docs/streamcuts.md
@@ -101,4 +101,4 @@ fetch segments which reside between the given `startStreamCut` and `endStreamCut
 It must be noted that passing `StreamCut.UNBOUNDED` to `startStreamCut` and `endStreamCut` will result in using the current head of stream and the current tail of the stream, respectively.
 
 
-We have provided a simple yet illustrative example of using StreamCut [here](https://github.com/pravega/pravega-samples/tree/v0.4.0/pravega-client-examples/src/main/java/io/pravega/example/streamcuts).
+We have provided a simple yet illustrative example of using StreamCut [here](https://github.com/pravega/pravega-samples/tree/v0.5.0/pravega-client-examples/src/main/java/io/pravega/example/streamcuts).

--- a/documentation/src/docs/transactions.md
+++ b/documentation/src/docs/transactions.md
@@ -14,7 +14,7 @@ Pravega Transactions.
 
 Instructions for running the sample applications can be found in the[ Pravega
 Samples
-readme](https://github.com/pravega/pravega-samples/blob/v0.4.0/pravega-client-examples/README.md).
+readme](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md).
 
 You really should be familiar with Pravega Concepts (see [Pravega
 Concepts](pravega-concepts.md)) before continuing reading this page.
@@ -25,7 +25,7 @@ We have written a couple of applications, ConsoleReader and ConsoleWriter that
 help illustrate reading and writing data with Pravega and in particular to
 illustrate the Transaction facility in the Pravega programming model.  You can
 find those applications
-[here](https://github.com/pravega/pravega-samples/tree/v0.4.0/pravega-client-examples/src/main/java/io/pravega/example/consolerw).
+[here](https://github.com/pravega/pravega-samples/tree/v0.5.0/pravega-client-examples/src/main/java/io/pravega/example/consolerw).
 
 ### ConsoleReader
 


### PR DESCRIPTION
**Change log description**  
Version number changed from 0.4.0 to 0.5.0 ih the hyperlink (https://github.com/pravega/pravega-samples/tree/v0.5.0/pravega-client-examples/src/main/java/io/pravega/example/streamcuts) in the following documents.
documentation/basic-reader-and-writer.md
documentation/state-synchronizer.md
documentation/transactions.md
documentation/streamcuts.md

**Purpose of the change**  
(_e.g._, Fixes #3551, Closes #3551)

