### PR TITLE
Issue 2830: PingTxnStatus now informs if the Transaction is closed

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/Transaction.java
+++ b/client/src/main/java/io/pravega/client/stream/Transaction.java
@@ -29,6 +29,12 @@ public interface Transaction<Type> {
         ABORTED
     }
 
+    enum PingStatus {
+        OPEN,
+        COMMITTED,
+        ABORTED
+    }
+
     /**
      * Returns a unique ID that can be used to identify this transaction.
      *

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -181,9 +181,9 @@ public interface Controller extends AutoCloseable {
      * @param stream     Stream name
      * @param txId       Transaction id
      * @param lease      Time for which transaction shall remain open with sending any heartbeat.
-     * @return           Void or PingFailedException
+     * @return           Transaction.PingStatus or PingFailedException
      */
-    CompletableFuture<Void> pingTransaction(final Stream stream, final UUID txId, final long lease);
+    CompletableFuture<Transaction.PingStatus> pingTransaction(final Stream stream, final UUID txId, final long lease);
 
     /**
      * Commits a transaction, atomically committing all events to the stream, subject to the

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -197,7 +197,7 @@ public final class ModelHelper {
                 result = Transaction.PingStatus.ABORTED;
                 break;
             default:
-                throw new PingFailedException("Ping transaction for " + logString + "failed with status " + status);
+                throw new PingFailedException("Ping transaction for " + logString + " failed with status " + status);
         }
         return result;
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -36,7 +36,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
 
 /**
  * Provides translation (encode/decode) between the Model classes and its gRPC representation.
@@ -180,9 +179,10 @@ public final class ModelHelper {
      * @param status     PingTxnStatus object instance.
      * @param logString Description text to be logged when ping transaction status is invalid.
      * @return Transaction.PingStatus
+     * @throws PingFailedException if status of Ping transaction operations is not successful.
      */
-    @SneakyThrows
-    public static final Transaction.PingStatus encode(final Controller.PingTxnStatus.Status status, final String logString) {
+    public static final Transaction.PingStatus encode(final Controller.PingTxnStatus.Status status, final String logString)
+            throws PingFailedException {
         Preconditions.checkNotNull(status, "status");
         Exceptions.checkNotNullOrEmpty(logString, "logString");
         Transaction.PingStatus result;

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -38,8 +38,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 
-import static io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus.Status.OK;
-
 /**
  * Provides translation (encode/decode) between the Model classes and its gRPC representation.
  */

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -1154,7 +1154,7 @@ public class ControllerImplTest {
     @Test
     public void testPingTransaction() throws Exception {
 
-        Predicate<Throwable> isPingFailedException = t -> Exceptions.unwrap(t)instanceof PingFailedException;
+        Predicate<Throwable> isPingFailedException = t -> t instanceof PingFailedException;
 
         CompletableFuture<Transaction.PingStatus> transaction;
         transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream1"), UUID.randomUUID(), 0);
@@ -1169,19 +1169,20 @@ public class ControllerImplTest {
         AssertExtensions.assertFutureThrows("Should throw Exception", transaction, isPingFailedException);
 
         // controller returns error with status DISCONNECTED
-        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream3"), UUID.randomUUID(), 0);
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream4"), UUID.randomUUID(), 0);
         AssertExtensions.assertFutureThrows("Should throw Exception", transaction,  isPingFailedException);
 
         // controller returns error with status COMMITTED
-        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream4"), UUID.randomUUID(), 0);
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream5"), UUID.randomUUID(), 0);
         assertEquals(transaction.get(), Transaction.PingStatus.COMMITTED);
 
         // controller returns error with status ABORTED
-        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream5"), UUID.randomUUID(), 0);
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream6"), UUID.randomUUID(), 0);
         assertEquals(transaction.get(), Transaction.PingStatus.ABORTED);
 
-        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream6"), UUID.randomUUID(), 0);
-        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, isPingFailedException);
+        // controller fails with internal exception causing the controller client to retry.
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream7"), UUID.randomUUID(), 0);
+        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, t -> t instanceof RetriesExhaustedException);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -18,6 +18,7 @@ import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -78,8 +79,9 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.extern.slf4j.Slf4j;
+import java.util.function.Predicate;
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
@@ -605,11 +607,34 @@ public class ControllerImplTest {
             @Override
             public void pingTransaction(PingTxnRequest request,
                     StreamObserver<PingTxnStatus> responseObserver) {
-                if (request.getStreamInfo().getStream().equals("stream1")) {
-                    responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build());
-                    responseObserver.onCompleted();
-                } else {
-                    responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
+                switch (request.getStreamInfo().getStream()) {
+                    case "stream1":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build());
+                        responseObserver.onCompleted();
+                        break;
+                    case "stream2":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.LEASE_TOO_LARGE).build());
+                        responseObserver.onCompleted();
+                        break;
+                    case "stream3":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.MAX_EXECUTION_TIME_EXCEEDED).build());
+                        responseObserver.onCompleted();
+                        break;
+                    case "stream4":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.DISCONNECTED).build());
+                        responseObserver.onCompleted();
+                        break;
+                    case "stream5":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.COMMITTED).build());
+                        responseObserver.onCompleted();
+                        break;
+                    case "stream6":
+                        responseObserver.onNext(PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.ABORTED).build());
+                        responseObserver.onCompleted();
+                        break;
+                    default:
+                        responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
+                        break;
                 }
             }
 
@@ -664,8 +689,8 @@ public class ControllerImplTest {
             }
 
             @Override
-            public void getDelegationToken(io.pravega.controller.stream.api.grpc.v1.Controller.StreamInfo request,
-                                           io.grpc.stub.StreamObserver<io.pravega.controller.stream.api.grpc.v1.Controller.DelegationToken> responseObserver) {
+            public void getDelegationToken(StreamInfo request,
+                                           StreamObserver<Controller.DelegationToken> responseObserver) {
                 responseObserver.onNext(Controller.DelegationToken.newBuilder().setDelegationToken("token").build());
                 responseObserver.onCompleted();
             }
@@ -1128,12 +1153,35 @@ public class ControllerImplTest {
 
     @Test
     public void testPingTransaction() throws Exception {
-        CompletableFuture<Void> transaction;
-        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream1"), UUID.randomUUID(), 0);
-        assertTrue(transaction.get() == null);
 
+        Predicate<Throwable> isPingFailedException = t -> Exceptions.unwrap(t)instanceof PingFailedException;
+
+        CompletableFuture<Transaction.PingStatus> transaction;
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream1"), UUID.randomUUID(), 0);
+        assertEquals(transaction.get(), Transaction.PingStatus.OPEN);
+
+        // controller returns error with status LEASE_TOO_LARGE
         transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream2"), UUID.randomUUID(), 0);
-        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, throwable -> true);
+        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, isPingFailedException);
+
+        // controller returns error with status MAX_EXECUTION_TIME_EXCEEDED
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream3"), UUID.randomUUID(), 0);
+        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, isPingFailedException);
+
+        // controller returns error with status DISCONNECTED
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream3"), UUID.randomUUID(), 0);
+        AssertExtensions.assertFutureThrows("Should throw Exception", transaction,  isPingFailedException);
+
+        // controller returns error with status COMMITTED
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream4"), UUID.randomUUID(), 0);
+        assertEquals(transaction.get(), Transaction.PingStatus.COMMITTED);
+
+        // controller returns error with status ABORTED
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream5"), UUID.randomUUID(), 0);
+        assertEquals(transaction.get(), Transaction.PingStatus.ABORTED);
+
+        transaction = controllerClient.pingTransaction(new StreamImpl("scope1", "stream6"), UUID.randomUUID(), 0);
+        AssertExtensions.assertFutureThrows("Should throw Exception", transaction, isPingFailedException);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.Transaction;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -102,7 +103,7 @@ public class PingerTest {
     public void startTxnKeepAliveError() throws Exception {
         final UUID txnID = UUID.randomUUID();
 
-        CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        CompletableFuture<Transaction.PingStatus> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RuntimeException("Error"));
         when(controller.pingTransaction(eq(stream), eq(txnID), anyLong())).thenReturn(failedFuture);
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -449,7 +449,7 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> pingTransaction(Stream stream, UUID txId, long lease) {
+    public CompletableFuture<Transaction.PingStatus> pingTransaction(Stream stream, UUID txId, long lease) {
         throw new UnsupportedOperationException();
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -11,7 +11,6 @@ package io.pravega.controller.server.eventProcessor;
 
 import com.google.common.base.Preconditions;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
@@ -31,7 +30,6 @@ import io.pravega.common.util.AsyncIterator;
 import io.pravega.common.util.ContinuationTokenAsyncIterator;
 import io.pravega.controller.server.ControllerService;
 import io.pravega.controller.server.rpc.auth.PravegaInterceptor;
-import io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentRange;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -317,11 +317,9 @@ public class LocalController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> pingTransaction(Stream stream, UUID txId, long lease) {
-        return Futures.toVoidExpecting(
-                controller.pingTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txId), lease),
-                PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build(),
-                PingFailedException::new);
+    public CompletableFuture<Transaction.PingStatus> pingTransaction(Stream stream, UUID txId, long lease) {
+        return controller.pingTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txId), lease)
+                         .thenApply(status -> ModelHelper.encode(status.getStatus(), stream + " " + txId));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -28,7 +28,6 @@ import io.pravega.controller.store.stream.VersionedTransactionData;
 import io.pravega.controller.store.stream.records.RecordHelper;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.task.TxnResource;
-import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus.Status;
 import io.pravega.controller.timeout.TimeoutService;

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -504,11 +504,11 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     private PingTxnStatus getPingTxnStatus(final TxnStatus txnStatus) {
         final PingTxnStatus status;
         if (txnStatus.equals(TxnStatus.COMMITTED) || txnStatus.equals(TxnStatus.COMMITTING)) {
-            status = createStatus(Status.COMMITTED);
+            status = createStatus(PingTxnStatus.Status.COMMITTED);
         } else if (txnStatus.equals(TxnStatus.ABORTED) || txnStatus.equals(TxnStatus.ABORTING)) {
-            status = createStatus(Status.ABORTED);
+            status = createStatus(PingTxnStatus.Status.ABORTED);
         } else {
-            status = createStatus(Status.OK);
+            status = createStatus(PingTxnStatus.Status.UNKNOWN);
         }
         return status;
     }

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -119,6 +119,7 @@ message PingTxnStatus {
         DISCONNECTED = 4;
         COMMITTED = 5;
         ABORTED = 6;
+        UNKNOWN = 7;
     }
     Status status = 1;
 }

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -117,6 +117,8 @@ message PingTxnStatus {
         MAX_EXECUTION_TIME_EXCEEDED = 2;
         SCALE_GRACE_TIME_EXCEEDED = 3 [deprecated=true];
         DISCONNECTED = 4;
+        COMMITTED = 5;
+        ABORTED = 6;
     }
     Status status = 1;
 }


### PR DESCRIPTION
**Change log description**  
Include more information in `Controller.PingTxnStatus` to indicate if the transaction is closed. 

**Purpose of the change**  
Fixes #2830

**What the code does**  
`io.pravega.client.stream.impl.ControllerImpl#pingTransaction` api now indicates if the transaction is closed (if the state of the transaction is `COMMITTING` , `COMMITTED`, `ABORTED` or `ABORTING`). This change will enable Pravega to stop pinging closed transactions described in issue issue #3463 .

**How to verify it**  
All the existing and newly added tests should pass.
(In the process of adding newer tests.)
