### PR TITLE
Issue 3274: (SegmentStore) Table Segment Compaction

### DIFF
--- a/common/src/main/java/io/pravega/common/io/StreamHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/StreamHelpers.java
@@ -11,6 +11,7 @@ package io.pravega.common.io;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -54,13 +55,17 @@ public final class StreamHelpers {
      * @param source The InputStream to read.
      * @param length The number of bytes to read.
      * @return A byte array containing the contents of the Stream.
-     * @throws IOException If unable to read from the given InputStream.
+     * @throws EOFException If the number of bytes remaining in the InputStream is less than length.
+     * @throws IOException  If unable to read from the given InputStream.
      */
     public static byte[] readAll(InputStream source, int length) throws IOException {
         byte[] ret = new byte[length];
         int readBytes = readAll(source, ret, 0, ret.length);
-        Preconditions.checkArgument(readBytes == ret.length,
-                "Invalid value for length (%s). Was only able to read %s bytes from the given InputStream.", ret.length, readBytes);
+        if (readBytes < ret.length) {
+            throw new EOFException(String.format(
+                    "Was only able to read %d bytes, which is less than the requested length of %d.", readBytes, ret.length));
+        }
+
         return ret;
     }
 }

--- a/common/src/main/java/io/pravega/common/io/StreamHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/StreamHelpers.java
@@ -55,8 +55,8 @@ public final class StreamHelpers {
      * @param source The InputStream to read.
      * @param length The number of bytes to read.
      * @return A byte array containing the contents of the Stream.
-     * @throws EOFException If the number of bytes remaining in the InputStream is less than length.
-     * @throws IOException  If unable to read from the given InputStream.
+     * @throws IOException If unable to read from the given InputStream. Throws {@link EOFException} if the number of bytes
+     * remaining in the InputStream is less than length.
      */
     public static byte[] readAll(InputStream source, int length) throws IOException {
         byte[] ret = new byte[length];

--- a/common/src/main/java/io/pravega/common/util/BitConverter.java
+++ b/common/src/main/java/io/pravega/common/util/BitConverter.java
@@ -228,6 +228,36 @@ public final class BitConverter {
     }
 
     /**
+     * Reads a 64-bit long from the given InputStream that was encoded using BitConverter.writeLong.
+     *
+     * @param source The InputStream to read from.
+     * @return The read number.
+     * @throws IOException If an exception got thrown.
+     */
+    public static long readLong(InputStream source) throws IOException {
+        int b1 = source.read();
+        int b2 = source.read();
+        int b3 = source.read();
+        int b4 = source.read();
+        int b5 = source.read();
+        int b6 = source.read();
+        int b7 = source.read();
+        int b8 = source.read();
+        if ((b1 | b2 | b3 | b4 | b5 | b6 | b7 | b8) < 0) {
+            throw new EOFException();
+        } else {
+            return ((long) b1 << 56) +
+                    ((long) (b2 & 255) << 48) +
+                    ((long) (b3 & 255) << 40) +
+                    ((long) (b4 & 255) << 32) +
+                    ((long) (b5 & 255) << 24) +
+                    (long) ((b6 & 255) << 16) +
+                    (long) ((b7 & 255) << 8) +
+                    (long) ((b8 & 255));
+        }
+    }
+
+    /**
      * Writes the given 64-bit Unsigned Long to the given byte array at the given offset. This value can then be
      * deserialized using {@link #readUnsignedLong}. This method is not interoperable with {@link #readLong}.
      *

--- a/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
@@ -10,6 +10,7 @@
 package io.pravega.common.io;
 
 import io.pravega.test.common.AssertExtensions;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Assert;
@@ -64,7 +65,7 @@ public class StreamHelpersTests {
         AssertExtensions.assertThrows(
                 "readAll accepted a length higher than the given input stream length.",
                 () -> StreamHelpers.readAll(new TestInputStream(buffer), buffer.length + 1),
-                ex -> ex instanceof IllegalArgumentException);
+                ex -> ex instanceof EOFException);
     }
 
     private static class TestInputStream extends InputStream {

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableAttributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableAttributes.java
@@ -41,6 +41,17 @@ public class TableAttributes extends Attributes {
     public static final UUID TOTAL_ENTRY_COUNT = new UUID(CORE_ATTRIBUTE_ID_PREFIX, TABLE_ATTRIBUTES_START_OFFSET + 3);
 
     /**
+     * Defines an attribute that is used to store the offset of a (Table) Segment where compaction has last run at.
+     */
+    public static final UUID COMPACTION_OFFSET = new UUID(CORE_ATTRIBUTE_ID_PREFIX, TABLE_ATTRIBUTES_START_OFFSET + 4);
+
+    /**
+     * Defines an attribute that is used to set the minimum utilization (as a percentage of {@link #ENTRY_COUNT} out of
+     * {@link #TOTAL_ENTRY_COUNT}) of a Table Segment below which a Table Compaction is triggered.
+     */
+    public static final UUID MIN_UTILIZATION = new UUID(CORE_ATTRIBUTE_ID_PREFIX, TABLE_ATTRIBUTES_START_OFFSET + 5);
+
+    /**
      * Defines a Map that contains all Table Attributes along with their default values.
      */
     public static final Map<UUID, Long> DEFAULT_VALUES = Collections.unmodifiableMap(

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -177,7 +177,7 @@ public class AsyncReadResultProcessor implements AutoCloseable {
         @Getter
         private final Duration requestContentTimeout;
         private final List<InputStream> parts = Collections.synchronizedList(new ArrayList<>());
-        final CompletableFuture<InputStream> result = new CompletableFuture<>();
+        private final CompletableFuture<InputStream> result = new CompletableFuture<>();
 
         @Override
         public boolean shouldRequestContents(ReadResultEntryType entryType, long streamSegmentOffset) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -9,17 +9,25 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
-import com.google.common.base.Preconditions;
-
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * An Asynchronous processor for ReadResult objects. Attaches to a ReadResult and executes a callback using an Executor
@@ -78,6 +86,21 @@ public class AsyncReadResultProcessor implements AutoCloseable {
         AsyncReadResultProcessor processor = new AsyncReadResultProcessor(readResult, entryHandler);
         processor.processResult(executor);
         return processor;
+    }
+
+    /**
+     * Processes the given {@link ReadResult} and returns the contents as an {@link InputStream}.
+     *
+     * @param readResult            The {@link ReadResult} to process.
+     * @param executor              An Executor to run asynchronous tasks on.
+     * @param requestContentTimeout Timeout for each call to {@link ReadResultEntry#requestContent(Duration)}, for those
+     *                              {@link ReadResultEntry} instances that are not already cached in memory.
+     * @return A CompletableFuture that, when completed, will contain an {@link InputStream} with the requested data.
+     */
+    public static CompletableFuture<InputStream> processAll(ReadResult readResult, Executor executor, Duration requestContentTimeout) {
+        ProcessAllHandler handler = new ProcessAllHandler(requestContentTimeout);
+        process(readResult, handler, executor);
+        return handler.result;
     }
 
     //endregion
@@ -148,5 +171,34 @@ public class AsyncReadResultProcessor implements AutoCloseable {
     }
 
     //endregion
+
+    @RequiredArgsConstructor
+    private static class ProcessAllHandler implements AsyncReadResultHandler {
+        @Getter
+        private final Duration requestContentTimeout;
+        private final List<InputStream> parts = Collections.synchronizedList(new ArrayList<>());
+        final CompletableFuture<InputStream> result = new CompletableFuture<>();
+
+        @Override
+        public boolean shouldRequestContents(ReadResultEntryType entryType, long streamSegmentOffset) {
+            return true;
+        }
+
+        @Override
+        public boolean processEntry(ReadResultEntry entry) {
+            this.parts.add(entry.getContent().join().getData());
+            return true;
+        }
+
+        @Override
+        public void processError(Throwable cause) {
+            this.result.completeExceptionally(cause);
+        }
+
+        @Override
+        public void processResultComplete() {
+            this.result.complete(new SequenceInputStream(Iterators.asEnumeration(this.parts.iterator())));
+        }
+    }
 }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -331,10 +331,26 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
 
     @Getter
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class DeserializedEntry {
+    static class DeserializedEntry {
+        /**
+         * The Entry's Header.
+         */
         private final EntrySerializer.Header header;
+
+        /**
+         * The computed Entry's Version. If explicitly defined in the Header, this mirrors it, otherwise this is the
+         * offset at which this Entry resides in the Segment.
+         */
         private final long version;
+
+        /**
+         * Key Data.
+         */
         private final byte[] key;
+
+        /**
+         * Value data. Null if a deletion.
+         */
         private final byte[] value;
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -121,7 +121,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
         val h = serializer.readHeader(input);
         long version = getKeyVersion(h, segmentOffset);
         byte[] key = StreamHelpers.readAll(input, h.getKeyLength());
-        byte[] value = h.isDeletion() ? null : h.getValueLength() == 0 ? new byte[0] : StreamHelpers.readAll(input, h.getValueLength());
+        byte[] value = h.isDeletion() ? null : (h.getValueLength() == 0 ? new byte[0] : StreamHelpers.readAll(input, h.getValueLength()));
         return new DeserializedEntry(h, version, key, value);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -113,7 +113,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
      * @param input         An InputStream to read from.
      * @param segmentOffset The Segment Offset that the first byte of the InputStream maps to. This wll be used as a Version,
      *                      unless the deserialized segment's Header contains an explicit version.
-     * @param serializer    The {@link EntrySerializer} to ues for deserializing entries.
+     * @param serializer    The {@link EntrySerializer} to use for deserializing entries.
      * @return A {@link DeserializedEntry} that contains all the components of the {@link TableEntry}.
      * @throws IOException If an Exception occurred while reading from the given InputStream.
      */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/BucketUpdate.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/BucketUpdate.java
@@ -11,11 +11,11 @@ package io.pravega.segmentstore.server.tables;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.util.HashedArray;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
  * Represents an update to a Table Bucket.
  */
 @RequiredArgsConstructor
-@NotThreadSafe
 class BucketUpdate {
     //region Members
 
@@ -33,50 +32,38 @@ class BucketUpdate {
      */
     @Getter
     private final TableBucket bucket;
-    private final Map<HashedArray, KeyInfo> existingKeys = new HashMap<>();
-    private final Map<HashedArray, KeyUpdate> updatedKeys = new HashMap<>();
-    private long maxUpdateOffset = -1;
+
+    /**
+     * Gets a collection of {@link KeyInfo} instances recorded in this Bucket Update.
+     */
+    @Getter
+    private final Collection<KeyInfo> existingKeys;
+    private final Map<HashedArray, KeyUpdate> updatedKeys;
+
+    /**
+     * The bucket offset, or -1 if no such offset (i.e., if everything in this bucket was deleted).
+     */
+    @Getter
+    private final long bucketOffset;
 
     //endregion
 
     //region Operations
 
     /**
-     * Records an existing Key that is relevant to this Bucket Update.
-     *
-     * @param keyInfo A {@link KeyInfo} to record. Any existing recordings for this {@link KeyInfo#getKey()} will be
-     *                overwritten with this value.
+     * Creates a new Builder for a {@link BucketUpdate} for the given Table Bucket.
+     * @param bucket The {@link TableBucket} to create a {@link BucketUpdate.Builder} for.
+     * @return A new builder instance.
      */
-    void withExistingKey(KeyInfo keyInfo) {
-        Preconditions.checkArgument(keyInfo.getOffset() >= 0, "KeyInfo.getOffset() must be a non-negative number.");
-        this.existingKeys.put(keyInfo.getKey(), keyInfo);
-    }
-
-    /**
-     * Records a key update that is relevant to this Bucket Update.
-     *
-     * @param update A {@link KeyUpdate} to record. Any existing (update) recordings for this {@link KeyUpdate#getKey()}
-     *               will be overwritten with this value.
-     */
-    void withKeyUpdate(KeyUpdate update) {
-        this.updatedKeys.put(update.getKey(), update);
-        if (!update.isDeleted()) {
-            this.maxUpdateOffset = Math.max(update.getOffset(), this.maxUpdateOffset);
-        }
-    }
-
-    /**
-     * Gets a collection of {@link KeyInfo} instances recorded in this Bucket Update.
-     */
-    Collection<KeyInfo> getExistingKeys() {
-        return Collections.unmodifiableCollection(this.existingKeys.values());
+    static BucketUpdate.Builder forBucket(TableBucket bucket) {
+        return new BucketUpdate.Builder(bucket);
     }
 
     /**
      * Gets a collection of {@link KeyUpdate} instances recorded in this Bucket Update.
      */
     Collection<KeyUpdate> getKeyUpdates() {
-        return Collections.unmodifiableCollection(this.updatedKeys.values());
+        return this.updatedKeys.values();
     }
 
     /**
@@ -96,20 +83,71 @@ class BucketUpdate {
         return !this.updatedKeys.isEmpty();
     }
 
-    /**
-     * Gets a value representing the last offset of any update - which will now become the Bucket offset.
-     *
-     * @return The bucket offset, or -1 if no such offset (i.e., if everything in this bucket was deleted).
-     */
-    long getBucketOffset() {
-        if (this.maxUpdateOffset >= 0) {
-            // We have non-deletion updates; return the pre-computed value.
-            return this.maxUpdateOffset;
-        } else {
-            // No updates (or all updates are deletions). Get the offset from the remaining existing keys (if any left).
-            return this.existingKeys.values().stream()
-                                    .filter(ek -> !this.updatedKeys.containsKey(ek.getKey()))
-                                    .mapToLong(KeyInfo::getOffset).max().orElse(-1);
+    //endregion
+
+    //region Builder
+
+    @RequiredArgsConstructor
+    static class Builder {
+        @NonNull
+        @Getter
+        private final TableBucket bucket;
+        private final Map<HashedArray, KeyInfo> existingKeys = new HashMap<>();
+        private final Map<HashedArray, KeyUpdate> updatedKeys = new HashMap<>();
+
+        /**
+         * Records an existing Key that is relevant to this Bucket Update.
+         *
+         * @param keyInfo A {@link KeyInfo} to record. Any existing recordings for this {@link KeyInfo#getKey()} will be
+         *                overwritten with this value.
+         */
+        Builder withExistingKey(KeyInfo keyInfo) {
+            Preconditions.checkArgument(keyInfo.getOffset() >= 0, "KeyInfo.getOffset() must be a non-negative number.");
+            this.existingKeys.put(keyInfo.getKey(), keyInfo);
+            return this;
+        }
+
+        /**
+         * Records a key update that is relevant to this Bucket Update.
+         *
+         * @param update A {@link KeyUpdate} to record. Any existing (update) recordings for this {@link KeyUpdate#getKey()}
+         *               will be overwritten with this value.
+         */
+        Builder withKeyUpdate(KeyUpdate update) {
+            this.updatedKeys.put(update.getKey(), update);
+            return this;
+        }
+
+        /**
+         * Creates a new {@link BucketUpdate} using the information contained in this builder.
+         *
+         * @return A new {@link BucketUpdate} instance.
+         */
+        BucketUpdate build() {
+            // Exclude updated keys that have smaller versions than existing keys.
+            ArrayList<HashedArray> toRemove = new ArrayList<>();
+            long bucketOffset = -1;
+            for (KeyUpdate u : this.updatedKeys.values()) {
+                KeyInfo existingKey = this.existingKeys.get(u.getKey());
+                if (!u.isDeleted() && existingKey != null && existingKey.supersedes(u)) {
+                    toRemove.add(u.getKey());
+                } else if (!u.isDeleted()) {
+                    bucketOffset = Math.max(bucketOffset, u.getOffset());
+                }
+            }
+
+            toRemove.forEach(this.updatedKeys::remove);
+
+            if (bucketOffset < 0) {
+                // No updates (or all updates are deletions). Get the offset from the remaining existing keys (if any left).
+                bucketOffset = this.existingKeys.values().stream()
+                        .filter(ek -> !this.updatedKeys.containsKey(ek.getKey()))
+                        .mapToLong(KeyInfo::getOffset)
+                        .max().orElse(-1);
+            }
+
+            return new BucketUpdate(this.bucket, Collections.unmodifiableCollection(this.existingKeys.values()),
+                    Collections.unmodifiableMap(this.updatedKeys), bucketOffset);
         }
     }
 
@@ -120,7 +158,6 @@ class BucketUpdate {
     /**
      * General Key Information.
      */
-    @RequiredArgsConstructor
     @Getter
     static class KeyInfo {
         /**
@@ -134,9 +171,35 @@ class BucketUpdate {
          */
         private final long offset;
 
+        /**
+         * Version of the key.
+         */
+        private final long version;
+
+        KeyInfo(@NonNull HashedArray key, long offset, long version) {
+            Preconditions.checkArgument(version <= offset, "version (%s) cannot be lower than offset (%s).", version, offset);
+            this.key = key;
+            this.offset = offset;
+            this.version = version;
+        }
+
+        /**
+         * Determines whether this {@link KeyInfo} instance supersedes the given {@link KeyInfo} instance. A supersedes B
+         * if one of the following is true:
+         * - A has a higher version than B (irrespective of Segment Offsets)
+         * - A has the same version as B, but A has a higher Segment Offset than B.
+         *
+         * @param other The {@link KeyInfo} instance to compare to.
+         * @return True if this instance supersedes the other instance.
+         */
+        boolean supersedes(KeyInfo other) {
+            return this.version > other.version
+                    || (this.version == other.version && this.offset > other.offset);
+        }
+
         @Override
         public String toString() {
-            return String.format("Offset=%s, Key={%s}", this.offset, key);
+            return String.format("Offset=%s, Version=%s, Key={%s}", this.offset, this.version, this.key);
         }
     }
 
@@ -145,6 +208,7 @@ class BucketUpdate {
      */
     @Getter
     static class KeyUpdate extends KeyInfo {
+
         /**
          * If true, indicates the Key has been deleted (as opposed from being updated).
          */
@@ -157,8 +221,8 @@ class BucketUpdate {
          * @param offset  The offset in the Segment where the update is serialized.
          * @param deleted True if the Key has been deleted via this update, false otherwise.
          */
-        KeyUpdate(HashedArray key, long offset, boolean deleted) {
-            super(key, offset);
+        KeyUpdate(HashedArray key, long offset, long version, boolean deleted) {
+            super(key, offset, version);
             this.deleted = deleted;
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -220,7 +220,6 @@ class ContainerKeyIndex implements AutoCloseable {
      * @param timer   Timer for the operation.
      * @return A CompletableFuture that, when completed, will contain the sought offset. If the  bucket does not exist,
      * it will contain {@link TableKey#NOT_EXISTS}.
-     * associated with it.
      */
     CompletableFuture<Long> getBucketOffsetDirect(DirectSegmentAccess segment, UUID keyHash, TimeoutTimer timer) {
         // Get the bucket offset from the segment, which will update the cache if actually newer.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -74,8 +74,8 @@ class EntrySerializer {
 
     /**
      * Serializes the given {@link TableEntry} collection into the given byte array, explicitly recording the versions
-     * for each entry ({@link TableKey#getVersion()). This should be used for {@link TableEntry} instances that were
-     * previously read from the Table Segment as only in that case does the version acurately reflect the entry's version.
+     * for each entry ({@link TableKey#getVersion()}). This should be used for {@link TableEntry} instances that were
+     * previously read from the Table Segment as only in that case does the version accurately reflect the entry's version.
      *
      * @param entries A Collection of {@link TableEntry} to serialize.
      * @param target  The byte array to serialize into.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -223,7 +223,7 @@ class EntrySerializer {
      */
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     static class Header {
-        private final byte version;
+        private final byte serializationVersion;
         @Getter
         private final int keyLength;
         @Getter

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -73,21 +73,6 @@ class EntrySerializer {
     }
 
     /**
-     * Serializes the given {@link TableEntry} collection into the given byte array, explicitly recording the versions
-     * for each entry ({@link TableKey#getVersion()}). This should be used for {@link TableEntry} instances that were
-     * previously read from the Table Segment as only in that case does the version accurately reflect the entry's version.
-     *
-     * @param entries A Collection of {@link TableEntry} to serialize.
-     * @param target  The byte array to serialize into.
-     */
-    void serializeUpdateWithExplicitVersion(@NonNull Collection<TableEntry> entries, byte[] target) {
-        int offset = 0;
-        for (TableEntry e : entries) {
-            offset = serializeUpdate(e, target, offset, e.getKey().getVersion());
-        }
-    }
-
-    /**
      * Serializes the given {@link TableEntry} to the given byte array.
      *
      * @param entry        The {@link TableEntry} to serialize.
@@ -116,6 +101,21 @@ class EntrySerializer {
         targetOffset += value.getLength();
 
         return targetOffset;
+    }
+
+    /**
+     * Serializes the given {@link TableEntry} collection into the given byte array, explicitly recording the versions
+     * for each entry ({@link TableKey#getVersion()}). This should be used for {@link TableEntry} instances that were
+     * previously read from the Table Segment as only in that case does the version accurately reflect the entry's version.
+     *
+     * @param entries A Collection of {@link TableEntry} to serialize.
+     * @param target  The byte array to serialize into.
+     */
+    void serializeUpdateWithExplicitVersion(@NonNull Collection<TableEntry> entries, byte[] target) {
+        int offset = 0;
+        for (TableEntry e : entries) {
+            offset = serializeUpdate(e, target, offset, e.getKey().getVersion());
+        }
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -36,9 +36,13 @@ import lombok.val;
  * requires us to read the whole thing before retrieving anything.
  */
 class EntrySerializer {
-    static final int HEADER_LENGTH = 1 + Integer.BYTES * 2; // Version, Key Length, Value Length.
+    static final int HEADER_LENGTH = 1 + Integer.BYTES * 2 + Long.BYTES; // Serialization Version, Key Length, Value Length, Entry Version.
     static final int MAX_KEY_LENGTH = 8 * 1024; // 8KB
     static final int MAX_SERIALIZATION_LENGTH = 1024 * 1024; // 1MB
+    private static final int VERSION_POSITION = 0;
+    private static final int KEY_POSITION = VERSION_POSITION + 1;
+    private static final int VALUE_POSITION = KEY_POSITION + Integer.BYTES;
+    private static final int ENTRY_VERSION_POSITION = VALUE_POSITION + Integer.BYTES;
     private static final byte CURRENT_SERIALIZATION_VERSION = 0;
     private static final int NO_VALUE = -1;
 
@@ -55,7 +59,8 @@ class EntrySerializer {
     }
 
     /**
-     * Serializes the given {@link TableEntry} collection into the given byte array.
+     * Serializes the given {@link TableEntry} collection into the given byte array, without explicitly recording the
+     * versions for each entry.
      *
      * @param entries A Collection of {@link TableEntry} to serialize.
      * @param target  The byte array to serialize into.
@@ -63,7 +68,22 @@ class EntrySerializer {
     void serializeUpdate(@NonNull Collection<TableEntry> entries, byte[] target) {
         int offset = 0;
         for (TableEntry e : entries) {
-            offset = serializeUpdate(e, target, offset);
+            offset = serializeUpdate(e, target, offset, TableKey.NO_VERSION);
+        }
+    }
+
+    /**
+     * Serializes the given {@link TableEntry} collection into the given byte array, explicitly recording the versions
+     * for each entry ({@link TableKey#getVersion()). This should be used for {@link TableEntry} instances that were
+     * previously read from the Table Segment as only in that case does the version acurately reflect the entry's version.
+     *
+     * @param entries A Collection of {@link TableEntry} to serialize.
+     * @param target  The byte array to serialize into.
+     */
+    void serializeUpdateWithExplicitVersion(@NonNull Collection<TableEntry> entries, byte[] target) {
+        int offset = 0;
+        for (TableEntry e : entries) {
+            offset = serializeUpdate(e, target, offset, e.getKey().getVersion());
         }
     }
 
@@ -73,9 +93,10 @@ class EntrySerializer {
      * @param entry        The {@link TableEntry} to serialize.
      * @param target       The byte array to serialize to.
      * @param targetOffset The first offset within the byte array to serialize at.
+     * @param version      The version to serialize. This will be encoded in the {@link Header}.
      * @return The first offset in the given byte array after the serialization.
      */
-    private int serializeUpdate(@NonNull TableEntry entry, byte[] target, int targetOffset) {
+    private int serializeUpdate(@NonNull TableEntry entry, byte[] target, int targetOffset, long version) {
         val key = entry.getKey().getKey();
         val value = entry.getValue();
         Preconditions.checkArgument(key.getLength() <= MAX_KEY_LENGTH, "Key too large.");
@@ -84,10 +105,7 @@ class EntrySerializer {
         Preconditions.checkElementIndex(targetOffset + serializationLength - 1, target.length, "serialization does not fit in target buffer");
 
         // Serialize Header.
-        target[targetOffset] = CURRENT_SERIALIZATION_VERSION;
-        targetOffset++;
-        targetOffset += BitConverter.writeInt(target, targetOffset, key.getLength());
-        targetOffset += BitConverter.writeInt(target, targetOffset, value.getLength());
+        targetOffset = writeHeader(target, targetOffset, key.getLength(), value.getLength(), version);
 
         // Key
         System.arraycopy(key.array(), key.arrayOffset(), target, targetOffset, key.getLength());
@@ -141,11 +159,8 @@ class EntrySerializer {
         int serializationLength = getRemovalLength(tableKey);
         Preconditions.checkElementIndex(targetOffset + serializationLength - 1, target.length, "serialization does not fit in target buffer");
 
-        // Serialize Header.
-        target[targetOffset] = CURRENT_SERIALIZATION_VERSION;
-        targetOffset++;
-        targetOffset += BitConverter.writeInt(target, targetOffset, key.getLength());
-        targetOffset += BitConverter.writeInt(target, targetOffset, NO_VALUE);
+        // Serialize Header. Not caring about explicit versions since we do not reinsert removals upon compaction.
+        targetOffset = writeHeader(target, targetOffset, key.getLength(), NO_VALUE, TableKey.NO_VERSION);
 
         // Key
         System.arraycopy(key.array(), key.arrayOffset(), target, targetOffset, key.getLength());
@@ -164,11 +179,12 @@ class EntrySerializer {
      * @throws SerializationException If an invalid header was detected.
      */
     Header readHeader(@NonNull ArrayView input) throws SerializationException {
-        byte version = input.get(0);
-        int keyLength = BitConverter.readInt(input, 1);
-        int valueLength = BitConverter.readInt(input, 1 + Integer.BYTES);
+        byte version = input.get(VERSION_POSITION);
+        int keyLength = BitConverter.readInt(input, KEY_POSITION);
+        int valueLength = BitConverter.readInt(input, VALUE_POSITION);
+        long entryVersion = BitConverter.readLong(input, ENTRY_VERSION_POSITION);
         validateHeader(keyLength, valueLength);
-        return new Header(version, keyLength, valueLength);
+        return new Header(version, keyLength, valueLength, entryVersion);
     }
 
     /**
@@ -182,8 +198,18 @@ class EntrySerializer {
         byte version = (byte) input.read();
         int keyLength = BitConverter.readInt(input);
         int valueLength = BitConverter.readInt(input);
+        long entryVersion = BitConverter.readLong(input);
         validateHeader(keyLength, valueLength);
-        return new Header(version, keyLength, valueLength);
+        return new Header(version, keyLength, valueLength, entryVersion);
+    }
+
+    private int writeHeader(byte[] target, int targetOffset, int keyLength, int valueLength, long entryVersion) {
+        target[targetOffset] = CURRENT_SERIALIZATION_VERSION;
+        targetOffset++;
+        targetOffset += BitConverter.writeInt(target, targetOffset, keyLength);
+        targetOffset += BitConverter.writeInt(target, targetOffset, valueLength);
+        targetOffset += BitConverter.writeLong(target, targetOffset, entryVersion);
+        return targetOffset;
     }
 
     private void validateHeader(int keyLength, int valueLength) throws SerializationException {
@@ -195,12 +221,15 @@ class EntrySerializer {
     /**
      * Defines a serialized Entry's Header.
      */
-    @Getter
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     static class Header {
         private final byte version;
+        @Getter
         private final int keyLength;
+        @Getter
         private final int valueLength;
+        @Getter
+        private final long entryVersion;
 
         int getKeyOffset() {
             return HEADER_LENGTH;
@@ -221,7 +250,7 @@ class EntrySerializer {
 
         @Override
         public String toString() {
-            return String.format("Length: Key=%s, Value=%s, Total=%s", this.keyLength, this.valueLength, getTotalLength());
+            return String.format("Length: {K=%s, V=%s}, EntryVersion: %s", this.keyLength, this.valueLength, this.entryVersion);
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
@@ -105,6 +105,26 @@ class IndexReader {
     }
 
     /**
+     * Gets the index in the Segment until which compaction has previously run.
+     *
+     * @param segmentInfo A {@link SegmentProperties} from which to extract the information.
+     * @return The index.
+     */
+    long getCompactionOffset(SegmentProperties segmentInfo) {
+        return segmentInfo.getAttributes().getOrDefault(TableAttributes.COMPACTION_OFFSET, 0L);
+    }
+
+    /**
+     * Gets the Segment Utilization (as a percentage) under which a compaction may be required.
+     *
+     * @param segmentInfo A {@link SegmentProperties} from which to extract the information.
+     * @return The result.
+     */
+    long getCompactionUtilizationThreshold(SegmentProperties segmentInfo) {
+        return segmentInfo.getAttributes().getOrDefault(TableAttributes.MIN_UTILIZATION, 0L);
+    }
+
+    /**
      * Locates the {@link TableBucket}s for the given Key Hashes in the given Segment's Extended Attribute Index.
      *
      * @param segment   A {@link DirectSegmentAccess} providing access to the Segment to look into.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexWriter.java
@@ -68,18 +68,18 @@ class IndexWriter extends IndexReader {
      * @param segment    The Segment to read from.
      * @param keyUpdates A Collection of {@link BucketUpdate.KeyUpdate} instances to index.
      * @param timer      Timer for the operation.
-     * @return A CompletableFuture that, when completed, will contain the a collection of {@link BucketUpdate}s.
+     * @return A CompletableFuture that, when completed, will contain the a collection of {@link BucketUpdate.Builder}s.
      */
-    CompletableFuture<Collection<BucketUpdate>> groupByBucket(DirectSegmentAccess segment, Collection<BucketUpdate.KeyUpdate> keyUpdates,
+    CompletableFuture<Collection<BucketUpdate.Builder>> groupByBucket(DirectSegmentAccess segment, Collection<BucketUpdate.KeyUpdate> keyUpdates,
                                                               TimeoutTimer timer) {
         val updatesByHash = keyUpdates.stream()
                                       .collect(Collectors.groupingBy(k -> this.hasher.hash(k.getKey())));
         return locateBuckets(segment, updatesByHash.keySet(), timer)
                 .thenApplyAsync(buckets -> {
-                    val result = new HashMap<TableBucket, BucketUpdate>();
+                    val result = new HashMap<TableBucket, BucketUpdate.Builder>();
                     buckets.forEach((keyHash, bucket) -> {
                         // Add the bucket to the result and record this Key as a "new" key in it.
-                        BucketUpdate bu = result.computeIfAbsent(bucket, BucketUpdate::new);
+                        BucketUpdate.Builder bu = result.computeIfAbsent(bucket, BucketUpdate::forBucket);
                         updatesByHash.get(keyHash).forEach(bu::withKeyUpdate);
                     });
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
@@ -62,11 +62,13 @@ class KeyUpdateCollection {
         }
 
         // Update remaining counters, regardless of whether we considered this update or not.
-        this.highestCopiedOffset = Math.max(this.highestCopiedOffset, originalOffset + entryLength);
         this.totalUpdateCount++;
         long lastOffset = update.getOffset() + entryLength;
         if (lastOffset > this.lastIndexedOffset) {
             this.lastIndexedOffset = lastOffset;
+        }
+        if (originalOffset >= 0) {
+            this.highestCopiedOffset = Math.max(this.highestCopiedOffset, originalOffset + entryLength);
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.tables;
+
+import io.pravega.common.util.HashedArray;
+import java.util.Collection;
+import java.util.HashMap;
+import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Getter;
+import lombok.val;
+
+/**
+ * Collection of Keys to their associated {@link BucketUpdate.KeyUpdate}s.
+ */
+@NotThreadSafe
+class KeyUpdateCollection {
+    private final HashMap<HashedArray, BucketUpdate.KeyUpdate> updates = new HashMap<>();
+    /**
+     * The total number of updates processed, including duplicated keys.
+     */
+    @Getter
+    private int totalUpdateCount;
+
+    /**
+     * The Segment offset before which every single byte has been indexed (i.e., the last offset of the last update).
+     */
+    @Getter
+    private long lastIndexedOffset = -1L;
+
+    /**
+     * Includes the given {@link BucketUpdate.KeyUpdate} into this collection.
+     *
+     * If we get multiple updates for the same key, only the one with highest version will be kept. Due to compaction,
+     * it is possible that a lower version of a Key will end up after a higher version of the same Key, in which case
+     * the higher version should take precedence.
+     *
+     * @param update      The {@link BucketUpdate.KeyUpdate} to include.
+     * @param entryLength The total length of the given update, as serialized in the Segment.
+     */
+    void add(BucketUpdate.KeyUpdate update, int entryLength) {
+        val existing = this.updates.get(update.getKey());
+        if (existing == null || update.supersedes(existing)) {
+            this.updates.put(update.getKey(), update);
+        }
+
+        // Update remaining counters, regardless of whether we considered this update or not.
+        this.totalUpdateCount++;
+        long lastOffset = update.getOffset() + entryLength;
+        if (lastOffset > this.lastIndexedOffset) {
+            this.lastIndexedOffset = lastOffset;
+        }
+    }
+
+    /**
+     * Gets a collection of {@link BucketUpdate.KeyUpdate} instances with unique keys that are ready for indexing.
+     *
+     * @return The result.
+     */
+    Collection<BucketUpdate.KeyUpdate> getUpdates() {
+        return this.updates.values();
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
@@ -36,12 +36,11 @@ class KeyUpdateCollection {
     private long lastIndexedOffset = -1L;
 
     /**
-     * The highest Explicit Version encountered in this collection, or {@link TableKey#NO_VERSION} if no entry has such
-     * a version set. The Explicit Version is the version serialized with the Table Entry when it is copied over as part
-     * of a compaction - it reflects its original version/offset.
+     * The highest offset encountered that was copied over during a compaction. If no copied entry was encountered,
+     * then this will be set to {@link TableKey#NO_VERSION}.
      */
     @Getter
-    private long highestExplicitVersion = TableKey.NO_VERSION;
+    private long highestCopiedOffset = TableKey.NO_VERSION;
 
     /**
      * Includes the given {@link BucketUpdate.KeyUpdate} into this collection.
@@ -50,19 +49,20 @@ class KeyUpdateCollection {
      * it is possible that a lower version of a Key will end up after a higher version of the same Key, in which case
      * the higher version should take precedence.
      *
-     * @param update          The {@link BucketUpdate.KeyUpdate} to include.
-     * @param entryLength     The total length of the given update, as serialized in the Segment.
-     * @param explicitVersion The explicit version of this update, as serialized in the Segment. If no explicit version
-     *                        was serialized, then {@link TableKey#NO_VERSION} should be used.
+     * @param update         The {@link BucketUpdate.KeyUpdate} to include.
+     * @param entryLength    The total length of the given update, as serialized in the Segment.
+     * @param originalOffset If this update was a result of a compaction copy, then this should be the original offset
+     *                       where it was copied from (as serialized in the Segment). If no such information exists, then
+     *                       {@link TableKey#NO_VERSION} should be used.
      */
-    void add(BucketUpdate.KeyUpdate update, int entryLength, long explicitVersion) {
+    void add(BucketUpdate.KeyUpdate update, int entryLength, long originalOffset) {
         val existing = this.updates.get(update.getKey());
         if (existing == null || update.supersedes(existing)) {
             this.updates.put(update.getKey(), update);
         }
 
         // Update remaining counters, regardless of whether we considered this update or not.
-        this.highestExplicitVersion = Math.max(this.highestExplicitVersion, explicitVersion);
+        this.highestCopiedOffset = Math.max(this.highestCopiedOffset, originalOffset + entryLength);
         this.totalUpdateCount++;
         long lastOffset = update.getOffset() + entryLength;
         if (lastOffset > this.lastIndexedOffset) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
@@ -162,10 +162,12 @@ abstract class TableBucketReader<ResultT> {
                             .getResult()
                             .thenComposeAsync(r -> {
                                 SearchContinuation sc = processResult(r, soughtKey);
-                                if (sc == SearchContinuation.ResultFound) {
+                                if (sc == SearchContinuation.ResultFound || sc == SearchContinuation.NoResult) {
+                                    // We either definitely found the result or definitely did not find the result.
+                                    // In the case we did not find what we were looking for, we may still have some
+                                    // partial result to return to the caller (i.e., a TableEntry with no value, but with
+                                    // a version, which indicates a deleted entry (as opposed from an inexistent one).
                                     result.complete(r);
-                                } else if (sc == SearchContinuation.NoResult) {
-                                    result.complete(null);
                                 } else {
                                     return this.getBackpointer.apply(this.segment, offset.get(), timer.getRemaining())
                                             .thenAccept(newOffset -> {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.tables;
+
+import io.pravega.segmentstore.server.DirectSegmentAccess;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class TableCompactor {
+    @NonNull
+    private final TableWriterConnector connector;
+
+    public CompletableFuture<Void> compactIfNeeded(DirectSegmentAccess segment, Duration timeout) {
+        // 1. Get Table Segment State and decide if compaction is needed.
+        // 2. Start reading Table Entries from the beginning (StartOffset) of the segment)
+        // 2.1. If Key is not in index or exists with higher version/offset, skip over. This will include removals.
+        // 2.2. If Key exists in index at the current offset, collect (into update collection).
+        // 3. When enough entries have been processed (config based):
+        // 3.1. execute conditional update to re-apply old keys,
+        // 3.2. Update Table Attributes and Truncate at the latest offset (atomically).
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -87,8 +87,7 @@ class TableCompactor {
         long entryCount = this.indexReader.getEntryCount(info);
         long utilization = totalEntryCount == 0 ? 100 : MathHelpers.minMax(Math.round(100.0 * entryCount / totalEntryCount), 0, 100);
         long utilizationThreshold = (int) MathHelpers.minMax(this.indexReader.getCompactionUtilizationThreshold(info), 0, 100);
-        //return utilization < utilizationThreshold;
-        return  false;
+        return utilization < utilizationThreshold;
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -123,16 +123,14 @@ class TableCompactor {
      * arguments provided.
      */
     long calculateTruncationOffset(SegmentProperties info, long highestCopiedOffset) {
-        // Due to the nature of compaction (all entries are copied in order of their original versions), if we encounter
-        // any copied Table Entries then the highest explicit version defined on any of them is
-        if (highestCopiedOffset > 0) {
-            return highestCopiedOffset;
-        }
-
-        // Did not encounter any copied entries. If we were able to index the whole segment, then we should be safe
-        // to truncate at wherever the compaction last finished.
         long truncateOffset = -1;
-        if (this.indexReader.getLastIndexedOffset(info) >= info.getLength()) {
+        if (highestCopiedOffset > 0) {
+            // Due to the nature of compaction (all entries are copied in order of their original versions), if we encounter
+            // any copied Table Entries then the highest explicit version defined on any of them is where we can truncate.
+            truncateOffset = highestCopiedOffset;
+        } else if (this.indexReader.getLastIndexedOffset(info) >= info.getLength()) {
+            // Did not encounter any copied entries. If we were able to index the whole segment, then we should be safe
+            // to truncate at wherever the compaction last finished.
             truncateOffset = this.indexReader.getCompactionOffset(info);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -9,25 +9,200 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.pravega.common.MathHelpers;
+import io.pravega.common.TimeoutTimer;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.contracts.ReadResult;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
+import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
+import io.pravega.segmentstore.server.reading.AsyncReadResultProcessor;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 @RequiredArgsConstructor
+@Slf4j
 class TableCompactor {
-    @NonNull
-    private final TableWriterConnector connector;
+    /**
+     * The maximum size of all the entries to process at once. If needing to move, these will all be processed as a single
+     * StreamSegmentAppend, so we should not make this too large.
+     */
+    private static final int MAX_READ_LENGTH = 4 * EntrySerializer.MAX_SERIALIZATION_LENGTH;
 
-    public CompletableFuture<Void> compactIfNeeded(DirectSegmentAccess segment, Duration timeout) {
-        // 1. Get Table Segment State and decide if compaction is needed.
-        // 2. Start reading Table Entries from the beginning (StartOffset) of the segment)
-        // 2.1. If Key is not in index or exists with higher version/offset, skip over. This will include removals.
-        // 2.2. If Key exists in index at the current offset, collect (into update collection).
-        // 3. When enough entries have been processed (config based):
-        // 3.1. execute conditional update to re-apply old keys,
-        // 3.2. Update Table Attributes and Truncate at the latest offset (atomically).
-        return CompletableFuture.completedFuture(null);
+    @NonNull
+    private final DirectSegmentAccess segment;
+    @NonNull
+    private final KeyHasher hasher;
+    @NonNull
+    private final EntrySerializer serializer;
+    @NonNull
+    private final IndexWriter indexWriter;
+    @NonNull
+    private final Executor executor;
+    @NonNull
+    private final String traceObjectId;
+
+    static CompletableFuture<Void> compactIfNeeded(DirectSegmentAccess segment, TableWriterConnector connector,
+                                                   IndexWriter indexWriter, Executor executor, Duration timeout) {
+        // Decide if compaction is needed. If not, bail out early.
+        SegmentState state = new SegmentState(segment.getInfo());
+        long startOffset = Math.max(state.compactionOffset, state.startOffset);
+        int maxLength = (int) Math.min(MAX_READ_LENGTH, state.lastIndexOffset - startOffset);
+        if (state.utilization >= state.utilizationThreshold || maxLength <= 0) {
+            // TODO: log.debug().
+            return CompletableFuture.completedFuture(null);
+        }
+
+        String traceObjectId = String.format("TableCompactor[%d-%d]", connector.getMetadata().getContainerId(), connector.getMetadata().getId());
+        TableCompactor c = new TableCompactor(segment, connector.getKeyHasher(), connector.getSerializer(), indexWriter, executor, traceObjectId);
+        return c.compactOnce(startOffset, maxLength, timeout);
     }
+
+    @VisibleForTesting
+    CompletableFuture<Void> compactOnce(long startOffset, int maxLength, Duration timeout) {
+        Preconditions.checkArgument(startOffset >= 0, "startOffset must be a non-negative number.");
+        Preconditions.checkArgument(maxLength > 0, "maxLength must be a positive number.");
+
+        // Read the Table Entries beginning at the specified offset, without exceeding the given maximum length.
+        TimeoutTimer timer = new TimeoutTimer(timeout);
+        return readEntriesFromSegment(this.segment, startOffset, maxLength, timer)
+                .thenComposeAsync(candidates -> excludeObsolete(candidates, timer), this.executor)
+                .thenComposeAsync(candidates -> moveCandidates(candidates, timer), this.executor);
+    }
+
+    private CompletableFuture<CandidateCollection> readEntriesFromSegment(DirectSegmentAccess segment, long startOffset, int maxLength, TimeoutTimer timer) {
+        ReadResult rr = segment.read(startOffset, maxLength, timer.getRemaining());
+        return AsyncReadResultProcessor.processAll(rr, this.executor, timer.getRemaining())
+                .thenApply(inputStream -> parseEntries(inputStream, startOffset));
+    }
+
+    @SneakyThrows(IOException.class)
+    private CandidateCollection parseEntries(InputStream input, long startOffset) {
+        val entries = new HashMap<UUID, List<Candidate>>();
+        long nextOffset = startOffset;
+        try {
+            while (true) {
+                val e = AsyncTableEntryReader.readEntryComponents(input, nextOffset, this.serializer);
+                if (!e.getHeader().isDeletion()) {
+                    // We only care about updates, and not removals.
+                    val hash = this.hasher.hash(e.getKey());
+                    List<Candidate> candidateList = entries.computeIfAbsent(hash, h -> new ArrayList<>());
+                    candidateList.add(new Candidate(nextOffset,
+                            TableEntry.versioned(new ByteArraySegment(e.getKey()), new ByteArraySegment(e.getValue()), e.getVersion())));
+                }
+
+                nextOffset += e.getHeader().getTotalLength();
+            }
+        } catch (EOFException ex) {
+            // We chose an arbitrary read length, so it is quite possible we stopped reading in the middle of an entry.
+            // As such, EOFException is the only way to know when to stop. When this happens, we will have collected the
+            // total read length in segmentOffset.
+            input.close();
+        }
+
+        return new CandidateCollection(startOffset, nextOffset, entries);
+    }
+
+    private CompletableFuture<CandidateCollection> excludeObsolete(CandidateCollection candidates, TimeoutTimer timer) {
+        return this.indexWriter.locateBuckets(this.segment, candidates.candidates.keySet(), timer)
+                .thenComposeAsync(buckets -> excludeObsolete(candidates, buckets, timer), this.executor);
+    }
+
+    private CompletableFuture<CandidateCollection> excludeObsolete(CandidateCollection candidates, Map<UUID, TableBucket> buckets, TimeoutTimer timer) {
+        // Exclude all those Table Entries whose buckets altogether do not exist.
+        val deletedBuckets = new ArrayList<UUID>();
+        for (val keyHash : candidates.candidates.keySet()) {
+            val bucket = buckets.get(keyHash);
+            if (bucket == null || !bucket.exists()) {
+                deletedBuckets.add(keyHash);
+            }
+        }
+
+        deletedBuckets.forEach(candidates.candidates::remove);
+
+        // For every Bucket that still exists, find all its Keys and match with our candidates.
+        // - If a candidate exists with higher version/offset, exclude it.
+        // - If a candidate in the index at the current offset, keep it, but remember any backpointers pointing at/from it.
+        // TODO: fix method below and handler. See TODO file.
+        val br = TableBucketReader.key(this.segment, this.indexWriter::getBackpointerOffset, this.executor);
+        return Futures.loop(
+                candidates.candidates.entrySet(),
+                e -> br.findAll(buckets.get(e.getKey()).getSegmentOffset(), null, timer).thenApply(v -> true),
+                this.executor)
+                .thenApply(ignored -> candidates);
+    }
+
+    private CompletableFuture<Void> moveCandidates(CandidateCollection candidateCollection, TimeoutTimer timer) {
+        // 3.1. Perform a Segment Append with re-serialized entries (Explicit versions) and atomic Index Updates.
+        // 3.2. Update Table Attributes and Truncate at the latest offset
+        // TODO: See TODO file.
+        return null;
+    }
+
+    @RequiredArgsConstructor
+    private static class CandidateCollection {
+        final long startOffset;
+        final long endOffset;
+        final Map<UUID, List<Candidate>> candidates;
+    }
+
+    @RequiredArgsConstructor
+    private static class Candidate {
+        final long offset;
+        final TableEntry entry;
+    }
+
+    //region SegmentState
+
+    @RequiredArgsConstructor
+    private static class SegmentState {
+        final long compactionOffset;
+        final long lastIndexOffset;
+        final long startOffset;
+        final long entryCount;
+        final long totalEntryCount;
+        final int utilization;
+        final int utilizationThreshold;
+
+        SegmentState(SegmentProperties segmentInfo) {
+            this.startOffset = segmentInfo.getStartOffset();
+
+            Map<UUID, Long> attributes = segmentInfo.getAttributes();
+            //TODO: use methods from IndexReader?
+            this.compactionOffset = attributes.getOrDefault(TableAttributes.COMPACTION_OFFSET, this.startOffset);
+            this.lastIndexOffset = attributes.getOrDefault(TableAttributes.INDEX_OFFSET, 0L);
+            this.entryCount = attributes.getOrDefault(TableAttributes.ENTRY_COUNT, 0L);
+            this.totalEntryCount = attributes.getOrDefault(TableAttributes.TOTAL_ENTRY_COUNT, 0L);
+            this.utilizationThreshold = (int) MathHelpers.minMax(attributes.getOrDefault(TableAttributes.MIN_UTILIZATION, 0L), 0, 100);
+            this.utilization = this.totalEntryCount == 0
+                    ? 0
+                    : MathHelpers.minMax((int) Math.round(100.0 * this.entryCount / this.totalEntryCount), 0, 100);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Start=%d/%d, End=%d, Entries=%d/%d, Util=%d%%/%d%%", this.compactionOffset, this.startOffset,
+                    this.lastIndexOffset, this.entryCount, this.totalEntryCount, this.utilization, this.utilizationThreshold);
+        }
+    }
+
+    //endregion
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
@@ -9,7 +9,7 @@
  */
 package io.pravega.segmentstore.server.tables;
 
-import io.pravega.segmentstore.contracts.Attributes;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import java.time.Duration;
@@ -51,10 +51,10 @@ interface TableWriterConnector extends AutoCloseable {
 
     /**
      * This method will be invoked by the {@link WriterTableProcessor} after every successful call to
-     * {@link WriterTableProcessor#flush} which advanced the value of the {@link Attributes#TABLE_INDEX_OFFSET} attribute
+     * {@link WriterTableProcessor#flush} which advanced the value of the {@link TableAttributes#INDEX_OFFSET} attribute
      * on the Table Segment this connector refers to.
      *
-     * @param lastIndexedOffset The current value of the {@link Attributes#TABLE_INDEX_OFFSET} attribute.
+     * @param lastIndexedOffset The current value of the {@link TableAttributes#INDEX_OFFSET} attribute.
      */
     void notifyIndexOffsetChanged(long lastIndexedOffset);
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
@@ -59,6 +59,13 @@ interface TableWriterConnector extends AutoCloseable {
     void notifyIndexOffsetChanged(long lastIndexedOffset);
 
     /**
+     * Gets a value representing the maximum length that a Table Segment compaction can process at once.
+     *
+     * @return The maximum compaction length.
+     */
+    int getMaxCompactionSize();
+
+    /**
      * This method will be invoked by the {@link WriterTableProcessor} when it is closed.
      */
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -203,7 +203,6 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
 
         CompletableFuture<Void> result;
         if (this.compactor.isCompactionRequired(info)) {
-            System.out.println("COMPACTION");
             result = this.compactor.compact(segment, timer);
         } else {
             log.debug("{}: No compaction required at this time.", this.traceObjectId);
@@ -225,7 +224,6 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
                     }
                 }, this.executor)
                 .exceptionally(ex -> {
-                    ex.printStackTrace(System.out);
                     // We want to record the compaction failure, but since this is not a critical step in making progress,
                     // we do not want to prevent the StorageWriter from ack-ing operations.
                     log.error("{}: Compaction failed.", this.traceObjectId, ex);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -214,8 +214,6 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
                 .thenComposeAsync(v -> {
                     // Calculate the safe truncation offset.
                     long truncateOffset = this.compactor.calculateTruncationOffset(segment.getInfo(), highestCopiedOffset);
-                    System.out.println(String.format("T: HCO=%s, TO=%s, CO=%s, LIDX=%s, L=%s", highestCopiedOffset, segment.getInfo().getStartOffset(),
-                            indexWriter.getCompactionOffset(segment.getInfo()), indexWriter.getLastIndexedOffset(segment.getInfo()), segment.getInfo().getLength()));
 
                     // Truncate if necessary.
                     if (truncateOffset > 0) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
@@ -62,7 +62,9 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
 
             // Get the result and compare it with the original key.
             val result = keyReader.getResult().get(BASE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-            val expectedVersion = e.isRemoval ? TableKey.NOT_EXISTS : 1L;
+            val expectedVersion = e.isRemoval
+                    ? TableKey.NOT_EXISTS
+                    : (e.explicitVersion == TableKey.NO_VERSION) ? 1L : e.explicitVersion;
             Assert.assertEquals("Unexpected version.", expectedVersion, result.getVersion());
             AssertExtensions.assertArrayEquals("Unexpected key read back.", e.key, 0,
                     result.getKey().array(), result.getKey().arrayOffset(), e.key.length);
@@ -74,7 +76,7 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testReadEmptyKey() {
-        val testItem = generateTestItem(new byte[0], new byte[0], false);
+        val testItem = generateTestItem(new byte[0], new byte[0], false, false);
 
         // Start a new reader & processor for this key-serialization pair.
         val keyReader = AsyncTableEntryReader.readKey(1L, SERIALIZER, new TimeoutTimer(TIMEOUT));
@@ -141,7 +143,11 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
                 Assert.assertNull("Not expecting a value for a removal.", result.getValue());
             } else {
                 // Verify we have a value and that it matches.
-                Assert.assertEquals("Unexpected key version for existing key.", keyVersion, result.getKey().getVersion());
+                if (item.explicitVersion == TableKey.NO_VERSION) {
+                    Assert.assertEquals("Unexpected key version for existing key.", keyVersion, result.getKey().getVersion());
+                } else {
+                    Assert.assertEquals("Unexpected (explicit) key version for existing key.", item.explicitVersion, result.getKey().getVersion());
+                }
                 Assert.assertNotNull("Expecting a value for non removal.", result.getValue());
                 val resultValue = result.getValue();
                 Assert.assertEquals("Unexpected value length.", item.value.length, resultValue.getLength());
@@ -210,24 +216,31 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
             byte[] value = new byte[rnd.nextInt(10)];
             rnd.nextBytes(key);
             rnd.nextBytes(value);
-            result.add(generateTestItem(key, value, i % 2 == 0));
+            result.add(generateTestItem(key, value, i % 2 == 0, i % 5 == 0));
         }
 
         return result;
     }
 
-    private static TestItem generateTestItem(byte[] key, byte[] value, boolean removal) {
+    private static TestItem generateTestItem(byte[] key, byte[] value, boolean removal, boolean explicitVersion) {
         byte[] serialization;
         if (removal) {
             val keyData = TableKey.unversioned(new ByteArraySegment(key));
             serialization = new byte[SERIALIZER.getRemovalLength(keyData)];
             SERIALIZER.serializeRemoval(Collections.singletonList(keyData), serialization);
+            return new TestItem(key, value, removal, TableKey.NO_VERSION, serialization);
         } else {
-            val entry = TableEntry.unversioned(new ByteArraySegment(key), new ByteArraySegment(value));
+            val entry = TableEntry.versioned(new ByteArraySegment(key), new ByteArraySegment(value), key.length);
             serialization = new byte[SERIALIZER.getUpdateLength(entry)];
-            SERIALIZER.serializeUpdate(Collections.singletonList(entry), serialization);
+            if (explicitVersion) {
+                SERIALIZER.serializeUpdateWithExplicitVersion(Collections.singletonList(entry), serialization);
+                return new TestItem(key, value, removal, entry.getKey().getVersion(), serialization);
+            } else {
+                SERIALIZER.serializeUpdate(Collections.singletonList(entry), serialization);
+                return new TestItem(key, value, removal, TableKey.NO_VERSION, serialization);
+            }
         }
-        return new TestItem(key, value, removal, serialization);
+
     }
 
     @RequiredArgsConstructor
@@ -235,6 +248,7 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
         final byte[] key;
         final byte[] value;
         final boolean isRemoval;
+        final long explicitVersion;
         final byte[] serialization;
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/BucketUpdateTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/BucketUpdateTests.java
@@ -24,28 +24,30 @@ public class BucketUpdateTests {
      * Tests general functionality.
      */
     @Test
-    public void testFunctionality() {
+    public void testBuilder() {
         int count = 5;
         val bucket = new TableBucket(UUID.randomUUID(), 0L);
-        val bu = new BucketUpdate(bucket);
-        Assert.assertEquals("Unexpected bucket.", bucket, bu.getBucket());
-        Assert.assertFalse("Not expecting any updates at this time.", bu.hasUpdates());
+        val builder = BucketUpdate.forBucket(bucket);
+        val b1 = builder.build();
+        Assert.assertEquals("Unexpected bucket.", bucket, b1.getBucket());
+        Assert.assertFalse("Not expecting any updates at this time.", b1.hasUpdates());
 
         for (int i = 0; i < count; i++) {
-            bu.withExistingKey(new BucketUpdate.KeyInfo(new HashedArray(new byte[]{(byte) i}), i));
-            bu.withKeyUpdate(new BucketUpdate.KeyUpdate(new HashedArray(new byte[]{(byte) -i}), i, i % 2 == 0));
+            builder.withExistingKey(new BucketUpdate.KeyInfo(new HashedArray(new byte[]{(byte) i}), i, i));
+            builder.withKeyUpdate(new BucketUpdate.KeyUpdate(new HashedArray(new byte[]{(byte) -i}), i, i, i % 2 == 0));
         }
 
+        val b2 = builder.build();
         Assert.assertTrue("Unexpected result from isKeyUpdated for updated key.",
-                bu.isKeyUpdated(new HashedArray(new byte[]{(byte) -1})));
+                b2.isKeyUpdated(new HashedArray(new byte[]{(byte) -1})));
         Assert.assertFalse("Unexpected result from isKeyUpdated for non-updated key.",
-                bu.isKeyUpdated(new HashedArray(new byte[]{(byte) -count})));
+                b2.isKeyUpdated(new HashedArray(new byte[]{(byte) -count})));
 
-        Assert.assertEquals("Unexpected existing keys count.", count, bu.getExistingKeys().size());
-        Assert.assertEquals("Unexpected updated keys count.", count, bu.getKeyUpdates().size());
+        Assert.assertEquals("Unexpected existing keys count.", count, b2.getExistingKeys().size());
+        Assert.assertEquals("Unexpected updated keys count.", count, b2.getKeyUpdates().size());
 
-        val existingIterator = bu.getExistingKeys().stream().sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset)).iterator();
-        val updatesIterator = bu.getKeyUpdates().stream().sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset)).iterator();
+        val existingIterator = b2.getExistingKeys().stream().sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset)).iterator();
+        val updatesIterator = b2.getKeyUpdates().stream().sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset)).iterator();
         for (int i = 0; i < count; i++) {
             val e = existingIterator.next();
             val u = updatesIterator.next();
@@ -55,5 +57,40 @@ public class BucketUpdateTests {
             Assert.assertEquals("Unexpected offset for update " + i, i, u.getOffset());
             Assert.assertEquals("Unexpected value for isDeleted " + i, i % 2 == 0, u.isDeleted());
         }
+    }
+
+    /**
+     * Tests the {@link BucketUpdate.KeyInfo#supersedes} method and {@link BucketUpdate.Builder#build} with superseded
+     * Key updates.
+     */
+    @Test
+    public void testSuperseding() {
+        val bucket = new TableBucket(UUID.randomUUID(), 0L);
+
+        val existingKey = new BucketUpdate.KeyInfo(new HashedArray(new byte[]{(byte) 1}), 10, 9);
+
+        // This one has the same version but higher offset, so it should supersede it.
+        val sameVersionHigherOffsetUpdate = new BucketUpdate.KeyUpdate(new HashedArray(new byte[]{(byte) 1}), 11, 9, false);
+        Assert.assertTrue(sameVersionHigherOffsetUpdate.supersedes(existingKey));
+        Assert.assertFalse(existingKey.supersedes(sameVersionHigherOffsetUpdate));
+        val bu1 = BucketUpdate.forBucket(bucket)
+                .withExistingKey(existingKey)
+                .withKeyUpdate(sameVersionHigherOffsetUpdate)
+                .build();
+        Assert.assertTrue("Expected superseded key to be reported as updated", bu1.isKeyUpdated(existingKey.getKey()));
+        Assert.assertEquals("Unexpected updated key that supersedes existing key.", sameVersionHigherOffsetUpdate, bu1.getKeyUpdates().stream().findFirst().orElse(null));
+        Assert.assertEquals("Unexpected Bucket Offset for superseding key.", sameVersionHigherOffsetUpdate.getOffset(), bu1.getBucketOffset());
+
+        // This one has a lower version but higher offset.
+        val lowerVersionUpdate = new BucketUpdate.KeyUpdate(new HashedArray(new byte[]{(byte) 1}), 12, 8, false);
+        Assert.assertTrue(existingKey.supersedes(lowerVersionUpdate));
+        Assert.assertFalse(lowerVersionUpdate.supersedes(existingKey));
+        val bu2 = BucketUpdate.forBucket(bucket)
+                .withExistingKey(existingKey)
+                .withKeyUpdate(lowerVersionUpdate)
+                .build();
+        Assert.assertFalse("Expected non-superseded key to not be reported as updated", bu2.isKeyUpdated(existingKey.getKey()));
+        Assert.assertTrue("Not expecting any updates for non-superseded key.", bu2.getKeyUpdates().isEmpty());
+        Assert.assertEquals("Unexpected Bucket Offset for non-superseding key.", existingKey.getOffset(), bu2.getBucketOffset());
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -29,6 +29,7 @@ import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -296,15 +297,15 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
 
         // Update the keys in the segment (via their buckets).
         val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
-        val bucketUpdates = buckets.entrySet().stream()
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
                 .map(e -> {
-                    BucketUpdate bu = new BucketUpdate(e.getValue());
+                    val builder = BucketUpdate.forBucket(e.getValue());
                     val ko = keysWithOffsets.get(e.getKey());
                     if (ko != null) {
-                        bu.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, false));
+                        builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
                     }
 
-                    return bu;
+                    return builder.build();
                 })
                 .collect(Collectors.toList());
 
@@ -364,12 +365,12 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
 
         // Update everything in the underlying index.
         val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
-        val bucketUpdates = buckets.entrySet().stream()
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
                                    .map(e -> {
-                                       BucketUpdate bu = new BucketUpdate(e.getValue());
+                                       val builder = BucketUpdate.forBucket(e.getValue());
                                        val ko = keysWithOffsets.get(e.getKey());
-                                       bu.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, false));
-                                       return bu;
+                                       builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                                       return builder.build();
                                    })
                                    .collect(Collectors.toList());
         iw.updateBuckets(context.segment, bucketUpdates, 0L, 1L, 0, TIMEOUT).join();
@@ -421,12 +422,12 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
 
         // Update the keys in the segment (via their buckets).
         val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
-        val bucketUpdates = buckets.entrySet().stream()
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
                                    .map(e -> {
-                                       BucketUpdate bu = new BucketUpdate(e.getValue());
+                                       val builder = BucketUpdate.forBucket(e.getValue());
                                        val ko = keysWithOffsets.get(e.getKey());
-                                       bu.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, false));
-                                       return bu;
+                                       builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                                       return builder.build();
                                    })
                                    .collect(Collectors.toList());
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -35,6 +35,7 @@ import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.storage.CacheFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryCacheFactory;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -52,6 +53,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -85,6 +87,7 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
     private static final int ITERATOR_BATCH_UPDATE_SIZE = 69;
     private static final double REMOVE_FRACTION = 0.3; // 30% of generated operations are removes.
     private static final int SHORT_TIMEOUT_MILLIS = 20; // To verify a get() is blocked.
+    private static final int DEFAULT_COMPACTION_SIZE = -1; // Inherits from parent.
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis() * 4, TimeUnit.MILLISECONDS);
@@ -236,15 +239,103 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the ability to retrieve and/or iterate over entries during compaction (when entries were moved and their
-     * original location was truncated out).
+     * Tests the ability update and access entries when compaction occurs using a {@link KeyHasher} that is not prone
+     * to collisions.
      */
     @Test
     public void testTableSegmentCompacted() {
-        // TODO: implement this
-        // Batch update a number of entries and wait to persist.
-        // Force-compact.
-        // Execute an iterator, get() and conditional update over compacted entries and verify they still work.
+        testTableSegmentCompacted(KeyHashers.DEFAULT_HASHER, this::check);
+    }
+
+    /**
+     * Tests the ability update and access entries when compaction occurs using a {@link KeyHasher} that is very prone
+     * to collisions.
+     */
+    @Test
+    public void testTableSegmentCompactedWithCollisions() {
+        // TODO: this fails.
+        testTableSegmentCompacted(KeyHashers.COLLISION_HASHER, this::check);
+    }
+
+    /**
+     * Tests the ability iterate over entries when compaction occurs using a {@link KeyHasher} that is not prone
+     * to collisions.
+     */
+    @Test
+    public void testTableSegmentCompactedIterators() {
+        // TODO: this doesn't exercise the truncation retry.
+        testTableSegmentCompacted(KeyHashers.DEFAULT_HASHER,
+                (expectedEntries, removedKeys, ext) -> checkIterators(expectedEntries, ext));
+    }
+
+    @SneakyThrows
+    private void testTableSegmentCompacted(KeyHasher keyHasher, CheckTable checkTable) {
+        final int maxCompactionLength = (MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * BATCH_SIZE;
+        @Cleanup
+        val context = new TestContext(keyHasher, maxCompactionLength);
+
+        // Create the segment and the Table Writer Processor.
+        context.ext.createSegment(SEGMENT_NAME, TIMEOUT).join();
+        context.segment().updateAttributes(Collections.singletonMap(TableAttributes.MIN_UTILIZATION, 99L));
+        @Cleanup
+        val processor = (WriterTableProcessor) context.ext.createWriterSegmentProcessors(context.segment().getMetadata()).stream().findFirst().orElse(null);
+        Assert.assertNotNull(processor);
+
+        // Generate test data (in update & remove batches).
+        val data = generateTestData(BATCH_UPDATE_COUNT, BATCH_SIZE, context);
+
+        // Process each such batch in turn. Keep track of the removed keys, as well as of existing key versions.
+        val removedKeys = new HashSet<ArrayView>();
+        val keyVersions = new HashMap<ArrayView, Long>();
+        Function<ArrayView, Long> getKeyVersion = k -> keyVersions.getOrDefault(k, TableKey.NOT_EXISTS);
+        TestBatchData last = null;
+        for (val current : data) {
+            // Update entries.
+            val toUpdate = current.toUpdate
+                    .entrySet().stream().map(e -> toUnconditionalTableEntry(e.getKey(), e.getValue(), getKeyVersion.apply(e.getKey())))
+                    .collect(Collectors.toList());
+            addToProcessor(
+                    () -> context.ext.put(SEGMENT_NAME, toUpdate, TIMEOUT)
+                                     .thenAccept(versions -> {
+                                         // Update key versions.
+                                         Assert.assertEquals(toUpdate.size(), versions.size());
+                                         for (int i = 0; i < versions.size(); i++) {
+                                             keyVersions.put(toUpdate.get(i).getKey().getKey(), versions.get(i));
+                                         }
+                                     }),
+                    processor,
+                    context.segment().getInfo()::getLength);
+            removedKeys.removeAll(current.toUpdate.keySet());
+
+            // Remove entries.
+            val toRemove = current.toRemove
+                    .stream().map(k -> toUnconditionalKey(k, getKeyVersion.apply(k))).collect(Collectors.toList());
+
+            addToProcessor(() -> context.ext.remove(SEGMENT_NAME, toRemove, TIMEOUT), processor, context.segment().getInfo()::getLength);
+            removedKeys.addAll(current.toRemove);
+            keyVersions.keySet().removeAll(current.toRemove);
+
+            // Flush the processor.
+            Assert.assertTrue("Unexpected result from WriterTableProcessor.mustFlush().", processor.mustFlush());
+            long initialLength = context.segment().getInfo().getLength();
+            processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (context.segment().getInfo().getLength() > initialLength) {
+                // Need to add an operation so we account for compaction and get it indexed.
+                addToProcessor(initialLength, (int) (context.segment().getInfo().getLength() - initialLength), processor);
+            }
+
+            // Verify result (from cache).
+            checkTable.accept(current.expectedEntries, removedKeys, context.ext);
+            last = current;
+        }
+
+        // Finally, remove all data and delete the segment.
+        val finalRemoval = last.expectedEntries.keySet().stream()
+                                               .map(k -> toUnconditionalKey(k, 1))
+                                               .collect(Collectors.toList());
+        context.ext.remove(SEGMENT_NAME, finalRemoval, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        removedKeys.addAll(last.expectedEntries.keySet());
+        deleteSegment(Collections.emptyList(), context.ext);
     }
 
     /**
@@ -384,6 +475,7 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
 
         // Create the segment and the Table Writer Processor.
         context.ext.createSegment(SEGMENT_NAME, TIMEOUT).join();
+        context.segment().updateAttributes(Collections.singletonMap(TableAttributes.MIN_UTILIZATION, 99L));
         @Cleanup
         val processor = (WriterTableProcessor) context.ext.createWriterSegmentProcessors(context.segment().getMetadata()).stream().findFirst().orElse(null);
         Assert.assertNotNull(processor);
@@ -490,15 +582,15 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
 
     @SneakyThrows
     private void checkIterators(Map<HashedArray, HashedArray> expectedEntries, ContainerTableExtension ext) {
-        // Get the existing keys. We will use this to check Key Versions.
-        val existingEntries = ext.get(SEGMENT_NAME, new ArrayList<>(expectedEntries.keySet()), TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-        existingEntries.sort(Comparator.comparingLong(e -> e.getKey().getVersion()));
-        val existingKeys = existingEntries.stream().map(TableEntry::getKey).collect(Collectors.toList());
-
         // Collect and verify all Table Entries.
         val entryIterator = ext.entryIterator(SEGMENT_NAME, null, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         val actualEntries = collectIteratorItems(entryIterator);
         actualEntries.sort(Comparator.comparingLong(e -> e.getKey().getVersion()));
+
+        // Get the existing keys. We will use this to check Key Versions.
+        val existingEntries = ext.get(SEGMENT_NAME, new ArrayList<>(expectedEntries.keySet()), TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        existingEntries.sort(Comparator.comparingLong(e -> e.getKey().getVersion()));
+        val existingKeys = existingEntries.stream().map(TableEntry::getKey).collect(Collectors.toList());
         AssertExtensions.assertListEquals("Unexpected Table Entries from entryIterator().", existingEntries, actualEntries, TableEntry::equals);
 
         // Collect and verify all Table Keys.
@@ -625,11 +717,15 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
         }
 
         TestContext(KeyHasher hasher) {
+            this(hasher, DEFAULT_COMPACTION_SIZE);
+        }
+
+        TestContext(KeyHasher hasher, int maxCompactionSize) {
             this.hasher = hasher;
             this.container = new MockSegmentContainer(() -> new SegmentMock(createSegmentMetadata(), executorService()));
             this.cacheFactory = new InMemoryCacheFactory();
             this.cacheManager = new CacheManager(CachePolicy.INFINITE, executorService());
-            this.ext = createExtension();
+            this.ext = createExtension(maxCompactionSize);
             this.random = new Random(0);
         }
 
@@ -640,9 +736,12 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
             this.cacheFactory.close();
             this.container.close();
         }
-
         ContainerTableExtensionImpl createExtension() {
-            return new ContainerTableExtensionImpl(this.container, this.cacheFactory, this.cacheManager, this.hasher, executorService());
+            return createExtension(DEFAULT_COMPACTION_SIZE);
+        }
+
+        ContainerTableExtensionImpl createExtension(int maxCompactionSize) {
+            return new TestTableExtensionImpl(this.container, this.cacheFactory, this.cacheManager, this.hasher, executorService(), maxCompactionSize);
         }
 
         UpdateableSegmentMetadata createSegmentMetadata() {
@@ -654,6 +753,21 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
 
         SegmentMock segment() {
             return this.container.segment.get();
+        }
+    }
+
+    private class TestTableExtensionImpl extends ContainerTableExtensionImpl {
+        private final int maxCompactionSize;
+
+        TestTableExtensionImpl(SegmentContainer segmentContainer, CacheFactory cacheFactory, CacheManager cacheManager,
+                               KeyHasher hasher, ScheduledExecutorService executor, int maxCompactionSize) {
+            super(segmentContainer, cacheFactory, cacheManager, hasher, executor);
+            this.maxCompactionSize = maxCompactionSize;
+        }
+
+        @Override
+        protected int getMaxCompactionSize() {
+            return this.maxCompactionSize == DEFAULT_COMPACTION_SIZE ? super.getMaxCompactionSize() : this.maxCompactionSize;
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -236,6 +236,18 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the ability to retrieve and/or iterate over entries during compaction (when entries were moved and their
+     * original location was truncated out).
+     */
+    @Test
+    public void testTableSegmentCompacted() {
+        // TODO: implement this
+        // Batch update a number of entries and wait to persist.
+        // Force-compact.
+        // Execute an iterator, get() and conditional update over compacted entries and verify they still work.
+    }
+
+    /**
      * Tests the ability to resume operations after a recovery event. Scenarios include:
      * - Index is up-to-date ({@link TableAttributes#INDEX_OFFSET} equals Segment.Length.
      * - Index is not up-to-date ({@link TableAttributes#INDEX_OFFSET} is less than Segment.Length.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
@@ -111,7 +111,8 @@ public class IndexReaderWriterTests extends ThreadPooledTestSuite {
             // Generate keys, and record them where needed.
             for (int j = 0; j < hashesPerBucket; j++) {
                 byte[] key = new byte[KeyHasher.HASH_SIZE_BYTES * 4];
-                keyUpdates.add(new BucketUpdate.KeyUpdate(new HashedArray(key), i * hashesPerBucket + j, i, true));
+                long offset = i * hashesPerBucket + j;
+                keyUpdates.add(new BucketUpdate.KeyUpdate(new HashedArray(key), offset, offset, true));
                 rnd.nextBytes(key);
                 hashToBuckets.put(KeyHashers.DEFAULT_HASHER.hash(key), bucket);
             }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
@@ -367,7 +367,6 @@ public class IndexReaderWriterTests extends ThreadPooledTestSuite {
     private long updateKeys(Map<HashedArray, Long> keysWithOffset, IndexWriter w, HashMap<Long, HashedArray> existingKeys, SegmentMock segment) {
         val timer = new TimeoutTimer(TIMEOUT);
 
-        // TODO adjust versions?
         val keyUpdates = keysWithOffset.entrySet().stream()
                 .map(e -> new BucketUpdate.KeyUpdate(e.getKey(), decodeOffset(e.getValue()), decodeOffset(e.getValue()), isRemoveOffset(e.getValue())))
                                        .sorted(Comparator.comparingLong(BucketUpdate.KeyUpdate::getOffset))

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyUpdateCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyUpdateCollectionTests.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.tables;
+
+import io.pravega.common.util.HashedArray;
+import io.pravega.test.common.AssertExtensions;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.stream.Collectors;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link KeyUpdateCollection} class.
+ */
+public class KeyUpdateCollectionTests {
+    /**
+     * Tests the {@link KeyUpdateCollection#add} method.
+     */
+    @Test
+    public void testAdd() {
+        final int keyCount = 10;
+        final int duplication = 2;
+        val rnd = new Random(0);
+        long maxOffset = 0;
+        val allUpdates = new ArrayList<BucketUpdate.KeyUpdate>();
+        val c = new KeyUpdateCollection();
+        for (int i = 0; i < keyCount; i++) {
+            byte[] key = new byte[i + 1];
+            rnd.nextBytes(key);
+            for (int j = 0; j < duplication; j++) {
+                long offset = 1 + rnd.nextInt(10000);
+                int length = key.length + rnd.nextInt(200);
+                long version = offset / 2 + (i % 2 == j % 2 ? 1 : -1);
+                val update = new BucketUpdate.KeyUpdate(new HashedArray(key), offset, version, false);
+                c.add(update, length);
+                maxOffset = Math.max(maxOffset, offset + length);
+                allUpdates.add(update);
+            }
+        }
+
+        Assert.assertEquals("Unexpected TotalUpdateCount.", keyCount * duplication, c.getTotalUpdateCount());
+        Assert.assertEquals("Unexpected LastIndexedOffset.", maxOffset, c.getLastIndexedOffset());
+
+        val allByKey = allUpdates.stream().collect(Collectors.groupingBy(BucketUpdate.KeyInfo::getKey));
+        val expected = allByKey.values().stream()
+                .map(l -> l.stream().max(Comparator.comparingLong(BucketUpdate.KeyInfo::getVersion)).get())
+                .sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset))
+                .collect(Collectors.toList());
+        val actual = c.getUpdates().stream()
+                .sorted(Comparator.comparingLong(BucketUpdate.KeyInfo::getOffset))
+                .collect(Collectors.toList());
+
+        AssertExtensions.assertListEquals("Unexpected result from getUpdates().", expected, actual,
+                (u1, u2) -> u1.getKey().equals(u2.getKey()) && u1.getVersion() == u2.getVersion() && u1.getOffset() == u2.getOffset());
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
@@ -107,15 +107,18 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the ability to (not) locate Table Entries in a Table Bucket for deleted keys.
+     * Tests the ability to (not) locate Table Entries in a Table Bucket for deleted and inexistent keys.
      */
     @Test
-    public void testFindEntryDeleted() throws Exception {
+    public void testFindEntryNotExists() throws Exception {
         val segment = new SegmentMock(executorService());
 
-        // Generate our test data and append it to the segment.
+        // Generate our test data.
         val es = new EntrySerializer();
-        val deletedKey = generateEntries(es).get(0).getKey();
+        val entries = generateEntries(es);
+
+        // Deleted key (that was previously indexed).
+        val deletedKey = entries.get(0).getKey();
         byte[] data = new byte[es.getRemovalLength(deletedKey)];
         es.serializeRemoval(Collections.singleton(deletedKey), data);
         segment.append(data, null, TIMEOUT).join();
@@ -124,7 +127,12 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
                 executorService());
 
         val deletedResult = reader.find(deletedKey.getKey(), 0L, new TimeoutTimer(TIMEOUT)).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-        Assert.assertNull("Not expecting any result for key that was deleted.", deletedResult);
+        Assert.assertNull("Expecting a TableEntry with null value for deleted key..", deletedResult.getValue());
+
+        // Inexistent key (that did not exist previously).
+        val inexistentKey = entries.get(1).getKey();
+        val inexistentResult = reader.find(inexistentKey.getKey(), 0L, new TimeoutTimer(TIMEOUT)).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        Assert.assertNull("Not expecting any result for key that was never present.", inexistentResult);
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.server.tables;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link TableCompactor} class.
+ */
+public class TableCompactorTests {
+
+    /**
+     * Tests the {@link TableCompactor#isCompactionRequired} method.
+     */
+    @Test
+    public void testIsCompactionRequired() {
+
+    }
+
+    /**
+     * Tests the {@link TableCompactor#compact} method when compaction is up-to-date.
+     */
+    @Test
+    public void testCompactionUpToDate() {
+
+    }
+
+    /**
+     * Tests the {@link TableCompactor#compact} method when compaction results in no entries needing copying.
+     */
+    @Test
+    public void testCompactionNoCopy() {
+
+    }
+
+    /**
+     * Tests the {@link TableCompactor#compact} method when compaction requires entries be copied.
+     */
+    @Test
+    public void testCompactionWithCopy() {
+
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
@@ -10,42 +10,404 @@
 
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.collect.ImmutableMap;
+import io.pravega.common.TimeoutTimer;
+import io.pravega.common.util.HashedArray;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
+import io.pravega.segmentstore.contracts.tables.TableEntry;
+import io.pravega.segmentstore.contracts.tables.TableKey;
+import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.DirectSegmentAccess;
+import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.Cleanup;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * Unit tests for the {@link TableCompactor} class.
  */
-public class TableCompactorTests {
+public class TableCompactorTests extends ThreadPooledTestSuite {
+    private static final int KEY_COUNT = 20; // Number of distinct keys in the tests, numbered 0 to KEY_COUNT-1.
+    private static final int SKIP_COUNT = 2; // At each iteration i, we update all keys K>=i*SKIP_COUNT+DELETE_COUNT.
+    private static final int DELETE_COUNT = 1; // At each iteration i, we remove keys K>=i*SKIP_COUNT to K<i*SKIP_COUNT+DELETE_COUNT
+    private static final int KEY_LENGTH = 64;
+    private static final int VALUE_LENGTH = 128;
+    private static final String SEGMENT_NAME = "TableSegment";
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final KeyHasher KEY_HASHER = KeyHashers.DEFAULT_HASHER;
+
+    @Override
+    protected int getThreadPoolSize() {
+        return 3;
+    }
 
     /**
      * Tests the {@link TableCompactor#isCompactionRequired} method.
      */
     @Test
     public void testIsCompactionRequired() {
+        @Cleanup
+        val c = new TestContext();
+        c.segmentMetadata.setLength(100);
 
+        // TruncationOffset < Compaction offset, and CompactionOffset >= LastIndexedOffset.
+        setSegmentState(50, 50, 1, 100, 50, c);
+        Assert.assertFalse("Unexpected result when CompactionOffset is equal to IndexOffset.", c.compactor.isCompactionRequired(c.segmentMetadata));
+
+        // TruncationOffset > Compaction offset, and TruncationOffset >= LastIndexedOffset.
+        c.segmentMetadata.setStartOffset(50);
+        setSegmentState(10, 50, 1, 100, 50, c);
+        Assert.assertFalse("Unexpected result when TruncationOffset is equal to IndexOffset.", c.compactor.isCompactionRequired(c.segmentMetadata));
+
+        // Utilization == Threshold
+        setSegmentState(0, 100, 50, 100, 50, c);
+        Assert.assertFalse("Unexpected result when Utilization==MinUtilization.", c.compactor.isCompactionRequired(c.segmentMetadata));
+
+        // Utilization > Threshold
+        setSegmentState(0, 100, 51, 100, 50, c);
+        Assert.assertFalse("Unexpected result when Utilization>MinUtilization.", c.compactor.isCompactionRequired(c.segmentMetadata));
+
+        // Empty table
+        setSegmentState(0, 100, 10, 0, 50, c);
+        Assert.assertFalse("Unexpected result when TotalEntryCount==0.", c.compactor.isCompactionRequired(c.segmentMetadata));
+
+        // Utilization < Threshold
+        setSegmentState(0, 100, 49, 100, 50, c);
+        Assert.assertTrue("Unexpected result when Utilization>MinUtilization.", c.compactor.isCompactionRequired(c.segmentMetadata));
     }
 
     /**
      * Tests the {@link TableCompactor#compact} method when compaction is up-to-date.
      */
     @Test
-    public void testCompactionUpToDate() {
+    public void testCompactionUpToDate() throws Exception {
+        @Cleanup
+        val context = new TestContext();
 
+        // Generate and index the data.
+        populate(context);
+
+        // Set the COMPACTION_OFFSET to the limit and verify the segment does not change.
+        long length = context.segmentMetadata.getLength();
+        setCompactionOffset(length, context);
+        setMinUtilization(100, context);
+        Assert.assertFalse("Not expecting compaction to be required.", context.compactor.isCompactionRequired(context.segmentMetadata));
+        context.compactor.compact(context.segment, context.timer).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Not expecting any segment modifications.", length, context.segmentMetadata.getLength());
+        Assert.assertEquals("Not expecting any compaction changes.", length, context.indexWriter.getCompactionOffset(context.segmentMetadata));
+
+        // Set the COMPACTION_OFFSET to an invalid value and verify the appropriate exception is thrown.
+        setCompactionOffset(length + 1, context);
+        Assert.assertFalse("Not expecting compaction to be required.", context.compactor.isCompactionRequired(context.segmentMetadata));
+        AssertExtensions.assertSuppliedFutureThrows(
+                "compac() worked with invalid segment state.",
+                () -> context.compactor.compact(context.segment, context.timer),
+                ex -> ex instanceof DataCorruptionException);
+
+        // Set Segment's StartOffset to max.
+        setCompactionOffset(length - 1, context);
+        context.segmentMetadata.setStartOffset(length);
+        Assert.assertFalse("Not expecting compaction to be required.", context.compactor.isCompactionRequired(context.segmentMetadata));
+        context.compactor.compact(context.segment, context.timer).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Not expecting any segment modifications.", length, context.segmentMetadata.getLength());
+        Assert.assertEquals("Not expecting any compaction changes.", length - 1, context.indexWriter.getCompactionOffset(context.segmentMetadata));
     }
 
     /**
      * Tests the {@link TableCompactor#compact} method when compaction results in no entries needing copying.
      */
     @Test
-    public void testCompactionNoCopy() {
+    public void testCompactionSingleEntry() throws Exception {
+        // We read one key at a time.
+        int readLength = KEY_LENGTH + VALUE_LENGTH + EntrySerializer.HEADER_LENGTH;
+        @Cleanup
+        val context = new TestContext(readLength);
 
+        // Generate and index the data.
+        val keyData = populate(context);
+        setMinUtilization(100, context);
+        Assert.assertTrue("Expecting compaction to be required.", context.compactor.isCompactionRequired(context.segmentMetadata));
+
+        // Sort the table entries by offset and identify which entries are "active" or not.
+        val sortedEntries = sort(keyData).iterator();
+
+        // Perform compaction, step-by-step.
+        long compactionOffset = context.indexWriter.getCompactionOffset(context.segmentMetadata);
+        final long lastIndexedOffset = context.indexWriter.getLastIndexedOffset(context.segmentMetadata);
+        long totalEntryCount = context.indexWriter.getTotalEntryCount(context.segmentMetadata);
+        final long entryCount = context.indexWriter.getEntryCount(context.segmentMetadata);
+        while (compactionOffset < lastIndexedOffset) {
+            Assert.assertTrue("No more entries to process yet compaction not done.", sortedEntries.hasNext());
+            val entry = sortedEntries.next();
+
+            // TODO: finalize this test. There is a runtime error.
+            long initialLength = context.segmentMetadata.getLength();
+
+            // Execute a compaction.
+            context.compactor.compact(context.segment, context.timer).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+            // Check that the appropriate Table Segment attributes changed as expected.
+            long newCompactionOffset = context.indexWriter.getCompactionOffset(context.segmentMetadata);
+            Assert.assertEquals("Expected COMPACTION_OFFSET to have advanced.", newCompactionOffset, compactionOffset + readLength);
+            long newTotalEntryCount = context.indexWriter.getTotalEntryCount(context.segmentMetadata);
+            Assert.assertEquals("Expected TOTAL_ENTRY_COUNT to have decreased.", totalEntryCount - 1, newTotalEntryCount);
+
+            // Check that these attributes have NOT changed.
+            Assert.assertEquals("Not expecting LAST_INDEX_OFFSET to have changed.",
+                    lastIndexedOffset, context.indexWriter.getLastIndexedOffset(context.segmentMetadata));
+            Assert.assertEquals("Not expecting ENTRY_COUNT to have changed.",
+                    entryCount, context.indexWriter.getEntryCount(context.segmentMetadata));
+
+            if (entry.isActive) {
+                // Check for copy
+                Assert.assertEquals("Expecting this entry to have been copied.",
+                        initialLength + readLength, context.segmentMetadata.getLength());
+                // TODO: verify copied entry is correct.
+            } else {
+                Assert.assertEquals("Not expected this entry to have been copied.",
+                        initialLength, context.segmentMetadata.getLength());
+            }
+
+            compactionOffset = newCompactionOffset;
+            totalEntryCount = newTotalEntryCount;
+        }
+
+        // TODO: verify that TOTAL_ENTRY_COUNT == ENTRY_COUNT
     }
 
     /**
      * Tests the {@link TableCompactor#compact} method when compaction requires entries be copied.
      */
     @Test
-    public void testCompactionWithCopy() {
+    public void testCompactionMultipleEntries() {
+        @Cleanup
+        val context = new TestContext();
 
+        // Generate and index the data.
+        val keyData = populate(context);
+        // TODO: maybe implement this test in a similar manner to the single entry one.
+
+    }
+
+    private Collection<KeyData> populate(TestContext context) {
+        val rnd = new Random(0);
+
+        // Generate keys.
+        val keys = new ArrayList<KeyData>();
+        for (int i = 0; i < KEY_COUNT; i++) {
+            byte[] key = new byte[KEY_LENGTH];
+            rnd.nextBytes(key);
+            keys.add(new KeyData(new HashedArray(key)));
+        }
+
+        // Populate segment.
+        int minIndex = 0;
+        setSegmentState(0, 0, 0, 0, 0, context);
+        while (minIndex < keys.size()) {
+            int deleteCount = Math.min(DELETE_COUNT, keys.size() - minIndex);
+            for (int i = 0; i < deleteCount; i++) {
+                // Serialize removal and append it to the segment.
+                val keyData = keys.get(minIndex);
+                val key = TableKey.unversioned(keyData.key);
+                val serialization = new byte[context.serializer.getRemovalLength(key)];
+                context.serializer.serializeRemoval(Collections.singleton(key), serialization);
+                val offset = context.segment.append(serialization, null, TIMEOUT).join();
+
+                // Index it.
+                val previousOffset = keyData.values.isEmpty() ? -1 : (long) keyData.values.lastKey();
+                keyData.values.put(offset, null);
+                minIndex++;
+                val keyUpdate = new BucketUpdate.KeyUpdate(keyData.key, offset, offset, true);
+                index(keyUpdate, offset, previousOffset, serialization.length, context);
+            }
+
+            // Update the rest.
+            for (int keyIndex = minIndex; keyIndex < keys.size(); keyIndex++) {
+                // Generate the value.
+                val keyData = keys.get(keyIndex);
+                byte[] valueData = new byte[VALUE_LENGTH];
+                rnd.nextBytes(valueData);
+                val value = new HashedArray(valueData);
+
+                // Serialize and append it to the segment.
+                val entry = TableEntry.unversioned(keyData.key, value);
+                val serialization = new byte[context.serializer.getUpdateLength(entry)];
+                context.serializer.serializeUpdate(Collections.singleton(entry), serialization);
+                val offset = context.segment.append(serialization, null, TIMEOUT).join();
+
+                // Index it.
+                val previousOffset = keyData.values.isEmpty() ? -1 : (long) keyData.values.lastKey();
+                keyData.values.put(offset, value);
+                val keyUpdate = new BucketUpdate.KeyUpdate(keyData.key, offset, offset, false);
+                index(keyUpdate, offset, previousOffset, serialization.length, context);
+            }
+
+            // Skip over the next few keys.
+            minIndex += Math.min(SKIP_COUNT, keys.size() - minIndex);
+        }
+
+        // Sanity checks before we can move on with any test.
+        Assert.assertEquals("Expecting the whole segment to have been indexed.",
+                context.segmentMetadata.getLength(), context.indexWriter.getLastIndexedOffset(context.segmentMetadata));
+        Assert.assertEquals("Not expecting any changes to the COMPACTION_OFFSET attribute.",
+                0, context.indexWriter.getCompactionOffset(context.segmentMetadata));
+        AssertExtensions.assertLessThan("Expecting fewer active Table Entries than keys.",
+                keys.size(), context.indexWriter.getEntryCount(context.segmentMetadata));
+        AssertExtensions.assertGreaterThan("Expecting more total Table Entries than keys.",
+                keys.size(), context.indexWriter.getTotalEntryCount(context.segmentMetadata));
+        return keys;
+    }
+
+    private void index(BucketUpdate.KeyUpdate keyUpdate, long offset, long previousOffset, int length, TestContext context) {
+        val b = context.indexWriter.groupByBucket(context.segment, Collections.singleton(keyUpdate), context.timer).join()
+                                   .stream().findFirst().get();
+        if (previousOffset >= 0) {
+            b.withExistingKey(new BucketUpdate.KeyInfo(keyUpdate.getKey(), previousOffset, previousOffset));
+        }
+
+        context.indexWriter.updateBuckets(context.segment, Collections.singleton(b.build()), offset, offset + length, 1, TIMEOUT).join();
+    }
+
+    private List<KeyInfo> sort(Collection<KeyData> keys) {
+        val result = new ArrayList<KeyInfo>();
+        for (val keyData : keys) {
+            long lastOffset = keyData.values.lastKey();
+            for (val e : keyData.values.entrySet()) {
+                // An Entry is active only if it is the last indexed value for that key and it is not a deletion.
+                boolean isActive = e.getKey() == lastOffset && e.getValue() != null;
+                result.add(new KeyInfo(keyData.key, e.getKey(), isActive));
+            }
+        }
+
+        result.sort(Comparator.comparingLong(k -> k.offset));
+        return result;
+    }
+
+    private void setSegmentState(long compactionOffset, long indexOffset, long entryCount, long totalEntryCount, long utilizationThreshold, TestContext context) {
+        context.segmentMetadata.updateAttributes(ImmutableMap.<UUID, Long>builder()
+                .put(TableAttributes.COMPACTION_OFFSET, compactionOffset)
+                .put(TableAttributes.INDEX_OFFSET, indexOffset)
+                .put(TableAttributes.ENTRY_COUNT, entryCount)
+                .put(TableAttributes.TOTAL_ENTRY_COUNT, totalEntryCount)
+                .put(TableAttributes.MIN_UTILIZATION, utilizationThreshold)
+                .build());
+    }
+
+    private void setMinUtilization(long utilizationThreshold, TestContext context) {
+        context.segmentMetadata.updateAttributes(ImmutableMap.<UUID, Long>builder()
+                .put(TableAttributes.MIN_UTILIZATION, utilizationThreshold)
+                .build());
+    }
+
+    private void setCompactionOffset(long compactionOffset, TestContext context) {
+        context.segmentMetadata.updateAttributes(ImmutableMap.<UUID, Long>builder()
+                .put(TableAttributes.COMPACTION_OFFSET, compactionOffset)
+                .build());
+    }
+
+    @RequiredArgsConstructor
+    private static class KeyInfo {
+        final HashedArray key;
+        final long offset;
+        final boolean isActive;
+
+        @Override
+        public String toString() {
+            return String.format("%s: %s (%s)", this.key.hashCode(), this.offset, this.isActive ? "active" : "obsolete");
+        }
+    }
+
+    private static class KeyData {
+        final HashedArray key;
+        final UUID keyHash;
+        final SortedMap<Long, HashedArray> values = new TreeMap<>();
+
+        KeyData(HashedArray key) {
+            this.key = key;
+            this.keyHash = KEY_HASHER.hash(key);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s: %s", this.key.hashCode(),
+                    this.values.entrySet().stream().map(e -> e.getKey() + (e.getValue() == null ? "[D]" : ""))
+                               .collect(Collectors.joining(", ")));
+        }
+    }
+
+    private class TestContext implements AutoCloseable {
+        final StreamSegmentMetadata segmentMetadata;
+        final SegmentMock segment;
+        final EntrySerializer serializer;
+        final TestConnector writerConnector;
+        final IndexWriter indexWriter;
+        final TableCompactor compactor;
+        final TimeoutTimer timer;
+
+        TestContext() {
+            this(TableCompactor.DEFAULT_MAX_READ_LENGTH);
+        }
+
+        TestContext(int compactorMaxReadLength) {
+            this.segmentMetadata = new StreamSegmentMetadata(SEGMENT_NAME, 1, 1);
+            this.segment = new SegmentMock(this.segmentMetadata, executorService());
+            this.indexWriter = new IndexWriter(KEY_HASHER, executorService());
+            this.serializer = new EntrySerializer();
+            this.writerConnector = new TestConnector(this.segment, this.serializer, KEY_HASHER);
+            this.compactor = new TableCompactor(this.writerConnector, this.indexWriter, executorService(), compactorMaxReadLength);
+            this.timer = new TimeoutTimer(TIMEOUT);
+        }
+
+        @Override
+        public void close() {
+            this.writerConnector.close();
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private class TestConnector implements TableWriterConnector {
+        private final SegmentMock segment;
+        private final EntrySerializer serializer;
+        private final KeyHasher keyHasher;
+
+        @Override
+        public SegmentMetadata getMetadata() {
+            return this.segment.getMetadata();
+        }
+
+        @Override
+        public CompletableFuture<DirectSegmentAccess> getSegment(Duration timeout) {
+            return CompletableFuture.completedFuture(this.segment);
+        }
+
+        @Override
+        public void notifyIndexOffsetChanged(long lastIndexedOffset) {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public void close() {
+            // Nothing to do.
+        }
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
@@ -1,13 +1,12 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.pravega.segmentstore.server.tables;
 
 import com.google.common.collect.ImmutableMap;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
@@ -312,7 +312,7 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
                 val actualEntry = TableBucketReader.entry(context.segmentMock, context.indexReader::getBackpointerOffset, executorService())
                                                    .find(key, bucket.getSegmentOffset(), timer)
                                                    .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-                Assert.assertEquals("", expectedEntry, actualEntry);
+                Assert.assertEquals("Unexpected entry.", expectedEntry, actualEntry);
             } else {
                 // This key should not exist.
                 if (bucket.exists()) {


### PR DESCRIPTION
**Change log description**  
- Implemented Table Segment Compaction
- Defined two more Table Segment Attributes that aid in compaction: one for tracking utilization and one for tracking compaction progress.
- Compaction is not enabled for any segment yet (all have MIN_UTILIZATION set to 0, which means no compaction). This will change in a future PR.

**Purpose of the change**  
Fixes #3274.

**What the code does**  
- Defined new `TableAttributes`
    - `COMPACTION_OFFSET`: keeps track of the last offset that was processed for compaction. Subsequent compaction runs will resume from here. This offset is always at a `TableEntry` boundary.
    - `MIN_UTILIZATION`: this is a user-set threshold that defines when compaction should be triggered. Utilization is defined as the ratio of `ENTRY_COUNT` to `TOTAL_ENTRY_COUNT`, expressed as a percentage (0..100). The former counts how many Table Entries are active in the segment, while the latter counts all entries, including overwritten and deleted ones.
- Table Entries can now have explicit versions
    - Previously, a Table Entry's version is defined by the offset at which it resides in the Segment. However, since compaction copies entries from the beginning of the Segment to the end, this would have a side effect of changing the entry's version, which would affect conditional updates.
    - Table Entries now have an additional serialized field which stores its explicit version. 
    - New entries (via the API) will not have this field set, in which case the Entry's version will still be inferred from the offset.
    - Copied entries (from compaction) will have this field set to whatever version the entry originally had (if it ends up being copied multiple times then the original version will be kept). As such, when being read, this version will be the one used for conditional updates.
- Compaction is performed in the background by the `WriterTableProcessor` and works along these lines:
    - A number of entries are read beginning at `COMPACTION_OFFSET`. There is a maximum of 4MB to be read at any given time to prevent compaction from using too much IO at any given time.
    - Of those entries that are read, we only consider those entries that are still active in the index (so we exclude deleted or obsolete entries). These will be copied over at the end of the Table Segment, while preserving their original version.
    - A subsequent iteration of the `WriterTableProcessor` will index these copied entries and update the index as needed. There is no special treatment of these in the indexer, except for the rules defined below.
- Reindexing rules
    - When a Table Entry is copied over, we need to account for the fact that we may get a concurrent update to that Entry (via the API). As such, we want to make sure that the copied entry will not override the new value we have just added via the API (previously, anything with a higher offset would supersede anything with lower offset).
    - The `IndexWriter` has not been changed for this purpose. It will continue to update the Table Bucket Index given the inputs we provide. As such, we tweak the inputs we provide to this class, done in `WriterTableProcessor` with the help of the following classes:
        - `KeyUpdateCollection`: this (existing) class helps the `WriterTableProcessor` to organize Table Entries as they are read from the segment for indexing (by de-duping entries with the same key). This has been changed to keep Table Entries with higher versions (and not with higher offsets). It does this by calculating the correct version for each entry (based on offset and explicit version).
        - `BucketUpdate`: this (existing class) contains the state of the Table Bucket that is sent to the `IndexWriter`. It deals with a single bucket and contains both existing and updated keys. It has been changed so that a key is no longer considered updated if it has an existing key that supersedes any updates to it (same superseding rules apply as in `KeyUpdateCollection`).

- Cache invalidation

    - The compaction happens on the segment itself, however the `ContainerTableExtensionImpl` keeps a `ContainerKeyIndex`/`Cache` for recently accessed keys. This cache will need to be partially invalidated if we encounter stale values due to compaction (it auto-updates for API calls, but compaction happens from underneath it).
    - Upon reading entries, if a `StreamSegmentTruncatedException` is encountered, the cache for that bucket is invalidated and it is re-fetched from the index (and recached).
    - There is another condition for invalidating cache, but only for buckets that contain collisions (a pretty rare event).

**How to verify it**  
All existing and newly added unit tests must pass.
Since this is not yet enabled on any segments, there is no need to run system tests against this PR.