### PR TITLE
Issue 3609: RequestSweeperTest.testRequestSweeper fails on java 11

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -642,7 +642,7 @@ public class StreamMetadataTasks extends TaskBase {
     public CompletableFuture<Void> writeEvent(ControllerEvent event) {
         CompletableFuture<Void> result = new CompletableFuture<>();
 
-        writerInitFuture.thenApply(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event)).whenComplete((r, e) -> {
+        writerInitFuture.thenCompose(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event)).whenComplete((r, e) -> {
             if (e != null) {
                 log.warn("exception while posting event {} {}", e.getClass().getName(), e.getMessage());
                 if (e instanceof TaskExceptions.ProcessingDisabledException) {

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -642,7 +642,7 @@ public class StreamMetadataTasks extends TaskBase {
     public CompletableFuture<Void> writeEvent(ControllerEvent event) {
         CompletableFuture<Void> result = new CompletableFuture<>();
 
-        writerInitFuture.thenApply(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event).whenComplete((r, e) -> {
+        writerInitFuture.thenApply(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event)).whenComplete((r, e) -> {
             if (e != null) {
                 log.warn("exception while posting event {} {}", e.getClass().getName(), e.getMessage());
                 if (e instanceof TaskExceptions.ProcessingDisabledException) {
@@ -655,7 +655,7 @@ public class StreamMetadataTasks extends TaskBase {
                 log.info("event posted successfully");
                 result.complete(null);
             }
-        }));
+        });
 
         return result;
 

--- a/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
@@ -139,7 +139,7 @@ public abstract class RequestSweeperTest {
         signalQueue.put(signal1);
         signalQueue.put(signal2);
         doAnswer(x -> {
-            signalQueue.take().complete(x.getArgument(0));
+            signalQueue.take().complete(null);
             return waitQueue.take();
         }).when(requestEventWriter).writeEvent(any(), any());
         

--- a/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
@@ -9,8 +9,6 @@
  */
 package io.pravega.controller.task.Stream;
 
-import io.pravega.client.ClientConfig;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
@@ -31,7 +29,6 @@ import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.shared.controller.event.ControllerEventSerializer;
 import io.pravega.shared.controller.event.ScaleOpEvent;
 import io.pravega.test.common.TestingServerStarter;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -91,9 +88,6 @@ public abstract class RequestSweeperTest {
         cli.start();
         streamStore = getStream();
 
-        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
-                                                                                        .controllerURI(URI.create("tcp://localhost"))
-                                                                                        .build());
         segmentHelperMock = SegmentHelperMock.getSegmentHelperMock();
         streamMetadataTasks = new StreamMetadataTasks(streamStore, StreamStoreFactory.createInMemoryBucketStore(),
                 TaskStoreFactory.createInMemoryStore(executor), segmentHelperMock, executor, HOSTNAME, AuthHelper.getDisabledAuthHelper(), 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
RequestSweeperTest.testRequestSweeper failed consistently on java 11 because we were completing a `Void` future in the test with a string. 

**Purpose of the change**  
Fixes #3609

**What the code does**  
The test was failing because the mock EventWriter was throwing an exception because we were completing a CompletableFuture<Void> future with a string value that compiler cannot catch because of type erasure in the mock. 

In the course, we also realized that this synchronously throw exception causes writeEvent to not complete the future. 

**How to verify it**  
Test should consistently pass. 
Added new test to verify future completion on synchronous failures during write event in streamMetadataTasks.java. 