### PR TITLE
Issue 3641: Update Pravega version in master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ gradleGitPluginVersion=2.2.0
 k8ClientVersion=3.0.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.5.0-SNAPSHOT
+pravegaVersion=0.6.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Updates Pravega version in master to 0.6.0-SNAPSHOT

**Purpose of the change**  
Fixes #3641 

**What the code does**  
There is no code change. It updates the Pravega version in `gradle.properties`.

**How to verify it**  
`./gradlew install` should produce the correct version.
