### PR TITLE
Issue 3596:  Improved Exception handling for ReplyProcessor.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
@@ -62,11 +62,12 @@ public class ClientConnectionImpl implements ClientConnection {
 
     @Override
     public void sendAsync(WireCommand cmd, CompletedCallback callback) {
+        Channel channel = null;
         try {
             checkClientConnectionClosed();
             nettyHandler.setRecentMessage();
 
-            Channel channel = nettyHandler.getChannel();
+            channel = nettyHandler.getChannel();
             channel.writeAndFlush(cmd)
                    .addListener((Future<? super Void> f) -> {
                        if (f.isSuccess()) {
@@ -76,8 +77,10 @@ public class ClientConnectionImpl implements ClientConnection {
                        }
                    });
         } catch (ConnectionFailedException cfe) {
+            log.debug("ConnectionFaileException observed when attempting to write WireCommand {} ", cmd);
             callback.complete(cfe);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
+            log.warn("Exception while attempting to write WireCommand {} on netty channel {}", cmd, channel);
             callback.complete(new ConnectionFailedException(e));
         }
     }

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -175,7 +175,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
                 rp.connectionDropped();
             } catch (Exception e) {
                 // Suppressing exception which prevents all ReplyProcessor.connectionDropped from being invoked.
-                log.warn("Encountered exception invoking ReplyProcessor for flow id " + flowId, e);
+                log.warn("Encountered exception invoking ReplyProcessor for flow id {}", flowId, e);
             }
         });
         super.channelUnregistered(ctx);
@@ -192,7 +192,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
                     rp.hello((WireCommands.Hello) cmd);
                 } catch (Exception e) {
                     // Suppressing exception which prevents all ReplyProcessor.hello from being invoked.
-                    log.warn("Encountered exception invoking ReplyProcessor.hello for flow id " + flowId, e);
+                    log.warn("Encountered exception invoking ReplyProcessor.hello for flow id {}", flowId, e);
                 }
             });
             return;
@@ -206,7 +206,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
             try {
                 processor.process(cmd);
             } catch (Exception e) {
-                log.error("ReplyProcessor.process failed for reply {} due to {}", cmd, e.getMessage());
+                log.warn("ReplyProcessor.process failed for reply {} due to {}", cmd, e.getMessage());
                 processor.processingFailure(e);
             }
         });
@@ -220,7 +220,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
                 rp.processingFailure(new ConnectionFailedException(cause));
             } catch (Exception e) {
                 // Suppressing exception which prevents all ReplyProcessor.processingFailure from being invoked.
-                log.warn("Encountered exception invoking ReplyProcessor.processingFailure for flow id " + flowId, e);
+                log.warn("Encountered exception invoking ReplyProcessor.processingFailure for flow id {}", flowId, e);
             }
         });
     }

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -206,7 +206,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
             try {
                 processor.process(cmd);
             } catch (Exception e) {
-                log.error("Encountered exception invoking ReplyProcessor.process for reply " + cmd, e);
+                log.error("ReplyProcessor.process failed for reply {} due to {}", cmd, e.getMessage());
                 processor.processingFailure(e);
             }
         });

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -170,8 +170,13 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         }
         channel.set(null);
         flowIdReplyProcessorMap.forEach((flowId, rp) -> {
-            rp.connectionDropped();
-            log.debug("Connection dropped for flow id {}", flowId);
+            try {
+                log.debug("Connection dropped for flow id {}", flowId);
+                rp.connectionDropped();
+            } catch (Exception e) {
+                // Suppressing exception which prevents all ReplyProcessor.connectionDropped from being invoked.
+                log.warn("Encountered exception invoking ReplyProcessor for flow id " + flowId, e);
+            }
         });
         super.channelUnregistered(ctx);
     }
@@ -182,7 +187,14 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         log.debug(connectionName + " processing reply {} with flow {}", cmd, Flow.from(cmd.getRequestId()));
 
         if (cmd instanceof WireCommands.Hello) {
-            flowIdReplyProcessorMap.forEach((flowId, rp) -> rp.hello((WireCommands.Hello) cmd));
+            flowIdReplyProcessorMap.forEach((flowId, rp) -> {
+                try {
+                    rp.hello((WireCommands.Hello) cmd);
+                } catch (Exception e) {
+                    // Suppressing exception which prevents all ReplyProcessor.hello from being invoked.
+                    log.warn("Encountered exception invoking ReplyProcessor.hello for flow id " + flowId, e);
+                }
+            });
             return;
         }
 
@@ -194,6 +206,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
             try {
                 processor.process(cmd);
             } catch (Exception e) {
+                log.error("Encountered exception invoking ReplyProcessor.process for reply " + cmd, e);
                 processor.processingFailure(e);
             }
         });
@@ -202,8 +215,13 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         flowIdReplyProcessorMap.forEach((flowId, rp) -> {
-            rp.processingFailure(new ConnectionFailedException(cause));
-            log.debug("Exception observed for flow id {}", flowId);
+            try {
+                log.debug("Exception observed for flow id {}", flowId, cause);
+                rp.processingFailure(new ConnectionFailedException(cause));
+            } catch (Exception e) {
+                // Suppressing exception which prevents all ReplyProcessor.processingFailure from being invoked.
+                log.warn("Encountered exception invoking ReplyProcessor.processingFailure for flow id " + flowId, e);
+            }
         });
     }
 

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -216,7 +216,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         flowIdReplyProcessorMap.forEach((flowId, rp) -> {
             try {
-                log.debug("Exception observed for flow id {}", flowId, cause);
+                log.debug("Exception observed for flow id {} due to {}", flowId, cause.getMessage());
                 rp.processingFailure(new ConnectionFailedException(cause));
             } catch (Exception e) {
                 // Suppressing exception which prevents all ReplyProcessor.processingFailure from being invoked.

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -181,8 +181,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
             return getConnection()
                     .whenComplete((connection, ex) -> {
                         if (ex != null) {
-                            log.warn("Exception while establishing connection with Pravega " +
-                                    "node", ex);
+                            log.warn("Exception while establishing connection with Pravega node", ex);
                             closeConnection(new ConnectionFailedException(ex));
                         }
                     }).thenCompose(c -> sendRequestOverConnection(request, c));

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -144,7 +144,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
-                log.trace("Iterator reading entry at", offset.get());
+                log.trace("Iterator reading entry at {}", offset.get());
                 in.setOffset(offset.get());
                 try {
                     data = in.read();

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -250,7 +250,7 @@ public class StateSynchronizerImpl<StateT extends Revisioned>
 
     @Override
     public void close() {
-        log.info("Closing stateSynchronizer ", this);
+        log.info("Closing stateSynchronizer {}", this);
         client.close();
     }
 

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -38,7 +38,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -20,11 +20,14 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.AppendBatchSizeTracker;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
+import io.pravega.shared.protocol.netty.Reply;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
 import io.pravega.shared.protocol.netty.WireCommands;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,7 +38,9 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static java.lang.String.valueOf;
@@ -46,9 +51,12 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -59,7 +67,6 @@ public class FlowHandlerTest {
 
     private Flow flow;
     private FlowHandler flowHandler;
-    private ClientConnection clientConnection;
     @Mock
     private ReplyProcessor processor;
     @Mock
@@ -94,11 +101,12 @@ public class FlowHandlerTest {
         when(ch.writeAndFlush(any(Object.class))).thenReturn(completedFuture);
 
         flowHandler = new FlowHandler("testConnection", tracker);
-        clientConnection = flowHandler.createFlow(flow, processor);
     }
 
     @Test
     public void sendNormal() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         // channelRegistered is invoked before send is invoked.
         // No exceptions are expected here.
         flowHandler.channelRegistered(ctx);
@@ -107,6 +115,8 @@ public class FlowHandlerTest {
 
     @Test(expected = ConnectionFailedException.class)
     public void sendError() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         //Send function is invoked without channel registered being invoked.
         //this causes a connectionFailed exception.
         clientConnection.send(appendCmd);
@@ -114,6 +124,8 @@ public class FlowHandlerTest {
 
     @Test(expected = ConnectionFailedException.class)
     public void sendErrorUnRegistered() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         //any send after channelUnregistered should throw a ConnectionFailedException.
         flowHandler.channelRegistered(ctx);
         flowHandler.channelUnregistered(ctx);
@@ -130,6 +142,8 @@ public class FlowHandlerTest {
 
     @Test
     public void completeWhenRegisteredDelayed() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         CompletableFuture<Void> testFuture = new CompletableFuture<>();
         flowHandler.completeWhenRegistered(testFuture);
         flowHandler.channelRegistered(ctx);
@@ -163,6 +177,8 @@ public class FlowHandlerTest {
 
     @Test
     public void testCloseSession() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         flowHandler.channelRegistered(ctx);
         clientConnection.send(appendCmd);
         flowHandler.closeFlow(clientConnection);
@@ -171,6 +187,8 @@ public class FlowHandlerTest {
 
     @Test
     public void testCloseSessionHandler() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         flowHandler.channelRegistered(ctx);
         WireCommands.GetSegmentAttribute cmd = new WireCommands.GetSegmentAttribute(flow.asLong(), "seg", UUID.randomUUID(), "");
         clientConnection.sendAsync(cmd, e -> fail("Exception while invoking sendAsync"));
@@ -192,6 +210,8 @@ public class FlowHandlerTest {
 
     @Test
     public void testChannelUnregistered() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         flowHandler.channelRegistered(ctx);
         clientConnection.send(appendCmd);
         //simulate a connection dropped
@@ -205,20 +225,90 @@ public class FlowHandlerTest {
 
     @Test
     public void testChannelReadWithHello() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         WireCommands.Hello helloCmd = new WireCommands.Hello(8, 4);
         InOrder order = inOrder(processor);
         flowHandler.channelRegistered(ctx);
         flowHandler.channelRead(ctx, helloCmd);
         order.verify(processor, times(1)).hello(helloCmd);
-
     }
 
     @Test
     public void testChannelReadDataAppended() throws Exception {
+        @Cleanup
+        ClientConnection clientConnection = flowHandler.createFlow(flow, processor);
         WireCommands.DataAppended dataAppendedCmd = new WireCommands.DataAppended(flow.asLong(), UUID.randomUUID(), 2, 1);
         InOrder order = inOrder(processor);
         flowHandler.channelRegistered(ctx);
         flowHandler.channelRead(ctx, dataAppendedCmd);
         order.verify(processor, times(1)).process(dataAppendedCmd);
+    }
+
+    @Test
+    public void testHelloWithErrorReplyProcessor() throws Exception {
+        ReplyProcessor errorProcessor = mock(ReplyProcessor.class);
+        @Cleanup
+        ClientConnection connection1 = flowHandler.createFlow(new Flow(11, 0), errorProcessor);
+        @Cleanup
+        ClientConnection connection2 = flowHandler.createFlow(flow, processor);
+        flowHandler.channelRegistered(ctx);
+        doAnswer((Answer<Void>) invocation -> {
+            throw new RuntimeException("Reply processor error");
+        }).when(errorProcessor).hello(any(WireCommands.Hello.class));
+
+        final WireCommands.Hello msg = new WireCommands.Hello(5, 4);
+        flowHandler.channelRead(ctx, msg);
+        verify(processor).hello(msg);
+        verify(errorProcessor).hello(msg);
+    }
+
+    @Test
+    public void testProcessWithErrorReplyProcessor() throws Exception {
+        @Cleanup
+        ClientConnection connection = flowHandler.createFlow(flow, processor);
+        flowHandler.channelRegistered(ctx);
+        doAnswer((Answer<Void>) invocation -> {
+            throw new RuntimeException("ReplyProcessorError");
+        }).when(processor).process(any(Reply.class));
+
+        WireCommands.DataAppended msg = new WireCommands.DataAppended(flow.asLong(), UUID.randomUUID(), 2, 1);
+        flowHandler.channelRead(ctx, msg);
+        verify(processor).process(msg);
+        verify(processor).processingFailure(any(RuntimeException.class));
+    }
+
+    @Test
+    public void testExceptionCaughtWithErrorReplyProcessor() throws Exception {
+        ReplyProcessor errorProcessor = mock(ReplyProcessor.class);
+        @Cleanup
+        ClientConnection connection1 = flowHandler.createFlow(new Flow(11, 0), errorProcessor);
+        @Cleanup
+        ClientConnection connection2 = flowHandler.createFlow(flow, processor);
+        flowHandler.channelRegistered(ctx);
+        doAnswer((Answer<Void>) invocation -> {
+            throw new RuntimeException("Reply processor error");
+        }).when(errorProcessor).processingFailure(any(ConnectionFailedException.class));
+
+        flowHandler.exceptionCaught(ctx, new IOException("netty error"));
+        verify(processor).processingFailure(any(ConnectionFailedException.class));
+        verify(errorProcessor).processingFailure(any(ConnectionFailedException.class));
+    }
+
+    @Test
+    public void testChannelUnregisteredWithErrorReplyProcessor() throws Exception {
+        ReplyProcessor errorProcessor = mock(ReplyProcessor.class);
+        @Cleanup
+        ClientConnection connection1 = flowHandler.createFlow(new Flow(11, 0), errorProcessor);
+        @Cleanup
+        ClientConnection connection2 = flowHandler.createFlow(flow, processor);
+        flowHandler.channelRegistered(ctx);
+        doAnswer((Answer<Void>) invocation -> {
+            throw new RuntimeException("Reply processor error");
+        }).when(errorProcessor).connectionDropped();
+
+        flowHandler.channelUnregistered(ctx);
+        verify(processor).connectionDropped();
+        verify(errorProcessor).connectionDropped();
     }
 }


### PR DESCRIPTION
**Change log description**  
Defensive exception handling for netty callbacks and `io.pravega.shared.protocol.netty.ReplyProcessor` invocations.

**Purpose of the change**  
Fixes #3596

**What the code does**  
This code does not modify/change any functionality, it enables defensive exception handling for netty related operations.

This enhancement request originally was to ensure `Throwable` is  caught for netty related operations. But on closer inspection of the code observed that catching `Throwable` is undesirable and catching `java.lang.Exception` is infact enough.
- `channel.writeAndFlush(..)` : This is now wrapped within  `try {} catch {}` block to handle any Exceptions.
- Reply processor invocation is now wrapped under a `try {} catch {}` block to ensure any exceptions (if thrown) do not cause other invocations to be skipped.
It should be noted that no exceptions were observed for any the cases handled in the pull request. This change enables defensive exception handling to ensure there are no code breakages with any future versions of the ReplyProcessor. 

**How to verify it**  
All the existing tests should continue to pass.
