### PR TITLE
Issue 3726: (SegmentStore) StorageWriter can't handle updating attributes after a segment merge

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -63,6 +63,11 @@ public class HDFSIntegrationTest extends BookKeeperIntegrationTestBase {
     //region StreamSegmentStoreTestBase Implementation
 
     @Override
+    protected boolean appendAfterMerging() {
+        return false; // HDFS is slow enough as it is; adding this would cause the test to take even longer.
+    }
+
+    @Override
     protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId) {
         ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
         return ServiceBuilder

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -117,7 +117,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         this.timer = Preconditions.checkNotNull(timer, "timer");
         this.executor = Preconditions.checkNotNull(executor, "executor");
         this.lastFlush = new AtomicReference<>(timer.getElapsed());
-        this.lastAddedOffset = new AtomicLong(-1); // Will be set properly in initialize().
+        this.lastAddedOffset = new AtomicLong(-1); // Will be set properly after we process a StorageOperation.
         this.mergeTransactionCount = new AtomicInteger();
         this.truncateCount = new AtomicInteger();
         this.hasSealPending = new AtomicBoolean();
@@ -398,7 +398,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
             // and it means this operation has already been applied to the index.
             Map<UUID, Long> attributes = getExtendedAttributes(operation);
             if (!attributes.isEmpty()) {
-                AggregatedAppendOperation aggregatedAppend = getOrCreateAggregatedAppend(this.metadata.getStorageLength(), operation.getSequenceNumber());
+                AggregatedAppendOperation aggregatedAppend = getOrCreateAggregatedAppend(this.lastAddedOffset.get(), operation.getSequenceNumber());
                 aggregatedAppend.includeAttributes(attributes);
             }
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -78,7 +78,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int THREADPOOL_SIZE_SEGMENT_STORE_STORAGE = 10;
     private static final int THREADPOOL_SIZE_TEST = 3;
     private static final String EMPTY_SEGMENT_NAME = "Empty_Segment";
-    private static final int SEGMENT_COUNT = 1;
+    private static final int SEGMENT_COUNT = 10;
     private static final int TRANSACTIONS_PER_SEGMENT = 1;
     private static final int APPENDS_PER_SEGMENT = 100;
     private static final int ATTRIBUTE_UPDATES_PER_SEGMENT = 100;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -78,7 +78,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int THREADPOOL_SIZE_SEGMENT_STORE_STORAGE = 10;
     private static final int THREADPOOL_SIZE_TEST = 3;
     private static final String EMPTY_SEGMENT_NAME = "Empty_Segment";
-    private static final int SEGMENT_COUNT = 10;
+    private static final int SEGMENT_COUNT = 1;
     private static final int TRANSACTIONS_PER_SEGMENT = 1;
     private static final int APPENDS_PER_SEGMENT = 100;
     private static final int ATTRIBUTE_UPDATES_PER_SEGMENT = 100;
@@ -186,6 +186,10 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             // Merge all transactions.
             mergeTransactions(transactionsBySegment, lengths, segmentContents, segmentStore).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             log.info("Finished merging transactions.");
+
+            // Check the status now. A nice side effect of this is that it loads all extended attributes from Storage so
+            // that we can modify them in the next step (during appending).
+            checkSegmentStatus(lengths, startOffsets, false, false, expectedAttributeValue, segmentStore);
 
             // Append more data.
             appendData(segmentNames, segmentContents, lengths, segmentStore).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
**Change log description**  
Fixed a bug in SegmentAggregator where a MergeTransactionOperation followed by an UpdateAttributesOperation would cause the SegmentAggregator to request invalid data from the ReadIndex and prevent progress from being made.

**Purpose of the change**  
Fixes #3726.

**What the code does**  
- The SegmentAggregator aggregates multiple operations of similar types together. This includes `UpdateAttributesOperation` and `SegmentAppendOperation`, but it does not include `MergeSegmentOperation`s.
- The first operation that is included will determine the starting offset of the resulting `AggregatedOperation`. For `SegmentAppendOperations` this works well, since `SegmentAppendOperation`s have well defined offsets. However, `UpdateAttributeOperations` do not, hence the code was assigning the current length of the Segment in Tier 2.
- This would be a problem in the following case:
    - A `MergeSegmentOperation` is queued up, then an `UpdateAttributesOperation`, then a `SegmentAppendOperation`
    - In the beginning the StorageLength of the segment is L1. 
    - As such, the `MergeSegmentOperation` also has an offset of L1 (correct), however, when queuing up the `UpdateAttributesOperation`, its corresponding offset would also be set to L1 (the merge hasn't been applied yet). 
    - The subsequent `SegmentAppendOperation` will be aggregated into this one as well, and its own offset would be disregarded.
    - When the `MergeSegmentOperation` is applied to Tier 2, the storage length of the segment would be incremented by M1 to become L1+M1.
    - When needing to flush the `AggregatedAppendOperation` made up of `UpdateAttributesOperation` and the `SegmentAppendOperation`, since that operation has the offset set to L1, it would attempt to read data from the ReadIndex beginning at L1, and it is correctly rejected due to L1 being less than L1+M1. If this had been allowed to proceed, we'd end up writing corrupted data in Tier 2.
- The solution is to use the last processed offset in the StorageWriter as the `UpdateAttributesOperation` offset when needing to begin an `AggregatedOperation` with it.

**How to verify it**  
New unit test added to verify this scenario.
