### PR TITLE
Issue 3702: Prevent suppression of stack traces in tests

### DIFF
--- a/common/src/test/java/io/pravega/common/util/RetryTests.java
+++ b/common/src/test/java/io/pravega/common/util/RetryTests.java
@@ -18,13 +18,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test methods for Retry utilities
@@ -163,18 +161,13 @@ public class RetryTests {
     }
 
     @Test
-    public void retryFutureInExecutorTests() {
+    public void retryFutureInExecutorTests() throws ExecutionException {
         ScheduledExecutorService executorService = ExecutorServiceHelpers.newScheduledThreadPool(5, "testpool");
 
         // 1. series of retryable exceptions followed by a failure
         begin = Instant.now();
         final CompletableFuture<Void> result1 = retryFutureInExecutor(uniformDelay, 1, maxLoops, maxDelay, true, executorService);
-        try {
-            Exceptions.handleInterrupted(() -> result1.get());
-        } catch (ExecutionException e) {
-            log.debug("Exception not expected", e);
-            fail("Exception observed in retryInExecutor");
-        }
+        Exceptions.handleInterrupted(() -> result1.get());
         end = Instant.now();
         duration = end.toEpochMilli() - begin.toEpochMilli();
         log.debug("Expected duration = {}", expectedDurationUniform);
@@ -199,12 +192,7 @@ public class RetryTests {
         // 3. exponential backoff
         begin = Instant.now();
         final CompletableFuture<Void> result3 = retryFutureInExecutor(exponentialInitialDelay, multiplier, maxLoops, maxDelay, true, executorService);
-        try {
-            Exceptions.handleInterrupted(() -> result3.get());
-        } catch (ExecutionException e) {
-            log.debug("Exception not expected", e);
-            fail("Exception observed in retryInExecutor");
-        }
+        Exceptions.handleInterrupted(() -> result3.get());
         end = Instant.now();
         duration = end.toEpochMilli() - begin.toEpochMilli();
         log.debug("Expected duration = {}", expectedDurationExponential);

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
@@ -16,14 +16,13 @@ import io.pravega.controller.store.host.HostMonitorConfig;
 import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
 import io.pravega.controller.timeout.TimeoutServiceConfig;
 import io.pravega.controller.util.Config;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * ControllerServiceMain tests.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
@@ -21,7 +21,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -39,10 +39,10 @@ public abstract class ControllerServiceMainTest {
     }
 
     @Before
-    public abstract void setup();
+    public abstract void setup() throws Exception;
 
     @After
-    public abstract void tearDown();
+    public abstract void tearDown() throws IOException;
 
     @Slf4j
     static class MockControllerServiceStarter extends ControllerServiceStarter {
@@ -86,17 +86,8 @@ public abstract class ControllerServiceMainTest {
                 MockControllerServiceStarter::new);
 
         controllerServiceMain.startAsync();
-        try {
-            controllerServiceMain.awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for controllerServiceMain to get ready");
-        }
-
-        try {
-            controllerServiceMain.awaitServiceStarting().awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for starter to get ready");
-        }
+        controllerServiceMain.awaitRunning();
+        controllerServiceMain.awaitServiceStarting().awaitRunning();
 
         Main.onShutdown(controllerServiceMain);
         
@@ -109,31 +100,11 @@ public abstract class ControllerServiceMainTest {
                 MockControllerServiceStarter::new);
 
         controllerServiceMain.startAsync();
-        try {
-            controllerServiceMain.awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for controllerServiceMain to get ready");
-        }
-
-        try {
-            controllerServiceMain.awaitServiceStarting().awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for starter to get ready");
-        }
-
+        controllerServiceMain.awaitRunning();
+        controllerServiceMain.awaitServiceStarting().awaitRunning();
         controllerServiceMain.stopAsync();
-
-        try {
-            controllerServiceMain.awaitServicePausing().awaitTerminated();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for termination of starter");
-        }
-
-        try {
-            controllerServiceMain.awaitTerminated();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for termination of controllerServiceMain");
-        }
+        controllerServiceMain.awaitServicePausing().awaitTerminated();
+        controllerServiceMain.awaitTerminated();
     }
 
     protected ControllerServiceConfig createControllerServiceConfig() {

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
@@ -53,34 +53,21 @@ public abstract class ControllerServiceStarterTest {
     }
 
     @Before
-    public abstract void setup();
+    public abstract void setup() throws Exception;
 
     @After
-    public abstract void tearDown();
+    public abstract void tearDown() throws Exception;
 
     @Test
-    public void testStartStop() {
+    public void testStartStop() throws URISyntaxException {
         Assert.assertNotNull(storeClient);
         ControllerServiceStarter starter = new ControllerServiceStarter(createControllerServiceConfig(), storeClient, 
                 SegmentHelperMock.getSegmentHelperMockForTables(executor));
         starter.startAsync();
-
-        try {
-            starter.awaitRunning();
-        } catch (IllegalStateException e) {
-            log.error("Error awaiting starter to get ready");
-            Assert.fail("Error awaiting starter to get ready");
-        }
+        starter.awaitRunning();
 
         // Now, that starter has started, perform some rpc operations.
-        URI uri;
-        try {
-            uri = new URI( (enableAuth ? "tls" : "tcp") + "://localhost:" + grpcPort);
-        } catch (URISyntaxException e) {
-            log.error("Error creating controller URI", e);
-            Assert.fail("Error creating controller URI");
-            return;
-        }
+        URI uri = new URI( (enableAuth ? "tls" : "tcp") + "://localhost:" + grpcPort);
 
         final String testScope = "testScope";
         StreamManager streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(uri)
@@ -92,12 +79,7 @@ public abstract class ControllerServiceStarterTest {
         streamManager.close();
 
         starter.stopAsync();
-        try {
-            starter.awaitTerminated();
-        } catch (IllegalStateException e) {
-            log.error("Error awaiting termination of starter");
-            Assert.fail("Error awaiting termination of starter");
-        }
+        starter.awaitTerminated();
     }
 
     protected ControllerServiceConfig createControllerServiceConfig() {

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
@@ -14,18 +14,16 @@ import io.pravega.controller.store.client.ZKClientConfig;
 import io.pravega.controller.store.client.impl.StoreClientConfigImpl;
 import io.pravega.controller.store.client.impl.ZKClientConfigImpl;
 import io.pravega.test.common.TestingServerStarter;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.test.TestingServer;
-import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.Assert.assertEquals;
 

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
@@ -41,13 +41,8 @@ public class PravegaTablesControllerServiceMainTest extends ControllerServiceMai
     }
 
     @Override
-    public void setup() {
-        try {
-            zkServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            log.error("Error starting test zk server");
-            Assert.fail("Error starting test zk server");
-        }
+    public void setup() throws Exception {
+        zkServer = new TestingServerStarter().start();
 
         ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
                 .initialSleepInterval(500)
@@ -59,13 +54,8 @@ public class PravegaTablesControllerServiceMainTest extends ControllerServiceMai
     }
 
     @Override
-    public void tearDown() {
-        try {
-            zkServer.close();
-        } catch (IOException e) {
-            log.error("Error stopping test zk server");
-            Assert.fail("Error stopping test zk server");
-        }
+    public void tearDown() throws IOException {
+        zkServer.close();
     }
     
     static class MockControllerServiceStarter extends ControllerServiceStarter {
@@ -104,46 +94,22 @@ public class PravegaTablesControllerServiceMainTest extends ControllerServiceMai
                 });
 
         controllerServiceMain.startAsync();
-
-        try {
-            controllerServiceMain.awaitRunning();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for controllerServiceMain to get ready", e);
-            Assert.fail("Failed waiting for controllerServiceMain to get ready");
-        }
+        controllerServiceMain.awaitRunning();
 
         MockControllerServiceStarter controllerServiceStarter = (MockControllerServiceStarter) controllerServiceMain.awaitServiceStarting();
-        try {
-            controllerServiceStarter.awaitRunning();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for controllerServiceStarter to get ready", e);
-            Assert.fail("Failed waiting for controllerServiceStarter to get ready");
-            return;
-        }
+        controllerServiceStarter.awaitRunning();
 
         assertEquals(1, clientQueue.size());
         CuratorFramework curatorClient = (CuratorFramework) clientQueue.poll().getClient();
         // Simulate ZK session timeout
         // we will submit zk session expiration and 
-        CompletableFuture.runAsync(() -> {
-            try {
-                curatorClient.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
-            } catch (Exception e) {
-                log.error("Failed while simulating client session expiry", e);
-                Assert.fail("Failed while simulating client session expiry");
-            }
-        });
+        curatorClient.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
+
         CompletableFuture<Void> callBackCalled = new CompletableFuture<>();
         // issue a zkClient request.. 
-        CompletableFuture.runAsync(() -> {
-            try {
-                curatorClient.getData().inBackground((client1, event) -> {
-                    callBackCalled.complete(null);
-                }).forPath("/test");
-            } catch (Exception e) {
-                Assert.fail("Failed while trying to submit a background request to curator");
-            }
-        });
+        curatorClient.getData().inBackground((client1, event) -> {
+            callBackCalled.complete(null);
+        }).forPath("/test");
 
         // verify that termination is started. We will first make sure curator calls the callback before we let the 
         // ControllerServiceStarter to shutdown completely. This simulates grpc behaviour where grpc waits until all 
@@ -155,19 +121,8 @@ public class PravegaTablesControllerServiceMainTest extends ControllerServiceMai
         waitingForShutdownSignal.complete(null);
         
         // Now, that session has expired, lets wait for starter to start again.
-        try {
-            controllerServiceMain.awaitServicePausing().awaitTerminated();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for controllerServiceStarter termination", e);
-            Assert.fail("Failed waiting for controllerServiceStarter termination");
-        }
-
-        try {
-            controllerServiceMain.awaitServiceStarting().awaitRunning();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for starter to get ready again", e);
-            Assert.fail("Failed waiting for controllerServiceStarter to get ready again");
-        }
+        controllerServiceMain.awaitServicePausing().awaitTerminated();
+        controllerServiceMain.awaitServiceStarting().awaitRunning();
 
         // assert that previous curator client has indeed shutdown. 
         assertEquals(curatorClient.getState(), CuratorFrameworkState.STOPPED);
@@ -177,19 +132,7 @@ public class PravegaTablesControllerServiceMainTest extends ControllerServiceMai
         assertEquals(((CuratorFramework) clientQueue.peek().getClient()).getState(), CuratorFrameworkState.STARTED);
 
         controllerServiceMain.stopAsync();
-
-        try {
-            controllerServiceMain.awaitServicePausing().awaitTerminated();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for controllerServiceStarter termination", e);
-            Assert.fail("Failed waiting for controllerServiceStarter termination");
-        }
-
-        try {
-            controllerServiceMain.awaitTerminated();
-        } catch (IllegalStateException e) {
-            log.error("Failed waiting for termination of controllerServiceMain", e);
-            Assert.fail("Failed waiting for termination of controllerServiceMain");
-        }
+        controllerServiceMain.awaitServicePausing().awaitTerminated();
+        controllerServiceMain.awaitTerminated();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
@@ -34,13 +34,8 @@ public class PravegaTablesControllerServiceStarterTest extends ControllerService
     }
 
     @Override
-    public void setup() {
-        try {
-            zkServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            log.error("Error starting test zk server");
-            Assert.fail("Error starting test zk server");
-        }
+    public void setup() throws Exception {
+        zkServer = new TestingServerStarter().start();
 
         ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
                 .initialSleepInterval(500)
@@ -55,20 +50,9 @@ public class PravegaTablesControllerServiceStarterTest extends ControllerService
     }
 
     @Override
-    public void tearDown() {
-        try {
-            storeClient.close();
-        } catch (Exception e) {
-            log.error("Error closing ZK client");
-            Assert.fail("Error closing ZK client");
-        }
-
-        try {
-            zkServer.close();
-        } catch (IOException e) {
-            log.error("Error stopping test zk server");
-            Assert.fail("Error stopping test zk server");
-        }
+    public void tearDown() throws Exception {
+        storeClient.close();
+        zkServer.close();
         executor.shutdown();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
@@ -14,13 +14,11 @@ import io.pravega.controller.store.client.ZKClientConfig;
 import io.pravega.controller.store.client.impl.StoreClientConfigImpl;
 import io.pravega.controller.store.client.impl.ZKClientConfigImpl;
 import io.pravega.test.common.TestingServerStarter;
+import java.util.UUID;
+import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
-
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.Executors;
 
 /**
  * ControllerServiceStarter backed by ZK store tests.

--- a/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
@@ -14,10 +14,8 @@ import io.pravega.controller.store.client.ZKClientConfig;
 import io.pravega.controller.store.client.impl.StoreClientConfigImpl;
 import io.pravega.controller.store.client.impl.ZKClientConfigImpl;
 import io.pravega.test.common.TestingServerStarter;
-import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.Assert;

--- a/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
@@ -34,13 +34,8 @@ public class ZKControllerServiceStarterTest extends ControllerServiceStarterTest
     }
 
     @Override
-    public void setup() {
-        try {
-            zkServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            log.error("Error starting test zk server");
-            Assert.fail("Error starting test zk server");
-        }
+    public void setup() throws Exception {
+        zkServer = new TestingServerStarter().start();
 
         ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
                 .initialSleepInterval(500)
@@ -55,20 +50,9 @@ public class ZKControllerServiceStarterTest extends ControllerServiceStarterTest
     }
 
     @Override
-    public void tearDown() {
-        try {
-            storeClient.close();
-        } catch (Exception e) {
-            log.error("Error closing ZK client");
-            Assert.fail("Error closing ZK client");
-        }
-
-        try {
-            zkServer.close();
-        } catch (IOException e) {
-            log.error("Error stopping test zk server");
-            Assert.fail("Error stopping test zk server");
-        }
+    public void tearDown() throws Exception {
+        storeClient.close();
+        zkServer.close();
         executor.shutdown();
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -1201,7 +1201,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         context.readIndex.append(segmentId, offset, data);
     }
 
-    private void appendDataInStorage(TestContext context, HashMap<Long, ByteArrayOutputStream> segmentContents) {
+    private void appendDataInStorage(TestContext context, HashMap<Long, ByteArrayOutputStream> segmentContents) throws IOException {
         int writeId = 0;
         for (int i = 0; i < APPENDS_PER_SEGMENT; i++) {
             for (long segmentId : context.metadata.getAllStreamSegmentIds()) {
@@ -1349,18 +1349,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         }
     }
 
-    private <T> void recordAppend(T segmentIdentifier, byte[] data, Map<T, ByteArrayOutputStream> segmentContents) {
+    private <T> void recordAppend(T segmentIdentifier, byte[] data, Map<T, ByteArrayOutputStream> segmentContents) throws IOException {
         ByteArrayOutputStream contents = segmentContents.getOrDefault(segmentIdentifier, null);
         if (contents == null) {
             contents = new ByteArrayOutputStream();
             segmentContents.put(segmentIdentifier, contents);
         }
-
-        try {
-            contents.write(data);
-        } catch (IOException ex) {
-            Assert.fail(ex.toString());
-        }
+        contents.write(data);
     }
 
     private ArrayList<Long> createSegments(TestContext context) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
@@ -49,6 +49,7 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
+    @Override
     protected int getThreadPoolSize() {
         return 2;
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -47,24 +47,16 @@ public class ControllerBootstrapTest {
     private TableStore tableStore;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         final String serviceHost = "localhost";
         final int containerCount = 4;
 
         // 1. Start ZK
-        try {
-            zkTestServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            Assert.fail("Failed starting ZK test server");
-        }
-
+        zkTestServer = new TestingServerStarter().start();
         // 2. Start controller
-        try {
-            controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
-                    controllerPort, serviceHost, servicePort, containerCount);
-        } catch (Exception e) {
-            Assert.fail("Failed starting ControllerWrapper");
-        }
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
+                                                  controllerPort, serviceHost, servicePort, containerCount);
+
     }
 
     @After

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -104,7 +104,6 @@ public class ControllerBootstrapTest {
         Boolean status = streamStatus.join();
         Assert.assertEquals(true, status);
 
-
         // Now create transaction should succeed.
         CompletableFuture<TxnSegments> txIdFuture = controller.createTransaction(new StreamImpl(SCOPE, STREAM), 10000);
 

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -9,22 +9,20 @@
  */
 package io.pravega.test.integration;
 
-import io.pravega.segmentstore.contracts.tables.TableStore;
-import io.pravega.test.common.TestingServerStarter;
-import io.pravega.test.integration.demo.ControllerWrapper;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
-import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.store.ServiceBuilder;
-import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.impl.TxnSegments;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
@@ -110,22 +108,16 @@ public class ControllerBootstrapTest {
         CompletableFuture<Boolean> streamStatus = controller.createStream(SCOPE, STREAM, streamConfiguration);
         Assert.assertTrue(!streamStatus.isDone());
         // Ensure that create stream succeeds.
-        try {
-            Boolean status = streamStatus.join();
-            Assert.assertEquals(true, status);
-        } catch (CompletionException ce) {
-            Assert.fail();
-        }
+
+        Boolean status = streamStatus.join();
+        Assert.assertEquals(true, status);
+
 
         // Now create transaction should succeed.
         CompletableFuture<TxnSegments> txIdFuture = controller.createTransaction(new StreamImpl(SCOPE, STREAM), 10000);
 
-        try {
-            TxnSegments id = txIdFuture.join();
-            Assert.assertNotNull(id);
-        } catch (CompletionException ce) {
-            Assert.fail();
-        }
+        TxnSegments id = txIdFuture.join();
+        Assert.assertNotNull(id);
 
         controllerWrapper.awaitRunning();
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -75,7 +75,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class ReadTest {
 
@@ -289,7 +288,7 @@ public class ReadTest {
     }
 
     @Test(timeout = 10000)
-    public void testEventPointer() throws ReinitializationRequiredException {
+    public void testEventPointer() throws ReinitializationRequiredException, NoSuchEventException {
         String endpoint = "localhost";
         String streamName = "abc";
         String readerName = "reader";
@@ -318,21 +317,12 @@ public class ReadTest {
         producer.flush();
 
         @Cleanup
-        EventStreamReader<String> reader = clientFactory
-                .createReader(readerName, readerGroup, serializer, ReaderConfig.builder().build());
-        try {
-            EventPointer pointer;
-            String read;
-
-            for (int i = 0; i < 100; i++) {
-                pointer = reader.readNextEvent(5000).getEventPointer();
-                read = reader.fetchEvent(pointer);
-                assertEquals(testString + i, read);
-            }
-        } catch (NoSuchEventException e) {
-            fail("Failed to read event using event pointer");
+        EventStreamReader<String> reader = clientFactory.createReader(readerName, readerGroup, serializer, ReaderConfig.builder().build());
+        for (int i = 0; i < 100; i++) {
+            EventPointer pointer = reader.readNextEvent(5000).getEventPointer();
+            String read = reader.fetchEvent(pointer);
+            assertEquals(testString + i, read);
         }
-
     }
 
     private void fillStoreForSegment(String segmentName, UUID clientId, byte[] data, int numEntries,

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
@@ -63,6 +63,7 @@ public class MetadataScalabilityLargeNumSegmentsTest extends MetadataScalability
      * @param sortedCurrentSegments sorted current segments
      * @return scale input for next scale
      */
+    @Override
     Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
         int i = counter.incrementAndGet();
         List<Long> segmentsToSeal = sortedCurrentSegments.stream()

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
@@ -62,6 +62,7 @@ public class MetadataScalabilityLargeScalesTest extends MetadataScalabilityTest 
      * @param sortedCurrentSegments segments in current epoch
      * @return scale input for next scale to perform
      */
+    @Override
     Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
         return new ImmutablePair<>(getSegmentsToSeal(sortedCurrentSegments), getNewRanges());     
     }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -20,7 +20,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -31,6 +30,10 @@ import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
@@ -40,15 +43,9 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
-import java.net.URI;
-import java.util.List;
-import java.util.UUID;
-
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
@@ -144,15 +141,10 @@ public class PravegaTest extends AbstractReadWriteTest {
 
         EventRead<String> event = null;
         do {
-            try {
-                event = reader.readNextEvent(10_000);
-                log.debug("Read event: {}.", event.getEvent());
-                if (event.getEvent() != null) {
-                    readCount++;
-                }
-            } catch (ReinitializationRequiredException e) {
-                log.error("Exception while reading event using readerId: {}", reader, e);
-                fail("Reinitialization Exception is not expected");
+            event = reader.readNextEvent(10_000);
+            log.debug("Read event: {}.", event.getEvent());
+            if (event.getEvent() != null) {
+                readCount++;
             }
             // try reading until all the written events are read, else the test will timeout.
         } while ((event.getEvent() != null || event.isCheckpoint()) && readCount < NUM_EVENTS);

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -226,9 +226,6 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
             EventRead<Integer> event = reader.readNextEvent(READ_TIMEOUT);
             assertTrue("Read for Checkpoint event", (event != null) && (event.isCheckpoint()));
             assertEquals("CheckPoint Name", checkPointName, event.getCheckpointName());
-        } catch (ReinitializationRequiredException e) {
-            log.error("Exception while reading event using readerId: {}", readerId, e);
-            fail("Reinitialization Exception is not expected");
         }
         return checkpoint.join();
     }


### PR DESCRIPTION
**Change log description**  
* Prevent tests from suppressing exception stack traces 

**Purpose of the change**  
Fixes #3702

**What the code does**  
Removes unneeded try catch code from tests. No functional changes.
