### PR TITLE
Issue 3630: Bookiefailovertest failure in docker swarm

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -65,8 +65,6 @@ public class BookkeeperDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.service.name", serviceName);
 
-        Mount mount1 = Mount.builder().type("volume").source("index-volume").target("/bk/index")
-                .build();
         Mount mount2 = Mount.builder().type("volume").source("bookkeeper-logs")
                 .target("/opt/dl_all/distributedlog-service/logs/")
                 .build();
@@ -76,10 +74,12 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
+        String env5 = "BK_useHostNameAsBookieID=false";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);
         stringList.add(env4);
+        stringList.add(env5);
 
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
@@ -88,7 +88,7 @@ public class BookkeeperDockerService extends DockerBasedService {
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())
-                        .mounts(Arrays.asList(mount1, mount2))
+                        .mounts(Arrays.asList(mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -83,6 +83,7 @@ public class PravegaSegmentStoreDockerService extends DockerBasedService {
         stringBuilderMap.put("log.level", "DEBUG");
         stringBuilderMap.put("curator-default-session-timeout", String.valueOf(30 * 1000));
         stringBuilderMap.put("hdfs.replaceDataNodesOnFailure", "false");
+        stringBuilderMap.put("bookkeeper.bkAckQuorumSize", "3");
         for (Map.Entry<String, String> entry : stringBuilderMap.entrySet()) {
             systemPropertyBuilder.append("-D").append(entry.getKey()).append("=").append(entry.getValue()).append(" ");
         }


### PR DESCRIPTION
**Change log description**  
1. Changed bookkeeper.bkAckQuorumSize to `3` in segmentstore
2. Removed index-volumes mount from bookkeeper and explicitly set `BK_useHostNameAsBookieID` to `false`

**Purpose of the change**  
Fixes #3630

**What the code does**  
Default bookkeeper.bkAckQuorumSize is changed from 3 to 2 in `r0.5`. So explicitly  setting to `3` in system tests.
Bookies were not scaling back as the index-volumes are not persisted and there is inconsistency between ZK metadata. 

**How to verify it**  
System tests should pass.
