### PR TITLE
Issue 3579: Sporadic unit test failure in TimeoutServiceTest 

### DIFF
--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -140,6 +140,8 @@ public class TimeoutServiceTest {
         streamMetadataTasks.close();
         streamTransactionMetadataTasks.close();
         ExecutorServiceHelpers.shutdown(executor);
+        timeoutService.stopAsync();
+        timeoutService.awaitTerminated();
         client.close();
         storeClient.close();
         zkTestServer.close();


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes an issue in the test where we do not tear down timeoutservice from previous test which can interfere with subsequent test run. 

**Purpose of the change**  
Fixes #3579 

**What the code does**  
We are not closing the timeout service from previous test in tear down

**How to verify it**  
Unit test should consistently pass
