### PR TITLE
Issue 3719: Port bug fixes to r0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -913,7 +913,7 @@ project('test:system') {
 
 def getProjectVersion() {
     String ver = pravegaVersion
-    if (ver.contains("-SNAPSHOT")) {
+    if (grgit && ver.contains("-SNAPSHOT")) {
         String versionLabel = ver.substring(0, ver.indexOf("-SNAPSHOT"))
         def count = grgit.log(includes:['HEAD']).size()
         def commitId = "${grgit.head().abbreviatedId}"

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -139,7 +139,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
 
     /**
      * Returns a {@link StreamCut} for each stream that this reader group is reading from.
-     * The stream cut corresponds to the last updated read offsets of the readers, and
+     * The stream cut corresponds to the last checkpointed read offsets of the readers, and
      * it can be used by the application as reference to such a position.
      * A more precise {@link StreamCut}, with the latest read offsets can be obtained using
      * {@link ReaderGroup#generateStreamCuts(ScheduledExecutorService)} API.

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -51,7 +51,7 @@ public class ReaderGroupConfig implements Serializable {
 
    public static class ReaderGroupConfigBuilder implements ObjectBuilder<ReaderGroupConfig> {
        private long groupRefreshTimeMillis = 3000; //default value
-       private long automaticCheckpointIntervalMillis = 120000; //default value
+       private long automaticCheckpointIntervalMillis = 30000; //default value
        // maximum outstanding checkpoint request that is allowed at any given time.
        private int maxOutstandingCheckpointRequest = 3; //default value
 

--- a/client/src/main/java/io/pravega/client/stream/Transaction.java
+++ b/client/src/main/java/io/pravega/client/stream/Transaction.java
@@ -29,6 +29,12 @@ public interface Transaction<Type> {
         ABORTED
     }
 
+    enum PingStatus {
+        OPEN,
+        COMMITTED,
+        ABORTED
+    }
+
     /**
      * Returns a unique ID that can be used to identify this transaction.
      *

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -181,9 +181,9 @@ public interface Controller extends AutoCloseable {
      * @param stream     Stream name
      * @param txId       Transaction id
      * @param lease      Time for which transaction shall remain open with sending any heartbeat.
-     * @return           Void or PingFailedException
+     * @return           Transaction.PingStatus or PingFailedException
      */
-    CompletableFuture<Void> pingTransaction(final Stream stream, final UUID txId, final long lease);
+    CompletableFuture<Transaction.PingStatus> pingTransaction(final Stream stream, final UUID txId, final long lease);
 
     /**
      * Commits a transaction, atomically committing all events to the stream, subject to the

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -859,28 +859,30 @@ public class ControllerImpl implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> pingTransaction(Stream stream, UUID txId, long lease) {
+    public CompletableFuture<Transaction.PingStatus> pingTransaction(final Stream stream, final UUID txId, final long lease) {
         Exceptions.checkNotClosed(closed.get(), this);
         long traceId = LoggerHelpers.traceEnter(log, "pingTransaction", stream, txId, lease);
 
         final CompletableFuture<PingTxnStatus> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<PingTxnStatus> callback = new RPCAsyncCallback<>(traceId, "pingTransaction");
-            client.pingTransaction(PingTxnRequest.newBuilder().setStreamInfo(
-                    ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
-                            .setTxnId(ModelHelper.decode(txId))
-                            .setLease(lease).build(),
-                    callback);
+            client.pingTransaction(PingTxnRequest.newBuilder()
+                                                 .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
+                                                 .setTxnId(ModelHelper.decode(txId))
+                                                 .setLease(lease).build(), callback);
             return callback.getFuture();
         }, this.executor);
-        return Futures.toVoidExpecting(result,
-                                             PingTxnStatus.newBuilder().setStatus(PingTxnStatus.Status.OK).build(),
-                                             PingFailedException::new)
-                      .whenComplete((x, e) -> {
-                    if (e != null) {
-                        log.warn("pingTransaction failed: ", e);
-                    }
-                    LoggerHelpers.traceLeave(log, "pingTransaction", traceId);
-                });
+        return result.thenApply(status -> {
+            try {
+                return ModelHelper.encode(status.getStatus(), stream + " " + txId);
+            } catch (PingFailedException ex) {
+                throw new CompletionException(ex);
+            }
+        }).whenComplete((s, e) -> {
+            if (e != null) {
+                log.warn("Ping Transaction failed:", e);
+            }
+            LoggerHelpers.traceLeave(log, "pingTransaction", traceId);
+        });
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import com.google.common.base.Preconditions;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.RetentionPolicy;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
@@ -168,6 +169,35 @@ public final class ModelHelper {
             case UNRECOGNIZED:
             default:
                 throw new IllegalStateException("Unknown status: " + state);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the status of Ping Transaction.
+     *
+     * @param status     PingTxnStatus object instance.
+     * @param logString Description text to be logged when ping transaction status is invalid.
+     * @return Transaction.PingStatus
+     * @throws PingFailedException if status of Ping transaction operations is not successful.
+     */
+    public static final Transaction.PingStatus encode(final Controller.PingTxnStatus.Status status, final String logString)
+            throws PingFailedException {
+        Preconditions.checkNotNull(status, "status");
+        Exceptions.checkNotNullOrEmpty(logString, "logString");
+        Transaction.PingStatus result;
+        switch (status) {
+            case OK:
+                result = Transaction.PingStatus.OPEN;
+                break;
+            case COMMITTED:
+                result = Transaction.PingStatus.COMMITTED;
+                break;
+            case ABORTED:
+                result = Transaction.PingStatus.ABORTED;
+                break;
+            default:
+                throw new PingFailedException("Ping transaction for " + logString + " failed with status " + status);
         }
         return result;
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
@@ -16,15 +16,17 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A position has two components
- * 1. ownedSegments -- segments that can be read currently. Each ownedSegment also has an offset indicating the
- * point until which events have been read from that segment. Completely read segments have offset of -1.
- * 2. futureOwnedSegments -- segments that can be read after one of the currently read segment is completely read. Each
- * segment in this set has exactly one previous segment that belongs to the set ownedSegments.
+ * A position has ownedSegments -- segments that can be read currently (or have been completed and
+ * not yet replaced).
+ * 
+ * A Position obtained at any given point will return a segment for all of the keyspace owned by
+ * the reader.
+ * 
+ * Each ownedSegment also has an offset indicating the point until which events have been read from
+ * that segment. Completely read segments have offset of -1.
  * <p>
- * Well-formed position object. A position is called well-formed iff the following hold.
- * 1. for each segment s in futureOwnedSegment, s.previous belongs to ownedSegments and s.previous.offset != -1
- * 2. for each segment s in ownedSegment, s.previous does not belongs to ownedSegments
+ * We say that a position object P is well-formed to denote that every segment `s` in `P`
+ * is not a predecessor of any segment in ownedSegments.
  */
 public abstract class PositionInternal implements Position {
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -536,13 +536,9 @@ public class ReaderGroupState implements Revisioned {
                 while (iter.hasNext()) {
                     Entry<Segment, Long> entry = iter.next();
                     Segment segment = entry.getKey();
-                    Long offset;
-                    if (ownedSegments == null || ownedSegments.isEmpty()) {
+                    Long offset = ownedSegments.get(segment);
+                    if (offset == null) {
                         offset = entry.getValue();
-                    } else {
-                        offset = ownedSegments.get(segment);
-                        Preconditions.checkState(offset != null,
-                                "No offset in lastPosition for assigned segment: " + segment);
                     }
                     finalPositions.put(segment, offset);
                     state.unassignedSegments.put(segment, offset);

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -92,8 +92,8 @@ public class ReaderGroupStateManager {
             nanoClock = System::nanoTime;
         }
         releaseTimer = new TimeoutTimer(TIME_UNIT, nanoClock);
-        acquireTimer = new TimeoutTimer(TIME_UNIT, nanoClock);
-        fetchStateTimer = new TimeoutTimer(TIME_UNIT, nanoClock);
+        acquireTimer = new TimeoutTimer(Duration.ZERO, nanoClock);
+        fetchStateTimer = new TimeoutTimer(Duration.ZERO, nanoClock);
         checkpointTimer = new TimeoutTimer(TIME_UNIT, nanoClock);
     }
 
@@ -137,12 +137,8 @@ public class ReaderGroupStateManager {
                 return;
             }
             log.debug("Removing reader {} from reader grop. CurrentState is: {}", readerId, state);
-            if (lastPosition != null && !lastPosition.asImpl().getOwnedSegments().containsAll(segments)) {
-                throw new IllegalArgumentException(
-                        "When shutting down a reader: Given position does not match the segments it was assigned: \n"
-                                + segments + " \n vs \n " + lastPosition.asImpl().getOwnedSegments());
-            }
-            updates.add(new RemoveReader(readerId, lastPosition == null ? null : lastPosition.asImpl().getOwnedSegmentsWithOffsets()));
+            updates.add(new RemoveReader(readerId, lastPosition == null ? Collections.emptyMap()
+                    : lastPosition.asImpl().getOwnedSegmentsWithOffsets()));
         });
     }
     
@@ -151,31 +147,41 @@ public class ReaderGroupStateManager {
     }
 
     /**
-     * Handles a segment being completed by calling the controller to gather all successors to the completed segment.
+     * Handles a segment being completed by calling the controller to gather all successors to the
+     * completed segment. To ensure consistent checkpoints, a segment cannot be released while a
+     * checkpoint for the reader is pending, so it may or may not succeed.
+     * 
+     * @return true if the completed segment was released successfully.
      */
-    void handleEndOfSegment(Segment segmentCompleted, boolean fetchSuccesors) throws ReaderNotInReaderGroupException {
+    boolean handleEndOfSegment(Segment segmentCompleted) throws ReaderNotInReaderGroupException {
         final Map<Segment, List<Long>> segmentToPredecessor;
-        if (fetchSuccesors) {
+        if (sync.getState().getEndSegments().containsKey(segmentCompleted)) {
+            segmentToPredecessor = Collections.emptyMap();
+        } else {
             val successors = getAndHandleExceptions(controller.getSuccessors(segmentCompleted), RuntimeException::new);
             segmentToPredecessor = successors.getSegmentToPredecessor();
-        } else {
-            segmentToPredecessor = Collections.emptyMap();
         }
 
         AtomicBoolean reinitRequired = new AtomicBoolean(false);
-        sync.updateState((state, updates) -> {
+        boolean result = sync.updateState((state, updates) -> {
             if (!state.isReaderOnline(readerId)) {
                 reinitRequired.set(true);
             } else {
                 log.debug("Marking segment {} as completed in reader group. CurrentState is: {}", segmentCompleted, state);
                 reinitRequired.set(false);
-                updates.add(new SegmentCompleted(readerId, segmentCompleted, segmentToPredecessor));
+                //This check guards against another checkpoint having started.
+                if (state.getCheckpointForReader(readerId) == null) {
+                    updates.add(new SegmentCompleted(readerId, segmentCompleted, segmentToPredecessor));
+                    return true;
+                }
             }
+            return false;
         });
         if (reinitRequired.get()) {
             throw new ReaderNotInReaderGroupException(readerId);
         }
         acquireTimer.zero();
+        return result;
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/EndOfDataNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/EndOfDataNotifier.java
@@ -10,7 +10,7 @@
 package io.pravega.client.stream.notifications.notifier;
 
 import java.util.concurrent.ScheduledExecutorService;
-
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.notifications.EndOfDataNotification;
@@ -28,6 +28,14 @@ public class EndOfDataNotifier extends AbstractPollingNotifier<EndOfDataNotifica
                              final StateSynchronizer<ReaderGroupState> synchronizer,
                              final ScheduledExecutorService executor) {
         super(notifySystem, executor, synchronizer);
+    }
+    
+    /**
+     * Invokes the periodic processing now in the current thread.
+     */
+    @VisibleForTesting
+    public void pollNow() {
+        this.checkAndTriggerEndOfStreamNotification();
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
@@ -12,7 +12,7 @@ package io.pravega.client.stream.notifications.notifier;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.concurrent.ScheduledExecutorService;
-
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.notifications.Listener;
@@ -33,6 +33,14 @@ public class SegmentNotifier extends AbstractPollingNotifier<SegmentNotification
                            final StateSynchronizer<ReaderGroupState> synchronizer,
                            final ScheduledExecutorService executor) {
         super(notifySystem, executor, synchronizer);
+    }
+    
+    /**
+     * Invokes the periodic processing now in the current thread.
+     */
+    @VisibleForTesting
+    public void pollNow() {
+        checkAndTriggerSegmentNotification();
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -52,7 +52,7 @@ public class StreamManagerImplTest {
     public void setUp() {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
-        this.controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        this.controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         this.streamManager = new StreamManagerImpl(controller, cf);
     }
 
@@ -107,7 +107,7 @@ public class StreamManagerImplTest {
                                       Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
-                                                           connectionFactory);
+                                                           connectionFactory, true);
         @Cleanup
         final StreamManager streamManager = new StreamManagerImpl(mockController, connectionFactory);
 
@@ -159,7 +159,7 @@ public class StreamManagerImplTest {
                 Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
-                connectionFactory);
+                connectionFactory, true);
         @Cleanup
         final StreamManager streamManager = new StreamManagerImpl(mockController, connectionFactory);
 

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -51,7 +51,7 @@ public class BatchClientImplTest {
 
         PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
         MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
-        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory, false);
         Stream stream = createStream(SCOPE, STREAM, 3, mockController);
         BatchClientFactoryImpl client = new BatchClientFactoryImpl(mockController, connectionFactory);
 
@@ -70,7 +70,7 @@ public class BatchClientImplTest {
 
         PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
         MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
-        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory, false);
         Stream stream = createStream(SCOPE, STREAM, 3, mockController);
         BatchClientFactoryImpl client = new BatchClientFactoryImpl(mockController, connectionFactory);
 
@@ -89,7 +89,7 @@ public class BatchClientImplTest {
 
         PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
         MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
-        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory, false);
         Stream stream = createStream(SCOPE, STREAM, 3, mockController);
         BatchClientFactoryImpl client = new BatchClientFactoryImpl(mockController, connectionFactory);
 
@@ -137,7 +137,7 @@ public class BatchClientImplTest {
                                       Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(location, connection);
         MockController mockController = new MockController(location.getEndpoint(), location.getPort(),
-                connectionFactory);
+                connectionFactory, false);
         BatchClientFactoryImpl client = new BatchClientFactoryImpl(mockController, connectionFactory);
 
         mockController.createScope(scope);
@@ -171,16 +171,6 @@ public class BatchClientImplTest {
     private MockConnectionFactoryImpl getMockConnectionFactory(PravegaNodeUri location) throws ConnectionFailedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         ClientConnection connection = mock(ClientConnection.class);
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                CreateSegment request = (CreateSegment) invocation.getArgument(0);
-                connectionFactory.getProcessor(location)
-                                 .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
-                return null;
-            }
-        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
-                                      Mockito.any(ClientConnection.CompletedCallback.class));
         Mockito.doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {

--- a/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
@@ -20,8 +20,6 @@ import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
-import io.pravega.shared.protocol.netty.WireCommands.CreateSegment;
-import io.pravega.shared.protocol.netty.WireCommands.SegmentCreated;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -30,8 +28,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
 
@@ -48,18 +44,8 @@ public class ByteStreamWriterTest {
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 0);
         connectionFactory = new MockConnectionFactoryImpl();
         ClientConnection connection = Mockito.mock(ClientConnection.class);
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                CreateSegment request = (CreateSegment) invocation.getArgument(0);
-                connectionFactory.getProcessor(endpoint)
-                                 .process(new SegmentCreated(request.getRequestId(), request.getSegment()));
-                return null;
-            }
-        }).when(connection).sendAsync(Mockito.any(CreateSegment.class),
-                                      Mockito.any(ClientConnection.CompletedCallback.class));
         connectionFactory.provideConnection(endpoint, connection);
-        controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         controller.createScope(SCOPE);
         controller.createStream(SCOPE, STREAM, StreamConfiguration.builder()
                                                    .scalingPolicy(ScalingPolicy.fixed(1))

--- a/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
@@ -40,7 +40,7 @@ public class RawClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         ClientConnection connection = Mockito.mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, connection);
         RawClient rawClient = new RawClient(controller, connectionFactory, new Segment("scope", "testHello", 0));
@@ -58,7 +58,7 @@ public class RawClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         ClientConnection connection = Mockito.mock(ClientConnection.class);
         connectionFactory.provideConnection(endpoint, connection);
         @Cleanup

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.client.netty.impl.ClientConnection;
+import io.pravega.client.netty.impl.Flow;
 import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -27,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -37,7 +39,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -82,14 +87,79 @@ public class AsyncSegmentInputStreamTest {
         CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
         assertEquals(segmentRead, readFuture.join());
         assertTrue(Futures.isSuccessful(readFuture));
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
         inOrder.verify(c).close();
-        inOrder.verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,   5678, "", in.getRequestId())),
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                                     Mockito.any(ClientConnection.CompletedCallback.class));
+        verifyNoMoreInteractions(c);
+    }
+
+    @Test(timeout = 10000)
+    public void testRetryWithConnectionFailures() {
+
+        Segment segment = new Segment("scope", "testRetry", 4);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
+        ClientConnection c = mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, c);
+        MockConnectionFactoryImpl mockedCF = spy(connectionFactory);
+        @Cleanup
+        AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, mockedCF, segment, "");
+        InOrder inOrder = Mockito.inOrder(c);
+
+        // Failed Connection
+        CompletableFuture<ClientConnection> failedConnection = new CompletableFuture<>();
+        failedConnection.completeExceptionally(new ConnectionFailedException("Netty error while establishing connection"));
+
+        // Successful Connection
+        CompletableFuture<ClientConnection> successfulConnection = new CompletableFuture<>();
+        successfulConnection.complete(c);
+
+        WireCommands.SegmentRead segmentRead = new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false,
+                                                                            ByteBufferUtils.EMPTY, in.getRequestId());
+        // simulate a establishConnection failure to segment store.
+        Mockito.doReturn(failedConnection)
+               .doCallRealMethod()
+               .when(mockedCF).establishConnection(any(Flow.class), eq(endpoint), any(ReplyProcessor.class));
+
+        ArgumentCaptor<ClientConnection.CompletedCallback> callBackCaptor =
+                ArgumentCaptor.forClass(ClientConnection.CompletedCallback.class);
+        Mockito.doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                // Simulate a connection failure post establishing connection to SegmentStore.
+                callBackCaptor.getValue().complete(new ConnectionFailedException("SendAsync exception since netty channel is null"));
+                return null;
+            }
+        }).doAnswer(new Answer<Void>() {
+                   public Void answer(InvocationOnMock invocation) {
+                       mockedCF.getProcessor(endpoint).segmentRead(segmentRead);
+                       return null;
+                   }
+               }).when(c).sendAsync(any(ReadSegment.class), callBackCaptor.capture());
+
+        // Read invocation.
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+
+        // Verification.
+        assertEquals(segmentRead, readFuture.join());
+        assertTrue(Futures.isSuccessful(readFuture)); // read completes after 3 retries.
+        // Verify that the reader attempts to establish connection 3 times ( 2 failures followed by a successful attempt).
+        verify(mockedCF, times(3)).establishConnection(any(Flow.class), eq(endpoint), any(ReplyProcessor.class));
+        // The second time sendAsync is invoked but it fail due to the exception.
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
+        // Validate that the connection is closed in case of an error.
+        inOrder.verify(c).close();
+        // Validate that the read command is send again over the new connection.
+        inOrder.verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
+                                    Mockito.any(ClientConnection.CompletedCallback.class));
+        // No more interactions since the SSS responds and the ReplyProcessor.segmentRead is invoked by netty.
         verifyNoMoreInteractions(c);
     }
     
@@ -130,7 +200,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);            
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(segmentRead, readFuture.join());
@@ -161,7 +231,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentIsTruncated(segmentIsTruncated);
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
         assertThrows(SegmentTruncatedException.class, () -> readFuture.get());
@@ -175,7 +245,7 @@ public class AsyncSegmentInputStreamTest {
             ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
             processor.segmentRead(segmentRead);
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 5656,  5678, "", in.getRequestId())),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 5656, 5678, "", in.getRequestId())),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture2));
         assertEquals(segmentRead, readFuture2.join());
@@ -200,7 +270,7 @@ public class AsyncSegmentInputStreamTest {
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1235, false, false, ByteBuffer.wrap(bad), in.getRequestId()));
             processor.segmentRead(new WireCommands.SegmentRead(segment.getScopedName(), 1234, false, false, ByteBuffer.wrap(good), in.getRequestId()));
         });
-        verify(c).sendAsync(Mockito.eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234,  5678, "", in.getRequestId() )),
+        verify(c).sendAsync(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId() )),
                             Mockito.any(ClientConnection.CompletedCallback.class));
         assertTrue(Futures.isSuccessful(readFuture));
         assertEquals(ByteBuffer.wrap(good), readFuture.join().getData());

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -50,7 +50,7 @@ public class AsyncSegmentInputStreamTest {
         Segment segment = new Segment("scope", "testRetry", 4);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
         ClientConnection c = mock(ClientConnection.class);
@@ -98,7 +98,7 @@ public class AsyncSegmentInputStreamTest {
         Segment segment = new Segment("scope", "testRetry", 4);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
         ClientConnection c = mock(ClientConnection.class);
@@ -116,7 +116,7 @@ public class AsyncSegmentInputStreamTest {
         Segment segment = new Segment("scope", "testRead", 1);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
 
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
@@ -143,7 +143,7 @@ public class AsyncSegmentInputStreamTest {
         Segment segment = new Segment("scope", "testRead", 1);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
 
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
@@ -189,7 +189,7 @@ public class AsyncSegmentInputStreamTest {
         byte[] bad = new byte[] { 9, 8, 7, 6 };
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
         @Cleanup
         AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment, "");
         ClientConnection c = mock(ClientConnection.class);

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -40,7 +40,7 @@ public class ConditionalOutputStreamTest {
     @Test(timeout = 5000)
     public void testWrite() throws ConnectionFailedException, SegmentSealedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController("localhost", 0, connectionFactory);
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
         ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
         Segment segment = new Segment("scope", "testWrite", 1);       
         ConditionalOutputStream cOut = factory.createConditionalOutputStream(segment, "token", EventWriterConfig.builder().build());
@@ -72,7 +72,7 @@ public class ConditionalOutputStreamTest {
     @Test(timeout = 10000)
     public void testClose() throws SegmentSealedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController("localhost", 0, connectionFactory);
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
         ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
         Segment segment = new Segment("scope", "testWrite", 1);       
         ConditionalOutputStream cOut = factory.createConditionalOutputStream(segment, "token", EventWriterConfig.builder().build());
@@ -83,7 +83,7 @@ public class ConditionalOutputStreamTest {
     @Test(timeout = 10000)
     public void testRetries() throws ConnectionFailedException, SegmentSealedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController("localhost", 0, connectionFactory);
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
         ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
         Segment segment = new Segment("scope", "testWrite", 1);       
         ConditionalOutputStream cOut = factory.createConditionalOutputStream(segment, "token", EventWriterConfig.builder().build());
@@ -128,7 +128,7 @@ public class ConditionalOutputStreamTest {
     @Test(timeout = 10000)
     public void testSegmentSealed() throws ConnectionFailedException, SegmentSealedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController("localhost", 0, connectionFactory);
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
         ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
         Segment segment = new Segment("scope", "testWrite", 1);       
         ConditionalOutputStream cOut = factory.createConditionalOutputStream(segment, "token", EventWriterConfig.builder().build());
@@ -158,7 +158,7 @@ public class ConditionalOutputStreamTest {
     @Test(timeout = 10000)
     public void testOnlyOneWriteAtATime() throws ConnectionFailedException, SegmentSealedException {
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController("localhost", 0, connectionFactory);
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
         ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
         Segment segment = new Segment("scope", "testWrite", 1);       
         ConditionalOutputStream cOut = factory.createConditionalOutputStream(segment, "token", EventWriterConfig.builder().build());

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -51,7 +51,7 @@ public class SegmentMetadataClientTest {
         @Cleanup
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         @Cleanup
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
@@ -80,7 +80,7 @@ public class SegmentMetadataClientTest {
         @Cleanup
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         @Cleanup
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
@@ -110,7 +110,7 @@ public class SegmentMetadataClientTest {
         @Cleanup
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         @Cleanup
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
@@ -141,7 +141,7 @@ public class SegmentMetadataClientTest {
         @Cleanup
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         @Cleanup
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
@@ -167,7 +167,7 @@ public class SegmentMetadataClientTest {
         Segment segment = new Segment("scope", "testRetry", 4);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 0);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
         @Cleanup
@@ -192,7 +192,7 @@ public class SegmentMetadataClientTest {
         @Cleanup
         MockConnectionFactoryImpl cf = Mockito.spy(new MockConnectionFactoryImpl());
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         @Cleanup
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(endpoint, connection);
@@ -240,7 +240,7 @@ public class SegmentMetadataClientTest {
         ConnectionFactory cf = Mockito.mock(ConnectionFactory.class);
         Mockito.when(cf.getInternalExecutor()).thenReturn(executor);
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), cf, true);
         ClientConnection connection1 = mock(ClientConnection.class);
         ClientConnection connection2 = mock(ClientConnection.class);
         AtomicReference<ReplyProcessor> processor = new AtomicReference<>();

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -100,7 +100,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
@@ -122,7 +122,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
 
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
@@ -145,7 +145,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
 
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         doThrow(ConnectionFailedException.class).doNothing().when(connection).send(any(SetupAppend.class));
         cf.provideConnection(uri, connection);
@@ -169,7 +169,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
 
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
@@ -193,7 +193,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
 
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
@@ -243,7 +243,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
@@ -261,7 +261,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         InOrder inOrder = inOrder(connection);
         cf.provideConnection(uri, connection);
@@ -319,7 +319,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
 
@@ -350,7 +350,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -391,7 +391,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -432,7 +432,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -471,7 +471,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
@@ -527,7 +527,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
@@ -585,7 +585,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
@@ -612,7 +612,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -637,7 +637,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -675,7 +675,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -710,7 +710,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -758,7 +758,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         InOrder inOrder = inOrder(connection);
         cf.provideConnection(uri, connection);
@@ -828,7 +828,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
         cf.setExecutor(executor);
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         AtomicBoolean shouldThrow = new AtomicBoolean(true);
@@ -871,7 +871,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -904,7 +904,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -939,7 +939,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
-        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf);
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -43,7 +43,7 @@ public class RevisionedStreamClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -83,7 +83,7 @@ public class RevisionedStreamClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -118,7 +118,7 @@ public class RevisionedStreamClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -154,7 +154,7 @@ public class RevisionedStreamClientTest {
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
         @Cleanup
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -9,7 +9,12 @@
  */
 package io.pravega.client.stream.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.pravega.client.admin.impl.ReaderGroupManagerImpl.ReaderGroupStateInitSerializer;
+import io.pravega.client.admin.impl.ReaderGroupManagerImpl.ReaderGroupStateUpdatesSerializer;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.NoSuchEventException;
@@ -21,17 +26,28 @@ import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
 import io.pravega.client.segment.impl.SegmentOutputStream;
 import io.pravega.client.segment.impl.SegmentSealedException;
 import io.pravega.client.segment.impl.SegmentTruncatedException;
+import io.pravega.client.state.StateSynchronizer;
+import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderNotInReaderGroupException;
 import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.TruncatedDataException;
+import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
+import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
+import io.pravega.shared.NameUtils;
+import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.test.common.AssertExtensions;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -41,11 +57,13 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import static io.pravega.client.stream.impl.ReaderGroupImpl.getEndSegmentsForStreams;
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 
@@ -114,11 +132,24 @@ public class EventStreamReaderTest {
                 orderer, clock::get,
                 ReaderConfig.builder().build());
 
+        InOrder inOrder = Mockito.inOrder(segmentInputStream1, groupState);
         EventRead<byte[]> event = reader.readNextEvent(100L);
+        assertNotNull(event.getEvent());
         //Validate that segmentInputStream1.close() is invoked on reaching endOffset.
         Mockito.verify(segmentInputStream1, Mockito.times(1)).close();
-        //Validate that groupState.handleEndOfSegment method is invoked.
-        Mockito.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment, false);
+        
+        // Verify groupstate is not updated before the checkpoint, but is after.
+        inOrder.verify(groupState, Mockito.times(0)).handleEndOfSegment(segment);
+        Mockito.when(groupState.getCheckpoint()).thenReturn("checkpoint").thenReturn(null);
+        assertEquals("checkpoint", reader.readNextEvent(0).getCheckpointName());
+        inOrder.verify(groupState).getCheckpoint();
+        // Verify groupstate is not updated before the checkpoint, but is after.
+        inOrder.verify(groupState, Mockito.times(0)).handleEndOfSegment(segment);
+        event = reader.readNextEvent(0);
+        assertFalse(event.isCheckpoint());
+        // Now it is called.
+        inOrder.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment);
+        
     }
 
     @SuppressWarnings("unchecked")
@@ -155,8 +186,7 @@ public class EventStreamReaderTest {
                 orderer, clock::get,
                 ReaderConfig.builder().build());
 
-        AssertExtensions.assertThrows(TruncatedDataException.class,
-                () -> reader.readNextEvent(100L));
+        assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(100L));
         //Validate that groupState.getOrRefreshDelegationTokenFor method is invoked.
         Mockito.verify(groupState, Mockito.times(1)).getOrRefreshDelegationTokenFor(segment);
     }
@@ -209,6 +239,7 @@ public class EventStreamReaderTest {
         Assert.assertEquals(segment1, readers.get(0).getSegmentId());
         Assert.assertEquals(segment2, readers.get(1).getSegmentId());
 
+        //Checkpoint is required to release a segment.
         Mockito.when(groupState.getCheckpoint()).thenReturn("checkpoint");
         assertTrue(reader.readNextEvent(0).isCheckpoint());
         Mockito.when(groupState.getCheckpoint()).thenReturn(null);
@@ -324,6 +355,82 @@ public class EventStreamReaderTest {
     }
     
     @Test(timeout = 10000)
+    public void testSilentCheckpointFollowingCheckpoint() throws SegmentSealedException, ReaderNotInReaderGroupException {
+        AtomicLong clock = new AtomicLong();
+        MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
+        Orderer orderer = new Orderer();
+        ReaderGroupStateManager groupState = Mockito.mock(ReaderGroupStateManager.class);
+        EventStreamReaderImpl<byte[]> reader = new EventStreamReaderImpl<>(segmentStreamFactory, segmentStreamFactory,
+                                                                           new ByteArraySerializer(), groupState,
+                                                                           orderer, clock::get,
+                                                                           ReaderConfig.builder().build());
+        Segment segment = Segment.fromScopedName("Foo/Bar/0");
+        Mockito.when(groupState.acquireNewSegmentsIfNeeded(0L)).thenReturn(ImmutableMap.of(segment, 0L)).thenReturn(Collections.emptyMap());
+        SegmentOutputStream stream = segmentStreamFactory.createOutputStreamForSegment(segment, segmentSealedCallback, writerConfig, "");
+        ByteBuffer buffer = writeInt(stream, 1);
+        Mockito.doReturn(true).when(groupState).isCheckpointSilent(Mockito.eq(ReaderGroupImpl.SILENT + "Foo"));
+        Mockito.when(groupState.getCheckpoint())
+               .thenReturn(ReaderGroupImpl.SILENT + "Foo")
+               .thenReturn("Bar")
+               .thenReturn(null);
+        EventRead<byte[]> eventRead = reader.readNextEvent(10000);
+        assertTrue(eventRead.isCheckpoint());
+        assertNull(eventRead.getEvent());
+        assertEquals("Bar", eventRead.getCheckpointName());
+        InOrder order = Mockito.inOrder(groupState);
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState).checkpoint(Mockito.eq(ReaderGroupImpl.SILENT + "Foo"), Mockito.any());
+        assertEquals(buffer, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState).checkpoint(Mockito.eq("Bar"), Mockito.any());
+        order.verify(groupState).getCheckpoint();
+        reader.close();
+    }
+    
+    @Test(timeout = 10000)
+    public void testCheckpointFollowingSilentCheckpointFollowingCheckpoint() throws SegmentSealedException, ReaderNotInReaderGroupException {
+        AtomicLong clock = new AtomicLong();
+        MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
+        Orderer orderer = new Orderer();
+        ReaderGroupStateManager groupState = Mockito.mock(ReaderGroupStateManager.class);
+        EventStreamReaderImpl<byte[]> reader = new EventStreamReaderImpl<>(segmentStreamFactory, segmentStreamFactory,
+                                                                           new ByteArraySerializer(), groupState,
+                                                                           orderer, clock::get,
+                                                                           ReaderConfig.builder().build());
+        Segment segment = Segment.fromScopedName("Foo/Bar/0");
+        Mockito.when(groupState.acquireNewSegmentsIfNeeded(0L))
+               .thenReturn(ImmutableMap.of(segment, 0L))
+               .thenReturn(Collections.emptyMap());
+        SegmentOutputStream stream = segmentStreamFactory.createOutputStreamForSegment(segment, segmentSealedCallback,
+                                                                                       writerConfig, "");
+        ByteBuffer buffer = writeInt(stream, 1);
+        Mockito.doReturn(true).when(groupState).isCheckpointSilent(Mockito.startsWith(ReaderGroupImpl.SILENT));
+        Mockito.when(groupState.getCheckpoint())
+               .thenReturn(ReaderGroupImpl.SILENT + "Foo")
+               .thenReturn("Bar")
+               .thenReturn(ReaderGroupImpl.SILENT + "Baz")
+               .thenReturn(null);
+        EventRead<byte[]> eventRead = reader.readNextEvent(10000);
+        assertTrue(eventRead.isCheckpoint());
+        assertNull(eventRead.getEvent());
+        assertEquals("Bar", eventRead.getCheckpointName());
+        EventRead<byte[]> nullEvent = reader.readNextEvent(0);
+        assertNull(nullEvent.getEvent());
+        assertFalse(nullEvent.isCheckpoint());
+        InOrder order = Mockito.inOrder(groupState);
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState).checkpoint(Mockito.eq(ReaderGroupImpl.SILENT + "Foo"), Mockito.any());
+        assertEquals(buffer, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState).checkpoint(Mockito.eq("Bar"), Mockito.any());
+        order.verify(groupState).getCheckpoint();
+        order.verify(groupState).checkpoint(Mockito.eq(ReaderGroupImpl.SILENT + "Baz"), Mockito.any());
+        order.verify(groupState).findSegmentToReleaseIfRequired();
+        order.verify(groupState).getCheckpoint();
+        reader.close();
+    }
+    
+    @Test(timeout = 10000)
     public void testRestore() throws SegmentSealedException, ReaderNotInReaderGroupException {
         AtomicLong clock = new AtomicLong();
         MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
@@ -338,12 +445,7 @@ public class EventStreamReaderTest {
         SegmentOutputStream stream = segmentStreamFactory.createOutputStreamForSegment(segment, segmentSealedCallback, writerConfig, "");
         ByteBuffer buffer = writeInt(stream, 1);
         Mockito.when(groupState.getCheckpoint()).thenThrow(new ReinitializationRequiredException());
-        try {
-            reader.readNextEvent(0);
-            fail();
-        } catch (ReinitializationRequiredException e) {
-            // expected
-        }
+        assertThrows(ReinitializationRequiredException.class, () -> reader.readNextEvent(0)); 
         assertTrue(reader.getReaders().isEmpty());
         reader.close();
     }
@@ -376,10 +478,10 @@ public class EventStreamReaderTest {
         assertEquals(buffer2, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
         metadataClient.truncateSegment(length);
         ByteBuffer buffer4 = writeInt(stream, 4);
-        AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
+        assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
         assertEquals(buffer4, ByteBuffer.wrap(reader.readNextEvent(0).getEvent()));
         assertNull(reader.readNextEvent(0).getEvent());
-        AssertExtensions.assertThrows(NoSuchEventException.class, () -> reader.fetchEvent(event1.getEventPointer()));
+        assertThrows(NoSuchEventException.class, () -> reader.fetchEvent(event1.getEventPointer()));
         reader.close();
     }
 
@@ -414,12 +516,235 @@ public class EventStreamReaderTest {
         Mockito.when(groupState.acquireNewSegmentsIfNeeded(0L))
                 .thenReturn(ImmutableMap.of(segment, 0L))
                 .thenReturn(Collections.emptyMap());
-
+        InOrder inOrder = Mockito.inOrder(groupState, segmentInputStream);
         // Validate that TruncatedDataException is thrown.
         AssertExtensions.assertThrows(TruncatedDataException.class, () -> reader.readNextEvent(0));
+        inOrder.verify(groupState).getCheckpoint();
         // Ensure this segment is closed.
-        Mockito.verify(segmentInputStream, Mockito.times(1)).close();
-        // Ensure groupstate is updated to handle end of segment.
-        Mockito.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment, true);
+        inOrder.verify(segmentInputStream, Mockito.times(1)).close();      
+        // Ensure groupstate is not updated before the checkpoint.
+        inOrder.verify(groupState, Mockito.times(0)).handleEndOfSegment(segment);
+        Mockito.when(groupState.getCheckpoint()).thenReturn("Foo").thenReturn(null);
+        EventRead<byte[]> event = reader.readNextEvent(0);
+        assertTrue(event.isCheckpoint());
+        assertEquals("Foo", event.getCheckpointName());
+        inOrder.verify(groupState).getCheckpoint();
+        // Verify groupstate is not updated before the checkpoint, but is after.
+        inOrder.verify(groupState, Mockito.times(0)).handleEndOfSegment(segment);
+        event = reader.readNextEvent(0);
+        assertFalse(event.isCheckpoint());
+        assertNull(event.getEvent());
+        // Now it is called.
+        inOrder.verify(groupState).handleEndOfSegment(segment);
     }
+    
+    @Test(timeout = 10000)
+    public void testSegmentSplit() throws EndOfSegmentException, SegmentTruncatedException, SegmentSealedException, ReaderNotInReaderGroupException {
+        AtomicLong clock = new AtomicLong();
+        MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
+
+        //Prep the mocks.
+        ReaderGroupStateManager groupState = Mockito.mock(ReaderGroupStateManager.class);
+
+        //Mock for the two SegmentInputStreams.
+        Segment segment1 = Segment.fromScopedName("Foo/Bar/1");
+        EventSegmentReader segmentInputStream1 = Mockito.mock(EventSegmentReader.class);
+        Mockito.when(segmentInputStream1.read(anyLong())).thenThrow(new EndOfSegmentException(EndOfSegmentException.ErrorType.END_OF_SEGMENT_REACHED));
+        Mockito.when(segmentInputStream1.getSegmentId()).thenReturn(segment1);
+
+        Segment segment2 = Segment.fromScopedName("Foo/Bar/2");
+        EventSegmentReader segmentInputStream2 = Mockito.mock(EventSegmentReader.class);
+        SegmentOutputStream stream2 = segmentStreamFactory.createOutputStreamForSegment(segment2, segmentSealedCallback, writerConfig, "");
+        Mockito.when(segmentInputStream2.read(anyLong())).thenReturn(writeInt(stream2, 2));
+        Mockito.when(segmentInputStream2.getSegmentId()).thenReturn(segment2);
+        
+        Segment segment3 = Segment.fromScopedName("Foo/Bar/3");
+        EventSegmentReader segmentInputStream3 = Mockito.mock(EventSegmentReader.class);
+        SegmentOutputStream stream3 = segmentStreamFactory.createOutputStreamForSegment(segment3, segmentSealedCallback, writerConfig, "");
+        Mockito.when(segmentInputStream2.read(anyLong())).thenReturn(writeInt(stream3, 3));
+        Mockito.when(segmentInputStream2.getSegmentId()).thenReturn(segment3);
+
+        SegmentInputStreamFactory inputStreamFactory = Mockito.mock(SegmentInputStreamFactory.class);
+        Mockito.when(inputStreamFactory.createEventReaderForSegment(segment1, Long.MAX_VALUE)).thenReturn(segmentInputStream1);
+        Mockito.when(inputStreamFactory.createEventReaderForSegment(segment2, Long.MAX_VALUE)).thenReturn(segmentInputStream2);
+        Mockito.when(inputStreamFactory.createEventReaderForSegment(segment3, Long.MAX_VALUE)).thenReturn(segmentInputStream3);     
+        
+        Mockito.when(groupState.getEndOffsetForSegment(any())).thenReturn(Long.MAX_VALUE);
+        
+        @Cleanup
+        EventStreamReaderImpl<byte[]> reader = new EventStreamReaderImpl<>(inputStreamFactory, segmentStreamFactory,
+                                                                           new ByteArraySerializer(), groupState,
+                                                                           new Orderer(), clock::get,
+                                                                           ReaderConfig.builder().build());
+
+        Mockito.when(groupState.acquireNewSegmentsIfNeeded(anyLong()))
+               .thenReturn(ImmutableMap.of(segment1, 0L))
+               .thenReturn(Collections.emptyMap());
+
+        InOrder inOrder = Mockito.inOrder(segmentInputStream1, groupState);
+        EventRead<byte[]> event = reader.readNextEvent(100L);
+        assertNull(event.getEvent());
+        event = reader.readNextEvent(100L);
+        assertNull(event.getEvent());
+
+        Mockito.when(groupState.getCheckpoint())
+               .thenReturn("checkpoint")
+               .thenReturn(null);
+        Mockito.when(groupState.acquireNewSegmentsIfNeeded(anyLong()))
+               .thenReturn(ImmutableMap.of(segment2, 0L, segment3, 0L))
+               .thenReturn(Collections.emptyMap());
+        assertEquals("checkpoint", reader.readNextEvent(0).getCheckpointName());
+        inOrder.verify(groupState).getCheckpoint();
+        // Ensure groupstate is not updated before the checkpoint.
+        inOrder.verify(groupState, Mockito.times(0)).handleEndOfSegment(segment1);
+        event = reader.readNextEvent(0);
+        assertFalse(event.isCheckpoint());
+        // Now it is called.
+        inOrder.verify(groupState, Mockito.times(1)).handleEndOfSegment(segment1);
+        assertEquals(ImmutableList.of(segmentInputStream2, segmentInputStream3), reader.getReaders());        
+        
+    }
+    
+    @Test
+    public void testReaderClose() throws SegmentSealedException {
+        String scope = "scope";
+        String stream = "stream";
+        AtomicLong clock = new AtomicLong();
+        MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        
+        //Mock for the two SegmentInputStreams.
+        Segment segment1 = new Segment(scope, stream, 0);
+        @Cleanup
+        SegmentOutputStream stream1 = segmentStreamFactory.createOutputStreamForSegment(segment1, segmentSealedCallback, writerConfig, "");
+        writeInt(stream1, 1);
+        writeInt(stream1, 1);
+        writeInt(stream1, 1);
+        Segment segment2 = new Segment(scope, stream, 1);
+        @Cleanup
+        SegmentOutputStream stream2 = segmentStreamFactory.createOutputStreamForSegment(segment2, segmentSealedCallback, writerConfig, "");
+        writeInt(stream2, 2);
+        writeInt(stream2, 2);
+        writeInt(stream2, 2);
+        StateSynchronizer<ReaderGroupState> sync = createStateSynchronizerForReaderGroup(connectionFactory, controller,
+                                                                                         segmentStreamFactory,
+                                                                                         Stream.of(scope, stream),
+                                                                                         "reader1", clock, 2);
+        @Cleanup
+        EventStreamReaderImpl<byte[]> reader1 = createReader(controller, segmentStreamFactory, "reader1", sync, clock);
+        @Cleanup
+        EventStreamReaderImpl<byte[]> reader2 = createReader(controller, segmentStreamFactory, "reader2", sync, clock);
+        
+        assertEquals(1, readInt(reader1.readNextEvent(0)));
+        assertEquals(2, readInt(reader2.readNextEvent(0)));
+        reader2.close();
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        assertEquals(1, readInt(reader1.readNextEvent(0)));
+        assertEquals(2, readInt(reader1.readNextEvent(0)));
+        assertEquals(1, readInt(reader1.readNextEvent(0)));
+        assertEquals(2, readInt(reader1.readNextEvent(0)));
+    }
+    
+    @Test
+    public void testPositionsContainSealedSegments() throws SegmentSealedException {
+        String scope = "scope";
+        String stream = "stream";
+        AtomicLong clock = new AtomicLong();
+        MockSegmentStreamFactory segmentStreamFactory = new MockSegmentStreamFactory();
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        
+        //Mock for the two SegmentInputStreams.
+        Segment segment1 = new Segment(scope, stream, 0);
+        @Cleanup
+        SegmentOutputStream stream1 = segmentStreamFactory.createOutputStreamForSegment(segment1, segmentSealedCallback, writerConfig, "");
+        writeInt(stream1, 1);
+        Segment segment2 = new Segment(scope, stream, 1);
+        @Cleanup
+        SegmentOutputStream stream2 = segmentStreamFactory.createOutputStreamForSegment(segment2, segmentSealedCallback, writerConfig, "");
+        writeInt(stream2, 2);
+        writeInt(stream2, 2);
+        writeInt(stream2, 2);
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> sync = createStateSynchronizerForReaderGroup(connectionFactory, controller,
+                                                                                         segmentStreamFactory,
+                                                                                         Stream.of(scope, stream),
+                                                                                         "reader1", clock, 2);
+        @Cleanup
+        EventStreamReaderImpl<byte[]> reader = createReader(controller, segmentStreamFactory, "reader1", sync, clock);
+        EventRead<byte[]> event = reader.readNextEvent(100);
+        assertEquals(2, readInt(event));
+        assertEquals(ImmutableSet.of(), event.getPosition().asImpl().getCompletedSegments());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getOwnedSegments());
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        event = reader.readNextEvent(100);
+        assertEquals(1, readInt(event));
+        assertEquals(ImmutableSet.of(), event.getPosition().asImpl().getCompletedSegments());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getOwnedSegments());
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        event = reader.readNextEvent(100);
+        assertEquals(2, readInt(event));
+        assertEquals(ImmutableSet.of(), event.getPosition().asImpl().getCompletedSegments());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getOwnedSegments());
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        event = reader.readNextEvent(100);
+        assertEquals(2, readInt(event));
+        assertEquals(ImmutableSet.of(segment1), event.getPosition().asImpl().getCompletedSegments());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getOwnedSegments());
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        event = reader.readNextEvent(10);
+        assertNull(event.getEvent());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getCompletedSegments());
+        assertEquals(ImmutableSet.of(segment1, segment2), event.getPosition().asImpl().getOwnedSegments());
+    }
+    
+    private int readInt(EventRead<byte[]> eventRead) {
+        byte[] event = eventRead.getEvent();
+        assertNotNull(event);
+        return ByteBuffer.wrap(event).getInt();
+    }
+
+    private EventStreamReaderImpl<byte[]> createReader(MockController controller,
+                                                       MockSegmentStreamFactory segmentStreamFactory, String readerId,
+                                                       StateSynchronizer<ReaderGroupState> sync, AtomicLong clock) {
+        ReaderGroupStateManager groupState = new ReaderGroupStateManager(readerId, sync, controller, clock::get);
+        groupState.initializeReader(0);
+        return new EventStreamReaderImpl<>(segmentStreamFactory, segmentStreamFactory, new ByteArraySerializer(),
+                                           groupState, new Orderer(), clock::get, ReaderConfig.builder().build());
+    }
+
+    private StateSynchronizer<ReaderGroupState> createStateSynchronizerForReaderGroup(ConnectionFactory connectionFactory,
+                                                                                      Controller controller,
+                                                                                      MockSegmentStreamFactory streamFactory,
+                                                                                      Stream stream, String readerId,
+                                                                                      AtomicLong clock,
+                                                                                      int numSegments) {
+        StreamConfiguration streamConfig = StreamConfiguration.builder()
+                                                              .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                              .build();
+        controller.createScope(stream.getScope());
+        controller.createStream(stream.getScope(), stream.getStreamName(), streamConfig);
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(stream.getScope(), controller, connectionFactory,
+                                                                streamFactory, streamFactory, streamFactory,
+                                                                streamFactory);
+        ReaderGroupConfig config = ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream(stream).build();
+        StateSynchronizer<ReaderGroupState> sync = clientFactory.createStateSynchronizer(NameUtils.getStreamForReaderGroup("readerGroup"),
+                                                                                         new ReaderGroupStateUpdatesSerializer(),
+                                                                                         new ReaderGroupStateInitSerializer(),
+                                                                                         SynchronizerConfig.builder()
+                                                                                                           .build());
+        Map<Segment, Long> segments = ReaderGroupImpl.getSegmentsForStreams(controller, config);
+        sync.initialize(new ReaderGroupState.ReaderGroupStateInit(config,
+                                                                  segments,
+                                                                  getEndSegmentsForStreams(config)));
+        return sync;
+    }
+
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.Transaction;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -102,7 +103,7 @@ public class PingerTest {
     public void startTxnKeepAliveError() throws Exception {
         final UUID txnID = UUID.randomUUID();
 
-        CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        CompletableFuture<Transaction.PingStatus> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RuntimeException("Error"));
         when(controller.pingTransaction(eq(stream), eq(txnID), anyLong())).thenReturn(failedFuture);
 

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -19,9 +19,12 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
+import io.pravega.client.stream.Position;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderNotInReaderGroupException;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ReaderGroupState.CreateCheckpoint;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -59,7 +62,7 @@ public class ReaderGroupStateManagerTest {
         private StreamSegmentsWithPredecessors successors;
 
         public MockControllerWithSuccessors(String endpoint, int port, ConnectionFactory connectionFactory, StreamSegmentsWithPredecessors successors) {
-            super(endpoint, port, connectionFactory);
+            super(endpoint, port, connectionFactory, false);
             this.successors = successors;
         }
 
@@ -75,7 +78,7 @@ public class ReaderGroupStateManagerTest {
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory,
@@ -163,7 +166,7 @@ public class ReaderGroupStateManagerTest {
         assertEquals(1, newSegments.size());
         assertEquals(Long.valueOf(1), newSegments.get(initialSegment));
 
-        readerState.handleEndOfSegment(initialSegment, true);
+        readerState.handleEndOfSegment(initialSegment);
         newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertEquals(2, newSegments.size());
         assertEquals(Long.valueOf(0), newSegments.get(successorA));
@@ -203,11 +206,11 @@ public class ReaderGroupStateManagerTest {
         assertEquals(Long.valueOf(1), newSegments.get(initialSegmentA));
         assertEquals(Long.valueOf(2), newSegments.get(initialSegmentB));
         
-        readerState.handleEndOfSegment(initialSegmentA, true);
+        readerState.handleEndOfSegment(initialSegmentA);
         newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertTrue(newSegments.isEmpty());
         
-        readerState.handleEndOfSegment(initialSegmentB, true);
+        readerState.handleEndOfSegment(initialSegmentB);
         newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertEquals(1, newSegments.size());
         assertEquals(Long.valueOf(0), newSegments.get(successor));
@@ -215,14 +218,14 @@ public class ReaderGroupStateManagerTest {
         newSegments = readerState.acquireNewSegmentsIfNeeded(0);
         assertTrue(newSegments.isEmpty());
     }
-    
+      
     @Test(timeout = 10000)
     public void testAddReader() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -248,12 +251,47 @@ public class ReaderGroupStateManagerTest {
     }
     
     @Test(timeout = 10000)
+    public void testReachEnd() throws ReaderNotInReaderGroupException {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
+        
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, SynchronizerConfig.builder().build());
+        Map<Segment, Long> segments = new HashMap<>();
+        Segment segment = new Segment(scope, stream, 0);
+        segments.put(segment, 1L);
+        StreamCutImpl start = new StreamCutImpl(Stream.of(scope, stream), ImmutableMap.of(segment, 0L));
+        StreamCutImpl end = new StreamCutImpl(Stream.of(scope, stream), ImmutableMap.of(segment, 100L));
+        ReaderGroupConfig config = ReaderGroupConfig.builder().stream(Stream.of(scope, stream), start, end).build();
+        stateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(config, segments,
+                                                                               ReaderGroupImpl.getEndSegmentsForStreams(config)));
+        ReaderGroupStateManager readerState = new ReaderGroupStateManager("testReader",
+                stateSynchronizer,
+                controller,
+                null);
+        readerState.initializeReader(0);
+        Segment toRelease = readerState.findSegmentToReleaseIfRequired();
+        assertNull(toRelease);
+        Map<Segment, Long> newSegments = readerState.acquireNewSegmentsIfNeeded(0);
+        assertFalse(newSegments.isEmpty());
+        assertEquals(1, newSegments.size());
+        assertTrue(newSegments.containsKey(segment));
+        assertTrue(readerState.handleEndOfSegment(segment));
+    }
+    
+    @Test(timeout = 10000)
     public void testRemoveReader() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -318,7 +356,7 @@ public class ReaderGroupStateManagerTest {
 
         // Setup mocks
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
 
         @Cleanup
@@ -371,7 +409,7 @@ public class ReaderGroupStateManagerTest {
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -430,7 +468,7 @@ public class ReaderGroupStateManagerTest {
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -476,7 +514,7 @@ public class ReaderGroupStateManagerTest {
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -550,7 +588,7 @@ public class ReaderGroupStateManagerTest {
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
-        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory);
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
         MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
         @Cleanup
         SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
@@ -656,8 +694,12 @@ public class ReaderGroupStateManagerTest {
         StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
         Map<Segment, Long> segments = new HashMap<>();
         segments.put(initialSegment, 1L);
-        stateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(ReaderGroupConfig.builder().stream(Stream.of(scope, stream)).build(),
-                segments, Collections.emptyMap()));
+        stateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(ReaderGroupConfig.builder()
+                                                                                                .stream(Stream.of(scope,
+                                                                                                                  stream))
+                                                                                                .disableAutomaticCheckpoints()
+                                                                                                .build(),
+                                                                               segments, Collections.emptyMap()));
         val readerState = new ReaderGroupStateManager("testReader", stateSynchronizer, controller, null);
         readerState.initializeReader(0);
         assertNull(readerState.getCheckpoint());
@@ -839,5 +881,51 @@ public class ReaderGroupStateManagerTest {
         assertNotNull(toRelease);
         assertTrue(readerState2.releaseSegment(toRelease, 10, 1));
         assertEquals(1, stateSynchronizer.getState().getNumberOfUnassignedSegments());
+    }
+    
+    @Test(timeout = 10000)
+    public void testReleaseCompletedSegment() throws ReaderNotInReaderGroupException {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        controller.createScope(scope);
+        controller.createStream(scope, stream, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(2)).build());
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
+
+        SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, config);
+        AtomicLong clock = new AtomicLong();
+        Map<Segment, Long> segments = new HashMap<>();
+        segments.put(new Segment(scope, stream, 0), 123L);
+        segments.put(new Segment(scope, stream, 1), 456L);
+        stateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(ReaderGroupConfig.builder().stream(Stream.of(scope, stream)).build(), segments, Collections.emptyMap()));
+        ReaderGroupStateManager readerState1 = new ReaderGroupStateManager("testReader", stateSynchronizer, controller,
+                                                                           clock::get);
+        readerState1.initializeReader(0);
+        Segment toRelease = readerState1.findSegmentToReleaseIfRequired();
+        assertNull(toRelease);
+        Map<Segment, Long> newSegments = readerState1.acquireNewSegmentsIfNeeded(0);
+        assertFalse(newSegments.isEmpty());
+        assertEquals(2, newSegments.size());
+
+        ReaderGroupStateManager readerState2 = new ReaderGroupStateManager("testReader2", stateSynchronizer, controller,
+                                                                           clock::get);
+        readerState2.initializeReader(0);
+        clock.addAndGet(ReaderGroupStateManager.UPDATE_WINDOW.toNanos());
+        Position pos = new PositionImpl(ImmutableMap.of(new Segment(scope, stream, 0), -1L,
+                                                        new Segment(scope, stream, 1), 789L));
+        ReaderGroupStateManager.readerShutdown("testReader", pos, stateSynchronizer);
+
+        newSegments = readerState2.acquireNewSegmentsIfNeeded(0);
+        assertEquals(2, newSegments.size());
+        assertEquals(Long.valueOf(789L), newSegments.get(new Segment(scope, stream, 1)));
+        assertEquals(0, stateSynchronizer.getState().getNumberOfUnassignedSegments());
+        AssertExtensions.assertThrows(ReaderNotInReaderGroupException.class,
+                                      () -> readerState1.acquireNewSegmentsIfNeeded(0L));
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockClientFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockClientFactory.java
@@ -37,7 +37,7 @@ public class MockClientFactory implements EventStreamClientFactory, Synchronizer
 
     public MockClientFactory(String scope, MockSegmentStreamFactory ioFactory) {
         this.connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        this.controller = new MockController("localhost", 0, connectionFactory);
+        this.controller = new MockController("localhost", 0, connectionFactory, false);
         this.impl = new ClientFactoryImpl(scope, controller, connectionFactory, ioFactory, ioFactory, ioFactory, ioFactory);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -74,6 +74,7 @@ public class MockController implements Controller {
     @GuardedBy("$lock")
     private final Map<Stream, StreamConfiguration> createdStreams = new HashMap<>();
     private final Supplier<Long> idGenerator = () -> Flow.create().asLong();
+    private final boolean callServer;
     
     @Override
     @Synchronized
@@ -206,6 +207,9 @@ public class MockController implements Controller {
     }
 
     private boolean createSegment(String name) {
+        if (!callServer) {
+            return true;
+        }
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
 
@@ -245,6 +249,9 @@ public class MockController implements Controller {
     }
     
     private boolean deleteSegment(String name) {
+        if (!callServer) {
+            return true;
+        }
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
 
@@ -312,6 +319,10 @@ public class MockController implements Controller {
     
     private CompletableFuture<Void> commitTxSegment(UUID txId, Segment segment) {
         CompletableFuture<Void> result = new CompletableFuture<>();
+        if (!callServer) {
+            result.complete(null);
+            return result;
+        }
         FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
 
             @Override
@@ -360,6 +371,10 @@ public class MockController implements Controller {
     
     private CompletableFuture<Void> abortTxSegment(UUID txId, Segment segment) {
         CompletableFuture<Void> result = new CompletableFuture<>();
+        if (!callServer) {
+            result.complete(null);
+            return result;
+        }
         FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
 
             @Override
@@ -415,6 +430,10 @@ public class MockController implements Controller {
 
     private CompletableFuture<Void> createSegmentTx(UUID txId, Segment segment) {
         CompletableFuture<Void> result = new CompletableFuture<>();
+        if (!callServer) {
+            result.complete(null);
+            return result;
+        }
         FailingReplyProcessor replyProcessor = new FailingReplyProcessor() {
 
             @Override

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -468,7 +468,7 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> pingTransaction(Stream stream, UUID txId, long lease) {
+    public CompletableFuture<Transaction.PingStatus> pingTransaction(Stream stream, UUID txId, long lease) {
         throw new UnsupportedOperationException();
     }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -56,7 +56,7 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
     public MockStreamManager(String scope, String endpoint, int port) {
         this.scope = scope;
         this.connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().controllerURI(URI.create("tcp://localhost")).build());
-        this.controller = new MockController(endpoint, port, connectionFactory);
+        this.controller = new MockController(endpoint, port, connectionFactory, true);
         this.clientFactory = new MockClientFactory(scope, controller);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/notifications/EndOfDataNotifierTest.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/EndOfDataNotifierTest.java
@@ -9,32 +9,29 @@
  */
 package io.pravega.client.stream.notifications;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import io.pravega.client.state.StateSynchronizer;
+import io.pravega.client.stream.impl.ReaderGroupState;
+import io.pravega.client.stream.notifications.notifier.EndOfDataNotifier;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.test.common.InlineExecutor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
+import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import io.pravega.client.state.StateSynchronizer;
-import io.pravega.client.stream.impl.ReaderGroupState;
-import io.pravega.client.stream.notifications.notifier.EndOfDataNotifier;
-import io.pravega.common.util.ReusableLatch;
-import io.pravega.test.common.InlineExecutor;
-import lombok.extern.slf4j.Slf4j;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 @Slf4j
@@ -49,15 +46,9 @@ public class EndOfDataNotifierTest {
     @Mock
     private ReaderGroupState state;
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("pravega.client.endOfDataNotification.poll.interval.seconds", String.valueOf(5));
-    }
-
-    @Test
+    @Test(timeout = 10000)
     public void endOfStreamNotifierTest() throws Exception {
         AtomicBoolean listenerInvoked = new AtomicBoolean();
-        ReusableLatch latch = new ReusableLatch();
 
         when(state.isEndOfData()).thenReturn(false).thenReturn(true);
         when(sync.getState()).thenReturn(state);
@@ -65,20 +56,19 @@ public class EndOfDataNotifierTest {
         Listener<EndOfDataNotification> listener1 = notification -> {
             log.info("listener 1 invoked");
             listenerInvoked.set(true);
-            latch.release();
         };
         Listener<EndOfDataNotification> listener2 = notification -> {
         };
 
         EndOfDataNotifier notifier = new EndOfDataNotifier(system, sync, executor);
         notifier.registerListener(listener1);
-        verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
-        latch.await();
+        verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(0L), anyLong(), any(TimeUnit.class));
+        notifier.pollNow();
         verify(state, times(2)).isEndOfData();
         assertTrue(listenerInvoked.get());
 
         notifier.registerListener(listener2);
-        verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(0L), anyLong(), any(TimeUnit.class));
 
         notifier.unregisterAllListeners();
         verify(system, times(1)).removeListeners(EndOfDataNotification.class.getSimpleName());

--- a/common/src/main/java/io/pravega/common/TimeoutTimer.java
+++ b/common/src/main/java/io/pravega/common/TimeoutTimer.java
@@ -11,10 +11,12 @@ package io.pravega.common;
 
 import java.time.Duration;
 import java.util.function.Supplier;
+import lombok.ToString;
 
 /**
  * Helps figuring out how much time is left from a particular (initial) timeout.
  */
+@ToString(of = { "timeout" })
 public class TimeoutTimer {
     private final Supplier<Long> getNanos;
     private volatile Duration timeout;

--- a/common/src/test/java/io/pravega/common/TimeoutTimerTest.java
+++ b/common/src/test/java/io/pravega/common/TimeoutTimerTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common;
+
+import java.time.Duration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TimeoutTimerTest {
+
+    @Test
+    public void testTimeouts() {
+        TimeoutTimer timer = new TimeoutTimer(Duration.ofMillis(0));
+        assertFalse(timer.hasRemaining());
+        timer.reset(Duration.ofMillis(10000));
+        assertTrue(timer.hasRemaining());
+        timer.zero();
+        assertFalse(timer.hasRemaining());
+    }
+    
+    
+    @Test
+    public void testResetToZero() {
+        TimeoutTimer timer = new TimeoutTimer(Duration.ofMillis(10000));
+        assertTrue(timer.hasRemaining());
+        timer.reset(Duration.ofMillis(0));
+        assertFalse(timer.hasRemaining());
+        timer.zero();
+        assertFalse(timer.hasRemaining());
+    }
+    
+}

--- a/common/src/test/java/io/pravega/common/util/IteratorTest.java
+++ b/common/src/test/java/io/pravega/common/util/IteratorTest.java
@@ -13,18 +13,19 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.test.common.AssertExtensions;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -97,8 +98,9 @@ public class IteratorTest {
                 });
             }
 
-            return CompletableFuture.completedFuture(
-                    new AbstractMap.SimpleEntry<>("" + endIndex, list.subList(startIndex, endIndex)));
+            CompletableFuture<Map.Entry<String, Collection<Integer>>> completedFuture = CompletableFuture.completedFuture(new AbstractMap.SimpleEntry<String, Collection<Integer>>(""
+                    + endIndex, list.subList(startIndex, endIndex)));
+            return completedFuture;
         }, ""));
 
         Integer next0 = iterator.getNext().join();

--- a/common/src/test/java/io/pravega/common/util/RetryTests.java
+++ b/common/src/test/java/io/pravega/common/util/RetryTests.java
@@ -18,13 +18,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test methods for Retry utilities
@@ -163,18 +161,13 @@ public class RetryTests {
     }
 
     @Test
-    public void retryFutureInExecutorTests() {
+    public void retryFutureInExecutorTests() throws ExecutionException {
         ScheduledExecutorService executorService = ExecutorServiceHelpers.newScheduledThreadPool(5, "testpool");
 
         // 1. series of retryable exceptions followed by a failure
         begin = Instant.now();
         final CompletableFuture<Void> result1 = retryFutureInExecutor(uniformDelay, 1, maxLoops, maxDelay, true, executorService);
-        try {
-            Exceptions.handleInterrupted(() -> result1.get());
-        } catch (ExecutionException e) {
-            log.debug("Exception not expected", e);
-            fail("Exception observed in retryInExecutor");
-        }
+        Exceptions.handleInterrupted(() -> result1.get());
         end = Instant.now();
         duration = end.toEpochMilli() - begin.toEpochMilli();
         log.debug("Expected duration = {}", expectedDurationUniform);
@@ -199,12 +192,7 @@ public class RetryTests {
         // 3. exponential backoff
         begin = Instant.now();
         final CompletableFuture<Void> result3 = retryFutureInExecutor(exponentialInitialDelay, multiplier, maxLoops, maxDelay, true, executorService);
-        try {
-            Exceptions.handleInterrupted(() -> result3.get());
-        } catch (ExecutionException e) {
-            log.debug("Exception not expected", e);
-            fail("Exception observed in retryInExecutor");
-        }
+        Exceptions.handleInterrupted(() -> result3.get());
         end = Instant.now();
         duration = end.toEpochMilli() - begin.toEpochMilli();
         log.debug("Expected duration = {}", expectedDurationExponential);

--- a/config/config.properties
+++ b/config/config.properties
@@ -344,6 +344,12 @@ hdfs.hdfsUrl=localhost:9000
 # Recommended values: Multiples of 1MB.
 #hdfs.blockSize=1048576
 
+# Whether to replace DataNodes on failure or not.
+# Valid values: Boolean.
+# Recommended values: false for small clusters, true otherwise. This should be set to true for deployments where
+# sufficient data nodes are available(More than Max(3, replication)), otherwise set to false.
+#hdfs.replaceDataNodesOnFailure=false
+
 ##endregion
 
 ##region Extended S3 settings

--- a/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
@@ -83,7 +83,7 @@ public class ZKHostStore implements HostControllerStore {
             ZKUtils.createPathIfNotExists(zkClient, zkPath, HostContainerMap.EMPTY.toBytes());
             hostContainerMapNode.getListenable().addListener(this::updateMap);
             hostContainerMapNode.start(true);
-
+            updateMap();
             zkInit = true;
         }
     }

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -149,16 +149,16 @@ public class SegmentContainerMonitorTest {
 
         //Rebalance should be triggered for the very first attempt. Verify that no hosts are added to the store.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
-        assertEquals(0, hostStore.getHostContainersMap().size());
         if (latches != null) {
-            latches.get(0).join();
+            latches.get(1).join();
         }
+        assertEquals(0, hostStore.getHostContainersMap().size());
 
         //New host added.
         cluster.registerHost(new Host("localhost1", 1, null));
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(1).join();
+            latches.get(2).join();
         }
         assertEquals(1, hostStore.getHostContainersMap().size());
 
@@ -169,7 +169,7 @@ public class SegmentContainerMonitorTest {
         cluster.deregisterHost(new Host("localhost1", 1, null));
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(2).join();
+            latches.get(3).join();
         }
         assertEquals(3, hostStore.getHostContainersMap().size());
 
@@ -181,7 +181,7 @@ public class SegmentContainerMonitorTest {
         //Wait for rebalance and verify the host update.
         assertTrue(sync.tryAcquire(10, TimeUnit.SECONDS));
         if (latches != null) {
-            latches.get(3).join();
+            latches.get(4).join();
         }
         assertEquals(4, hostStore.getHostContainersMap().size());
 

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
@@ -16,14 +16,13 @@ import io.pravega.controller.store.host.HostMonitorConfig;
 import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
 import io.pravega.controller.timeout.TimeoutServiceConfig;
 import io.pravega.controller.util.Config;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * ControllerServiceMain tests.
@@ -39,10 +38,10 @@ public abstract class ControllerServiceMainTest {
     }
 
     @Before
-    public abstract void setup();
+    public abstract void setup() throws Exception;
 
     @After
-    public abstract void tearDown();
+    public abstract void tearDown() throws IOException;
 
     @Slf4j
     static class MockControllerServiceStarter extends ControllerServiceStarter {
@@ -86,17 +85,8 @@ public abstract class ControllerServiceMainTest {
                 MockControllerServiceStarter::new);
 
         controllerServiceMain.startAsync();
-        try {
-            controllerServiceMain.awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for controllerServiceMain to get ready");
-        }
-
-        try {
-            controllerServiceMain.awaitServiceStarting().awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for starter to get ready");
-        }
+        controllerServiceMain.awaitRunning();
+        controllerServiceMain.awaitServiceStarting().awaitRunning();
 
         Main.onShutdown(controllerServiceMain);
         
@@ -109,31 +99,11 @@ public abstract class ControllerServiceMainTest {
                 MockControllerServiceStarter::new);
 
         controllerServiceMain.startAsync();
-        try {
-            controllerServiceMain.awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for controllerServiceMain to get ready");
-        }
-
-        try {
-            controllerServiceMain.awaitServiceStarting().awaitRunning();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for starter to get ready");
-        }
-
+        controllerServiceMain.awaitRunning();
+        controllerServiceMain.awaitServiceStarting().awaitRunning();
         controllerServiceMain.stopAsync();
-
-        try {
-            controllerServiceMain.awaitServicePausing().awaitTerminated();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for termination of starter");
-        }
-
-        try {
-            controllerServiceMain.awaitTerminated();
-        } catch (IllegalStateException e) {
-            Assert.fail("Failed waiting for termination of controllerServiceMain");
-        }
+        controllerServiceMain.awaitServicePausing().awaitTerminated();
+        controllerServiceMain.awaitTerminated();
     }
 
     protected ControllerServiceConfig createControllerServiceConfig() {

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
@@ -53,34 +53,21 @@ public abstract class ControllerServiceStarterTest {
     }
 
     @Before
-    public abstract void setup();
+    public abstract void setup() throws Exception;
 
     @After
-    public abstract void tearDown();
+    public abstract void tearDown() throws Exception;
 
     @Test
-    public void testStartStop() {
+    public void testStartStop() throws URISyntaxException {
         Assert.assertNotNull(storeClient);
         ControllerServiceStarter starter = new ControllerServiceStarter(createControllerServiceConfig(), storeClient, 
                 SegmentHelperMock.getSegmentHelperMockForTables(executor));
         starter.startAsync();
-
-        try {
-            starter.awaitRunning();
-        } catch (IllegalStateException e) {
-            log.error("Error awaiting starter to get ready");
-            Assert.fail("Error awaiting starter to get ready");
-        }
+        starter.awaitRunning();
 
         // Now, that starter has started, perform some rpc operations.
-        URI uri;
-        try {
-            uri = new URI( (enableAuth ? "tls" : "tcp") + "://localhost:" + grpcPort);
-        } catch (URISyntaxException e) {
-            log.error("Error creating controller URI", e);
-            Assert.fail("Error creating controller URI");
-            return;
-        }
+        URI uri = new URI( (enableAuth ? "tls" : "tcp") + "://localhost:" + grpcPort);
 
         final String testScope = "testScope";
         StreamManager streamManager = new StreamManagerImpl(ClientConfig.builder().controllerURI(uri)
@@ -92,12 +79,7 @@ public abstract class ControllerServiceStarterTest {
         streamManager.close();
 
         starter.stopAsync();
-        try {
-            starter.awaitTerminated();
-        } catch (IllegalStateException e) {
-            log.error("Error awaiting termination of starter");
-            Assert.fail("Error awaiting termination of starter");
-        }
+        starter.awaitTerminated();
     }
 
     protected ControllerServiceConfig createControllerServiceConfig() {

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
@@ -14,13 +14,11 @@ import io.pravega.controller.store.client.ZKClientConfig;
 import io.pravega.controller.store.client.impl.StoreClientConfigImpl;
 import io.pravega.controller.store.client.impl.ZKClientConfigImpl;
 import io.pravega.test.common.TestingServerStarter;
+import java.util.UUID;
+import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
-
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.Executors;
 
 /**
  * ControllerServiceStarter backed by ZK store tests.
@@ -34,13 +32,8 @@ public class PravegaTablesControllerServiceStarterTest extends ControllerService
     }
 
     @Override
-    public void setup() {
-        try {
-            zkServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            log.error("Error starting test zk server");
-            Assert.fail("Error starting test zk server");
-        }
+    public void setup() throws Exception {
+        zkServer = new TestingServerStarter().start();
 
         ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
                 .initialSleepInterval(500)
@@ -55,20 +48,9 @@ public class PravegaTablesControllerServiceStarterTest extends ControllerService
     }
 
     @Override
-    public void tearDown() {
-        try {
-            storeClient.close();
-        } catch (Exception e) {
-            log.error("Error closing ZK client");
-            Assert.fail("Error closing ZK client");
-        }
-
-        try {
-            zkServer.close();
-        } catch (IOException e) {
-            log.error("Error stopping test zk server");
-            Assert.fail("Error stopping test zk server");
-        }
+    public void tearDown() throws Exception {
+        storeClient.close();
+        zkServer.close();
         executor.shutdown();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
@@ -14,10 +14,8 @@ import io.pravega.controller.store.client.ZKClientConfig;
 import io.pravega.controller.store.client.impl.StoreClientConfigImpl;
 import io.pravega.controller.store.client.impl.ZKClientConfigImpl;
 import io.pravega.test.common.TestingServerStarter;
-import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
@@ -34,13 +32,8 @@ public class ZKControllerServiceStarterTest extends ControllerServiceStarterTest
     }
 
     @Override
-    public void setup() {
-        try {
-            zkServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            log.error("Error starting test zk server");
-            Assert.fail("Error starting test zk server");
-        }
+    public void setup() throws Exception {
+        zkServer = new TestingServerStarter().start();
 
         ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
                 .initialSleepInterval(500)
@@ -55,20 +48,9 @@ public class ZKControllerServiceStarterTest extends ControllerServiceStarterTest
     }
 
     @Override
-    public void tearDown() {
-        try {
-            storeClient.close();
-        } catch (Exception e) {
-            log.error("Error closing ZK client");
-            Assert.fail("Error closing ZK client");
-        }
-
-        try {
-            zkServer.close();
-        } catch (IOException e) {
-            log.error("Error stopping test zk server");
-            Assert.fail("Error stopping test zk server");
-        }
+    public void tearDown() throws Exception {
+        storeClient.close();
+        zkServer.close();
         executor.shutdown();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -29,8 +29,12 @@ import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Host store tests.
@@ -93,9 +97,16 @@ public class HostStoreTest {
                 latch.complete(null);
             });
             // Update host store map.
-            hostStore.updateHostContainersMap(HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount));
+            Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
+            hostStore.updateHostContainersMap(hostContainerMap);
             latch.join();
             validateStore(hostStore);
+
+            // verify that a new hostStore is initialized with map set by previous host store. 
+            HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+
+            Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
+            assertEquals(hostContainerMap, map);
         } catch (Exception e) {
             log.error("Unexpected error", e);
             Assert.fail();

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -89,20 +89,27 @@ public class HostStoreTest {
                     .containerCount(containerCount)
                     .build();
 
-            // Create ZK based host store.
-            HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
-
-            CompletableFuture<Void> latch = new CompletableFuture<>();
-            ((ZKHostStore) hostStore).addListener(() -> {
-                latch.complete(null);
-            });
             // Update host store map.
             Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
+
+            // Create ZK based host store.
+            HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+            CompletableFuture<Void> latch1 = new CompletableFuture<>();
+            CompletableFuture<Void> latch2 = new CompletableFuture<>();
+            ((ZKHostStore) hostStore).addListener(() -> {
+                // With the addition of updateMap() in tryInit(), this listener is actually called twice, and we need to
+                // wait for the second operation to complete (related to updateHostContainersMap()).
+                if (latch1.isDone()) {
+                    latch2.complete(null);
+                }
+                latch1.complete(null);
+            });
             hostStore.updateHostContainersMap(hostContainerMap);
-            latch.join();
+            latch1.join();
+            latch2.join();
             validateStore(hostStore);
 
-            // verify that a new hostStore is initialized with map set by previous host store. 
+            // verify that a new hostStore is initialized with map set by previous host store.
             HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
 
             Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -67,57 +67,52 @@ public class HostStoreTest {
     }
 
     @Test(timeout = 10000L)
-    public void zkHostStoreTests() {
-        try {
-            @Cleanup
-            TestingServer zkTestServer = new TestingServerStarter().start();
+    public void zkHostStoreTests() throws Exception {
+        @Cleanup
+        TestingServer zkTestServer = new TestingServerStarter().start();
 
-            ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkTestServer.getConnectString())
-                    .initialSleepInterval(2000)
-                    .maxRetries(1)
-                    .sessionTimeoutMs(10 * 1000)
-                    .namespace("hostStoreTest/" + UUID.randomUUID())
-                    .build();
-            StoreClientConfig storeClientConfig = StoreClientConfigImpl.withZKClient(zkClientConfig);
+        ZKClientConfig zkClientConfig = ZKClientConfigImpl.builder().connectionString(zkTestServer.getConnectString())
+                .initialSleepInterval(2000)
+                .maxRetries(1)
+                .sessionTimeoutMs(10 * 1000)
+                .namespace("hostStoreTest/" + UUID.randomUUID())
+                .build();
+        StoreClientConfig storeClientConfig = StoreClientConfigImpl.withZKClient(zkClientConfig);
 
-            @Cleanup
-            StoreClient storeClient = StoreClientFactory.createStoreClient(storeClientConfig);
+        @Cleanup
+        StoreClient storeClient = StoreClientFactory.createStoreClient(storeClientConfig);
 
-            HostMonitorConfig hostMonitorConfig = HostMonitorConfigImpl.builder()
-                    .hostMonitorEnabled(true)
-                    .hostMonitorMinRebalanceInterval(10)
-                    .containerCount(containerCount)
-                    .build();
+        HostMonitorConfig hostMonitorConfig = HostMonitorConfigImpl.builder()
+                .hostMonitorEnabled(true)
+                .hostMonitorMinRebalanceInterval(10)
+                .containerCount(containerCount)
+                .build();
 
-            // Update host store map.
-            Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
+        // Update host store map.
+        Map<Host, Set<Integer>> hostContainerMap = HostMonitorConfigImpl.getHostContainerMap(host, controllerPort, containerCount);
 
-            // Create ZK based host store.
-            HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
-            CompletableFuture<Void> latch1 = new CompletableFuture<>();
-            CompletableFuture<Void> latch2 = new CompletableFuture<>();
-            ((ZKHostStore) hostStore).addListener(() -> {
-                // With the addition of updateMap() in tryInit(), this listener is actually called twice, and we need to
-                // wait for the second operation to complete (related to updateHostContainersMap()).
-                if (latch1.isDone()) {
-                    latch2.complete(null);
-                }
-                latch1.complete(null);
-            });
-            hostStore.updateHostContainersMap(hostContainerMap);
-            latch1.join();
-            latch2.join();
-            validateStore(hostStore);
+        // Create ZK based host store.
+        HostControllerStore hostStore = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+        CompletableFuture<Void> latch1 = new CompletableFuture<>();
+        CompletableFuture<Void> latch2 = new CompletableFuture<>();
+        ((ZKHostStore) hostStore).addListener(() -> {
+            // With the addition of updateMap() in tryInit(), this listener is actually called twice, and we need to
+            // wait for the second operation to complete (related to updateHostContainersMap()).
+            if (latch1.isDone()) {
+                latch2.complete(null);
+            }
+            latch1.complete(null);
+        });
+        hostStore.updateHostContainersMap(hostContainerMap);
+        latch1.join();
+        latch2.join();
+        validateStore(hostStore);
 
-            // verify that a new hostStore is initialized with map set by previous host store.
-            HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
+        // verify that a new hostStore is initialized with map set by previous host store.
+        HostControllerStore hostStore2 = HostStoreFactory.createStore(hostMonitorConfig, storeClient);
 
-            Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
-            assertEquals(hostContainerMap, map);
-        } catch (Exception e) {
-            log.error("Unexpected error", e);
-            Assert.fail();
-        }
+        Map<Host, Set<Integer>> map = hostStore2.getHostContainersMap();
+        assertEquals(hostContainerMap, map);
     }
 
     private void validateStore(HostControllerStore hostStore) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -265,17 +265,6 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
         return forSegmentCache(segmentId, SegmentKeyCache::getTailBucketOffsets, Collections.emptyMap());
     }
 
-    /**
-     * Gets a value representing the difference between the number of Table Buckets updated (or inserted) and the ones
-     * that have been removed for the given Segment.
-     *
-     * @param segmentId The Id of the Segment to get the difference for.
-     * @return The result.
-     */
-    int getBucketCountDelta(long segmentId) {
-        return forSegmentCache(segmentId, SegmentKeyCache::getBucketCountDelta, 0);
-    }
-
     private <T> T forSegmentCache(long segmentId, Function<SegmentKeyCache, T> ifExists, T ifNotExists) {
         SegmentKeyCache cache;
         synchronized (this.segmentCaches) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -124,6 +124,7 @@ class ContainerKeyIndex implements AutoCloseable {
      * @param segment The Segment to perform the action on.
      * @param action  A Supplier that, when invoked, will begin executing the action. This returns a CompletableFuture
      *                that will indicate when the action completed.
+     * @param timer   Timer for the operation.
      * @param <T>     Return type.
      * @return A CompletableFuture that, when completed normally, will indicate that the action was executed. If it failed,
      * or if the segment is not empty, it will be failed with the appropriate exception. Notable exceptions:
@@ -131,21 +132,58 @@ class ContainerKeyIndex implements AutoCloseable {
      * <li>{@link TableSegmentNotEmptyException} If the Segment is not empty.
      * </ul>
      */
-    <T> CompletableFuture<T> executeIfEmpty(DirectSegmentAccess segment, Supplier<CompletableFuture<T>> action) {
+    <T> CompletableFuture<T> executeIfEmpty(DirectSegmentAccess segment, Supplier<CompletableFuture<T>> action, TimeoutTimer timer) {
         return this.recoveryTracker.waitIfNeeded(segment, () -> this.conditionalUpdateProcessor.addWithFilter(
                 conditionKey -> conditionKey.getKey() == segment.getSegmentId(),
-                () -> {
-                    SegmentProperties sp = segment.getInfo();
-                    long entryCount = this.indexReader.getBucketCount(sp) + this.cache.getBucketCountDelta(segment.getSegmentId());
-                    if (entryCount <= 0) {
-                        // Segment is empty.
-                        return action.get();
-                    } else {
-                        // Segment is not empty.
-                        return Futures.failedFuture(new TableSegmentNotEmptyException(sp.getName()));
-                    }
-                }
-        ));
+                () -> isTableSegmentEmpty(segment, timer)
+                        .thenCompose(isEmpty -> {
+                            if (isEmpty) {
+                                // Segment is empty.
+                                return action.get();
+                            } else {
+                                // Segment is not empty.
+                                return Futures.failedFuture(new TableSegmentNotEmptyException(segment.getInfo().getName()));
+                            }
+                        })));
+    }
+
+    /**
+     * Determines if a Table Segment is empty or not, by accounting for both the indexed portion and the unindexed (tail)
+     * section.
+     *
+     * @param segment The Segment to verify.
+     * @param timer   Timer for the operation.
+     * @return A CompletableFuture that, when completed, will indicate if the Table Segment is empty or not.
+     */
+    private CompletableFuture<Boolean> isTableSegmentEmpty(DirectSegmentAccess segment, TimeoutTimer timer) {
+        // Get a snapshot of the Tail Index and identify all bucket removals.
+        val tailHashes = this.cache.getTailHashes(segment.getSegmentId());
+        val tailRemovals = tailHashes.entrySet().stream()
+                                     .filter(e -> e.getValue().isRemoval())
+                                     .map(Map.Entry::getKey)
+                                     .collect(Collectors.toList());
+        if (tailHashes.size() > tailRemovals.size()) {
+            // Tail Index has at least one update, which implies the Table Segment is not empty.
+            return CompletableFuture.completedFuture(false);
+        } else {
+            // Get the number of indexed Table Buckets.
+            SegmentProperties sp = segment.getInfo();
+            long indexedBucketCount = this.indexReader.getBucketCount(sp);
+            if (tailRemovals.isEmpty()) {
+                // No removals in the Tail index, so we can derive our response from the total number of indexed buckets.
+                return CompletableFuture.completedFuture(indexedBucketCount <= 0);
+            } else {
+                // Tail Index has at least one removal. We need to check which of these removals point to a real Table Bucket.
+                // It is possible that we received an unconditional remove for a Table Bucket that does not exist or a Table
+                // Bucket has been created and immediately deleted (before being included in the main Index). In order to
+                // determine if the table is empty, we need to figure out the exact count of removed buckets.
+                return this.indexReader.locateBuckets(segment, tailRemovals, timer)
+                                       .thenApply(buckets -> {
+                                           long removedCount = buckets.values().stream().filter(TableBucket::exists).count();
+                                           return indexedBucketCount <= removedCount;
+                                       });
+            }
+        }
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -155,7 +155,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
             return this.segmentContainer
                     .forSegment(segmentName, timer.getRemaining())
                     .thenComposeAsync(segment -> this.keyIndex.executeIfEmpty(segment,
-                            () -> this.segmentContainer.deleteStreamSegment(segmentName, timer.getRemaining())),
+                            () -> this.segmentContainer.deleteStreamSegment(segmentName, timer.getRemaining()), timer),
                             this.executor);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -12,7 +12,7 @@ package io.pravega.segmentstore.server.tables;
 import com.google.common.base.Preconditions;
 import io.pravega.common.hash.HashHelper;
 import io.pravega.common.util.BitConverter;
-import io.pravega.segmentstore.contracts.Attributes;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.storage.Cache;
 import java.util.ArrayList;
@@ -232,7 +232,7 @@ class SegmentKeyCache {
     }
 
     /**
-     * Updates the Last Indexed Offset (cached value of the Segment's {@link Attributes#TABLE_INDEX_OFFSET} attribute).
+     * Updates the Last Indexed Offset (cached value of the Segment's {@link TableAttributes#INDEX_OFFSET} attribute).
      * Clears out any backpointers whose source offsets will be smaller than the new value for Last Indexed Offset.
      */
     void setLastIndexedOffset(long currentLastIndexedOffset, int cacheGeneration) {
@@ -284,21 +284,6 @@ class SegmentKeyCache {
      */
     synchronized Map<UUID, CacheBucketOffset> getTailBucketOffsets() {
         return new HashMap<>(this.tailOffsets);
-    }
-
-    /**
-     * Gets a value representing the difference between the number of Table Buckets updated (or inserted) and the ones
-     * that have been removed.
-     *
-     * @return The result.
-     */
-    synchronized int getBucketCountDelta() {
-        int result = 0;
-        for (val s : this.tailOffsets.values()) {
-            result += s.isRemoval() ? -1 : 1;
-        }
-
-        return result;
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -1201,7 +1201,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         context.readIndex.append(segmentId, offset, data);
     }
 
-    private void appendDataInStorage(TestContext context, HashMap<Long, ByteArrayOutputStream> segmentContents) {
+    private void appendDataInStorage(TestContext context, HashMap<Long, ByteArrayOutputStream> segmentContents) throws IOException {
         int writeId = 0;
         for (int i = 0; i < APPENDS_PER_SEGMENT; i++) {
             for (long segmentId : context.metadata.getAllStreamSegmentIds()) {
@@ -1349,18 +1349,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         }
     }
 
-    private <T> void recordAppend(T segmentIdentifier, byte[] data, Map<T, ByteArrayOutputStream> segmentContents) {
+    private <T> void recordAppend(T segmentIdentifier, byte[] data, Map<T, ByteArrayOutputStream> segmentContents) throws IOException {
         ByteArrayOutputStream contents = segmentContents.getOrDefault(segmentIdentifier, null);
         if (contents == null) {
             contents = new ByteArrayOutputStream();
             segmentContents.put(segmentIdentifier, contents);
         }
-
-        try {
-            contents.write(data);
-        } catch (IOException ex) {
-            Assert.fail(ex.toString());
-        }
+        contents.write(data);
     }
 
     private ArrayList<Long> createSegments(TestContext context) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -473,22 +473,12 @@ public class ContainerKeyCacheTests {
                 Assert.assertEquals("Unexpected value from getSegmentOffset().", e.getValue().getSegmentOffset(), result.getSegmentOffset());
             }
         }
-
-        checkBucketCountDelta(keyCache);
     }
 
     private void checkNotInCache(List<TestKey> keys, ContainerKeyCache keyCache) {
         for (val e : keys) {
             val result = keyCache.get(e.segmentId, e.keyHash);
             Assert.assertNull("Found key that is not supposed to be in the cache.", result);
-        }
-    }
-
-    private void checkBucketCountDelta(ContainerKeyCache keyCache) {
-        for (long segmentId = 0; segmentId < SEGMENT_COUNT; segmentId++) {
-            val expected = keyCache.getTailHashes(segmentId).values().stream().mapToInt(e -> e.isRemoval() ? -1 : 1).sum();
-            val actual = keyCache.getBucketCountDelta(segmentId);
-            Assert.assertEquals("Unexpected value from getBucketCountDelta()", expected, actual);
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
@@ -49,6 +49,7 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
+    @Override
     protected int getThreadPoolSize() {
         return 2;
     }

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -117,6 +117,9 @@ message PingTxnStatus {
         MAX_EXECUTION_TIME_EXCEEDED = 2;
         SCALE_GRACE_TIME_EXCEEDED = 3 [deprecated=true];
         DISCONNECTED = 4;
+        COMMITTED = 5;
+        ABORTED = 6;
+        UNKNOWN = 7;
     }
     Status status = 1;
 }

--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -9,37 +9,22 @@
  */
 package io.pravega.local;
 
+import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientConfig;
-import io.pravega.client.ClientFactory;
-import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
-
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.ReinitializationRequiredException;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
 import java.net.URI;
-import java.util.UUID;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 /**
- * Integration tests for auth enabled in-process standalone cluster.
+ * This class contains tests for auth enabled in-process standalone cluster. It inherits the test methods defined
+ * in the parent class.
  */
 @Slf4j
 public class AuthEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest {
@@ -52,96 +37,37 @@ public class AuthEnabledInProcPravegaClusterTest extends InProcPravegaClusterTes
     }
 
     @Override
-    public void createTestStream() {
-        // This test from the base is unnecessary in this class as that and more is already being
-        // tested in another test method.
+    String scopeName() {
+        return "AuthTestScope";
+    }
+
+    @Override
+    String streamName() {
+        return "AuthTestStream";
+    }
+
+    @Override
+    String eventMessage() {
+        return "Test message on the plaintext channel with auth credentials";
+    }
+
+    @Override
+    ClientConfig prepareValidClientConfig() {
+        return ClientConfig.builder()
+                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
+                .build();
     }
 
     /**
-     * Compares reads and writes to verify that an in-process Pravega cluster runs properly with
-     * with valid auth (authentication and authorization) configuration.
+     * This test verifies that create stream fails when the client config is invalid.
      *
-     * Note:
-     * Strictly speaking, this test is really an "integration test" and is a little time consuming. For now, its
-     * intended to also run as a unit test, but it could be moved to an integration test suite if and when necessary.
-     *
+     * Note: The timeout being used for the test is kept rather large so that there is ample time for the expected
+     * exception to be raised even in case of abnormal delays in test environments.
      */
-    @Test(timeout = 50000)
-    public void testWriteAndReadEventsWhenConfigIsProper() throws ReinitializationRequiredException {
-        String scope = "org.example.auth";
-        String streamName = "stream1";
-        int numSegments = 1;
-
-        ClientConfig clientConfig = ClientConfig.builder()
-                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
-                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                .build();
-        log.info("Done creating client config");
-
-        @Cleanup
-        StreamManager streamManager = StreamManager.create(clientConfig);
-        log.info("Created a stream manager");
-
-        streamManager.createScope(scope);
-        log.info("Created a scope [{}]", scope);
-
-        streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                .build());
-        log.info("Created a stream with name [{}]", streamName);
-
-        @Cleanup
-        ClientFactory clientFactory = ClientFactory.withScope(scope, clientConfig);
-
-        @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                new JavaSerializer<String>(),
-                EventWriterConfig.builder().build());
-        log.info("Got a writer");
-
-        String writeEvent1 = "This is event 1";
-        writer.writeEvent(writeEvent1);
-        log.info("Done writing event [{}]", writeEvent1);
-
-        String writeEvent2 = "This is event 2";
-        writer.writeEvent(writeEvent2);
-        log.info("Done writing event [{}]", writeEvent2);
-
-        // Now, read the events from the stream.
-
-        String readerGroup = UUID.randomUUID().toString().replace("-", "");
-        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
-                .stream(Stream.of(scope, streamName))
-                .disableAutomaticCheckpoints()
-                .build();
-
-        @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
-        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
-
-        @Cleanup
-        EventStreamReader<String> reader = clientFactory.createReader(
-                "readerId", readerGroup,
-                new JavaSerializer<String>(), ReaderConfig.builder().build());
-
-        // Keeping the read timeout large so that there is ample time for reading the event even in
-        // case of abnormal delays in test environments.
-        String readEvent1 = reader.readNextEvent(10000).getEvent();
-        log.info("Done reading event [{}]", readEvent1);
-
-        String readEvent2 = reader.readNextEvent(10000).getEvent();
-        log.info("Done reading event [{}]", readEvent2);
-
-        assertEquals(writeEvent1, readEvent1);
-        assertEquals(writeEvent2, readEvent2);
-    }
-
-    @Test
-    public void testCreateStreamFailsWhenCredentialsAreInvalid() {
-        Assert.assertNotNull("Pravega not initialized", localPravega);
-        String scope = "Scope";
-
-        ClientConfig clientConfig = ClientConfig.builder()
+    @Test(timeout = 300000)
+    public void testCreateStreamFailsWithInvalidClientConfig() {
+       ClientConfig clientConfig = ClientConfig.builder()
                 .credentials(new DefaultCredentials("", ""))
                 .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
                 .build();
@@ -149,8 +75,19 @@ public class AuthEnabledInProcPravegaClusterTest extends InProcPravegaClusterTes
         @Cleanup
         StreamManager streamManager = StreamManager.create(clientConfig);
 
-        AssertExtensions.assertThrows(RuntimeException.class,
-                () -> streamManager.createScope(scope));
+        AssertExtensions.assertThrows("Auth exception did not occur.",
+                () -> streamManager.createScope(scopeName()),
+                e -> hasAuthExceptionAsRootCause(e));
+    }
+
+    private boolean hasAuthExceptionAsRootCause(Throwable e) {
+        Throwable innermostException = ExceptionUtils.getRootCause(e);
+
+        // Depending on an exception message for determining whether the given exception represents auth failure
+        // is not a good thing to do, but we have no other choice here because auth failures are represented as the
+        // overly general io.grpc.StatusRuntimeException.
+        return innermostException instanceof StatusRuntimeException &&
+             innermostException.getMessage().toUpperCase().contains("UNAUTHENTICATED");
     }
 
     @After

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -11,16 +11,24 @@ package io.pravega.local;
 
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.TestUtils;
 import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
@@ -28,11 +36,18 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.pravega.local.LocalPravegaEmulator.LocalPravegaEmulatorBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
- * Unit tests for standalone
+ * This class contains tests for in-process standalone cluster. It also configures and runs standalone mode cluster
+ * with appropriate configuration for itself as well as for sub-classes.
  */
 @Slf4j
 public class InProcPravegaClusterTest {
+
     boolean restEnabled = true;
     boolean authEnabled = false;
     boolean tlsEnabled = false;
@@ -46,65 +61,128 @@ public class InProcPravegaClusterTest {
                 .build();
         SingleNodeConfig conf = config.getConfig(SingleNodeConfig::builder);
 
-        localPravega = LocalPravegaEmulator.builder()
+        LocalPravegaEmulatorBuilder emulatorBuilder = LocalPravegaEmulator.builder()
                 .controllerPort(TestUtils.getAvailableListenPort())
                 .segmentStorePort(TestUtils.getAvailableListenPort())
                 .zkPort(TestUtils.getAvailableListenPort())
                 .restServerPort(TestUtils.getAvailableListenPort())
                 .enableRestServer(restEnabled)
                 .enableAuth(authEnabled)
-                .enableTls(tlsEnabled)
-                .certFile("../config/cert.pem")
-                .keyFile("../config/key.pem")
-                .jksKeyFile("../config/standalone.keystore.jks")
-                .jksTrustFile("../config/standalone.truststore.jks")
-                .keyPasswordFile("../config/standalone.keystore.jks.passwd")
-                .passwdFile("../config/passwd")
-                .userName("admin")
-                .passwd("1111_aaaa")
-                .build();
+                .enableTls(tlsEnabled);
 
+        // Since the server is being built right here, avoiding delegating these conditions to subclasses via factory
+        // methods. This is so that it is easy to see the difference in server configs all in one place. This is also
+        // unlike the ClientConfig preparation which is being delegated to factory methods to make their preparation
+        // explicit in the respective test classes.
+
+        if (authEnabled) {
+            emulatorBuilder.passwdFile("../config/passwd")
+                    .userName("admin")
+                    .passwd("1111_aaaa");
+        }
+        if (tlsEnabled) {
+            emulatorBuilder.certFile("../config/cert.pem")
+                    .keyFile("../config/key.pem")
+                    .jksKeyFile("../config/standalone.keystore.jks")
+                    .jksTrustFile("../config/standalone.truststore.jks")
+                    .keyPasswordFile("../config/standalone.keystore.jks.passwd");
+        }
+
+        localPravega = emulatorBuilder.build();
         localPravega.start();
     }
 
-    /**
-     * Create the test stream.
-     *
-     * @throws Exception on any errors.
-     */
-    @Test
-    public void createTestStream()
-            throws Exception {
-        Assert.assertNotNull("Pravega not initialized", localPravega);
-        String scope = "Scope";
-        String streamName = "Stream";
-        int numSegments = 10;
+    //region Factory methods. These should be overridden in subclasses.
 
-        ClientConfig clientConfig = ClientConfig.builder()
-                                                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                                                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
-                                                .trustStore("../config/cert.pem")
-                                                .validateHostName(false)
-                                                .build();
+    String scopeName() {
+        return "TestScope";
+    }
+
+    String streamName() {
+        return "TestStream";
+    }
+
+    String eventMessage() {
+        return "Test message on the plaintext channel";
+    }
+
+    ClientConfig prepareValidClientConfig() {
+        return ClientConfig.builder()
+                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .build();
+    }
+
+    //endregion
+
+    /**
+     * Compares reads and writes to verify that an in-process Pravega cluster responds properly with
+     * with valid client configuration.
+     *
+     * Note:
+     * Strictly speaking, this test is really an "integration test" and is a little time consuming. For now, its
+     * intended to also run as a unit test, but it could be moved to an integration test suite if and when necessary.
+     *
+     */
+    @Test(timeout = 50000)
+    public void testWriteAndReadEventWithValidClientConfig() throws ExecutionException,
+            InterruptedException, ReinitializationRequiredException {
+
+        String scope = scopeName();
+        String streamName = streamName();
+        int numSegments = 1;
+        String message = eventMessage();
+
+        ClientConfig clientConfig = prepareValidClientConfig();
+
         @Cleanup
         StreamManager streamManager = StreamManager.create(clientConfig);
+        assertNotNull(streamManager);
 
-        streamManager.createScope(scope);
-        Assert.assertTrue("Stream creation is not successful ",
-                streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                                   .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                                   .build()));
-        log.info("Created stream: " + streamName);
+        boolean isScopeCreated = streamManager.createScope(scope);
+        assertTrue("Failed to create scope", isScopeCreated);
 
+        boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                .build());
+        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
+
+        @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
+
+        // Write an event to the stream.
+
+        @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
                 new JavaSerializer<String>(),
                 EventWriterConfig.builder().build());
-        log.info("Created writer for stream: " + streamName);
+        writer.writeEvent(message).get();
+        log.debug("Done writing message '{}' to stream '{} / {}'", message, scope, streamName);
 
-        writer.writeEvent("hello").get();
-        log.info("Wrote data to the stream");
+        // Now, read the event from the stream.
+
+        String readerGroup = UUID.randomUUID().toString().replace("-", "");
+        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
+                .stream(Stream.of(scope, streamName))
+                .disableAutomaticCheckpoints()
+                .build();
+
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
+
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader(
+                "readerId", readerGroup,
+                new JavaSerializer<String>(), ReaderConfig.builder().build());
+
+        // Keeping the read timeout large so that there is ample time for reading the event even in
+        // case of abnormal delays in test environments.
+        String readMessage = reader.readNextEvent(10000).getEvent();
+        log.info("Done reading event [{}]", readMessage);
+
+        assertEquals(message, readMessage);
     }
+
 
     @After
     public void tearDown() throws Exception {

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -10,19 +10,15 @@
 package io.pravega.local;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.impl.DefaultCredentials;
-import io.pravega.test.common.AssertExtensions;
 import java.net.URI;
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
- * Unit tests for secure standalone cluster.
+ * This class holds tests for TLS and auth enabled in-process standalone cluster. It inherits the test methods defined
+ * in the parent class.
  */
 @Slf4j
 public class SecurePravegaClusterTest extends InProcPravegaClusterTest {
@@ -34,29 +30,33 @@ public class SecurePravegaClusterTest extends InProcPravegaClusterTest {
         super.setUp();
     }
 
-    /**
-     * Create the test stream.
-     *
-     * @throws Exception on any errors.
-     */
-    @Test
-    public void failingCreateTestStream()
-            throws Exception {
-        Assert.assertNotNull("Pravega not initialized", localPravega);
-        String scope = "Scope";
-        String streamName = "Stream";
-        int numSegments = 10;
+    @Override
+    String scopeName() {
+        return "TlsAndAuthTestScope";
+    }
 
-        ClientConfig clientConfig = ClientConfig.builder()
-                                                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
-                                                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
-                                                .validateHostName(false)
-                                                .build();
-        @Cleanup
-        StreamManager streamManager = StreamManager.create(clientConfig);
+    @Override
+    String streamName() {
+        return "TlsAndAuthTestStream";
+    }
 
-        AssertExtensions.assertThrows(RuntimeException.class,
-                () -> streamManager.createScope(scope));
+    @Override
+    String eventMessage() {
+        return "Test message on the encrypted channel with auth credentials";
+    }
+
+    @Override
+    ClientConfig prepareValidClientConfig() {
+        return ClientConfig.builder()
+                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+
+                // TLS-related
+                .trustStore("../config/cert.pem")
+                .validateHostName(false)
+
+                // Auth-related
+                .credentials(new DefaultCredentials("1111_aaaa", "admin"))
+                .build();
     }
 
     @After

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
@@ -129,7 +129,7 @@ public class AppendReconnectTest {
 
         @Cleanup
         ConnectionFactoryImpl clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
 
@@ -166,7 +166,7 @@ public class AppendReconnectTest {
 
         @Cleanup
         ConnectionFactoryImpl clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
 

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -213,7 +213,7 @@ public class AppendTest {
 
         @Cleanup
         ConnectionFactory clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
 
@@ -242,7 +242,7 @@ public class AppendTest {
 
         @Cleanup
         ConnectionFactory clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
 

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -59,6 +59,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -232,7 +233,7 @@ public class BoundedStreamReaderTest {
         @Cleanup
         ReaderGroupManager groupManager = ReaderGroupManager.withScope(SCOPE, controllerUri);
 
-        ReaderGroupConfig readerGroupCfg1 = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+        ReaderGroupConfig readerGroupCfg1 = ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
                 .stream(Stream.of(SCOPE, STREAM1),
                         //startStreamCut points to the current HEAD of stream
                         StreamCut.UNBOUNDED,
@@ -251,7 +252,7 @@ public class BoundedStreamReaderTest {
         //The following read should not return events 3, 4 due to the endStreamCut configuration.
         Assert.assertNull("Null is expected", reader1.readNextEvent(2000).getEvent());
 
-        final ReaderGroupConfig readerGroupCfg2 = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+        final ReaderGroupConfig readerGroupCfg2 = ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
                                                              .stream(Stream.of(SCOPE, STREAM1),
                                                                      getStreamCut(STREAM1, 60L, 0),
                                                                      //endStreamCut points to the offset after two events.(i.e 2 * 30(event size) = 60)
@@ -264,6 +265,8 @@ public class BoundedStreamReaderTest {
         @Cleanup
         EventStreamReader<String> reader2 = clientFactory.createReader("readerId2", "group", serializer,
                 ReaderConfig.builder().build());
+        assertNull(reader2.readNextEvent(100).getEvent());
+        readerGroup.initiateCheckpoint("c1", executor);
         readAndVerify(reader2, 3, 4, 5);
         Assert.assertNull("Null is expected", reader2.readNextEvent(2000).getEvent());
     }
@@ -347,9 +350,9 @@ public class BoundedStreamReaderTest {
     private void readAndVerify(final EventStreamReader<String> reader, int...index) throws ReinitializationRequiredException {
         ArrayList<String> results = new ArrayList<>(index.length);
         for (int i = 0; i < index.length; i++) {
-            String event = reader.readNextEvent(15000).getEvent();
+            String event = reader.readNextEvent(1000).getEvent();
             while (event == null) { //try until a non null event is read.
-                event = reader.readNextEvent(15000).getEvent();
+                event = reader.readNextEvent(1000).getEvent();
             }
             results.add(event);
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -9,22 +9,20 @@
  */
 package io.pravega.test.integration;
 
-import io.pravega.segmentstore.contracts.tables.TableStore;
-import io.pravega.test.common.TestingServerStarter;
-import io.pravega.test.integration.demo.ControllerWrapper;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
-import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.store.ServiceBuilder;
-import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.impl.TxnSegments;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
@@ -49,24 +47,16 @@ public class ControllerBootstrapTest {
     private TableStore tableStore;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         final String serviceHost = "localhost";
         final int containerCount = 4;
 
         // 1. Start ZK
-        try {
-            zkTestServer = new TestingServerStarter().start();
-        } catch (Exception e) {
-            Assert.fail("Failed starting ZK test server");
-        }
-
+        zkTestServer = new TestingServerStarter().start();
         // 2. Start controller
-        try {
-            controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
-                    controllerPort, serviceHost, servicePort, containerCount);
-        } catch (Exception e) {
-            Assert.fail("Failed starting ControllerWrapper");
-        }
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
+                                                  controllerPort, serviceHost, servicePort, containerCount);
+
     }
 
     @After
@@ -110,22 +100,15 @@ public class ControllerBootstrapTest {
         CompletableFuture<Boolean> streamStatus = controller.createStream(SCOPE, STREAM, streamConfiguration);
         Assert.assertTrue(!streamStatus.isDone());
         // Ensure that create stream succeeds.
-        try {
-            Boolean status = streamStatus.join();
-            Assert.assertEquals(true, status);
-        } catch (CompletionException ce) {
-            Assert.fail();
-        }
+
+        Boolean status = streamStatus.join();
+        Assert.assertEquals(true, status);
 
         // Now create transaction should succeed.
         CompletableFuture<TxnSegments> txIdFuture = controller.createTransaction(new StreamImpl(SCOPE, STREAM), 10000);
 
-        try {
-            TxnSegments id = txIdFuture.join();
-            Assert.assertNotNull(id);
-        } catch (CompletionException ce) {
-            Assert.fail();
-        }
+        TxnSegments id = txIdFuture.join();
+        Assert.assertNotNull(id);
 
         controllerWrapper.awaitRunning();
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -27,9 +27,8 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamImpl;
-import io.pravega.common.Exceptions;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
@@ -42,6 +41,7 @@ import io.pravega.shared.metrics.MetricRegistryUtils;
 import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.StatsProvider;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
@@ -162,8 +161,8 @@ public class MetricsTest extends ThreadPooledTestSuite {
         }
     }
 
-    @Test
-    public void metricsTimeBasedCacheEvictionTest() throws InterruptedException, ExecutionException {
+    @Test(timeout = 120000)
+    public void metricsTimeBasedCacheEvictionTest() throws Exception {
         try (ConnectionFactory cf = new ConnectionFactoryImpl(ClientConfig.builder().build());
              StreamManager streamManager = new StreamManagerImpl(controller, cf)) {
             boolean createScopeStatus = streamManager.createScope(scope);
@@ -177,64 +176,48 @@ public class MetricsTest extends ThreadPooledTestSuite {
              ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
              ReaderGroupManager readerGroupManager = new ReaderGroupManagerImpl(scope, controller, clientFactory, connectionFactory)) {
             EventStreamWriter<String> writer1 = clientFactory.createEventWriter(STREAM_NAME,
-                    new JavaSerializer<>(),
+                    new UTF8StringSerializer(),
                     EventWriterConfig.builder().build());
             String event = "12345";
-            long bytesWritten = TOTAL_NUM_EVENTS * event.length() * 4;
+            long bytesWritten = TOTAL_NUM_EVENTS * (8 + event.length());
 
-            for (int i = 0; i < TOTAL_NUM_EVENTS; i++) {
-                try {
-                    log.info("Writing event {}", event);
-                    writer1.writeEvent("", event);
-                    writer1.flush();
-                } catch (Throwable e) {
-                    log.warn("Test exception writing events: {}", e);
-                    break;
-                }
-            }
+            writeEvents(event, writer1);
 
             String readerGroupName1 = readerGroupName + "1";
             log.info("Creating Reader group : {}", readerGroupName1);
 
-            readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder().stream(Stream.of(scope, STREAM_NAME)).build());
+            readerGroupManager.createReaderGroup(readerGroupName1,
+                                                 ReaderGroupConfig.builder()
+                                                                  .stream(Stream.of(scope, STREAM_NAME))
+                                                                  .automaticCheckpointIntervalMillis(2000)
+                                                                  .build());
 
             EventStreamReader<String> reader1 = clientFactory.createReader(readerName,
                     readerGroupName1,
-                    new JavaSerializer<>(),
+                    new UTF8StringSerializer(),
                     ReaderConfig.builder().build());
 
-            for (int j = 0; j < TOTAL_NUM_EVENTS; j++) {
-                try {
-                    String eventRead1 = reader1.readNextEvent(SECONDS.toMillis(2)).getEvent();
-                    log.info("Reading event {}", eventRead1);
-                } catch (ReinitializationRequiredException e) {
-                    log.warn("Test Exception while reading from the stream", e);
-                }
-            }
+            readAllEvents(reader1);
 
-            long initialCount = (long) MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes", segmentTags(scope + "/" + STREAM_NAME + "/0.#epoch.0")).count();
-            Assert.assertEquals(bytesWritten, initialCount);
-
-            Exceptions.handleInterrupted(() -> Thread.sleep(10 * 1000));
+            AssertExtensions.assertEventuallyEquals(bytesWritten, () -> {
+                return (long) MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes", segmentTags(scope + "/" + STREAM_NAME + "/0.#epoch.0")).count();
+            }, 10000);
 
             String readerGroupName2 = readerGroupName + "2";
             log.info("Creating Reader group : {}", readerGroupName2);
 
-            readerGroupManager.createReaderGroup(readerGroupName2, ReaderGroupConfig.builder().stream(Stream.of(scope, STREAM_NAME)).build());
+            readerGroupManager.createReaderGroup(readerGroupName2,
+                                                 ReaderGroupConfig.builder()
+                                                                  .stream(Stream.of(scope, STREAM_NAME))
+                                                                  .automaticCheckpointIntervalMillis(2000)
+                                                                  .build());
 
             EventStreamReader<String> reader2 = clientFactory.createReader(readerName,
                     readerGroupName2,
-                    new JavaSerializer<>(),
+                    new UTF8StringSerializer(),
                     ReaderConfig.builder().build());
 
-            for (int q = 0; q < TOTAL_NUM_EVENTS; q++) {
-                try {
-                    String eventRead2 = reader2.readNextEvent(SECONDS.toMillis(2)).getEvent();
-                    log.info("Reading event {}", eventRead2);
-                } catch (ReinitializationRequiredException e) {
-                    log.warn("Test Exception while reading from the stream", e);
-                }
-            }
+            readAllEvents(reader2);
 
             long countAfterCacheEvicted = (long) MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes", segmentTags(scope + "/" + STREAM_NAME + "/0.#epoch.0")).count();
 
@@ -253,34 +236,16 @@ public class MetricsTest extends ThreadPooledTestSuite {
             Assert.assertTrue(scaleStatus.get());
 
             EventStreamWriter<String> writer2 = clientFactory.createEventWriter(STREAM_NAME,
-                    new JavaSerializer<>(),
+                    new UTF8StringSerializer(),
                     EventWriterConfig.builder().build());
 
-            for (int i = 0; i < TOTAL_NUM_EVENTS; i++) {
-                try {
-                    log.info("Writing event {}", event);
-                    writer2.writeEvent("", event);
-                    writer2.flush();
-                } catch (Throwable e) {
-                    log.warn("Test exception writing events: {}", e);
-                    break;
-                }
-            }
+            writeEvents(event, writer2);
 
-            Exceptions.handleInterrupted(() -> Thread.sleep(10 * 1000));
+            readAllEvents(reader1);
 
-            for (int j = 0; j < TOTAL_NUM_EVENTS; j++) {
-                try {
-                    String eventRead2 = reader1.readNextEvent(SECONDS.toMillis(2)).getEvent();
-                    log.info("Reading event {}", eventRead2);
-                } catch (ReinitializationRequiredException e) {
-                    log.warn("Test Exception while reading from the stream", e);
-                }
-            }
-
-            long countFromSecondSegment = (long) MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes", segmentTags(scope + "/" + STREAM_NAME + "/1.#epoch.1")).count();
-
-            Assert.assertEquals(bytesWritten, countFromSecondSegment);
+            AssertExtensions.assertEventuallyEquals(bytesWritten, () -> {
+                return (long) MetricRegistryUtils.getCounter("pravega.segmentstore.segment.read_bytes", segmentTags(scope + "/" + STREAM_NAME + "/1.#epoch.1")).count();
+            }, 10000);
 
             readerGroupManager.deleteReaderGroup(readerGroupName1);
             readerGroupManager.deleteReaderGroup(readerGroupName2);
@@ -299,6 +264,33 @@ public class MetricsTest extends ThreadPooledTestSuite {
         }
 
         log.info("Metrics Time based Cache Eviction test succeeds");
+    }
+
+    private void writeEvents(String event, EventStreamWriter<String> writer) {
+        for (int i = 0; i < TOTAL_NUM_EVENTS; i++) {
+            try {
+                log.info("Writing event {}", event);
+                writer.writeEvent("", event);
+            } catch (Throwable e) {
+                log.warn("Test exception writing events: {}", e);
+                break;
+            }
+        }
+        writer.flush();
+    }
+
+    private void readAllEvents(EventStreamReader<String> reader) {
+        for (int q = 0; q < TOTAL_NUM_EVENTS;) {
+            try {
+                String eventRead2 = reader.readNextEvent(SECONDS.toMillis(2)).getEvent();
+                if (eventRead2 != null) {
+                    q++;
+                }
+                log.info("Reading event {}", eventRead2);
+            } catch (ReinitializationRequiredException e) {
+                log.warn("Test Exception while reading from the stream", e);
+            }
+        }
     }
        
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -183,7 +183,7 @@ public class ReadTest {
         PravegaConnectionListener server = new PravegaConnectionListener(false, port, store, tableStore);
         server.startListening();
         ConnectionFactory clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
 
@@ -227,7 +227,7 @@ public class ReadTest {
         PravegaConnectionListener server = new PravegaConnectionListener(false, port, store, tableStore);
         server.startListening();
         ConnectionFactory clientCF = new ConnectionFactoryImpl(ClientConfig.builder().build());
-        Controller controller = new MockController(endpoint, port, clientCF);
+        Controller controller = new MockController(endpoint, port, clientCF, true);
         controller.createScope(scope);
         controller.createStream(scope, stream, StreamConfiguration.builder().build());
         
@@ -271,7 +271,7 @@ public class ReadTest {
         @Cleanup
         MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
         MockClientFactory clientFactory = streamManager.getClientFactory();
-        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().stream(Stream.of(scope, streamName)).build();
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder().stream(Stream.of(scope, streamName)).disableAutomaticCheckpoints().build();
         streamManager.createScope(scope);
         streamManager.createStream(scope, streamName, null);
         streamManager.createReaderGroup(readerGroup, groupConfig);

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -75,7 +75,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class ReadTest {
 
@@ -289,7 +288,7 @@ public class ReadTest {
     }
 
     @Test(timeout = 10000)
-    public void testEventPointer() throws ReinitializationRequiredException {
+    public void testEventPointer() throws ReinitializationRequiredException, NoSuchEventException {
         String endpoint = "localhost";
         String streamName = "abc";
         String readerName = "reader";
@@ -318,21 +317,12 @@ public class ReadTest {
         producer.flush();
 
         @Cleanup
-        EventStreamReader<String> reader = clientFactory
-                .createReader(readerName, readerGroup, serializer, ReaderConfig.builder().build());
-        try {
-            EventPointer pointer;
-            String read;
-
-            for (int i = 0; i < 100; i++) {
-                pointer = reader.readNextEvent(5000).getEventPointer();
-                read = reader.fetchEvent(pointer);
-                assertEquals(testString + i, read);
-            }
-        } catch (NoSuchEventException e) {
-            fail("Failed to read event using event pointer");
+        EventStreamReader<String> reader = clientFactory.createReader(readerName, readerGroup, serializer, ReaderConfig.builder().build());
+        for (int i = 0; i < 100; i++) {
+            EventPointer pointer = reader.readNextEvent(5000).getEventPointer();
+            String read = reader.fetchEvent(pointer);
+            assertEquals(testString + i, read);
         }
-
     }
 
     private void fillStoreForSegment(String segmentName, UUID clientId, byte[] data, int numEntries,

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -31,6 +31,8 @@ import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.notifications.EndOfDataNotification;
 import io.pravega.client.stream.notifications.Listener;
 import io.pravega.client.stream.notifications.SegmentNotification;
+import io.pravega.client.stream.notifications.notifier.EndOfDataNotifier;
+import io.pravega.client.stream.notifications.notifier.SegmentNotifier;
 import io.pravega.common.util.ReusableLatch;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
@@ -54,10 +56,10 @@ import lombok.val;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -77,12 +79,6 @@ public class ReaderGroupNotificationTest {
     private ScheduledExecutorService executor;
     private AtomicBoolean listenerInvoked = new AtomicBoolean();
     private ReusableLatch listenerLatch = new ReusableLatch();
-
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("pravega.client.segmentNotification.poll.interval.seconds", String.valueOf(5));
-        System.setProperty("pravega.client.endOfDataNotification.poll.interval.seconds", String.valueOf(5));
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -121,7 +117,7 @@ public class ReaderGroupNotificationTest {
     public void testSegmentNotifications() throws Exception {
         final String streamName = "stream1";
         StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .scalingPolicy(ScalingPolicy.fixed(1))
                                                         .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope(SCOPE).get();
@@ -150,12 +146,12 @@ public class ReaderGroupNotificationTest {
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
                 connectionFactory);
         groupManager.createReaderGroup("reader", ReaderGroupConfig
-                .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, streamName)).build());
+                .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, streamName)).groupRefreshTimeMillis(0).build());
         @Cleanup
         ReaderGroup readerGroup = groupManager.getReaderGroup("reader");
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
-                ReaderConfig.builder().build());
+                ReaderConfig.builder().initialAllocationDelay(0).build());
 
         val notificationResults = new ArrayBlockingQueue<SegmentNotification>(2);
 
@@ -164,21 +160,30 @@ public class ReaderGroupNotificationTest {
             log.info("Number of Segments: {}, Number of Readers: {}", notification.getNumOfSegments(), notification.getNumOfReaders());
             notificationResults.add(notification);
         };
-        readerGroup.getSegmentNotifier(executor).registerListener(l1);
+        SegmentNotifier segmentNotifier = (SegmentNotifier) readerGroup.getSegmentNotifier(executor);
+        segmentNotifier.registerListener(l1);
 
         // Read first event and validate notification.
-        EventRead<String> event1 = reader1.readNextEvent(15000);
-        assertNotNull(event1);
+        EventRead<String> event1 = reader1.readNextEvent(5000);
         assertEquals("data1", event1.getEvent());
+
+        segmentNotifier.pollNow();
         SegmentNotification initialSegmentNotification = notificationResults.take();
         assertNotNull(initialSegmentNotification);
         assertEquals(1, initialSegmentNotification.getNumOfReaders());
         assertEquals(1, initialSegmentNotification.getNumOfSegments());
-
+        
+        EventRead<String> emptyEvent = reader1.readNextEvent(0);
+        assertNull(emptyEvent.getEvent());
+        assertFalse(emptyEvent.isCheckpoint());
+        readerGroup.initiateCheckpoint("cp", executor);
+        EventRead<String> cpEvent = reader1.readNextEvent(1000);
+        assertTrue(cpEvent.isCheckpoint());
+        
         // Read second event and validate notification.
-        EventRead<String> event2 = reader1.readNextEvent(15000);
-        assertNotNull(event2);
+        EventRead<String> event2 = reader1.readNextEvent(10000);
         assertEquals("data2", event2.getEvent());
+        segmentNotifier.pollNow();
         SegmentNotification segmentNotificationPostScale = notificationResults.take();
         assertEquals(1, segmentNotificationPostScale.getNumOfReaders());
         assertEquals(2, segmentNotificationPostScale.getNumOfSegments());
@@ -188,7 +193,7 @@ public class ReaderGroupNotificationTest {
     public void testEndOfStreamNotifications() throws Exception {
         final String streamName = "stream2";
         StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .scalingPolicy(ScalingPolicy.fixed(1))
                                                         .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope(SCOPE).get();
@@ -218,29 +223,45 @@ public class ReaderGroupNotificationTest {
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
                 connectionFactory);
         groupManager.createReaderGroup("reader", ReaderGroupConfig
-                .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, streamName)).build());
+                .builder().disableAutomaticCheckpoints().stream(Stream.of(SCOPE, streamName)).groupRefreshTimeMillis(0).build());
         @Cleanup
         ReaderGroup readerGroup = groupManager.getReaderGroup("reader");
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId", "reader", new JavaSerializer<>(),
-                ReaderConfig.builder().build());
+                ReaderConfig.builder().initialAllocationDelay(0).build());
 
         //Add segment event listener
         Listener<EndOfDataNotification> l1 = notification -> {
             listenerInvoked.set(true);
             listenerLatch.release();
         };
-        readerGroup.getEndOfDataNotifier(executor).registerListener(l1);
+        EndOfDataNotifier endOfDataNotifier = (EndOfDataNotifier) readerGroup.getEndOfDataNotifier(executor);
+        endOfDataNotifier.registerListener(l1);
 
         EventRead<String> event1 = reader1.readNextEvent(10000);
-        EventRead<String> event2 = reader1.readNextEvent(10000);
-        EventRead<String> event3 = reader1.readNextEvent(10000);
-        assertNotNull(event1);
         assertEquals("data1", event1.getEvent());
-        assertNotNull(event2);
+        EventRead<String> emptyEvent = reader1.readNextEvent(0);
+        assertNull(emptyEvent.getEvent());
+        assertFalse(emptyEvent.isCheckpoint());
+        readerGroup.initiateCheckpoint("cp", executor);
+        EventRead<String> cpEvent = reader1.readNextEvent(10000);
+        assertTrue(cpEvent.isCheckpoint());
+        EventRead<String> event2 = reader1.readNextEvent(10000);
         assertEquals("data2", event2.getEvent());
-        assertNull(event3.getEvent());
+        emptyEvent = reader1.readNextEvent(0);
+        assertNull(emptyEvent.getEvent());
+        assertFalse(emptyEvent.isCheckpoint());
+        emptyEvent = reader1.readNextEvent(0);
+        assertNull(emptyEvent.getEvent());
+        assertFalse(emptyEvent.isCheckpoint());
+        readerGroup.initiateCheckpoint("cp2", executor);
+        cpEvent = reader1.readNextEvent(10000);
+        assertTrue(cpEvent.isCheckpoint());
+        emptyEvent = reader1.readNextEvent(0);
+        assertNull(emptyEvent.getEvent());
+        assertFalse(emptyEvent.isCheckpoint());
 
+        endOfDataNotifier.pollNow();
         listenerLatch.await();
         assertTrue("Listener invoked", listenerInvoked.get());
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
@@ -82,7 +82,11 @@ public class TransactionTest {
         MockStreamManager streamManager = new MockStreamManager("scope", endpoint, port);
         streamManager.createScope("scope");
         streamManager.createStream("scope", streamName, StreamConfiguration.builder().build());
-        streamManager.createReaderGroup(groupName, ReaderGroupConfig.builder().stream(Stream.of("scope", streamName)).build());
+        streamManager.createReaderGroup(groupName,
+                                        ReaderGroupConfig.builder()
+                                                         .stream(Stream.of("scope", streamName))
+                                                         .disableAutomaticCheckpoints()
+                                                         .build());
         MockClientFactory clientFactory = streamManager.getClientFactory();
         @Cleanup
         EventStreamWriter<String> producer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),
@@ -181,7 +185,11 @@ public class TransactionTest {
         MockStreamManager streamManager = new MockStreamManager("scope", endpoint, port);
         streamManager.createScope("scope");
         streamManager.createStream("scope", streamName, StreamConfiguration.builder().build());
-        streamManager.createReaderGroup(groupName, ReaderGroupConfig.builder().stream(Stream.of("scope", streamName)).build());
+        streamManager.createReaderGroup(groupName,
+                                        ReaderGroupConfig.builder()
+                                                         .stream(Stream.of("scope", streamName))
+                                                         .disableAutomaticCheckpoints()
+                                                         .build());
         MockClientFactory clientFactory = streamManager.getClientFactory();
         @Cleanup
         EventStreamWriter<String> producer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(),

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
@@ -14,11 +14,13 @@ import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.netty.impl.ConnectionPoolImpl;
+import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
@@ -40,6 +42,7 @@ import io.pravega.test.integration.demo.ControllerWrapper;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +54,7 @@ import org.junit.Test;
 import static io.pravega.test.common.AssertExtensions.assertEventuallyEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -126,8 +130,8 @@ public class EndToEndChannelLeakTest {
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
                 connectionFactory);
-        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().
-                stream(Stream.of(SCOPE, STREAM_NAME)).build());
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
+                                       .stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, new JavaSerializer<>(),
@@ -137,7 +141,6 @@ public class EndToEndChannelLeakTest {
 
         //Read an event.
         EventRead<String> event = reader1.readNextEvent(10000);
-        assertNotNull(event);
         assertEquals("zero", event.getEvent());
 
         // scale
@@ -148,6 +151,16 @@ public class EndToEndChannelLeakTest {
         map.put(0.66, 1.0);
         Boolean result = controller.scaleStream(stream, Collections.singletonList(0L), map, executor).getFuture().get();
         assertTrue(result);
+
+        event = reader1.readNextEvent(0);
+        assertNull(event.getEvent());
+
+        @Cleanup
+        ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);
+        readerGroup.initiateCheckpoint("cp", executor);
+
+        event = reader1.readNextEvent(5000);
+        assertEquals("cp", event.getCheckpointName());
 
         //Write more events.
         writer.writeEvent("0", "one").get();
@@ -168,7 +181,7 @@ public class EndToEndChannelLeakTest {
         assertChannelCount(5, connectionPool);
     }
 
-    @Test(timeout = 30000)
+    @Test//(timeout = 30000)
     public void testDetectChannelLeakMultiReaderPooled() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder()
                                                         .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
@@ -201,8 +214,8 @@ public class EndToEndChannelLeakTest {
                 connectionFactory);
         assertChannelCount(expectedChannelCount, connectionPool); // no changes expected.
       
-        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints()
-                .stream(Stream.of(SCOPE, STREAM_NAME)).build());
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
+                                       .stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         //create a reader and read an event.
         @Cleanup
@@ -211,8 +224,6 @@ public class EndToEndChannelLeakTest {
         //Creating a reader spawns a revisioned stream client which opens 4 sockets ( read, write, metadataClient and conditionalUpdates).
         EventRead<String> event = reader1.readNextEvent(10000);
         //reader creates a new connection to the segment 0;
-
-        assertNotNull(event);
         assertEquals("zero", event.getEvent());
         //Connection to segment 0 does not cause an increase in number of open connections since we have reached the maxConnection count.
         assertChannelCount(5, connectionPool);
@@ -227,6 +238,10 @@ public class EndToEndChannelLeakTest {
         assertTrue(result);
         //No changes to the channel count.
         assertChannelCount(5, connectionPool);
+        
+        //Reaches EOS
+        event = reader1.readNextEvent(1000);
+        assertNull(event.getEvent());
 
         //Write more events.
         writer.writeEvent("1", "one").get();
@@ -240,24 +255,21 @@ public class EndToEndChannelLeakTest {
         // -1 flow to segment 0 which is sealed.)
         assertChannelCount(5, connectionPool);
 
-        //Add a new reader
-        @Cleanup
-        EventStreamReader<String> reader2 = clientFactory.createReader("readerId2", READER_GROUP, serializer,
-                ReaderConfig.builder().build());
-        //Creating a reader spawns a revisioned stream client which opens 4 flows ( read, write, metadataClient and conditionalUpdates).
-
+        ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);
+        CompletableFuture<Checkpoint> future = readerGroup.initiateCheckpoint("cp1", executor);
+        //4 more from the state synchronizer
+        assertChannelCount(5, connectionPool);
+        event = reader1.readNextEvent(5000);
+        assertEquals("cp1", event.getCheckpointName());
+        event = reader1.readNextEvent(5000);
+        assertNotNull(event.getEvent());
+        future.join();
+        //Checkpoint should close connections back down
+        readerGroup.close();
+        assertChannelCount(5, connectionPool);
+        
         event = reader1.readNextEvent(10000);
         assertNotNull(event.getEvent());
-
-        //+1 flow (-1 since segment 0 of stream is sealed + 2 connections to two segments of stream (there are
-        // 2 readers and 3 segments and the reader1 will be assigned 2 segments))
-        assertChannelCount(5, connectionPool);
-
-        event = reader2.readNextEvent(10000);
-        assertNotNull(event.getEvent());
-
-        //+1 flow (a new flow to the remaining stream segment)
-        expectedChannelCount += 1;
         assertChannelCount(5, connectionPool);
     }
     
@@ -275,31 +287,39 @@ public class EndToEndChannelLeakTest {
         ConnectionPoolImpl connectionPool = new ConnectionPoolImpl(clientConfig);
         @Cleanup
         ConnectionFactoryImpl connectionFactory =
-                new ConnectionFactoryImpl(clientConfig, connectionPool,
-                                          new InlineExecutor());
+                new ConnectionFactoryImpl(clientConfig, connectionPool, executor);
         @Cleanup
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE, controller, connectionFactory);
 
+        int channelCount = 0;
+        assertChannelCount(channelCount, connectionPool);
+        
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
+                                                                     connectionFactory);
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
+                                       .stream(Stream.of(SCOPE, STREAM_NAME)).build());
+        
+        //Should not add any connections
+        assertChannelCount(channelCount, connectionPool);
+        
         //Create a writer.
         @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(SCOPE, new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
 
-        @Cleanup
-        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
-                connectionFactory);
-        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().
-                stream(Stream.of(SCOPE, STREAM_NAME)).build());
+        //Write an event.
+        writer.writeEvent("0", "zero").get();
+        channelCount += 1;
+        assertChannelCount(channelCount, connectionPool);
 
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, new JavaSerializer<>(),
                 ReaderConfig.builder().build());
-        //Write an event.
-        writer.writeEvent("0", "zero").get();
         
-        connectionPool.pruneUnusedConnections();
-        int channelCount = connectionFactory.getActiveChannelCount(); //store the open channel count before reading.
-
+        channelCount += 4; //One for segment 3 for state synchronizer
+        assertChannelCount(channelCount, connectionPool);
+        
         //Read an event.
         EventRead<String> event = reader1.readNextEvent(10000);
         assertEquals("zero", event.getEvent());
@@ -315,23 +335,41 @@ public class EndToEndChannelLeakTest {
         map.put(0.66, 1.0);
         Boolean result = controller.scaleStream(stream, Collections.singletonList(0L), map, executor).getFuture().get();
         assertTrue(result);
+
+        event = reader1.readNextEvent(0);
+        assertNull(event.getEvent());
+        channelCount -= 1; //Reader should see EOS
+        assertChannelCount(channelCount, connectionPool);
         
+        writer.writeEvent("1", "one").get(); //should detect end of segment
+        channelCount += 2; //Close one segment open 3.
+        assertChannelCount(channelCount, connectionPool);
+        
+        ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);
+        readerGroup.getMetrics().unreadBytes();
+        CompletableFuture<Checkpoint> future = readerGroup.initiateCheckpoint("cp1", executor);
+        //3 more from the state synchronizer
+        channelCount += 4;
+        assertChannelCount(channelCount, connectionPool);
+        event = reader1.readNextEvent(5000);
+        assertEquals("cp1", event.getCheckpointName());
+        
+        event = reader1.readNextEvent(10000);
+        assertEquals("one", event.getEvent());
+        channelCount += 3; //From new segments on reader
+        assertChannelCount(channelCount, connectionPool);
+        
+        future.join();
+        //Checkpoint should close connections back down
+        readerGroup.close();
+        channelCount -= 4;
+        assertChannelCount(channelCount, connectionPool);
+
         //Write more events.
-        writer.writeEvent("0", "one").get();
-        writer.writeEvent("0", "two").get();
-        writer.writeEvent("1", "three").get();
-        
-        channelCount += 2; //from the new segments and close of old segment
-        assertChannelCount(channelCount, connectionPool);
-
-        event = reader1.readNextEvent(10000);
-        assertNotNull(event.getEvent());
-        //Number of sockets will increase by 3 for the new segments and decrease by 1 from the old segment 
-        channelCount += 2;
-        assertChannelCount(channelCount, connectionPool);
-
-        event = reader1.readNextEvent(10000);
-        assertNotNull(event.getEvent());
+        writer.writeEvent("2", "two").get();
+        writer.writeEvent("3", "three").get();
+        writer.writeEvent("4", "four").get();
+   
         //no changes to socket count.
         assertChannelCount(channelCount, connectionPool);
 
@@ -383,8 +421,8 @@ public class EndToEndChannelLeakTest {
                 connectionFactory);
         assertChannelCount(expectedChannelCount, connectionPool); // no changes expected.
       
-        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints()
-                .stream(Stream.of(SCOPE, STREAM_NAME)).build());
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0)
+                                       .stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         //create a reader and read an event.
         @Cleanup
@@ -396,7 +434,6 @@ public class EndToEndChannelLeakTest {
         
         //reader creates a new connection to the segment 0;
         expectedChannelCount += 1;
-        assertNotNull(event);
         assertEquals("zero", event.getEvent());
         assertChannelCount(expectedChannelCount, connectionPool);
 
@@ -411,6 +448,14 @@ public class EndToEndChannelLeakTest {
         //No changes to the channel count.
         assertChannelCount(expectedChannelCount, connectionPool);
 
+        event = reader1.readNextEvent(0);
+        assertNull(event.getEvent());
+        event = reader1.readNextEvent(0);
+        assertNull(event.getEvent());
+        //should decrease channel count from close connection
+        expectedChannelCount -= 1;
+        assertChannelCount(expectedChannelCount, connectionPool);
+        
         //Write more events.
         writer.writeEvent("1", "one").get();
         writer.writeEvent("2", "two").get();
@@ -418,32 +463,44 @@ public class EndToEndChannelLeakTest {
         writer.writeEvent("4", "four").get();
         writer.writeEvent("5", "five").get();
         writer.writeEvent("6", "six").get();
-
-        //2 new flows  are opened.(+3 connections to the segments 1,2,3 after scale by the writer,
-        // -1 flow to segment 0 which is sealed.)
+        
+        //Open 3 new segments close one old one. 
         expectedChannelCount += 2;
         assertChannelCount(expectedChannelCount, connectionPool);
-
+        
+        ReaderGroup readerGroup = groupManager.getReaderGroup(READER_GROUP);
+        CompletableFuture<Checkpoint> future = readerGroup.initiateCheckpoint("cp1", executor);
+        //4 more from the state synchronizer
+        expectedChannelCount += 4;
+        assertChannelCount(expectedChannelCount, connectionPool);
+        event = reader1.readNextEvent(5000);
+        assertEquals("cp1", event.getCheckpointName());
+        
         //Add a new reader
         @Cleanup
         EventStreamReader<String> reader2 = clientFactory.createReader("readerId2", READER_GROUP, serializer,
                 ReaderConfig.builder().build());
-        //Creating a reader spawns a revisioned stream client which opens 4 flows ( read, write, metadataClient and conditionalUpdates).
+        //Creating a reader spawns a revisioned stream client which opens 4 sockets ( read, write, metadataClient and conditionalUpdates).
         expectedChannelCount += 4;
         assertChannelCount(expectedChannelCount, connectionPool);
-        event = reader1.readNextEvent(10000);
-        assertNotNull(event.getEvent());
 
-        //+1 flow (-1 since segment 0 of stream is sealed + 2 connections to two segments of stream (there are
-        // 2 readers and 3 segments and the reader1 will be assigned 2 segments))
-        expectedChannelCount += 1;
+        event = reader1.readNextEvent(5000);
+        assertNotNull(event.getEvent());
+        event = reader2.readNextEvent(5000);
+        assertNotNull(event.getEvent());
+        //3 more from the new segments
+        expectedChannelCount += 3;
         assertChannelCount(expectedChannelCount, connectionPool);
-
-        event = reader2.readNextEvent(10000);
-        assertNotNull(event.getEvent());
-
-        //+1 flow (a new flow to the remaining stream segment)
-        expectedChannelCount += 1;
+        
+        future.join();
+        //Checkpoint should close connections back down
+        readerGroup.close();
+        expectedChannelCount -= 4;
+        assertChannelCount(expectedChannelCount, connectionPool);
+        
+        reader1.close();
+        reader2.close();
+        expectedChannelCount -= 8 + 3;
         assertChannelCount(expectedChannelCount, connectionPool);
     }
     

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -19,13 +19,11 @@ import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
@@ -48,7 +46,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static io.pravega.test.common.AssertExtensions.assertEventuallyEquals;
 
 @Slf4j
 public class EndToEndStatsTest {
@@ -114,20 +112,17 @@ public class EndToEndStatsTest {
         for (int i = 0; i < 10; i++) {
             test.writeEvent("test").get();
         }
-        assertEquals(statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 10);
+        assertEventuallyEquals(10, () -> statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 2000);
 
         Transaction<String> transaction = test.beginTxn();
         for (int i = 0; i < 10; i++) {
             transaction.writeEvent("0", "txntest1");
         }
-        assertEquals(statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 10);
+        assertEventuallyEquals(10, () -> statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 2000);
 
         transaction.commit();
-        Stream stream = new StreamImpl("test", "test");
-        while (!controller.checkTransactionStatus(stream, transaction.getTxnId()).get().equals(Transaction.Status.COMMITTED)) {
-            Thread.sleep(100);
-        }
-        assertEquals(statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 20);
+
+        assertEventuallyEquals(20, () -> statsRecorder.getSegments().get(StreamSegmentNameUtils.getQualifiedStreamSegmentName("test", "test", 0L)).get(), 10000);
     }
 
     private static class TestStatsRecorder implements SegmentStatsRecorder {

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -129,7 +129,12 @@ public class EndToEndTransactionOrderTest {
 
         clientFactory = new MockClientFactory("test", controller);
         readerGroupManager = new ReaderGroupManagerImpl("test", controller, clientFactory, connectionFactory);
-        readerGroupManager.createReaderGroup("readergrp", ReaderGroupConfig.builder().stream("test/test").build());
+        readerGroupManager.createReaderGroup("readergrp",
+                                             ReaderGroupConfig.builder()
+                                                              .automaticCheckpointIntervalMillis(2000)
+                                                              .groupRefreshTimeMillis(1000)
+                                                              .stream("test/test")
+                                                              .build());
 
         reader = clientFactory.createReader("1",
                 "readergrp",

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
@@ -54,8 +53,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.pravega.test.common.AssertExtensions.assertEventuallyEquals;
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -109,7 +111,7 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
     @Test(timeout = 10000)
     public void testTxnWithScale() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .scalingPolicy(ScalingPolicy.fixed(1))
                                                         .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
@@ -121,10 +123,12 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
         @Cleanup
         TransactionalEventStreamWriter<String> test = clientFactory.createTransactionalEventWriter("test", new UTF8StringSerializer(),
                 EventWriterConfig.builder().transactionTimeoutTime(10000).build());
-        Transaction<String> transaction = test.beginTxn();
-        transaction.writeEvent("0", "txntest1");
-        transaction.commit();
+        Transaction<String> transaction1 = test.beginTxn();
+        transaction1.writeEvent("0", "txntest1");
+        transaction1.commit();
 
+        assertEventuallyEquals(Transaction.Status.COMMITTED, () -> transaction1.checkStatus(), 5000);
+        
         // scale
         Stream stream = new StreamImpl("test", "test");
         Map<Double, Double> map = new HashMap<>();
@@ -135,27 +139,31 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
 
         assertTrue(result);
 
-        transaction = test.beginTxn();
-        transaction.writeEvent("0", "txntest2");
-        transaction.commit();
+        Transaction<String> transaction2 = test.beginTxn();
+        transaction2.writeEvent("0", "txntest2");
+        transaction2.commit();
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory, connectionFactory);
-        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream("test/test").build());
+        groupManager.createReaderGroup("reader", ReaderGroupConfig.builder().disableAutomaticCheckpoints().groupRefreshTimeMillis(0).stream("test/test").build());
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader("readerId", "reader", new UTF8StringSerializer(),
                 ReaderConfig.builder().build());
-        EventRead<String> event = reader.readNextEvent(10000);
-        assertNotNull(event);
+        EventRead<String> event = reader.readNextEvent(5000);
+        assertNotNull(event.getEvent());
         assertEquals("txntest1", event.getEvent());
-        event = reader.readNextEvent(10000);
-        assertNotNull(event);
+        assertNull(reader.readNextEvent(100).getEvent());
+        groupManager.getReaderGroup("reader").initiateCheckpoint("cp", executorService());
+        event = reader.readNextEvent(5000);
+        assertEquals("cp", event.getCheckpointName());
+        event = reader.readNextEvent(5000);
+        assertNotNull(event.getEvent());
         assertEquals("txntest2", event.getEvent());
     }
 
     @Test(timeout = 30000)
     public void testTxnWithErrors() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder()
-                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                                        .scalingPolicy(ScalingPolicy.fixed(1))
                                                         .build();
         Controller controller = controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope(SCOPE).get();
@@ -171,13 +179,11 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
         transaction.writeEvent("0", "txntest1");
         //abort the transaction to simulate a txn abort due to a missing ping request.
         controller.abortTransaction(Stream.of(SCOPE, STREAM), transaction.getTxnId()).join();
-        TimeUnit.SECONDS.sleep(10);
         //check the status of the transaction.
-        Transaction.Status status = controller.checkTransactionStatus(Stream.of(SCOPE, STREAM), transaction.getTxnId()).join();
-        assertEquals("Transaction status should be Aborted", Transaction.Status.ABORTED, status);
+        assertEventuallyEquals(Transaction.Status.ABORTED, () -> controller.checkTransactionStatus(Stream.of(SCOPE, STREAM), transaction.getTxnId()).join(), 10000);
         transaction.writeEvent("0", "txntest2");
         //verify that commit fails with TxnFailedException.
-        AssertExtensions.assertThrows("TxnFailedException should be thrown", () -> transaction.commit(), t -> t instanceof TxnFailedException);
+        assertThrows("TxnFailedException should be thrown", () -> transaction.commit(), t -> t instanceof TxnFailedException);
     }
 
 

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -139,6 +139,7 @@ public abstract class AbstractService implements Service {
                 .put("autoScale.cacheCleanUpInSeconds", "120")
                 .put("curator-default-session-timeout", "10000")
                 .put("bookkeeper.bkAckQuorumSize", "3")
+                .put("hdfs.replaceDataNodesOnFailure", "false")
                 // Controller properties.
                 .put("controller.transaction.maxLeaseValue", "60000")
                 .put("controller.retention.frequencyMinutes", "2")

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
@@ -63,6 +63,7 @@ public class MetadataScalabilityLargeNumSegmentsTest extends MetadataScalability
      * @param sortedCurrentSegments sorted current segments
      * @return scale input for next scale
      */
+    @Override
     Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
         int i = counter.incrementAndGet();
         List<Long> segmentsToSeal = sortedCurrentSegments.stream()

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
@@ -62,6 +62,7 @@ public class MetadataScalabilityLargeScalesTest extends MetadataScalabilityTest 
      * @param sortedCurrentSegments segments in current epoch
      * @return scale input for next scale to perform
      */
+    @Override
     Pair<List<Long>, Map<Double, Double>> getScaleInput(ArrayList<Segment> sortedCurrentSegments) {
         return new ImmutablePair<>(getSegmentsToSeal(sortedCurrentSegments), getNewRanges());     
     }

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -20,7 +20,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -31,6 +30,10 @@ import io.pravega.test.system.framework.Environment;
 import io.pravega.test.system.framework.SystemTestRunner;
 import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
@@ -40,15 +43,9 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
-import java.net.URI;
-import java.util.List;
-import java.util.UUID;
-
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
@@ -144,15 +141,10 @@ public class PravegaTest extends AbstractReadWriteTest {
 
         EventRead<String> event = null;
         do {
-            try {
-                event = reader.readNextEvent(10_000);
-                log.debug("Read event: {}.", event.getEvent());
-                if (event.getEvent() != null) {
-                    readCount++;
-                }
-            } catch (ReinitializationRequiredException e) {
-                log.error("Exception while reading event using readerId: {}", reader, e);
-                fail("Reinitialization Exception is not expected");
+            event = reader.readNextEvent(10_000);
+            log.debug("Read event: {}.", event.getEvent());
+            if (event.getEvent() != null) {
+                readCount++;
             }
             // try reading until all the written events are read, else the test will timeout.
         } while ((event.getEvent() != null || event.isCheckpoint()) && readCount < NUM_EVENTS);

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -226,9 +226,6 @@ public class ReaderCheckpointTest extends AbstractSystemTest {
             EventRead<Integer> event = reader.readNextEvent(READ_TIMEOUT);
             assertTrue("Read for Checkpoint event", (event != null) && (event.isCheckpoint()));
             assertEquals("CheckPoint Name", checkPointName, event.getCheckpointName());
-        } catch (ReinitializationRequiredException e) {
-            log.error("Exception while reading event using readerId: {}", readerId, e);
-            fail("Reinitialization Exception is not expected");
         }
         return checkpoint.join();
     }


### PR DESCRIPTION
**Change log description**  
* Ports bug fixes to r0.5

**Purpose of the change**  
Fixes #3719 

**What the code does**  
There is no code change, this PR is porting fixes to `r0.5`. The list of PRs included is the following:

```
Issue 3638: Ensure the AsyncSegmentInputStreamImpl handles ConnectionFailedException during sendAsync. (#3654)
Issue 3702: Prevent suppression of stack traces in tests (#3703)
Issue 2830: PingTxnStatus now informs if the Transaction is closed (#3704)
Issue 3710: (SegmentStore) Delete Segment if Empty Bug Fix (#3711)
Issue 3708: Sporadic failure of HostStoreTest.zkHostStoreTests (#3712)
Issue #3333, #2572: Keep completed segments in position objects. (#3364)
Issue 3673: New controller instance is not updating segment container map unless there is an update (#3682)
Issue 3649: Invoke grgit plugin only if git repository is present. (#3667)
Issue 3643: Fix reliability issues of standalone mode tests (#3656)
Issue 3659: Update the config.properties file to document hdfs.replaceDataNodesOnFailure usage. (#3680)
Issue 3659: Set hdfs.replaceDataNodesOnFailure = false in K8s system tests. (#3660)
```

**How to verify it**  
Build should succeed.
