### PR TITLE
Issue 3575: Enable running of system tests in a Distributed Pravega Cluster with basic authentication enabled.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -818,7 +818,9 @@ project('test:system') {
         if (System.getProperty("imageVersion") == null) {
             systemProperty "imageVersion", "INVALID_IMAGE_VERSION"
         }
-
+        
+        systemProperty "securityEnabled", System.getProperty("securityEnabled", "false")
+       
         maxParallelForks = 1
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -457,7 +457,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         }
                     });
         } catch (Exception e) {
-            log.error("Controller api failed with authenticator error");
+            log.error("Controller api failed with authenticator error", e);
             logAndUntrackRequestTag(requestTag);
             streamObserver.onError(Status.UNAUTHENTICATED
                     .withDescription("Authentication failed")

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -26,6 +26,7 @@ import io.kubernetes.client.models.V1beta1SubjectBuilder;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.test.system.framework.TestExecutor;
 import io.pravega.test.system.framework.TestFrameworkException;
+import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.kubernetes.ClientFactory;
 import io.pravega.test.system.framework.kubernetes.K8sClient;
 import java.util.Map;
@@ -106,6 +107,7 @@ public class K8SequentialExecutor implements TestExecutor {
     }
 
     private V1Pod getTestPod(String className, String methodName, String podName) {
+        log.info("Running test pod with security enabled :{}", Utils.AUTH_ENABLED);
         return new V1PodBuilder()
                 .withNewMetadata().withName(podName).withNamespace(NAMESPACE).withLabels(ImmutableMap.of("POD_NAME", podName)).endMetadata()
                 .withNewSpec().withServiceAccountName(SERVICE_ACCOUNT).withAutomountServiceAccountToken(true)
@@ -117,7 +119,7 @@ public class K8SequentialExecutor implements TestExecutor {
                 .withImage("openjdk:8u181-jre-alpine")
                 .withImagePullPolicy("IfNotPresent")
                 .withCommand("/bin/sh")
-                .withArgs("-c", "java -DexecType=KUBERNETES -cp /data/test-collection.jar io.pravega.test.system.SingleJUnitTestRunner "
+                .withArgs("-c", "java -DexecType=KUBERNETES -DsecurityEnabled=" + Utils.AUTH_ENABLED + " -cp /data/test-collection.jar io.pravega.test.system.SingleJUnitTestRunner "
                                   + className + "#" + methodName /*+ " > server.log 2>&1 */ + "; exit $?")
                 .withVolumeMounts(new V1VolumeMountBuilder().withMountPath("/data").withName("task-pv-storage").build())
                 .endContainer()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
@@ -9,15 +9,16 @@
  */
 package io.pravega.test.system.framework.services.kubernetes;
 
+import com.google.common.collect.ImmutableMap;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.test.system.framework.TestFrameworkException;
 import lombok.extern.slf4j.Slf4j;
-
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+
 
 import static io.pravega.test.system.framework.TestFrameworkException.Type.RequestFailed;
 
@@ -25,15 +26,17 @@ import static io.pravega.test.system.framework.TestFrameworkException.Type.Reque
 public class PravegaSegmentStoreK8sService extends AbstractService {
 
     private final URI zkUri;
+    private final ImmutableMap<String, String> properties;
 
-    public PravegaSegmentStoreK8sService(final String id, final URI zkUri) {
+    public PravegaSegmentStoreK8sService(final String id, final URI zkUri, ImmutableMap<String, String> properties) {
         super(id);
         this.zkUri = zkUri;
+        this.properties = properties;
     }
 
     @Override
     public void start(boolean wait) {
-        Futures.getAndHandleExceptions(deployPravegaUsingOperator(zkUri, DEFAULT_CONTROLLER_COUNT, DEFAULT_SEGMENTSTORE_COUNT, DEFAULT_BOOKIE_COUNT),
+        Futures.getAndHandleExceptions(deployPravegaUsingOperator(zkUri, DEFAULT_CONTROLLER_COUNT, DEFAULT_SEGMENTSTORE_COUNT, DEFAULT_BOOKIE_COUNT, properties),
                                        t -> new TestFrameworkException(RequestFailed, "Failed to deploy pravega operator/pravega services", t));
         if (wait) {
             Futures.getAndHandleExceptions(k8sClient.waitUntilPodIsRunning(NAMESPACE, "component", PRAVEGA_SEGMENTSTORE_LABEL, DEFAULT_SEGMENTSTORE_COUNT),
@@ -94,7 +97,7 @@ public class PravegaSegmentStoreK8sService extends AbstractService {
                            log.debug("Current instance counts : Bookkeeper {} Controller {} SegmentStore {}.", currentBookkeeperCount,
                                      currentControllerCount, currentSegmentStoreCount);
                            if (currentSegmentStoreCount != newInstanceCount) {
-                               return deployPravegaUsingOperator(zkUri, currentControllerCount, newInstanceCount, currentBookkeeperCount)
+                               return deployPravegaUsingOperator(zkUri, currentControllerCount, newInstanceCount, currentBookkeeperCount, properties)
                                        .thenCompose(v -> k8sClient.waitUntilPodIsRunning(NAMESPACE, "component", PRAVEGA_SEGMENTSTORE_LABEL, newInstanceCount));
                            } else {
                                return CompletableFuture.completedFuture(null);

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -43,16 +43,15 @@ abstract class AbstractScaleTests extends AbstractReadWriteTest {
 
     public AbstractScaleTests() {
         controllerURI = createControllerURI();
-        connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        controller = createController();
-        clientFactory = new ClientFactoryImpl(SCOPE, getController());
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+        connectionFactory = new ConnectionFactoryImpl(clientConfig);
+        controller = createController(clientConfig);
+        clientFactory = new ClientFactoryImpl(SCOPE, getController(), new ConnectionFactoryImpl(clientConfig));
     }
 
-    private ControllerImpl createController() {
+    private ControllerImpl createController(final ClientConfig clientConfig) {
         return new ControllerImpl(ControllerImplConfig.builder()
-                                                      .clientConfig(ClientConfig.builder()
-                                                                                .controllerURI(getControllerURI())
-                                                                                .build())
+                                                      .clientConfig(clientConfig)
                                                       .build(),
                                   getConnectionFactory().getInternalExecutor());
     }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -27,7 +27,6 @@ import static io.pravega.test.system.framework.Utils.EXECUTOR_TYPE;
  */
 @Slf4j
 abstract class AbstractSystemTest {
-
     static final Predicate<URI> ISGRPC = uri -> {
         switch (EXECUTOR_TYPE) {
             case REMOTE_SEQUENTIAL:
@@ -50,6 +49,10 @@ abstract class AbstractSystemTest {
 
     static void startBookkeeperInstances(final URI zkUri) {
         Service bkService = Utils.createBookkeeperService(zkUri);
+        startBkService(bkService);
+    }
+
+    private static void startBkService(Service bkService) {
         if (!bkService.isRunning()) {
             bkService.start(true);
         }
@@ -59,6 +62,10 @@ abstract class AbstractSystemTest {
 
     static URI ensureControllerRunning(final URI zkUri) {
         Service conService = Utils.createPravegaControllerService(zkUri);
+        return startControllerService(conService);
+    }
+
+    private static URI startControllerService(Service conService) {
         if (!conService.isRunning()) {
             conService.start(true);
         }
@@ -70,6 +77,10 @@ abstract class AbstractSystemTest {
 
     static List<URI> ensureSegmentStoreRunning(final URI zkUri, final URI controllerURI) {
         Service segService = Utils.createPravegaSegmentStoreService(zkUri, controllerURI);
+        return startSegmentStoreService(segService);
+    }
+
+    private static List<URI> startSegmentStoreService(Service segService) {
         if (!segService.isRunning()) {
             segService.start(true);
         }

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -10,10 +10,10 @@
 
 package io.pravega.test.system;
 
-import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -114,20 +114,21 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
 
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                 "BookieFailoverTest-controller");
+
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                .clientConfig(Utils.buildClientConfig(controllerURIDirect))
                 .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
 
         testState = new TestState(false);
         //read and write count variables
         testState.writersListComplete.add(0, testState.writersComplete);
-        streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(Utils.buildClientConfig(controllerURIDirect));
         createScopeAndStream(SCOPE, STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", SCOPE);
-        clientFactory = new ClientFactoryImpl(SCOPE, controller);
-        readerGroupManager = ReaderGroupManager.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        clientFactory = new ClientFactoryImpl(SCOPE, controller, new ConnectionFactoryImpl(Utils.buildClientConfig(controllerURIDirect)));
+        readerGroupManager = ReaderGroupManager.withScope(SCOPE, Utils.buildClientConfig(controllerURIDirect));
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ByteClientTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ByteClientTest.java
@@ -10,7 +10,6 @@
 package io.pravega.test.system;
 
 import io.pravega.client.ByteStreamClientFactory;
-import io.pravega.client.ClientConfig;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.byteStream.ByteStreamReader;
@@ -94,7 +93,8 @@ public class ByteClientTest extends AbstractSystemTest {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();
         controllerURI = ctlURIs.get(0);
-        streamManager = StreamManager.create(controllerURI);
+
+        streamManager = StreamManager.create(Utils.buildClientConfig(controllerURI));
         assertTrue("Creating scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, config));
     }
@@ -115,11 +115,12 @@ public class ByteClientTest extends AbstractSystemTest {
      */
     @Test
     public void byteClientTest() throws IOException {
+        log.info("byteClientTest:: with security enabled: {}", Utils.AUTH_ENABLED);
+
         @Cleanup
-        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(Utils.buildClientConfig(controllerURI));
         ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder()
-                .clientConfig(ClientConfig.builder()
-                        .controllerURI(controllerURI).build()).build(),
+                                                                           .clientConfig(Utils.buildClientConfig(controllerURI)).build(),
                 connectionFactory.getInternalExecutor());
         @Cleanup
         ClientFactory clientFactory = new ClientFactoryImpl(SCOPE, controller);

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -96,10 +96,11 @@ public class ControllerFailoverTest extends AbstractSystemTest {
         Map<Double, Double> newRangesToCreate = new HashMap<>();
         newRangesToCreate.put(0.0, 1.0);
 
+        ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         // Connect with first controller instance.
         final Controller controller1 = new ControllerImpl(
                 ControllerImplConfig.builder()
-                                    .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                    .clientConfig(clientConfig)
                                     .build(), executorService);
 
         // Create scope, stream, and a transaction with high timeout value.
@@ -131,11 +132,12 @@ public class ControllerFailoverTest extends AbstractSystemTest {
         controllerURIDirect = URI.create("tcp://" + String.join(",", uris));
         log.info("Controller Service direct URI: {}", controllerURIDirect);
 
+        ClientConfig clientConf = Utils.buildClientConfig(controllerURIDirect);
         // Connect to another controller instance.
         @Cleanup
         final Controller controller2 = new ControllerImpl(
                 ControllerImplConfig.builder()
-                                    .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                    .clientConfig(clientConf)
                                     .build(), executorService);
 
         // Note: if scale does not complete within desired time, test will timeout.

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -1,11 +1,10 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.system;
 
@@ -13,6 +12,7 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -95,23 +95,20 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         assertTrue(segmentStoreInstance.isRunning());
         log.info("Pravega Segmentstore service instance details: {}", segmentStoreInstance.getServiceDetails());
         //executor service
-        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 2,
-                                                                        "MultiReaderTxnWriterWithFailoverTest-main");
-        controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
-                                                                                  "MultiReaderTxnWriterWithFailoverTest-controller");
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(NUM_READERS + NUM_WRITERS + 2, "MultiReaderTxnWriterWithFailoverTest-main");
+        controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2, "MultiReaderTxnWriterWithFailoverTest-controller");
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         //get Controller Uri
-        controller = new ControllerImpl(
-                                        ControllerImplConfig.builder()
-                                                            .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
-                                                            .maxBackoffMillis(5000).build(),
-                                        controllerExecutorService);
+        controller = new ControllerImpl(ControllerImplConfig.builder()
+                                                            .clientConfig(clientConfig)
+                                                            .maxBackoffMillis(5000).build(), controllerExecutorService);
         testState = new TestState(true);
         //read and write count variables
-        streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(clientConfig);
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
-        clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,  ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        clientFactory = new ClientFactoryImpl(scope, controller, new ConnectionFactoryImpl(clientConfig));
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
     }
 
     @After
@@ -128,7 +125,7 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
         //scale the controller and segmentStore back to 1 instance.
         Futures.getAndHandleExceptions(controllerInstance.scaleService(1), ExecutionException::new);
         Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(1), ExecutionException::new);
-}
+    }
 
     @Test
     public void multiReaderTxnWriterWithFailOverTest() throws Exception {

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -13,6 +13,7 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -98,19 +99,22 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
 
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                 "MultiReaderWriterWithFailoverTest-controller");
+
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                    .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                    .clientConfig(clientConfig)
                                     .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
 
         testState = new TestState(false);
+
         //read and write count variables
-        streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(clientConfig);
         createScopeAndStream(scope, STREAM_NAME, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
-        clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        clientFactory = new ClientFactoryImpl(scope, controller, new ConnectionFactoryImpl(clientConfig));
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -127,8 +127,9 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
         String scope = "testscope" + RandomStringUtils.randomAlphanumeric(10);
         String stream = "teststream" + RandomStringUtils.randomAlphanumeric(10);
 
+        ClientConfig clientConfig = Utils.buildClientConfig(controllerUri);
         @Cleanup
-        StreamManager streamManager = StreamManager.create(ClientConfig.builder().controllerURI(controllerUri).build());
+        StreamManager streamManager = StreamManager.create(clientConfig);
         Assert.assertTrue(streamManager.createScope(scope));
 
         // Create stream with large number of segments so that most segment containers are used.
@@ -138,7 +139,7 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
 
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerUri).build());
+                clientConfig);
 
         log.info("Invoking writer with controller URI: {}", controllerUri);
         @Cleanup
@@ -156,7 +157,7 @@ public class MultiSegmentStoreTest extends AbstractSystemTest {
 
         log.info("Invoking reader with controller URI: {}", controllerUri);
         final String readerGroup = "testreadergroup" + RandomStringUtils.randomAlphanumeric(10);
-        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerUri).build());
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(scope, clientConfig);
         groupManager.createReaderGroup(readerGroup,
                 ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream(Stream.of(scope, stream)).build());
 

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -14,6 +14,7 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
@@ -101,17 +102,19 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
                 "ReadTxnWriteAutoScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                 "ReadTxnWriteAutoScaleWithFailoverTest-controller");
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                         .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                         .clientConfig(clientConfig)
                                          .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(true);
-        streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(clientConfig);
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
-        clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope, ClientConfig.builder().controllerURI(controllerURIDirect).build());
+
+        clientFactory = new ClientFactoryImpl(scope, controller, new ConnectionFactoryImpl(clientConfig));
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -106,18 +106,18 @@ public class ReadTxnWriteScaleWithFailoverTest extends AbstractFailoverTests {
                 "ReadTxnWriteScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                 "ReadTxnWriteScaleWithFailoverTest-controller");
+        ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                    .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                    .clientConfig(clientConfig)
                                     .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(true);
-        streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(clientConfig);
         createScopeAndStream(scope, stream, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -25,6 +25,7 @@ import io.pravega.common.hash.RandomFactory;
 import io.pravega.common.util.Retry;
 import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
+import io.pravega.test.system.framework.Utils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -121,7 +122,7 @@ public class ReadWithAutoScaleTest extends AbstractScaleTests {
         //2.1 Create a reader group.
         log.info("Creating Reader group : {}", READER_GROUP_NAME);
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, Utils.buildClientConfig(controllerUri));
         readerGroupManager.createReaderGroup(READER_GROUP_NAME, ReaderGroupConfig.builder().stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         //2.2 Create readers.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.test.system;
 
-import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
@@ -101,19 +100,19 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
                                                                         "ReadWriteAndAutoScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                                                                                   "ReadWriteAndAutoScaleWithFailoverTest-controller");
+
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                                            .clientConfig( ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                                            .clientConfig(Utils.buildClientConfig(controllerURIDirect))
                                                             .maxBackoffMillis(5000).build(),
                                         controllerExecutorService);
         testState = new TestState(false);
-        streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(Utils.buildClientConfig(controllerURIDirect));
         createScopeAndStream(scope, AUTO_SCALE_STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
 
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        readerGroupManager = ReaderGroupManager.withScope(scope, Utils.buildClientConfig(controllerURIDirect));
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -107,18 +107,19 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
                 "ReadWriteAndScaleWithFailoverTest-main");
         controllerExecutorService = ExecutorServiceHelpers.newScheduledThreadPool(2,
                 "ReadWriteAndScaleWithFailoverTest-controller");
+
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURIDirect);
         //get Controller Uri
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                    .clientConfig(ClientConfig.builder().controllerURI(controllerURIDirect).build())
+                                    .clientConfig(clientConfig)
                                     .maxBackoffMillis(5000).build(),
                 controllerExecutorService);
         testState = new TestState(false);
-        streamManager = new StreamManagerImpl( ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        streamManager = new StreamManagerImpl(clientConfig);
         createScopeAndStream(scope, SCALE_STREAM, config, streamManager);
         log.info("Scope passed to client factory {}", scope);
         clientFactory = new ClientFactoryImpl(scope, controller);
-        readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder().controllerURI(controllerURIDirect).build());
+        readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
     }
 
     @After

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -101,12 +101,14 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     @Test
     public void readerCheckpointTest() {
         controllerURI = fetchControllerURI();
-        StreamManager streamManager = StreamManager.create(controllerURI);
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        StreamManager streamManager = StreamManager.create(clientConfig);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_1));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_1, STREAM, streamConfig));
 
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_1, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_1, clientConfig);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME,
                 ReaderGroupConfig.builder().stream(io.pravega.client.stream.Stream.of(SCOPE_1, STREAM)).build());
         @Cleanup
@@ -155,13 +157,16 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
 
     @Test
     public void generateStreamCutsTest() {
+
         controllerURI = fetchControllerURI();
-        StreamManager streamManager = StreamManager.create(controllerURI);
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        StreamManager streamManager = StreamManager.create(clientConfig);
         assertTrue("Creating Scope", streamManager.createScope(SCOPE_2));
         assertTrue("Creating stream", streamManager.createStream(SCOPE_2, STREAM, streamConfig));
 
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_2, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_2, clientConfig);
         readerGroupManager.createReaderGroup(READER_GROUP_NAME,
                                              ReaderGroupConfig.builder()
                                                               .stream(io.pravega.client.stream.Stream.of(SCOPE_2, STREAM))
@@ -216,7 +221,9 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         String readerId = "checkPointReader";
         CompletableFuture<Checkpoint> checkpoint = null;
 
-        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE_1, ClientConfig.builder().controllerURI(controllerURI).build());
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE_1, clientConfig);
              EventStreamReader<Integer> reader = clientFactory.createReader(readerId, READER_GROUP_NAME,
                      new JavaSerializer<Integer>(), readerConfig)) {
 
@@ -235,7 +242,9 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
         String readerId = "streamCut";
         CompletableFuture<Map<io.pravega.client.stream.Stream, StreamCut>> streamCuts = null;
 
-        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE_2, ClientConfig.builder().controllerURI(controllerURI).build());
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE_2, clientConfig);
              EventStreamReader<Integer> reader = clientFactory.createReader(readerId, READER_GROUP_NAME,
                                                                             new JavaSerializer<Integer>(), readerConfig)) {
 
@@ -297,7 +306,9 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     private <T extends Serializable> List<EventRead<T>> readEvents(final String scope, final String readerId) {
         List<EventRead<T>> events = new ArrayList<>();
 
-        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder().controllerURI(controllerURI).build());
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
              EventStreamReader<T> reader = clientFactory.createReader(readerId,
                      READER_GROUP_NAME,
                      new JavaSerializer<T>(),
@@ -326,7 +337,9 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
     }
 
     private <T extends Serializable> void writeEvents(final String scope, final List<T> events) {
-        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder().controllerURI(controllerURI).build());
+
+        ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+        try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
              EventStreamWriter<T> writer = clientFactory.createEventWriter(STREAM,
                      new JavaSerializer<T>(),
                      EventWriterConfig.builder().build())) {

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -101,10 +101,14 @@ public class StreamCutsTest extends AbstractReadWriteTest {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();
         controllerURI = ctlURIs.get(0);
+
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                                            .clientConfig( ClientConfig.builder().controllerURI(controllerURI).build())
+                                                            .clientConfig(clientConfig)
                                                             .maxBackoffMillis(5000).build(), executor);
-        streamManager = StreamManager.create(controllerURI);
+        streamManager = StreamManager.create(clientConfig);
+
         assertTrue("Creating scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream one", streamManager.createStream(SCOPE, STREAM_ONE,
                 StreamConfiguration.builder()
@@ -133,10 +137,12 @@ public class StreamCutsTest extends AbstractReadWriteTest {
      */
     @Test
     public void streamCutsTest() {
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
         @Cleanup
-        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, ClientConfig.builder().controllerURI(controllerURI).build());
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, clientConfig);
         @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, controllerURI);
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE, clientConfig);
         readerGroupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder()
                                                                             .stream(Stream.of(SCOPE, STREAM_ONE))
                                                                             .stream(Stream.of(SCOPE, STREAM_TWO)).build());

--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -80,9 +80,12 @@ public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();
         controllerURI = ctlURIs.get(0);
-        streamManager = StreamManager.create(controllerURI);
+
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
+        streamManager = StreamManager.create(clientConfig);
         controller = new ControllerImpl(ControllerImplConfig.builder()
-                                                            .clientConfig(ClientConfig.builder().controllerURI(controllerURI).build())
+                                                            .clientConfig(clientConfig)
                                                             .maxBackoffMillis(5000).build(), executor);
 
         // Performance inspection.
@@ -148,6 +151,9 @@ public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
     }
 
     private void testCreateSealAndDeleteStreams(String scope) {
+
+        final ClientConfig clientConfig = Utils.buildClientConfig(controllerURI);
+
         for (int j = 1; j <= NUM_STREAMS; j++) {
             final String stream = String.valueOf(j);
             StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(j)).build();
@@ -171,7 +177,7 @@ public class StreamsAndScopesManagementTest extends AbstractReadWriteTest {
             if (j % 2 == 0) {
                 log.info("Writing events in stream {}/{}.", scope, stream);
                 @Cleanup
-                EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder().controllerURI(controllerURI).build());
+                EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
                 writeEvents(clientFactory, stream, NUM_EVENTS);
             }
 

--- a/test/system/src/test/resources/pravega.properties
+++ b/test/system/src/test/resources/pravega.properties
@@ -1,0 +1,16 @@
+# Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+autoScale.muteInSeconds=120
+autoScale.cooldownInSeconds=120
+autoScale.cacheExpiryInSeconds=120
+autoScale.cacheCleanUpInSeconds=120
+curator-default-session-timeout=10000
+bookkeeper.bkAckQuorumSize=3
+controller.transaction.maxLeaseValue=60000
+controller.retention.frequencyMinutes=2
+log.level=DEBUG

--- a/test/system/src/test/resources/pravega_withAuth.properties
+++ b/test/system/src/test/resources/pravega_withAuth.properties
@@ -1,0 +1,21 @@
+# Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+autoScale.muteInSeconds=120
+autoScale.cooldownInSeconds=120
+autoScale.cacheExpiryInSeconds=120
+autoScale.cacheCleanUpInSeconds=120
+curator-default-session-timeout=10000
+bookkeeper.bkAckQuorumSize=3
+controller.transaction.maxLeaseValue=60000
+controller.retention.frequencyMinutes=2
+log.level=DEBUG
+controller.auth.enabled=true
+controller.auth.userPasswordFile=/opt/pravega/conf/passwd
+controller.auth.tokenSigningKey=secret
+autoScale.authEnabled=true
+autoScale.tokenSigningKey=secret


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Allow users to run all system tests on a Pravega Distributed Cluster, with basic authentication enabled . 

**Purpose of the change**  
Fixes #3575  
This change enables running of system tests with authentication enabled in Controller and Segment Store. The basic 'admin' username & password provided via default password file in the controller image (/opt/pravega/conf/passwd) are used for authentication.

**What the code does**  
Moved the system properties being set inside AbstractService.java into a properties file in the resources folder. These are set to their default values when security is disabled, and include the appropriate additional properties when security is enabled.
The current gradle task 'startK8SystemTests' can now be invoked with "-DsecurityEnabled=true" flag to run all system tests with security (auth) enabled. When not set (default), the value of this flag would be 'false' and tests would run with security 'disabled'. Jenkins jobs would also have the option of running system tests with security enabled or disabled.

**How to verify it**  

After this test run, verified options set in pravega cluster using :

'kubectl get pravegacluster pravega -o yaml'
And the following security properties were present in the pravega spec under 'options':
"controller.auth.enabled" "true"
"controller.auth.userPasswordFile" "/opt/pravega/conf/passwd"
"controller.auth.tokenSigningKey" "secret"
"autoScale.authEnabled" "true"
"autoScale.tokenSigningKey" "secret"

Also checked the Controller and segment store logs for these system properties to be set at startup.

Executed all system tests successfully with security disabled.
Test Results: https://asd-nautilus-jenkins.isus.emc.com/job/test-pravega-continuous/1960/System_20Tests/
StreamCutsTest fails with security enabled and disabled.
But failure is not due to authentication in both cases.

On executing tests with security(auth) enabled,  the following tests failed with security enabled:
AutoScaleTest - Authentication between Controller and Segment Store fails.
ControllerRestAPITest - fails even when default basic auth credentials are added to jersey client and tls is enabled.
Readtxnwriteautoscalewithfailovertest - Authentication between Controller and Segment Store fails.

These require fixes on Controller and Segment Store and would be addressed as part of issue: https://github.com/pravega/pravega/issues/3777 and https://github.com/pravega/pravega/issues/3779


