### PR TITLE
Issue 3638: Ensure the AsyncSegmentInputStreamImpl handles ConnectionFailedException during sendAsync.

### DIFF
--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.client.netty.impl.ClientConnection;
+import io.pravega.client.netty.impl.Flow;
 import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -22,11 +23,13 @@ import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.InlineExecutor;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -37,7 +40,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -82,14 +88,79 @@ public class AsyncSegmentInputStreamTest {
         CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
         assertEquals(segmentRead, readFuture.join());
         assertTrue(Futures.isSuccessful(readFuture));
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
+        verifyNoMoreInteractions(c);
+    }
+
+    @Test(timeout = 10000)
+    public void testRetryWithConnectionFailures() {
+
+        Segment segment = new Segment("scope", "testRetry", 4);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        ClientConnection c = mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, c);
+        MockConnectionFactoryImpl mockedCF = spy(connectionFactory);
+        @Cleanup
+        AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, mockedCF, segment, "");
+        InOrder inOrder = Mockito.inOrder(c);
+
+        // Failed Connection
+        CompletableFuture<ClientConnection> failedConnection = new CompletableFuture<>();
+        failedConnection.completeExceptionally(new ConnectionFailedException("Netty error while establishing connection"));
+
+        // Successful Connection
+        CompletableFuture<ClientConnection> successfulConnection = new CompletableFuture<>();
+        successfulConnection.complete(c);
+
+        WireCommands.SegmentRead segmentRead = new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false,
+                                                                            ByteBufferUtils.EMPTY, in.getRequestId());
+        // simulate a establishConnection failure to segment store.
+        Mockito.doReturn(failedConnection)
+               .doCallRealMethod()
+               .when(mockedCF).establishConnection(any(Flow.class), eq(endpoint), any(ReplyProcessor.class));
+
+        ArgumentCaptor<ClientConnection.CompletedCallback> callBackCaptor =
+                ArgumentCaptor.forClass(ClientConnection.CompletedCallback.class);
+        Mockito.doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                // Simulate a connection failure post establishing connection to SegmentStore.
+                callBackCaptor.getValue().complete(new ConnectionFailedException("SendAsync exception since netty channel is null"));
+                return null;
+            }
+        }).doAnswer(new Answer<Void>() {
+                   public Void answer(InvocationOnMock invocation) {
+                       mockedCF.getProcessor(endpoint).segmentRead(segmentRead);
+                       return null;
+                   }
+               }).when(c).sendAsync(any(ReadSegment.class), callBackCaptor.capture());
+
+        // Read invocation.
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+
+        // Verification.
+        assertEquals(segmentRead, readFuture.join());
+        assertTrue(Futures.isSuccessful(readFuture)); // read completes after 3 retries.
+        // Verify that the reader attempts to establish connection 3 times ( 2 failures followed by a successful attempt).
+        verify(mockedCF, times(3)).establishConnection(any(Flow.class), eq(endpoint), any(ReplyProcessor.class));
+        // The second time sendAsync is invoked but it fail due to the exception.
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
+        // Validate that the connection is closed in case of an error.
+        inOrder.verify(c).close();
+        // Validate that the read command is send again over the new connection.
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
+        // No more interactions since the SSS responds and the ReplyProcessor.segmentRead is invoked by netty.
         verifyNoMoreInteractions(c);
     }
     
@@ -130,7 +201,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);            
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(segmentRead, readFuture.join());
@@ -161,7 +232,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentIsTruncated(segmentIsTruncated);
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
         assertThrows(SegmentTruncatedException.class, () -> readFuture.get());
@@ -175,7 +246,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 5656, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture2));
         assertEquals(segmentRead, readFuture2.join());
@@ -200,7 +271,7 @@ public class AsyncSegmentInputStreamTest {
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.wrap(bad), in.getRequestId()));
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.wrap(good), in.getRequestId()));
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId() )),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId() )),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(ByteBuffer.wrap(good), readFuture.join().getData());

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -23,7 +23,6 @@ import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import io.pravega.test.common.AssertExtensions;
-import io.pravega.test.common.InlineExecutor;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -105,7 +105,7 @@ public class AsyncSegmentInputStreamTest {
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
 
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         ClientConnection c = mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, c);
         MockConnectionFactoryImpl mockedCF = spy(connectionFactory);


### PR DESCRIPTION
**Change log description**  
- Ensure AsyncSegmentInputStreamImpl closes the connection incase a `ConnectionFailedException` is observed during `io.pravega.client.netty.impl.ClientConnection#sendAsync()`

**Purpose of the change**  
Related to issue #3638

**What the code does**  
AsycnSegmentInputStreamImpl invokes `ClientConnection.sendAsync(...)` to send commands like `WireCommand.ReadSegment`. This method can throw a `ConnectionFailedException` incase the underlying Netty Channel was set to null due to `channelUnregistered()` callback by netty. This can cause the AsyncSegmentInputStream to retry until the replyProcessor.connectionDropped() is invoked by `FlowHandler`.

**How to verify it**  
All the existing and newly added tests should pass.
