### PR TITLE
Issue 3582: Sporadic unit test failures because of low zk timeouts 

### DIFF
--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -47,7 +47,7 @@ public class StoreClientFactoryTest {
         executor.shutdown();
     }
     
-    @Test
+    @Test(timeout = 60000)
     public void testZkSessionExpiryRetry() throws Exception {
         CompletableFuture<Void> sessionExpiry = new CompletableFuture<>();
         AtomicInteger expirationRetryCounter = new AtomicInteger();

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
@@ -46,7 +46,7 @@ public class ZKStoreHelperTest {
     @Before
     public void setup() throws Exception {
         zkServer = new TestingServerStarter().start();
-        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 100, 100, new RetryNTimes(0, 0));
+        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 10000, 10000, new RetryNTimes(0, 0));
         cli.start();
         zkStoreHelper = new ZKStoreHelper(cli, executor);
     }
@@ -94,6 +94,7 @@ public class ZKStoreHelperTest {
 
         Assert.assertTrue(zkStoreHelper2.createEphemeralZNode("/testEphemeral", new byte[0]).join());
         Assert.assertNotNull(zkStoreHelper2.getData("/testEphemeral", x -> x).join());
+        zkStoreHelper2.getClient().getZookeeperClient().close();
         zkStoreHelper2.getClient().close();
         // let session get expired.
         // now read the data again. Verify that node no longer exists

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
@@ -46,7 +46,7 @@ public class ZkOrderedStoreTest {
     @Before
     public void setup() throws Exception {
         zkServer = new TestingServerStarter().start();
-        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 100, 100, new RetryNTimes(0, 0));
+        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 10000, 10000, new RetryNTimes(0, 0));
         cli.start();
         zkStoreHelper = new ZKStoreHelper(cli, executor);
     }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Increased zk session timeout in couple of tests where the timeout was set to as low as 100ms

**Purpose of the change**  
Fixes #3582 

**What the code does**  
increases zk session timeout in tests. 

Also added test timeout to zksessionExpiration test. 

**How to verify it**  
Unit tests should consistently pass