### PR TITLE
Issue #3624: Fix backward compatibility issue with WireCommands.

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -95,7 +95,7 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
                 bytesLeftInBlock = currentBlockSize;
                 segmentBeingAppendedTo = append.segment;
                 writerIdPerformingAppends = append.writerId;
-                writeMessage(new AppendBlock(append.getRequestId(), session.id), out);
+                writeMessage(new AppendBlock(session.id), out);
                 if (ctx != null) {
                     ctx.executor().schedule(new BlockTimeouter(ctx.channel(), currentBlockSize),
                                             blockSizeSupplier.getBatchTimeout(),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -544,7 +544,7 @@ public final class WireCommands {
 
         public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
-            byte[] data = new byte[length - Long.SIZE * 2];
+            byte[] data = new byte[length - Long.BYTES * 2];
             in.readFully(data);
             return new AppendBlock(writerId, wrappedBuffer(data));
         }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -524,34 +524,29 @@ public final class WireCommands {
         final WireCommandType type = WireCommandType.APPEND_BLOCK;
         final UUID writerId;
         final ByteBuf data;
-        final long requestId;
 
-        AppendBlock(long requestId, UUID writerId) {
+        AppendBlock(UUID writerId) {
             this.writerId = writerId;
             this.data = Unpooled.EMPTY_BUFFER; // Populated on read path
-            this.requestId = requestId;
         }
 
-        AppendBlock(long requestId, UUID writerId, ByteBuf data) {
+        AppendBlock(UUID writerId, ByteBuf data) {
             this.writerId = writerId;
             this.data = data;
-            this.requestId = requestId;
         }
 
         @Override
         public void writeFields(DataOutput out) throws IOException {
             out.writeLong(writerId.getMostSignificantBits());
             out.writeLong(writerId.getLeastSignificantBits());
-            out.writeLong(requestId);
             // Data not written, as it should be null.
         }
 
         public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
-            byte[] data = new byte[length - Long.BYTES * 3];
-            long requestId = (in.available() >= Long.BYTES) ? in.readLong() : -1L;
+            byte[] data = new byte[length - Long.SIZE * 2];
             in.readFully(data);
-            return new AppendBlock(requestId, writerId, wrappedBuffer(data));
+            return new AppendBlock(writerId, wrappedBuffer(data));
         }
     }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -68,7 +68,7 @@ public class WireCommandsTest {
 
     @Test
     public void testAppendBlock() throws IOException {
-        testCommand(new WireCommands.AppendBlock(l, uuid));
+        testCommand(new WireCommands.AppendBlock(uuid));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Remove unneeded requestId on AppendBlock.

**Purpose of the change**  
Fixes #3624

**What the code does**  
In #3562 a requestId was added to each wire command so that replies could be associated with the appropriate command. This was not strictly necessary (but should have been harmless) for AppendBlock as it gets combined with AppendBlockEnd before being processed and is never replied to individually. The problem was that the logic which was intended to check for the presence of the new field would incorrectly always detect it's presence. This meant that using an older client with a newer server would fail as soon as an append was attempted. This change removes the unneeded field altogether. This returns AppendBlock to it's original format.