### PR TITLE
Issue 3626: Change assertions in ControllerMetricsTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -209,8 +209,9 @@ public class ControllerMetricsTest {
         //Put assertion on different lines so it can tell more information in case of failure.
         Timer latencyValues1 = MetricRegistryUtils.getTimer(getTimerMetricName(CREATE_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues1);
-        Assert.assertTrue("Iterations " + iterations + ", Count " + latencyValues1.count(),  //also system streams created so count() is larger
-                iterations <= latencyValues1.count());
+        AssertExtensions.assertGreaterThanOrEqual("Number of iterations and latency count do not match.",
+                iterations, latencyValues1.count());
+
         Timer latencyValues2 = MetricRegistryUtils.getTimer(getTimerMetricName(SEAL_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues2);
         Assert.assertEquals(iterations, latencyValues2.count());

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -209,23 +209,23 @@ public class ControllerMetricsTest {
         //Put assertion on different lines so it can tell more information in case of failure.
         Timer latencyValues1 = MetricRegistryUtils.getTimer(getTimerMetricName(CREATE_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues1);
-        Assert.assertTrue(iterations <= latencyValues1.count());  //also system streams created so count() is bigger
-
+        Assert.assertTrue("Iterations " + iterations + ", Count " + latencyValues1.count(),  //also system streams created so count() is larger
+                iterations <= latencyValues1.count());
         Timer latencyValues2 = MetricRegistryUtils.getTimer(getTimerMetricName(SEAL_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues2);
-        Assert.assertTrue(iterations == latencyValues2.count());
+        Assert.assertEquals(iterations, latencyValues2.count());
 
         Timer latencyValues3 = MetricRegistryUtils.getTimer(getTimerMetricName(DELETE_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues3);
-        Assert.assertTrue(iterations == latencyValues3.count());
+        Assert.assertEquals(iterations, latencyValues3.count());
 
         Timer latencyValues4 = MetricRegistryUtils.getTimer(getTimerMetricName(UPDATE_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues4);
-        Assert.assertTrue(iterations * iterations == latencyValues4.count());
+        Assert.assertEquals(iterations * iterations, latencyValues4.count());
 
         Timer latencyValues5 = MetricRegistryUtils.getTimer(getTimerMetricName(TRUNCATE_STREAM_LATENCY));
         Assert.assertNotNull(latencyValues5);
-        Assert.assertTrue(iterations * iterations == latencyValues5.count());
+        Assert.assertEquals(iterations * iterations, latencyValues5.count());
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Changes assertions in `ControllerMetricsTest` from `assertTrue` to `assertEquals`. 

**Purpose of the change**  
Fixes #3626 

**What the code does**  
This PR only touches test code. We change in `ControllerMetricsTest` some of the assertions to use `assertEquals` rather than `assertTrue` so that in the case of test failure we observe the values compared.

**How to verify it**  
`./gradlew :test:integration:test -Dtest.single=ControllerMetricsTest`
