### PR TITLE
Issue 3659: Update the config.properties file to document hdfs.replaceDataNodesOnFailure usage

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -344,6 +344,12 @@ hdfs.hdfsUrl=localhost:9000
 # Recommended values: Multiples of 1MB.
 #hdfs.blockSize=1048576
 
+# Whether to replace DataNodes on failure or not.
+# Valid values: Boolean.
+# Recommended values: false for small clusters, true otherwise. This should be set to true for deployments where
+# sufficient data nodes are available(More than Max(3, replication)), otherwise set to false.
+#hdfs.replaceDataNodesOnFailure=false
+
 ##endregion
 
 ##region Extended S3 settings


### PR DESCRIPTION
Issue 3659: Update the config.properties file to document hdfs.replaceDataNodesOnFailure usage

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  

Update the config.properties file to document hdfs.replaceDataNodesOnFailure usage

**Purpose of the change**  
Related #3659 , #3400, #2967 

**What the code does**  
No code changes.
The configuration hdfs.replaceDataNodesOnFailure is not documented/exposed in the config.properties though HDFSStorageConfig makes use of this property.Need to fix the configuration file to include this property. 

**How to verify it**  
No code changes. 
