### PR TITLE
Issue #3632: Add session to connection before it is established

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -59,12 +59,12 @@ public class ClientConfig implements Serializable {
     /**
      * If the flag {@link #isEnableTls()}  is set, this flag decides whether to enable host name validation or not.
      */
-    private boolean validateHostName;
+    private final boolean validateHostName;
 
     /**
      * Maximum number of connections per Segment store.
      */
-    private int maxConnectionsPerSegmentStore;
+    private final int maxConnectionsPerSegmentStore;
 
     public boolean isEnableTls() {
         String scheme = this.controllerURI.getScheme();

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -9,9 +9,7 @@
  */
 package io.pravega.client.netty.impl;
 
-import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.Data;
 
@@ -22,16 +20,18 @@ import lombok.Data;
 @Data
 public class Connection {
     private final PravegaNodeUri uri;
-    private final CompletableFuture<SessionHandler> sessionHandler;
+    private final SessionHandler sessionHandler;
     
     /**
-     * Returns the number of open sessions on this connection, if the connection has been established.       
+     * A future that completes when the connection is first established.
      */
-    public Optional<Integer> getSessionCount() {
-        if (!Futures.isSuccessful(sessionHandler)) {
-            return Optional.empty();
-        }
-        return Optional.of(sessionHandler.join().getNumOpenSession());
+    private final CompletableFuture<Void> connected;
+    
+    /**
+     * Returns the number of open sessions on this connection     
+     */
+    public int getSessionCount() {
+        return sessionHandler.getNumOpenSession();
     }
 }
 

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -28,7 +28,7 @@ public class Connection {
     private final CompletableFuture<Void> connected;
     
     /**
-     * Returns the number of open flows on this connection     
+     * Returns the number of open flows on this connection. 
      */
     public int getFlowCount() {
         return flowHandler.getOpenFlowCount();

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -184,7 +184,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
      * @param location The Pravega Node Uri
      * @param handler The flow handler for the connection
      * @return A future, which completes once the connection has been established, returning a FlowHandler that can be used to create
-     * sessions on the connection.
+     * flows on the connection.
      */
     private CompletableFuture<Void> establishConnection(PravegaNodeUri location, FlowHandler handler) {  
         final Bootstrap b = getNettyBootstrap().handler(getChannelInitializer(location, handler));

--- a/client/src/main/java/io/pravega/client/netty/impl/SessionHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/SessionHandler.java
@@ -42,6 +42,7 @@ public class SessionHandler extends ChannelInboundHandlerAdapter implements Auto
     private final AtomicReference<ScheduledFuture<?>> keepAliveFuture = new AtomicReference<>();
     private final AtomicBoolean recentMessage = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    @Getter
     private final AppendBatchSizeTracker batchSizeTracker;
     private final ReusableFutureLatch<Void> registeredFutureLatch = new ReusableFutureLatch<>();
     @VisibleForTesting


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Add first session to connection before the connection is established so the pool will know it is used.

**Purpose of the change**  
Fixes #3632 

**What the code does**  
Previously the connection pool was adding the session to the connection once the connection was established. This meant that a concurrent call to open a connection could see the connection as unused if the session had not been added yet. This caused two sessions to be added to the same newly created connection, which made ConnectionLeakTest flaky because the same number of connections were not always used. This change splits out the connection future from the session handler on the connection object. This way the session can be added to the session handler before the connection is established. 

Additionally changes are made to the connection leak test to make it deterministic.

**How to verify it**  
Connection leak test should no longer be flaky.
