### PR TITLE
Issue 3715: replaced the non thread safe map with SimpleMeterRegistry

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -39,8 +39,8 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import lombok.Cleanup;
 import lombok.Getter;
@@ -144,7 +144,7 @@ public class EndToEndStatsTest {
 
         // A placeholder to keep strong references to metric objects, as caching is skipped in the test.
         // Note Micrometer registry holds weak references only, so there is chance metric objects without strong references might be garbage collected.
-        private List<Meter> references = Collections.synchronizedList(new LinkedList<Meter>());
+        private List<Meter> references = Collections.synchronizedList(new ArrayList<Meter>());
 
         @Override
         public void createSegment(String streamSegmentName, byte type, int targetRate, Duration elapsed) {

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -120,30 +120,30 @@ public class EndToEndStatsTest {
         for (int i = 0; i < 10; i++) {
             test.writeEvent("test").get();
         }
-        assertEventuallyEquals(10, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 2000);
-        assertEventuallyEquals(190, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
+        assertEventuallyEquals(10, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 2000);
+        assertEventuallyEquals(190, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
 
         Transaction<String> transaction = test.beginTxn();
         for (int i = 0; i < 10; i++) {
             transaction.writeEvent("0", "txntest1");
         }
-        assertEventuallyEquals(10, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 2000);
-        assertEventuallyEquals(190, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
+        assertEventuallyEquals(10, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 2000);
+        assertEventuallyEquals(190, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
 
         transaction.commit();
 
-        assertEventuallyEquals(20, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 10000);
-        assertEventuallyEquals(420, () -> (int)(statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
+        assertEventuallyEquals(20, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_EVENTS, tags).count()), 10000);
+        assertEventuallyEquals(420, () -> (int) (statsRecorder.getRegistry().counter(SEGMENT_WRITE_BYTES, tags).count()), 100);
     }
 
     private static class TestStatsRecorder implements SegmentStatsRecorder {
 
+        @Getter
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
         // A set to keep strong references to metric objects, as caching is skipped in the test.
         // Note Micrometer registry holds weak references only, so there is chance metric objects without strong references might be garbage collected.
         private Set<Meter> metrics = new HashSet<>();
-
-        @Getter
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
         @Override
         public void createSegment(String streamSegmentName, byte type, int targetRate, Duration elapsed) {


### PR DESCRIPTION
**Change log description**  
Replaced the non-thread safe map inside the TestStatsRecorder with solid SimpleMeterRegistry to fix the sporadic multi-threading failure.

**Purpose of the change**  
Fixes #3715 

**What the code does**  
1. Inside `EndToEndStatsTest.TestStatsRecorder`, replaces the non thread safe map with Micrometer `SimpleMeterRegistry`.
2. Use Micrometer API to retrieve counters, instead of the unsafe map get operation.
3. Added `SEGMENT_WRITE_BYTES` tests, in addition to the existing `SEGMENT_WRITE_EVENTS` tests.
4. Added a set to hold strong references to metric objects, to further consolidate the code for the most intensive runtime environment.

**How to verify it**  
Integration test should pass, no matter how many times it repeats.
(The old implementation usually fails after a few hundreds repeats)
