### PR TITLE
Issue 3590: Improve the latency of small size events

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  */
 class AppendBatchSizeTrackerImpl implements AppendBatchSizeTracker {
     private static final int MAX_BATCH_TIME_MILLIS = 100;
-    private static final int MAX_BATCH_SIZE = 32 * 1024;
+    private static final int MAX_BATCH_SIZE = 8 * 1024;
 
     private final Supplier<Long> clock;
     private final AtomicLong lastAppendNumber;


### PR DESCRIPTION
**Change log description**  
The MAX_BATCH_SIZE is set to 8K at the pravega client to reduce the latency of small size events.

**Purpose of the change**  
fixes #3590 

**What the code does**  
The pravega client accumulates upto 8K (earlier it was 32K) and sends the messages/events to pravega cluster. with 32K , the median latency was 8ms ; by setting it to 8K , the median latency is 6ms.

**How to verify it**  
The Benchmark tests are executed to confirm the latency improvement by this change.

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>