### PR TITLE
Issue 3635: Sporadic test failure PravegaTablesStreamMetadataTasksTest > checkTruncateCompleteTest 

### DIFF
--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1207,7 +1207,7 @@ public abstract class StreamMetadataTasksTest {
 
         VersionedMetadata<StreamConfigurationRecord> configurationRecord = streamStorePartialMock.getConfigurationRecord(SCOPE, test, null, executor).join();
         assertTrue(configurationRecord.getObject().isUpdating());
-        streamStorePartialMock.completeUpdateConfiguration(SCOPE, test, configurationRecord, null, executor);
+        streamStorePartialMock.completeUpdateConfiguration(SCOPE, test, configurationRecord, null, executor).join();
 
         assertFalse(streamMetadataTasks.isUpdated(SCOPE, test, configuration2, null).get());
 
@@ -1251,7 +1251,7 @@ public abstract class StreamMetadataTasksTest {
 
         VersionedMetadata<StreamTruncationRecord> truncationRecord = streamStorePartialMock.getTruncationRecord(SCOPE, test, null, executor).join();
         assertTrue(truncationRecord.getObject().isUpdating());
-        streamStorePartialMock.completeTruncation(SCOPE, test, truncationRecord, null, executor);
+        streamStorePartialMock.completeTruncation(SCOPE, test, truncationRecord, null, executor).join();
 
         assertFalse(streamMetadataTasks.isTruncated(SCOPE, test, map, null).get());
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
* Adds a call to join to existing test futures to guarantee that the future completes before the assertion. 

**Purpose of the change**  
Fixes #3635 

**What the code does**  
Fixes the test issue where we call a future but dont wait for its completion and check the status of what the future is supposed to do. 

**How to verify it**  
(Optional: steps to verify that the changes are effective)
