### PR TITLE
Issue 3619: Rename session to flow.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
@@ -30,17 +30,17 @@ public class ClientConnectionImpl implements ClientConnection {
     @Getter
     private final String connectionName;
     @Getter
-    private final int session;
+    private final int flowId;
     @VisibleForTesting
     @Getter
-    private final SessionHandler nettyHandler;
+    private final FlowHandler nettyHandler;
     private final AppendBatchSizeTracker batchSizeTracker;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public ClientConnectionImpl(String connectionName,  int session, AppendBatchSizeTracker batchSizeTracker,
-                                SessionHandler nettyHandler) {
+    public ClientConnectionImpl(String connectionName, int flowId, AppendBatchSizeTracker batchSizeTracker,
+                                FlowHandler nettyHandler) {
         this.connectionName = connectionName;
-        this.session = session;
+        this.flowId = flowId;
         this.batchSizeTracker = batchSizeTracker;
         this.nettyHandler = nettyHandler;
     }
@@ -110,14 +110,14 @@ public class ClientConnectionImpl implements ClientConnection {
     @Override
     public void close() {
         if (!closed.getAndSet(true)) {
-            nettyHandler.closeSession(this);
+            nettyHandler.closeFlow(this);
         }
     }
 
     private void checkClientConnectionClosed() throws ConnectionFailedException {
         if (closed.get()) {
-            log.error("ClientConnection to {} with session id {} is already closed", connectionName, session);
-            throw new ConnectionFailedException("Client connection already closed for session " + session);
+            log.error("ClientConnection to {} with flow id {} is already closed", connectionName, flowId);
+            throw new ConnectionFailedException("Client connection already closed for flow " + flowId);
         }
     }
 

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -17,21 +17,21 @@ import lombok.Data;
 
 /**
  * This class represents a Connection that is established with a Segment Store instance and its
- * attributes. (e.g: SessionCount, WriterCount)
+ * attributes. (e.g: FlowCount, WriterCount)
  */
 @Data
 public class Connection {
     private final PravegaNodeUri uri;
-    private final CompletableFuture<SessionHandler> sessionHandler;
+    private final CompletableFuture<FlowHandler> flowHandler;
     
     /**
-     * Returns the number of open sessions on this connection, if the connection has been established.       
+     * Returns the number of open flows on this connection, if the connection has been established.
      */
-    public Optional<Integer> getSessionCount() {
-        if (!Futures.isSuccessful(sessionHandler)) {
+    public Optional<Integer> getFlowCount() {
+        if (!Futures.isSuccessful(flowHandler)) {
             return Optional.empty();
         }
-        return Optional.of(sessionHandler.join().getNumOpenSession());
+        return Optional.of(flowHandler.join().getOpenFlowCount());
     }
 }
 

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
@@ -30,7 +30,7 @@ public interface ConnectionPool extends AutoCloseable {
     CompletableFuture<ClientConnection> getClientConnection(Flow flow, PravegaNodeUri uri, ReplyProcessor rp);
 
     /**
-     * This is used to create a {@link ClientConnection} where sessions are disabled. This implies that only one ClientConnection
+     * This is used to create a {@link ClientConnection} where flows are disabled. This implies that only one ClientConnection
      * can exist on the underlying connection.
      *
      * @param uri The Pravega Node Uri.

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -34,9 +34,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class SessionHandler extends ChannelInboundHandlerAdapter implements AutoCloseable {
+public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoCloseable {
 
-    private static final int SESSION_DISABLED = -1;
+    private static final int FLOW_DISABLED = -1;
     private final String connectionName;
     private final AtomicReference<Channel> channel = new AtomicReference<>();
     private final AtomicReference<ScheduledFuture<?>> keepAliveFuture = new AtomicReference<>();
@@ -46,10 +46,10 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
     private final ReusableFutureLatch<Void> registeredFutureLatch = new ReusableFutureLatch<>();
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)
-    private final ConcurrentHashMap<Integer, ReplyProcessor> sessionIdReplyProcessorMap = new ConcurrentHashMap<>();
-    private final AtomicBoolean disableSession = new AtomicBoolean(false);
+    private final ConcurrentHashMap<Integer, ReplyProcessor> flowIdReplyProcessorMap = new ConcurrentHashMap<>();
+    private final AtomicBoolean disableFlow = new AtomicBoolean(false);
 
-    public SessionHandler(String connectionName, AppendBatchSizeTracker batchSizeTracker) {
+    public FlowHandler(String connectionName, AppendBatchSizeTracker batchSizeTracker) {
         this.connectionName = connectionName;
         this.batchSizeTracker = batchSizeTracker;
     }
@@ -60,46 +60,46 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
      * @param rp ReplyProcessor for the specified flow.
      * @return Client Connection object.
      */
-    public ClientConnection createSession(final Flow flow, final ReplyProcessor rp) {
+    public ClientConnection createFlow(final Flow flow, final ReplyProcessor rp) {
         Exceptions.checkNotClosed(closed.get(), this);
-        Preconditions.checkState(!disableSession.get(), "Ensure sessions are enabled.");
-        log.info("Creating Flow {} for Endpoint {}. The current Channel is {}.", flow.getFlowId(), connectionName, channel.get());
-        if (sessionIdReplyProcessorMap.put(flow.getFlowId(), rp) != null) {
-            throw new IllegalArgumentException("Multiple sessions cannot be created with the same Flow id " + flow.getFlowId());
+        Preconditions.checkState(!disableFlow.get(), "Ensure flows are enabled.");
+        log.info("Creating Flow {} for endpoint {}. The current Channel is {}.", flow.getFlowId(), connectionName, channel.get());
+        if (flowIdReplyProcessorMap.put(flow.getFlowId(), rp) != null) {
+            throw new IllegalArgumentException("Multiple flows cannot be created with the same Flow id " + flow.getFlowId());
         }
         return new ClientConnectionImpl(connectionName, flow.getFlowId(), batchSizeTracker, this);
     }
 
     /**
-     * Create a {@link ClientConnection} where sessions are disabled. This implies that there is only one session on the underlying
+     * Create a {@link ClientConnection} where flows are disabled. This implies that there is only one flow on the underlying
      * network connection.
      * @param rp  The ReplyProcessor.
      * @return Client Connection object.
      */
-    public ClientConnection createConnectionWithSessionDisabled(final ReplyProcessor rp) {
+    public ClientConnection createConnectionWithFlowDisabled(final ReplyProcessor rp) {
         Exceptions.checkNotClosed(closed.get(), this);
-        Preconditions.checkState(!disableSession.getAndSet(true), "Sessions are disabled, incorrect usage pattern.");
-        log.info("Creating a new connection with session disabled for Endpoint {}. The current Channel is {}.", connectionName, channel.get());
-        sessionIdReplyProcessorMap.put(SESSION_DISABLED, rp);
-        return new ClientConnectionImpl(connectionName, SESSION_DISABLED, batchSizeTracker, this);
+        Preconditions.checkState(!disableFlow.getAndSet(true), "Flows are disabled, incorrect usage pattern.");
+        log.info("Creating a new connection with flow disabled for endpoint {}. The current Channel is {}.", connectionName, channel.get());
+        flowIdReplyProcessorMap.put(FLOW_DISABLED, rp);
+        return new ClientConnectionImpl(connectionName, FLOW_DISABLED, batchSizeTracker, this);
     }
 
     /**
-     * Close a session. This is invoked when the ClientConnection is closed.
+     * Close a flow. This is invoked when the ClientConnection is closed.
      * @param clientConnection Client Connection.
      */
-    public void closeSession(ClientConnection clientConnection) {
+    public void closeFlow(ClientConnection clientConnection) {
         final ClientConnectionImpl clientConnectionImpl = (ClientConnectionImpl) clientConnection;
-        int session = clientConnectionImpl.getSession();
-        log.info("Closing Flow: {} for Endpoint: {}", session, clientConnectionImpl.getConnectionName());
-        sessionIdReplyProcessorMap.remove(session);
+        int flow = clientConnectionImpl.getFlowId();
+        log.info("Closing Flow {} for endpoint {}", flow, clientConnectionImpl.getConnectionName());
+        flowIdReplyProcessorMap.remove(flow);
     }
 
     /**
-     * Returns the number of open sessions.
+     * Returns the number of open flows.
      */
-    public int getNumOpenSession() {
-        return sessionIdReplyProcessorMap.size();
+    public int getOpenFlowCount() {
+        return flowIdReplyProcessorMap.size();
     }
     
     /**
@@ -145,7 +145,7 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
         super.channelRegistered(ctx);
         Channel ch = ctx.channel();
         channel.set(ch);
-        log.info("Connection established with Endpoint: {} on ChannelId: {}.", connectionName, ch);
+        log.info("Connection established with endpoint {} on ChannelId {}", connectionName, ch);
         ch.write(new WireCommands.Hello(WireCommands.WIRE_VERSION, WireCommands.OLDEST_COMPATIBLE_VERSION), ch.voidPromise());
         registeredFutureLatch.release(null); //release all futures waiting for channel registration to complete.
         // WireCommands.KeepAlive messages are sent for every network connection to a SegmentStore.
@@ -156,7 +156,7 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
     }
 
     /**
-     * Invoke all the {@link ReplyProcessor#connectionDropped()} for all the registered sessions once the
+     * Invoke all the {@link ReplyProcessor#connectionDropped()} for all the registered flows once the
      * connection is disconnected.
      *
      * @see io.netty.channel.ChannelInboundHandler#channelUnregistered(ChannelHandlerContext)
@@ -169,9 +169,9 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
             future.cancel(false);
         }
         channel.set(null);
-        sessionIdReplyProcessorMap.forEach((sessionId, rp) -> {
+        flowIdReplyProcessorMap.forEach((flowId, rp) -> {
             rp.connectionDropped();
-            log.debug("Connection dropped for session id : {}", sessionId);
+            log.debug("Connection dropped for flow id {}", flowId);
         });
         super.channelUnregistered(ctx);
     }
@@ -179,10 +179,10 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         Reply cmd = (Reply) msg;
-        log.debug(connectionName + " processing reply: {} with session {}.", cmd, Flow.from(cmd.getRequestId()));
+        log.debug(connectionName + " processing reply {} with flow {}", cmd, Flow.from(cmd.getRequestId()));
 
         if (cmd instanceof WireCommands.Hello) {
-            sessionIdReplyProcessorMap.forEach((sessionId, rp) -> rp.hello((WireCommands.Hello) cmd));
+            flowIdReplyProcessorMap.forEach((flowId, rp) -> rp.hello((WireCommands.Hello) cmd));
             return;
         }
 
@@ -201,9 +201,9 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        sessionIdReplyProcessorMap.forEach((sessionId, rp) -> {
+        flowIdReplyProcessorMap.forEach((flowId, rp) -> {
             rp.processingFailure(new ConnectionFailedException(cause));
-            log.debug("Exception observed for session id : {}", sessionId);
+            log.debug("Exception observed for flow id {}", flowId);
         });
     }
 
@@ -212,10 +212,10 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
         if (closed.compareAndSet(false, true)) {
             Channel ch = channel.get();
             if (ch != null) {
-                log.debug("Closing channel:{} ", ch);
-                final int openSessionCount = sessionIdReplyProcessorMap.size();
-                if (openSessionCount != 0) {
-                    log.warn("{} sessions are not closed", openSessionCount);
+                log.debug("Closing channel {} ", ch);
+                final int openFlowCount = flowIdReplyProcessorMap.size();
+                if (openFlowCount != 0) {
+                    log.warn("{} flows are not closed", openFlowCount);
                 }
                 ch.close();
             }
@@ -230,17 +230,17 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
                     Futures.getAndHandleExceptions(getChannel().writeAndFlush(new WireCommands.KeepAlive()), ConnectionFailedException::new);
                 }
             } catch (Exception e) {
-                log.warn("Keep alive failed, killing connection {} due to {} ", connectionName, e.getMessage());
+                log.warn("Keep alive failed, killing connection {} due to {}", connectionName, e.getMessage());
                 close();
             }
         }
     }
 
     private Optional<ReplyProcessor> getReplyProcessor(Reply cmd) {
-        int sessionId = disableSession.get() ? SESSION_DISABLED : Flow.from(cmd.getRequestId()).getFlowId();
-        final ReplyProcessor processor = sessionIdReplyProcessorMap.get(sessionId);
+        int flowId = disableFlow.get() ? FLOW_DISABLED : Flow.from(cmd.getRequestId()).getFlowId();
+        final ReplyProcessor processor = flowIdReplyProcessorMap.get(flowId);
         if (processor == null) {
-            log.warn("No ReplyProcessor found for the provided sessionId {}. Ignoring response", sessionId);
+            log.warn("No ReplyProcessor found for the provided flowId {}. Ignoring response", flowId);
         }
         return Optional.ofNullable(processor);
     }

--- a/client/src/test/java/io/pravega/client/netty/impl/ConnectionPoolingTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/ConnectionPoolingTest.java
@@ -70,10 +70,10 @@ public class ConnectionPoolingTest {
     private final long offset = 1234L;
     private final int length = 1024;
     private final String data = "data";
-    private Function<Long, WireCommands.ReadSegment> readRequestGenerator = session ->
-            new WireCommands.ReadSegment(seg, offset, length, "", session);
-    private Function<Long, WireCommands.SegmentRead> readResponseGenerator = session ->
-            new WireCommands.SegmentRead(seg, offset, true, false, ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8)), session);
+    private Function<Long, WireCommands.ReadSegment> readRequestGenerator = id ->
+            new WireCommands.ReadSegment(seg, offset, length, "", id);
+    private Function<Long, WireCommands.SegmentRead> readResponseGenerator = id ->
+            new WireCommands.SegmentRead(seg, offset, true, false, ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8)), id);
 
     private class EchoServerHandler extends ChannelInboundHandlerAdapter {
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
@@ -22,24 +22,24 @@ public class Append implements Request, Comparable<Append> {
     final int eventCount;
     final ByteBuf data;
     final Long expectedLength;
-    final long sessionId;
+    final long flowId;
 
-    public Append(String segment, UUID writerId, long eventNumber, Event event, long sessionId) {
-        this(segment, writerId, eventNumber, 1, event.getAsByteBuf(), null, sessionId);
+    public Append(String segment, UUID writerId, long eventNumber, Event event, long flowId) {
+        this(segment, writerId, eventNumber, 1, event.getAsByteBuf(), null, flowId);
     }
     
-    public Append(String segment, UUID writerId, long eventNumber, Event event, long expectedLength, long sessionId) {
-        this(segment, writerId, eventNumber, 1, event.getAsByteBuf(), expectedLength, sessionId);
+    public Append(String segment, UUID writerId, long eventNumber, Event event, long expectedLength, long flowId) {
+        this(segment, writerId, eventNumber, 1, event.getAsByteBuf(), expectedLength, flowId);
     }
     
-    public Append(String segment, UUID writerId, long eventNumber, int eventCount, ByteBuf data, Long expectedLength, long sessionId) {
+    public Append(String segment, UUID writerId, long eventNumber, int eventCount, ByteBuf data, Long expectedLength, long flowId) {
         this.segment = segment;
         this.writerId = writerId;
         this.eventNumber = eventNumber;
         this.eventCount = eventCount;
         this.data = data;
         this.expectedLength = expectedLength;
-        this.sessionId = sessionId;
+        this.flowId = flowId;
     }
     
     public int getDataLength() {
@@ -62,6 +62,6 @@ public class Append implements Request, Comparable<Append> {
 
     @Override
     public long getRequestId() {
-        return sessionId;
+        return flowId;
     }
 }


### PR DESCRIPTION
**Change log description**  
Rename session references in the code to flow.

**Purpose of the change**  
Fixes #3619 

**What the code does**  
No changes to functionality. All the remaining `session` references are renamed to `flow`

**How to verify it**  
All the tests should continue to pass.
