### PR TITLE
Issue 3673: New controller instance is not updating segment container map unless there is an update

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
@@ -83,7 +83,7 @@ public class ZKHostStore implements HostControllerStore {
             ZKUtils.createPathIfNotExists(zkClient, zkPath, HostContainerMap.EMPTY.toBytes());
             hostContainerMapNode.getListenable().addListener(this::updateMap);
             hostContainerMapNode.start(true);
-
+            updateMap();
             zkInit = true;
         }
     }

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -146,7 +146,7 @@ public class SegmentContainerMonitorTest {
         monitor.startAsync().awaitRunning();
 
         assertEquals(hostStore.getContainerCount(), Config.HOST_STORE_CONTAINER_COUNT);
-        
+
         //Rebalance should be triggered for the very first attempt. Verify that no hosts are added to the store.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -146,18 +146,13 @@ public class SegmentContainerMonitorTest {
         monitor.startAsync().awaitRunning();
 
         assertEquals(hostStore.getContainerCount(), Config.HOST_STORE_CONTAINER_COUNT);
-
-        assertEquals(0, hostStore.getHostContainersMap().size());
-        if (latches != null) {
-            latches.get(0).join();
-        }
-
+        
         //Rebalance should be triggered for the very first attempt. Verify that no hosts are added to the store.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
-        assertEquals(0, hostStore.getHostContainersMap().size());
         if (latches != null) {
             latches.get(1).join();
         }
+        assertEquals(0, hostStore.getHostContainersMap().size());
 
         //New host added.
         cluster.registerHost(new Host("localhost1", 1, null));

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -147,18 +147,23 @@ public class SegmentContainerMonitorTest {
 
         assertEquals(hostStore.getContainerCount(), Config.HOST_STORE_CONTAINER_COUNT);
 
+        assertEquals(0, hostStore.getHostContainersMap().size());
+        if (latches != null) {
+            latches.get(0).join();
+        }
+
         //Rebalance should be triggered for the very first attempt. Verify that no hosts are added to the store.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         assertEquals(0, hostStore.getHostContainersMap().size());
         if (latches != null) {
-            latches.get(0).join();
+            latches.get(1).join();
         }
 
         //New host added.
         cluster.registerHost(new Host("localhost1", 1, null));
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(1).join();
+            latches.get(2).join();
         }
         assertEquals(1, hostStore.getHostContainersMap().size());
 
@@ -169,7 +174,7 @@ public class SegmentContainerMonitorTest {
         cluster.deregisterHost(new Host("localhost1", 1, null));
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(2).join();
+            latches.get(3).join();
         }
         assertEquals(3, hostStore.getHostContainersMap().size());
 
@@ -181,7 +186,7 @@ public class SegmentContainerMonitorTest {
         //Wait for rebalance and verify the host update.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(3).join();
+            latches.get(4).join();
         }
         assertEquals(4, hostStore.getHostContainersMap().size());
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -29,8 +29,12 @@ import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Host store tests.
@@ -93,9 +97,16 @@ public class HostStoreTest {
                 latch.complete(null);
             });
             // Update host store map.
-            hostStore.updateHostContainersMap(HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount));
+            Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
+            hostStore.updateHostContainersMap(hostContainerMap);
             latch.join();
             validateStore(hostStore);
+
+            // verify that a new hostStore is initialized with map set by previous host store. 
+            HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+
+            Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
+            assertEquals(hostContainerMap, map);
         } catch (Exception e) {
             log.error("Unexpected error", e);
             Assert.fail();


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes the ZkHost store to initialize the segment container to host map field with initial value read in NodeCache. 

**Purpose of the change**  
Fixes #3673

**What the code does**  
ZkHostStore was recently changed to use NodeCache. And we build initial node cache map but do not set the local field segmentcontainer-Host map with initialized value. This means the field is only updated if there is a change in segment store nodes. 

This means, in longevity, if a controller restarts, then it doesnt update its container-host map and has an empty map and any queries received by it are failed because it cannot find a host to container mapping. 

**How to verify it**  
Unit test updated to verify that initial value is also set to the map. 
