### PR TITLE
Issue 3663: R0.5 - Cherry pick #3639(Add session to connection before it is established)

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -59,12 +59,12 @@ public class ClientConfig implements Serializable {
     /**
      * If the flag {@link #isEnableTls()}  is set, this flag decides whether to enable host name validation or not.
      */
-    private boolean validateHostName;
+    private final boolean validateHostName;
 
     /**
      * Maximum number of connections per Segment store.
      */
-    private int maxConnectionsPerSegmentStore;
+    private final int maxConnectionsPerSegmentStore;
 
     public boolean isEnableTls() {
         String scheme = this.controllerURI.getScheme();

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -9,9 +9,7 @@
  */
 package io.pravega.client.netty.impl;
 
-import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.Data;
 
@@ -22,16 +20,18 @@ import lombok.Data;
 @Data
 public class Connection {
     private final PravegaNodeUri uri;
-    private final CompletableFuture<FlowHandler> flowHandler;
+    private final FlowHandler flowHandler;
     
     /**
-     * Returns the number of open flows on this connection, if the connection has been established.
+     * A future that completes when the connection is first established.
      */
-    public Optional<Integer> getFlowCount() {
-        if (!Futures.isSuccessful(flowHandler)) {
-            return Optional.empty();
-        }
-        return Optional.of(flowHandler.join().getOpenFlowCount());
+    private final CompletableFuture<Void> connected;
+    
+    /**
+     * Returns the number of open flows on this connection. 
+     */
+    public int getFlowCount() {
+        return flowHandler.getOpenFlowCount();
     }
 }
 

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -72,8 +72,8 @@ public class ConnectionPoolImpl implements ConnectionPool {
     private static final Comparator<Connection> COMPARATOR = new Comparator<Connection>() {
         @Override
         public int compare(Connection c1, Connection c2) {
-            int v1 = c1.getFlowCount().orElse(Integer.MAX_VALUE);
-            int v2 = c2.getFlowCount().orElse(Integer.MAX_VALUE);
+            int v1 = Futures.isSuccessful(c1.getConnected()) ? c1.getFlowCount() : Integer.MAX_VALUE;
+            int v2 = Futures.isSuccessful(c2.getConnected()) ? c2.getFlowCount() : Integer.MAX_VALUE;
             return Integer.compare(v1, v2);
         }
     }; 
@@ -105,8 +105,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
         // remove connections for which the underlying network connection is disconnected.
         List<Connection> prunedConnectionList = connectionList.stream().filter(connection -> {
             // Filter out Connection objects which have been completed exceptionally or have been disconnected.
-            CompletableFuture<FlowHandler> r = connection.getFlowHandler();
-            return !r.isDone() || (Futures.isSuccessful(r) && r.join().isConnectionEstablished());
+            return !connection.getConnected().isDone() || (Futures.isSuccessful(connection.getConnected()) && connection.getFlowHandler().isConnectionEstablished());
         }).collect(Collectors.toList());
         log.debug("List of connections to {} that can be used: {}", location, prunedConnectionList);
 
@@ -115,19 +114,20 @@ public class ConnectionPoolImpl implements ConnectionPool {
 
         final Connection connection;
         if (suggestedConnection.isPresent() && (prunedConnectionList.size() >= clientConfig.getMaxConnectionsPerSegmentStore() || isUnused(suggestedConnection.get()))) {
-            log.debug("Reusing connection: {}", suggestedConnection.get());
-            Connection oldConnection = suggestedConnection.get();
-            prunedConnectionList.remove(oldConnection);
-            connection = new Connection(oldConnection.getUri(), oldConnection.getFlowHandler());
+            log.info("Reusing connection: {}", suggestedConnection.get());
+            connection = suggestedConnection.get();
         } else {
             // create a new connection.
-            log.debug("Creating a new connection to {}", location);
-            CompletableFuture<FlowHandler> flowHandlerFuture = establishConnection(location);
-            connection = new Connection(location, flowHandlerFuture);
+            log.info("Creating a new connection to {}", location);
+            final AppendBatchSizeTracker batchSizeTracker = new AppendBatchSizeTrackerImpl();
+            final FlowHandler handler = new FlowHandler(location.getEndpoint(), batchSizeTracker);
+            CompletableFuture<Void> establishedFuture = establishConnection(location, handler);
+            connection = new Connection(location, handler, establishedFuture);
+            prunedConnectionList.add(connection);
         }
-        prunedConnectionList.add(connection);
+        ClientConnection result = connection.getFlowHandler().createFlow(flow, rp);
         connectionMap.put(location, prunedConnectionList);
-        return connection.getFlowHandler().thenApply(flowHandler -> flowHandler.createFlow(flow, rp));
+        return connection.getConnected().thenApply(v -> result);
     }
 
     @Override
@@ -137,25 +137,29 @@ public class ConnectionPoolImpl implements ConnectionPool {
         Exceptions.checkNotClosed(closed.get(), this);
 
         // create a new connection.
-        CompletableFuture<FlowHandler> flowHandlerFuture = establishConnection(location);
-        Connection connection = new Connection(location, flowHandlerFuture);
-        return connection.getFlowHandler().thenApply(flowHandler -> flowHandler.createConnectionWithFlowDisabled(rp));
+        final AppendBatchSizeTracker batchSizeTracker = new AppendBatchSizeTrackerImpl();
+        final FlowHandler handler = new FlowHandler(location.getEndpoint(), batchSizeTracker);
+        CompletableFuture<Void> connectedFuture = establishConnection(location, handler);
+        Connection connection = new Connection(location, handler, connectedFuture);
+        ClientConnection result = connection.getFlowHandler().createConnectionWithFlowDisabled(rp);
+        return connectedFuture.thenApply(v -> result);
     }
 
     private boolean isUnused(Connection connection) {
-        return connection.getFlowCount().isPresent() && connection.getFlowCount().get() == 0;
+        return Futures.isSuccessful(connection.getConnected()) && connection.getFlowCount() == 0;
     }
 
     /**
      * Used only for testing.
      */
     @VisibleForTesting
+    @Synchronized
     public void pruneUnusedConnections() {
         for (List<Connection> connections : connectionMap.values()) {
             for (Iterator<Connection> iterator = connections.iterator(); iterator.hasNext();) {
                 Connection connection = iterator.next();
                 if (isUnused(connection)) {
-                    connection.getFlowHandler().join().close();
+                    connection.getFlowHandler().close();
                     iterator.remove();
                 }
             }
@@ -178,16 +182,14 @@ public class ConnectionPoolImpl implements ConnectionPool {
     /**
      * Establish a new connection to the Pravega Node.
      * @param location The Pravega Node Uri
+     * @param handler The flow handler for the connection
      * @return A future, which completes once the connection has been established, returning a FlowHandler that can be used to create
      * flows on the connection.
      */
-    private CompletableFuture<FlowHandler> establishConnection(PravegaNodeUri location) {
-        final AppendBatchSizeTracker batchSizeTracker = new AppendBatchSizeTrackerImpl();
-        final FlowHandler handler = new FlowHandler(location.getEndpoint(), batchSizeTracker);
-        final Bootstrap b = getNettyBootstrap().handler(getChannelInitializer(location, batchSizeTracker, handler));
-
+    private CompletableFuture<Void> establishConnection(PravegaNodeUri location, FlowHandler handler) {  
+        final Bootstrap b = getNettyBootstrap().handler(getChannelInitializer(location, handler));
         // Initiate Connection.
-        final CompletableFuture<FlowHandler> connectionComplete = new CompletableFuture<>();
+        final CompletableFuture<Void> connectionComplete = new CompletableFuture<>();
         try {
             b.connect(location.getEndpoint(), location.getPort()).addListener((ChannelFutureListener) future -> {
                 if (future.isSuccess()) {
@@ -196,7 +198,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
                     log.debug("Connect operation completed for channel:{}, local address:{}, remote address:{}",
                               ch.id(), ch.localAddress(), ch.remoteAddress());
                     channelGroup.add(ch); // Once a channel is closed the channel group implementation removes it.
-                    connectionComplete.complete(handler);
+                    connectionComplete.complete(null);
                 } else {
                     connectionComplete.completeExceptionally(new ConnectionFailedException(future.cause()));
                 }
@@ -208,7 +210,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
         final CompletableFuture<Void> channelRegisteredFuture = new CompletableFuture<>(); //to track channel registration.
         handler.completeWhenRegistered(channelRegisteredFuture);
 
-        return connectionComplete.thenCombine(channelRegisteredFuture, (flowHandler, v) -> flowHandler);
+        return CompletableFuture.allOf(connectionComplete, channelRegisteredFuture);
     }
 
     /**
@@ -226,7 +228,6 @@ public class ConnectionPoolImpl implements ConnectionPool {
      * Create a Channel Initializer which is to to setup {@link ChannelPipeline}.
      */
     private ChannelInitializer<SocketChannel> getChannelInitializer(final PravegaNodeUri location,
-                                                                    final AppendBatchSizeTracker batchSizeTracker,
                                                                     final FlowHandler handler) {
         final SslContext sslCtx = getSslContext();
 
@@ -247,7 +248,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
                 }
                 p.addLast(
                         new ExceptionLoggingHandler(location.getEndpoint()),
-                        new CommandEncoder(batchSizeTracker),
+                        new CommandEncoder(handler.getBatchSizeTracker()),
                         new LengthFieldBasedFrameDecoder(WireCommands.MAX_WIRECOMMAND_SIZE, 4, 4),
                         new CommandDecoder(),
                         handler);

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -42,6 +42,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
     private final AtomicReference<ScheduledFuture<?>> keepAliveFuture = new AtomicReference<>();
     private final AtomicBoolean recentMessage = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    @Getter
     private final AppendBatchSizeTracker batchSizeTracker;
     private final ReusableFutureLatch<Void> registeredFutureLatch = new ReusableFutureLatch<>();
     @VisibleForTesting


### PR DESCRIPTION
**Change log description**  
- Cherry picking PR #3639 into R0.5
   * Adds first session to connection before the connection is established so the pool will know it is used.

**Purpose of the change**  
Backport PR #3639 , Issue #3632 
Fixes #3663

**What the code does**  
See #3639 

**How to verify it**  
See #3639 
