### PR TITLE
Issue 3550: Correct maximum event size

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -25,8 +25,8 @@ import lombok.Data;
 @Data
 public class PendingEvent {
     /**
-     * The max write size should differ to max event payload size, because the wire protocol adds extra bytes to the
-     * event payload. The addition is 8 bytes (2 integer fields: the command type code and the payload size).
+     * The serialized event max size. Equals to max event payload size plus additional 8 bytes for the wire command code
+	 * and the payload size.
      */
     public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -25,8 +25,8 @@ import lombok.Data;
 @Data
 public class PendingEvent {
     /**
-     * The serialized event max size. Equals to max event payload size plus additional 8 bytes for the wire command code
-	 * and the payload size.
+     * The serialized event max size. Equals to the max event payload size plus additional 8 bytes for the wire command
+	 * code and the payload size.
      */
     public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -26,7 +26,7 @@ import lombok.Data;
 public class PendingEvent {
     /**
      * The serialized event max size. Equals to the max event payload size plus additional 8 bytes for the wire command
-	 * code and the payload size.
+	 * code and the payload size. See {@link Event} for the details.
      */
     public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -26,7 +26,8 @@ import lombok.Data;
 public class PendingEvent {
     /**
      * The serialized event max size. Equals to the max event payload size plus additional 8 bytes for the wire command
-	 * code and the payload size. See {@link Event} for the details.
+	 * code and the payload size.
+	 * @see Event for the details.
      */
     public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -24,7 +24,6 @@ import lombok.Data;
  */
 @Data
 public class PendingEvent {
-
     /**
      * The max write size should differ to max event payload size, because the wire protocol adds extra bytes to the
      * event payload. The addition is 8 bytes (2 integer fields: the command type code and the payload size).

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -26,8 +26,8 @@ import lombok.Data;
 public class PendingEvent {
     /**
      * The serialized event max size. Equals to the max event payload size plus additional 8 bytes for the wire command
-	 * code and the payload size.
-	 * @see Event for the details.
+     * code and the payload size.
+     * @see Event for the details.
      */
     public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -24,7 +24,12 @@ import lombok.Data;
  */
 @Data
 public class PendingEvent {
-    public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE;
+
+    /**
+     * The max write size should differ to max event payload size, because the wire protocol adds extra bytes to the
+     * event payload. The addition is 8 bytes (2 integer fields: the command type code and the payload size).
+     */
+    public static final int MAX_WRITE_SIZE = Serializer.MAX_EVENT_SIZE + 8;
     /**
      * The routing key that was provided to route the data.
      */


### PR DESCRIPTION
Signed-off-by: Kurilov, Andrey <andrey.kurilov@emc.com>

**Change log description**
Allow max event size payload = 1MB

**Purpose of the change**  
Fixes #3550
Pravega v0.4.0 brakes the compatibility. It was possible to write events with size up to 1MB (including this value). Since v0.4.0 the upper limit is 8 bytes less due to the additional headers introduced to distinguish byte streams and event streams. 

**What the code does**  
Change the max *serialized* event size to 1MB + 8 bytes

**How to verify it**  
Try to write an event with payload size = 1MB
