### PR TITLE
Issue 3710: (SegmentStore) Delete Segment if Empty Bug Fix

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -265,17 +265,6 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
         return forSegmentCache(segmentId, SegmentKeyCache::getTailBucketOffsets, Collections.emptyMap());
     }
 
-    /**
-     * Gets a value representing the difference between the number of Table Buckets updated (or inserted) and the ones
-     * that have been removed for the given Segment.
-     *
-     * @param segmentId The Id of the Segment to get the difference for.
-     * @return The result.
-     */
-    int getBucketCountDelta(long segmentId) {
-        return forSegmentCache(segmentId, SegmentKeyCache::getBucketCountDelta, 0);
-    }
-
     private <T> T forSegmentCache(long segmentId, Function<SegmentKeyCache, T> ifExists, T ifNotExists) {
         SegmentKeyCache cache;
         synchronized (this.segmentCaches) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -155,7 +155,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
             return this.segmentContainer
                     .forSegment(segmentName, timer.getRemaining())
                     .thenComposeAsync(segment -> this.keyIndex.executeIfEmpty(segment,
-                            () -> this.segmentContainer.deleteStreamSegment(segmentName, timer.getRemaining())),
+                            () -> this.segmentContainer.deleteStreamSegment(segmentName, timer.getRemaining()), timer),
                             this.executor);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -12,7 +12,7 @@ package io.pravega.segmentstore.server.tables;
 import com.google.common.base.Preconditions;
 import io.pravega.common.hash.HashHelper;
 import io.pravega.common.util.BitConverter;
-import io.pravega.segmentstore.contracts.Attributes;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.storage.Cache;
 import java.util.ArrayList;
@@ -232,7 +232,7 @@ class SegmentKeyCache {
     }
 
     /**
-     * Updates the Last Indexed Offset (cached value of the Segment's {@link Attributes#TABLE_INDEX_OFFSET} attribute).
+     * Updates the Last Indexed Offset (cached value of the Segment's {@link TableAttributes#INDEX_OFFSET} attribute).
      * Clears out any backpointers whose source offsets will be smaller than the new value for Last Indexed Offset.
      */
     void setLastIndexedOffset(long currentLastIndexedOffset, int cacheGeneration) {
@@ -284,21 +284,6 @@ class SegmentKeyCache {
      */
     synchronized Map<UUID, CacheBucketOffset> getTailBucketOffsets() {
         return new HashMap<>(this.tailOffsets);
-    }
-
-    /**
-     * Gets a value representing the difference between the number of Table Buckets updated (or inserted) and the ones
-     * that have been removed.
-     *
-     * @return The result.
-     */
-    synchronized int getBucketCountDelta() {
-        int result = 0;
-        for (val s : this.tailOffsets.values()) {
-            result += s.isRemoval() ? -1 : 1;
-        }
-
-        return result;
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -473,22 +473,12 @@ public class ContainerKeyCacheTests {
                 Assert.assertEquals("Unexpected value from getSegmentOffset().", e.getValue().getSegmentOffset(), result.getSegmentOffset());
             }
         }
-
-        checkBucketCountDelta(keyCache);
     }
 
     private void checkNotInCache(List<TestKey> keys, ContainerKeyCache keyCache) {
         for (val e : keys) {
             val result = keyCache.get(e.segmentId, e.keyHash);
             Assert.assertNull("Found key that is not supposed to be in the cache.", result);
-        }
-    }
-
-    private void checkBucketCountDelta(ContainerKeyCache keyCache) {
-        for (long segmentId = 0; segmentId < SEGMENT_COUNT; segmentId++) {
-            val expected = keyCache.getTailHashes(segmentId).values().stream().mapToInt(e -> e.isRemoval() ? -1 : 1).sum();
-            val actual = keyCache.getBucketCountDelta(segmentId);
-            Assert.assertEquals("Unexpected value from getBucketCountDelta()", expected, actual);
         }
     }
 


### PR DESCRIPTION
**Change log description**  
Fixed a bug in `ContainerKeyIndex` where it would incorrectly determine that a Table Segment is empty when it actually is not.

**Purpose of the change**  
Fixes #3710.

**What the code does**  
Cause:
- The cause for this was an incorrect way of calculating the number of Table Entries in a Segment, given both indexed and non-indexed entries.
- The previous calculation methodology was incorrectly assuming that all Table Key removals recorded in the cache are for keys that actually exist. 
    - While this may be true for conditional removals, unconditional removals perform no precondition checks and simply record the action (unconditionally removing an inexistent key is a valid operation)
- All removals were recorded in the `SegmentKeyCache` and when asked to calculate a delta of bucket updates (how many buckets added minus how many removed) this calculation would be thrown off by this.

This has been changed in the following way:
- The `ContainerKeyIndex` fetches the list of all bucket updates from the tail. 
- It filters out all Buckets that are marked for removal and queries the Index to see if they previously existed. Only in that case can they be discounted from the total number of buckets.

**How to verify it**  
Added a new unit test to cover this scenario.
