### PR TITLE
Issue 3576: Improve logging to make it easier to debug security issues

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -94,9 +94,6 @@ public class ClientConfig implements Serializable {
                 controllerURI = URI.create("tcp://localhost:9090");
             }
             extractCredentials();
-            if (credentials == null) {
-                log.warn("The credentials are not specified or could not be extracted.");
-            }
             return new ClientConfig(controllerURI, credentials, trustStore, validateHostName);
         }
 

--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -11,11 +11,13 @@ package io.pravega.client.stream;
 
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 /**
  * A policy that specifies how the number of segments in a stream should scale over time.
@@ -23,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@ToString
 public class ScalingPolicy implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -164,6 +164,8 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 monitor.startAsync();
             }
 
+            log.info(serviceConfig.getGRPCServerConfig().get().toString());
+
             ClientConfig clientConfig = ClientConfig.builder()
                                                     .controllerURI(URI.create((serviceConfig.getGRPCServerConfig().get().isTlsEnabled() ?
                                                                           "tls://" : "tcp://") + "localhost"))

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -112,6 +112,8 @@ public class ControllerServiceStarter extends AbstractIdleService {
     protected void startUp() {
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.objectId, "startUp");
         log.info("Initiating controller service startUp");
+
+        log.info("Controller serviceConfig = {}", serviceConfig.toString());
         log.info("Event processors enabled = {}", serviceConfig.getEventProcessorConfig().isPresent());
         log.info("Cluster listener enabled = {}", serviceConfig.isControllerClusterListenerEnabled());
         log.info("    Host monitor enabled = {}", serviceConfig.getHostMonitorConfig().isHostMonitorEnabled());
@@ -163,8 +165,6 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 log.info("Starting segment container monitor");
                 monitor.startAsync();
             }
-
-            log.info(serviceConfig.getGRPCServerConfig().get().toString());
 
             ClientConfig clientConfig = ClientConfig.builder()
                                                     .controllerURI(URI.create((serviceConfig.getGRPCServerConfig().get().isTlsEnabled() ?

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
@@ -18,10 +18,12 @@ import io.pravega.client.stream.ScalingPolicy;
 import com.google.common.base.Preconditions;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Configuration of controller event processors.
  */
+@ToString
 @Getter
 public class ControllerEventProcessorConfigImpl implements ControllerEventProcessorConfig {
 

--- a/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
@@ -21,12 +21,14 @@ import io.pravega.controller.timeout.TimeoutServiceConfig;
 import com.google.common.base.Preconditions;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.Optional;
 
 /**
  * Controller Service Configuration.
  */
+@ToString
 @Getter
 public class ControllerServiceConfigImpl implements ControllerServiceConfig {
 

--- a/controller/src/main/java/io/pravega/controller/server/rest/impl/RESTServerConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/impl/RESTServerConfigImpl.java
@@ -39,4 +39,21 @@ public class RESTServerConfigImpl implements RESTServerConfig {
         this.keyFilePath = keyFilePath;
         this.keyFilePasswordPath = keyFilePasswordPath;
     }
+
+    @Override
+    public String toString() {
+        // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
+        // in order to avoid returning a string containing sensitive security configuration.
+
+        return new StringBuilder(String.format("%s(", getClass().getSimpleName()))
+                .append(String.format("host: %s, ", host))
+                .append(String.format("port: %d, ", port))
+                .append(String.format("tlsEnabled: %b, ", tlsEnabled))
+                .append(String.format("keyFilePath is %s, ",
+                        Strings.isNullOrEmpty(keyFilePath) ? "unspecified" : "specified"))
+                .append(String.format("keyFilePasswordPath is %s",
+                        Strings.isNullOrEmpty(keyFilePasswordPath) ? "unspecified" : "specified"))
+                .append(")")
+                .toString();
+    }
 }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.server.rpc.grpc.impl;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import io.pravega.common.Exceptions;
 import io.pravega.controller.server.rpc.grpc.GRPCServerConfig;
 import java.util.Optional;
@@ -60,5 +61,43 @@ public class GRPCServerConfigImpl implements GRPCServerConfig {
         this.tokenSigningKey = tokenSigningKey;
         this.replyWithStackTraceOnError = replyWithStackTraceOnError;
         this.requestTracingEnabled = requestTracingEnabled;
+    }
+
+    @Override
+    public String toString() {
+        // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
+        // in order to avoid returning a string containing sensitive security configuration.
+
+        return new StringBuilder("GRPCServerConfigImpl(")
+
+                // Endpoint config
+                .append(String.format("port: %d, ", port))
+                .append(String.format("publishedRPCHost: %s, ",
+                        publishedRPCHost.isPresent() ? publishedRPCHost.get() : "null"))
+                .append(String.format("publishedRPCPort: %d, ",
+                        publishedRPCPort.isPresent() ? publishedRPCPort.get() : "null"))
+
+                // Auth config
+                .append(String.format("authorizationEnabled: %b, ", authorizationEnabled))
+                .append(String.format("userPasswordFile is %s, ",
+                        Strings.isNullOrEmpty(userPasswordFile) ? "unspecified" : "specified"))
+                .append(String.format("tokenSigningKey is %s, ",
+                        Strings.isNullOrEmpty(tokenSigningKey) ? "unspecified" : "specified"))
+
+                // TLS config
+                .append(String.format("tlsEnabled: %b, ", tlsEnabled))
+                .append(String.format("tlsCertFile is %s, ",
+                        Strings.isNullOrEmpty(tlsCertFile) ? "unspecified" : "specified"))
+                .append(String.format("tlsKeyFile is %s, ",
+                        Strings.isNullOrEmpty(tlsKeyFile) ? "unspecified" : "specified"))
+                .append(String.format("tlsTrustStore is %s, ",
+                        Strings.isNullOrEmpty(tlsTrustStore) ? "unspecified" : "specified"))
+
+                // Request processing config
+                .append(String.format("replyWithStackTraceOnError: %b, ", replyWithStackTraceOnError))
+                .append(String.format("requestTracingEnabled: %b", requestTracingEnabled))
+
+                .append(")")
+                .toString();
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
@@ -74,7 +74,7 @@ public class GRPCServerConfigImpl implements GRPCServerConfig {
                 .append(String.format("port: %d, ", port))
                 .append(String.format("publishedRPCHost: %s, ",
                         publishedRPCHost.isPresent() ? publishedRPCHost.get() : "null"))
-                .append(String.format("publishedRPCPort: %d, ",
+                .append(String.format("publishedRPCPort: %s, ",
                         publishedRPCPort.isPresent() ? publishedRPCPort.get() : "null"))
 
                 // Auth config

--- a/controller/src/main/java/io/pravega/controller/store/client/impl/StoreClientConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/impl/StoreClientConfigImpl.java
@@ -15,12 +15,14 @@ import io.pravega.controller.store.client.StoreType;
 import io.pravega.controller.store.client.ZKClientConfig;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.Optional;
 
 /**
  * Store client configuration.
  */
+@ToString
 @Getter
 public class StoreClientConfigImpl implements StoreClientConfig {
 

--- a/controller/src/main/java/io/pravega/controller/store/client/impl/ZKClientConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/impl/ZKClientConfigImpl.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.store.client.impl;
 
+import com.google.common.base.Strings;
 import io.pravega.common.Exceptions;
 import io.pravega.controller.store.client.ZKClientConfig;
 import lombok.Builder;
@@ -51,5 +52,25 @@ public class ZKClientConfigImpl implements ZKClientConfig {
         this.secureConnectionToZooKeeper = secureConnectionToZooKeeper;
         this.trustStorePath = trustStorePath;
         this.trustStorePasswordPath = trustStorePasswordPath;
+    }
+
+    @Override
+    public String toString() {
+        // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
+        // in order to avoid returning a string containing sensitive security configuration.
+
+        return new StringBuilder(String.format("%s(", getClass().getSimpleName()))
+                .append(String.format("connectionString: %s, ", connectionString))
+                .append(String.format("namespace: %s, ", namespace))
+                .append(String.format("initialSleepInterval: %d, ", initialSleepInterval))
+                .append(String.format("maxRetries: %d, ", maxRetries))
+                .append(String.format("sessionTimeoutMs: %d, ", sessionTimeoutMs))
+                .append(String.format("secureConnectionToZooKeeper: %b, ", secureConnectionToZooKeeper))
+                .append(String.format("trustStorePath is %s, ",
+                        Strings.isNullOrEmpty(trustStorePath) ? "unspecified" : "specified"))
+                .append(String.format("trustStorePasswordPath is %s",
+                        Strings.isNullOrEmpty(trustStorePasswordPath) ? "unspecified" : "specified"))
+                .append(")")
+                .toString();
     }
 }

--- a/controller/src/main/java/io/pravega/controller/timeout/TimeoutServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimeoutServiceConfig.java
@@ -12,10 +12,12 @@ package io.pravega.controller.timeout;
 import com.google.common.base.Preconditions;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Timeout service config.
  */
+@ToString
 @Getter
 public class TimeoutServiceConfig {
     private final long maxLeaseValue;

--- a/controller/src/test/java/io/pravega/controller/server/rest/impl/RESTServerConfigImplTests.java
+++ b/controller/src/test/java/io/pravega/controller/server/rest/impl/RESTServerConfigImplTests.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.rest.impl;
+
+import io.pravega.controller.server.rest.RESTServerConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class RESTServerConfigImplTests {
+    // region Tests that verify the toString() method.
+
+    // Note: It might seem odd that we are unit testing the toString() method of the code under test. The reason we are
+    // doing that is that the method is hand-rolled and there is a bit of logic there that isn't entirely unlikely to fail.
+
+    @Test
+    public void testToStringIsSuccessfulWithAllConfigSpecified() {
+        RESTServerConfig config = new RESTServerConfigImpl("localhost", 2020, true,
+                "/rest.keystore.jks", "/keystore.jks.passwd");
+        assertNotNull(config.toString());
+    }
+
+    @Test
+    public void testToStringIsSuccessfulWithTlsDisabled() {
+        RESTServerConfig config = new RESTServerConfigImpl("localhost", 2020, false,
+                null, null);
+        assertNotNull(config.toString());
+    }
+
+    // endregion
+}

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImplTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.rpc.grpc.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class GRPCServerConfigImplTest {
+
+    // region Tests that verify the toString() method.
+
+    // Note: It might seem odd that we are unit testing the toString() method of the code under test. The reason we are
+    // doing that is that the method is hand-rolled and there is a bit of logic there that isn't entirely unlikely to fail.
+
+    @Test
+    public void toStringReturnsSuccessfullyWithAllConfigSpecified() {
+        GRPCServerConfigImpl config = new GRPCServerConfigImpl(9090, "localhost",
+                9090, true, "/passwd", true,
+                "/cert.pem", "./key.pem", "secret", "/cert.pem",
+                true, true);
+        assertNotNull(config.toString());
+    }
+
+    @Test
+    public void toStringReturnsSuccessfullyWithSomeConfigNullOrEmpty() {
+        GRPCServerConfigImpl config = new GRPCServerConfigImpl(9090, null,
+                9090, true, null, true,
+                "", " ", "secret", "/cert.pem",
+                false, true);
+        assertNotNull(config.toString());
+    }
+
+    // endregion
+}

--- a/controller/src/test/java/io/pravega/controller/store/client/impl/ZKClientConfigImplTests.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/impl/ZKClientConfigImplTests.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.client.impl;
+
+import io.pravega.controller.store.client.ZKClientConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ZKClientConfigImplTests {
+    // region Tests that verify the toString() method.
+
+    // Note: It might seem odd that we are unit testing the toString() method of the code under test. The reason we are
+    // doing that is that the method is hand-rolled and there is a bit of logic there that isn't entirely unlikely to fail.
+    @Test
+    public void testToStringIsSuccessfulWithAllConfigSpecified() {
+        ZKClientConfig config = new ZKClientConfigImpl("connectString", "namespace",
+                5, 2, 60000, true,
+                "/zk.truststore.jks", "zk.truststore.password");
+        assertNotNull(config.toString());
+    }
+
+    @Test
+    public void testToStringIsSuccessfulWithTlsDisabled() {
+        ZKClientConfig config = new ZKClientConfigImpl("connectString", "namespace",
+                5, 2, 60000, false,
+                null, null);
+        assertNotNull(config.toString());
+    }
+
+    // endregion
+}

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -104,11 +104,17 @@ public final class ServiceStarter {
         autoScaleMonitor = new AutoScaleMonitor(service, builderConfig.getConfig(AutoScalerConfig::builder));
 
         TokenVerifierImpl tokenVerifier = new TokenVerifierImpl(builderConfig.getConfig(AutoScalerConfig::builder));
+
+        // Log the configuration
+        log.info(serviceConfig.toString());
+        log.info(builderConfig.getConfig(AutoScalerConfig::builder).toString());
+
         this.listener = new PravegaConnectionListener(this.serviceConfig.isEnableTls(), this.serviceConfig.getListeningIPAddress(),
                                                       this.serviceConfig.getListeningPort(), service, tableStoreService,
                                                       autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(),
                                                       tokenVerifier, this.serviceConfig.getCertFile(), this.serviceConfig.getKeyFile(),
                                                       this.serviceConfig.isReplyWithStackTraceOnError());
+
         this.listener.startListening();
         log.info("PravegaConnectionListener started successfully.");
         log.info("StreamSegmentService started.");

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
@@ -138,7 +138,7 @@ public class AutoScalerConfig {
         // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
         // in order to avoid returning a string containing sensitive security configuration.
 
-        return new StringBuilder("AutoScalerConfig(")
+        return new StringBuilder(String.format("%s(", getClass().getSimpleName()))
                 .append(String.format("controllerUri: %s, ", (controllerUri != null) ? controllerUri.toString() : "null"))
                 .append(String.format("internalRequestStream: %s, ", internalRequestStream))
                 .append(String.format("cooldownDuration: %s, ", (cooldownDuration != null) ? cooldownDuration.toString() : "null"))

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.host.stat;
 
+import com.google.common.base.Strings;
 import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.Property;
@@ -130,5 +131,29 @@ public class AutoScalerConfig {
 
     public static ConfigBuilder<AutoScalerConfig> builder() {
         return new ConfigBuilder<>(COMPONENT_CODE, AutoScalerConfig::new);
+    }
+
+    @Override
+    public String toString() {
+        // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
+        // in order to avoid returning a string containing sensitive security configuration.
+
+        return new StringBuilder("AutoScalerConfig(")
+                .append(String.format("controllerUri: %s, ", (controllerUri != null) ? controllerUri.toString() : "null"))
+                .append(String.format("internalRequestStream: %s, ", internalRequestStream))
+                .append(String.format("cooldownDuration: %s, ", (cooldownDuration != null) ? cooldownDuration.toString() : "null"))
+                .append(String.format("muteDuration: %s, ", (muteDuration != null) ? muteDuration.toString() : "null"))
+                .append(String.format("cacheExpiry: %s, ", (cacheExpiry != null) ? cacheExpiry.toString() : "null"))
+                .append(String.format("cacheCleanup: %s, ", (cacheCleanup != null) ? cacheCleanup.toString() : "null"))
+                .append(String.format("tlsEnabled: %b, ", tlsEnabled))
+                .append(String.format("tlsCertFile is %s, ",
+                        Strings.isNullOrEmpty(tlsCertFile) ? "unspecified" : "specified"))
+                .append(String.format("authEnabled: %b, ", authEnabled))
+                .append(String.format("tokenSigningKey is %s, ",
+                        Strings.isNullOrEmpty(tokenSigningKey) ? "unspecified" : "specified"))
+                .append(String.format("validateHostName: %b, ", validateHostName))
+                .append(String.format("threadPoolSize: %d, ", threadPoolSize))
+                .append(")")
+                .toString();
     }
 }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
@@ -152,7 +152,7 @@ public class AutoScalerConfig {
                 .append(String.format("tokenSigningKey is %s, ",
                         Strings.isNullOrEmpty(tokenSigningKey) ? "unspecified" : "specified"))
                 .append(String.format("validateHostName: %b, ", validateHostName))
-                .append(String.format("threadPoolSize: %d, ", threadPoolSize))
+                .append(String.format("threadPoolSize: %d", threadPoolSize))
                 .append(")")
                 .toString();
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfigTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfigTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.stat;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class AutoScalerConfigTest {
+
+    // region Tests that verify the toString() method.
+
+    // Note: It might seem odd that we are unit testing the toString() method of the code under test. The reason we are
+    // doing that is that the method is hand-rolled and there is a bit of logic there that isn't entirely unlikely to fail.
+
+    @Test
+    public void testToStringIsSuccessfulWithAllNonDefaultConfigSpecified() {
+        AutoScalerConfig config = AutoScalerConfig.builder()
+                .with(AutoScalerConfig.TLS_CERT_FILE, "/cert.pem")
+                .build();
+        assertNotNull(config.toString());
+    }
+
+    @Test
+    public void testToStringIsSuccessfulWithNoConfigSpecified() {
+        AutoScalerConfig config = AutoScalerConfig.builder()
+                .build();
+        assertNotNull(config.toString());
+    }
+
+    // endregion
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -328,7 +328,7 @@ public class ServiceConfig {
         // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
         // in order to avoid returning a string containing sensitive security configuration.
 
-        return new StringBuilder("ServiceConfig(")
+        return new StringBuilder(String.format("%s(", getClass().getSimpleName()))
                 .append(String.format("containerCount: %d, ", containerCount))
                 .append(String.format("coreThreadPoolSize: %d, ", coreThreadPoolSize))
                 .append(String.format("storageThreadPoolSize: %d, ", storageThreadPoolSize))
@@ -348,15 +348,13 @@ public class ServiceConfig {
                 .append(String.format("clusterName: %s, ", clusterName))
                 .append(String.format("dataLogTypeImplementation: %s, ", dataLogTypeImplementation.name()))
                 .append(String.format("storageImplementation: %s, ", storageImplementation.name()))
-                .append(String.format("storageImplementation: %s, ", storageImplementation.name()))
                 .append(String.format("readOnlySegmentStore: %b, ", readOnlySegmentStore))
                 .append(String.format("enableTls: %b, ", enableTls))
                 .append(String.format("certFile is %s, ",
                         Strings.isNullOrEmpty(certFile) ? "unspecified" : "specified"))
                 .append(String.format("keyFile is %s, ",
                         Strings.isNullOrEmpty(keyFile) ? "unspecified" : "specified"))
-                .append(String.format("cachePolicy is %s, ",
-                        Strings.isNullOrEmpty(keyFile) ? "unspecified" : "specified"))
+                .append(String.format("cachePolicy is %s, ", (cachePolicy != null) ? cachePolicy.toString() : "null"))
                 .append(String.format("replyWithStackTraceOnError: %b, ", replyWithStackTraceOnError))
                 .append(String.format("instanceId: %s", instanceId))
                 .append(")")

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -255,6 +255,7 @@ public class ServiceConfig {
 
     //endregion
 
+
     //region Constructor
 
     /**
@@ -321,6 +322,47 @@ public class ServiceConfig {
     }
 
     //endregion
+
+    @Override
+    public String toString() {
+        // Note: We don't use Lombok @ToString to automatically generate an implementation of this method,
+        // in order to avoid returning a string containing sensitive security configuration.
+
+        return new StringBuilder("ServiceConfig(")
+                .append(String.format("containerCount: %d, ", containerCount))
+                .append(String.format("coreThreadPoolSize: %d, ", coreThreadPoolSize))
+                .append(String.format("storageThreadPoolSize: %d, ", storageThreadPoolSize))
+                .append(String.format("listeningPort: %d, ", listeningPort))
+                .append(String.format("listeningIPAddress: %s, ", listeningIPAddress))
+                .append(String.format("publishedPort: %d, ", publishedPort))
+                .append(String.format("publishedIPAddress: %s, ", publishedIPAddress))
+                .append(String.format("zkURL: %s, ", zkURL))
+                .append(String.format("zkRetrySleepMs: %d, ", zkRetrySleepMs))
+                .append(String.format("zkSessionTimeoutMs: %d, ", zkSessionTimeoutMs))
+                .append(String.format("zkRetryCount: %d, ", zkRetryCount))
+                .append(String.format("secureZK: %b, ", secureZK))
+                .append(String.format("zkTrustStore is %s, ",
+                        Strings.isNullOrEmpty(zkTrustStore) ? "unspecified" : "specified"))
+                .append(String.format("zkTrustStorePasswordPath is %s, ",
+                        Strings.isNullOrEmpty(zkTrustStorePasswordPath) ? "unspecified" : "specified"))
+                .append(String.format("clusterName: %s, ", clusterName))
+                .append(String.format("dataLogTypeImplementation: %s, ", dataLogTypeImplementation.name()))
+                .append(String.format("storageImplementation: %s, ", storageImplementation.name()))
+                .append(String.format("storageImplementation: %s, ", storageImplementation.name()))
+                .append(String.format("readOnlySegmentStore: %b, ", readOnlySegmentStore))
+                .append(String.format("enableTls: %b, ", enableTls))
+                .append(String.format("certFile is %s, ",
+                        Strings.isNullOrEmpty(certFile) ? "unspecified" : "specified"))
+                .append(String.format("keyFile is %s, ",
+                        Strings.isNullOrEmpty(keyFile) ? "unspecified" : "specified"))
+                .append(String.format("cachePolicy is %s, ",
+                        Strings.isNullOrEmpty(keyFile) ? "unspecified" : "specified"))
+                .append(String.format("replyWithStackTraceOnError: %b, ", replyWithStackTraceOnError))
+                .append(String.format("instanceId: %s", instanceId))
+                .append(")")
+                .toString();
+    }
+
 
     @SneakyThrows(UnknownHostException.class)
     private static String getHostAddress() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
@@ -54,4 +54,25 @@ public class ServiceConfigTests {
                         && cfg3.getListeningPort() != cfg3.getPublishedPort());
     }
 
+    // region Tests that verify the toString() method.
+
+    @Test
+    public void testToStringIsSuccessfulWithAllNonDefaultConfigSpecified() {
+        ServiceConfig config = ServiceConfig.builder()
+                .with(ServiceConfig.CONTAINER_COUNT, 1)
+                .with(ServiceConfig.LISTENING_IP_ADDRESS, "localhost")
+                .with(ServiceConfig.PUBLISHED_PORT, 4000)
+                .with(ServiceConfig.LISTENING_IP_ADDRESS, "1.2.3.4")
+                .with(ServiceConfig.PUBLISHED_IP_ADDRESS, "1.2.3.4")
+                .with(ServiceConfig.ZK_TRUSTSTORE_LOCATION, "/zkTruststorePath")
+                .with(ServiceConfig.ZK_TRUST_STORE_PASSWORD_PATH, "/zkTruststorePasswordPath")
+                .with(ServiceConfig.CERT_FILE, "/cert.pem")
+                .with(ServiceConfig.KEY_FILE, "/key.pem")
+                .with(ServiceConfig.INSTANCE_ID, "1234")
+                .build();
+        Assert.assertNotNull(config.toString());
+    }
+
+
+    // endregion
 }


### PR DESCRIPTION
**Change log description**  
The PR addresses two things:
* Removes a log entry about missing credentials in ClientConfig which was erroneous and misleading (as explained in issue #3576)
* Logs controller and segment store configuration (including security configuration). For sensitive security configuration, it only tells whether the configuration is specified. 

**Purpose of the change**  
Resolves #3576 

**What the code does**  
* Removes a log entry in ClientConfig that was causing problem no. 1 mentioned in the issue. 
* Adds custom toString() implementations to Controller and Segment Store configuration classes where security information present; for rest of the config classes, adds Lombok toString annotation. 
 
   While the scope of the PR was logging for security debugging, it didn't make sense to log only security configuration; The code would be much less elegant and would add a bit of inessential complexity if we limit the scope to logging security config only. So, all configuration is logged, which will also be useful for debugging in general. 
* Uses the above config objects' `toString()` methods to log the config when the Controller and Segment Store Services are started. 

While the code logs the config, it avoids logging configuration information that is sensitive from a security perspective. 

Below are a few examples of what gets logged: 

*Controller Server Config:*
```
ControllerServiceConfigImpl(threadPoolSize=80, storeClientConfig=StoreClientConfigImpl(storeType=Zookeeper, 
zkClientConfig=Optional[ZKClientConfigImpl(connectionString: localhost:4000, namespace: 
pravega/singlenode-92105678-0ece-4afb-a44c-bc0d64d424eb, initialSleepInterval: 2000, maxRetries: 1,
 sessionTimeoutMs: 10000, secureConnectionToZooKeeper: true, trustStorePath is specified, 
trustStorePasswordPath is specified)]), 
hostMonitorConfig=io.pravega.controller.store.host.impl.HostMonitorConfigImpl@638465ac, 
controllerClusterListenerEnabled=false, 
timeoutServiceConfig=TimeoutServiceConfig(maxLeaseValue=120000), 
eventProcessorConfig=Optional[ControllerEventProcessorConfigImpl(scopeName=_system, 
commitStreamName=_commitStream, 
commitStreamScalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, 
scaleFactor=0, minNumSegments=2), abortStreamName=_abortStream, 
abortStreamScalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, 
scaleFactor=0, minNumSegments=2), scaleStreamName=_requeststream, 
scaleStreamScalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, 
scaleFactor=0, minNumSegments=2), commitReaderGroupName=commitStreamReaders, 
commitReaderGroupSize=1, abortReaderGroupName=abortStreamReaders, abortReaderGroupSize=1, 
scaleReaderGroupName=scaleGroup, scaleReaderGroupSize=1, 
commitCheckpointConfig=CheckpointConfig(type=Periodic, 
checkpointPeriod=CheckpointConfig.CheckpointPeriod(numEvents=10, numSeconds=10)), 
abortCheckpointConfig=CheckpointConfig(type=Periodic, 
checkpointPeriod=CheckpointConfig.CheckpointPeriod(numEvents=10, numSeconds=10)), 
scaleCheckpointConfig=CheckpointConfig(type=None, checkpointPeriod=null))], 
gRPCServerConfig=Optional[GRPCServerConfigImpl(port: 9090, publishedRPCHost: localhost, 
publishedRPCPort: 9090, authorizationEnabled: true, userPasswordFile is specified, tokenSigningKey is 
specified, tlsEnabled: true, tlsCertFile is specified, tlsKeyFile is specified, tlsTrustStore is specified, 
replyWithStackTraceOnError: false, requestTracingEnabled: true)], 
restServerConfig=Optional[RESTServerConfigImpl(host: 0.0.0.0, port: 9091, tlsEnabled: true, keyFilePath is 
specified, keyFilePasswordPath is specified)])

```

*SegmentStore ServiceConfig:*
```
ServiceConfig(containerCount: 4, coreThreadPoolSize: 20, storageThreadPoolSize: 200, 
listeningPort: 6000, listeningIPAddress: 127.0.1.1, publishedPort: 6000, publishedIPAddress: 127.0.1.1,
zkURL: localhost:4000, zkRetrySleepMs: 5000, zkSessionTimeoutMs: 10000, zkRetryCount: 5, 
secureZK: true, zkTrustStore is specified, zkTrustStorePasswordPath is specified, 
clusterName: singlenode-0ca69158-a58a-48ac-a6e2-b7169f23203b, dataLogTypeImplementation: 
INMEMORY, storageImplementation: INMEMORY, storageImplementation: INMEMORY, 
readOnlySegmentStore: false, enableTls: true, certFile is specified, keyFile is specified, cachePolicy is 
specified, replyWithStackTraceOnError: false, instanceId: )
```

*SegmentStore AutoScalerConfig:*
```
AutoScalerConfig(controllerUri: tls://localhost:9090, internalRequestStream: _requeststream, 
cooldownDuration: PT10M, muteDuration: PT10M, cacheExpiry: PT20M, cacheCleanup: PT5M, 
tlsEnabled: true, tlsCertFile is specified, authEnabled: true, tokenSigningKey is specified, 
validateHostName: false, threadPoolSize: 10)
```

**How to verify it**  
All unit and system tests should pass. 
