### PR TITLE
Issue 3708: Sporadic failure of HostStoreTest.zkHostStoreTests

### DIFF
--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -94,12 +94,19 @@ public class HostStoreTest {
 
             // Create ZK based host store.
             HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
-            CompletableFuture<Void> latch = new CompletableFuture<>();
+            CompletableFuture<Void> latch1 = new CompletableFuture<>();
+            CompletableFuture<Void> latch2 = new CompletableFuture<>();
             ((ZKHostStore) hostStore).addListener(() -> {
-                latch.complete(null);
+                // With the addition of updateMap() in tryInit(), this listener is actually called twice, and we need to
+                // wait for the second operation to complete (related to updateHostContainersMap()).
+                if (latch1.isDone()) {
+                    latch2.complete(null);
+                }
+                latch1.complete(null);
             });
             hostStore.updateHostContainersMap(hostContainerMap);
-            latch.join();
+            latch1.join();
+            latch2.join();
             validateStore(hostStore);
 
             // verify that a new hostStore is initialized with map set by previous host store.

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -29,8 +29,12 @@ import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Host store tests.
@@ -85,17 +89,24 @@ public class HostStoreTest {
                     .containerCount(containerCount)
                     .build();
 
+            // Update host store map.
+            Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
+
             // Create ZK based host store.
             HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
-
             CompletableFuture<Void> latch = new CompletableFuture<>();
             ((ZKHostStore) hostStore).addListener(() -> {
                 latch.complete(null);
             });
-            // Update host store map.
-            hostStore.updateHostContainersMap(HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount));
+            hostStore.updateHostContainersMap(hostContainerMap);
             latch.join();
             validateStore(hostStore);
+
+            // verify that a new hostStore is initialized with map set by previous host store.
+            HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+
+            Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
+            assertEquals(hostContainerMap, map);
         } catch (Exception e) {
             log.error("Unexpected error", e);
             Assert.fail();

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -29,12 +29,8 @@ import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Host store tests.
@@ -97,16 +93,9 @@ public class HostStoreTest {
                 latch.complete(null);
             });
             // Update host store map.
-            Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
-            hostStore.updateHostContainersMap(hostContainerMap);
+            hostStore.updateHostContainersMap(HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount));
             latch.join();
             validateStore(hostStore);
-
-            // verify that a new hostStore is initialized with map set by previous host store. 
-            HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
-
-            Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
-            assertEquals(hostContainerMap, map);
         } catch (Exception e) {
             log.error("Unexpected error", e);
             Assert.fail();


### PR DESCRIPTION
**Change log description**  
Fixes sporadic failure in zkHostStoreTests.

**Purpose of the change**  
Fixes #3708.

**What the code does**  
PR #3682 introduced a call to `updateMap()` in `ZKHostStore:tryInit()` that internally triggers the listener used for testing purposes. Such a listener is used to ensure that an update to the host store is completed before performing any assertion/check in a test case; an example of this use case is `zkHostStoreTests`.

However, the fact that the new `updateMap()` call introduced PR #3682 triggers the listener in `ZKHostStore`, breaks the logic of `zkHostStoreTests`. The reason is that `zkHostStoreTests` uses a `CompletableFuture` that is assumed to be completed when the listener is triggered after executing `hostStore.updateHostContainersMap(hostContainerMap);`. As now the listener is triggered first by `ZKHostStore:tryInit()`, the `CompletableFuture` is actually completed before the call to `updateHostContainersMap` (that also triggers the listener). This poses a race condition that makes the test to fail sporadically, specially in Jenkins. 

As the listener is now triggered twice, we just added a second `CompletableFuture` for the test to wait for completion. By doing this, the test actually waits for `updateHostContainersMap` to complete and it passes.

**How to verify it**  
Executed 2 Jenkins builds in which this test has passed (before, it was persistently failing):
`21:20:41 io.pravega.controller.store.stream.HostStoreTest > zkHostStoreTests PASSED`
`21:32:10 io.pravega.controller.store.stream.HostStoreTest > zkHostStoreTests PASSED`