### PR TITLE
Issue 3649: Invoke grgit plugin only if git repository is present.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -913,7 +913,7 @@ project('test:system') {
 
 def getProjectVersion() {
     String ver = pravegaVersion
-    if (ver.contains("-SNAPSHOT")) {
+    if (grgit && ver.contains("-SNAPSHOT")) {
         String versionLabel = ver.substring(0, ver.indexOf("-SNAPSHOT"))
         def count = grgit.log(includes:['HEAD']).size()
         def commitId = "${grgit.head().abbreviatedId}"


### PR DESCRIPTION
**Change log description**  
- Ensure grgit plugin is invoked only if git repository is present.

**Purpose of the change**  
Fixes #3649 

**What the code does**  
`grgit` plugin is used to fetch information about the git repository like the commit id and commit count.
Invoking `./gradlew distribution` on `branch-0.5` (`https://github.com/pravega/pravega/archive/branch-0.5.tar.gz`) release causes the grgit plugin to fail since it is not a git repository. This change ensures that commit id is fetched only in case grgit plugin is able to fetch details of the repository.


**How to verify it**  
No changes to functionality. Verified that `./gradlew distribution` works when invoked on `branch-0.5` located @ `https://github.com/pravega/pravega/archive/branch-0.5.tar.gz`
