### PR TITLE
Issue 3758: Fix typo in controller API call name

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -667,7 +667,7 @@ public class ControllerImpl implements Controller {
 
         final CompletableFuture<SuccessorResponse> resultFuture = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<SuccessorResponse> callback = new RPCAsyncCallback<>(traceId, "getSuccessors");
-            client.getSegmentsImmediatlyFollowing(ModelHelper.decode(segment), callback);
+            client.getSegmentsImmediatelyFollowing(ModelHelper.decode(segment), callback);
             return callback.getFuture();
         }, this.executor);
         return resultFuture.thenApply(successors -> {

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -397,7 +397,7 @@ public class ControllerImplTest {
             }
 
             @Override
-            public void getSegmentsImmediatlyFollowing(SegmentId request, StreamObserver<SuccessorResponse> responseObserver) {
+            public void getSegmentsImmediatelyFollowing(SegmentId request, StreamObserver<SuccessorResponse> responseObserver) {
                 if (request.getStreamInfo().getStream().equals("stream1")) {
                     Map<SegmentId, Pair<Double, Double>> result = new HashMap<>();
                     if (request.getSegmentId() == 0) {
@@ -1030,7 +1030,7 @@ public class ControllerImplTest {
     }
 
     @Test
-    public void testGetSegmentsImmediatlyFollowing() throws Exception {
+    public void testGetSegmentsImmediatelyFollowing() throws Exception {
         CompletableFuture<Map<Segment, List<Long>>> successors;
         successors = controllerClient.getSuccessors(new Segment("scope1", "stream1", 0L))
                 .thenApply(StreamSegmentsWithPredecessors::getSegmentToPredecessor);

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -204,7 +204,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void getSegmentsImmediatlyFollowing(SegmentId segmentId, StreamObserver<SuccessorResponse> responseObserver) {
+    public void getSegmentsImmediatelyFollowing(SegmentId segmentId, StreamObserver<SuccessorResponse> responseObserver) {
         log.info("getSegmentsImmediatelyFollowing called for segment {} ", segmentId);
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(segmentId.getStreamInfo().getScope(),

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -530,15 +530,15 @@ public abstract class ControllerServiceImplTest {
     }
 
     @Test
-    public void getSegmentsImmediatlyFollowingTest() {
+    public void getSegmentsImmediatelyFollowingTest() {
         scaleTest();
         ResultObserver<SuccessorResponse> result = new ResultObserver<>();
-        this.controllerService.getSegmentsImmediatlyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 1), result);
+        this.controllerService.getSegmentsImmediatelyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 1), result);
         final SuccessorResponse successorResponse = result.get();
         Assert.assertEquals(2, successorResponse.getSegmentsCount());
 
         ResultObserver<SuccessorResponse> result2 = new ResultObserver<>();
-        this.controllerService.getSegmentsImmediatlyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 0),
+        this.controllerService.getSegmentsImmediatelyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 0),
                 result2);
         final SuccessorResponse successorResponse2 = result2.get();
         Assert.assertEquals(0, successorResponse2.getSegmentsCount());

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -542,6 +542,19 @@ public abstract class ControllerServiceImplTest {
                 result2);
         final SuccessorResponse successorResponse2 = result2.get();
         Assert.assertEquals(0, successorResponse2.getSegmentsCount());
+
+        /* Testing deprecated RPC. This test code should be removed once we address: */
+        /* https://github.com/pravega/pravega/issues/3760                            */
+        ResultObserver<SuccessorResponse> resultDeprecated = new ResultObserver<>();
+        this.controllerService.getSegmentsImmediatlyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 1), resultDeprecated);
+        final SuccessorResponse successorResponseDeprecated = result.get();
+        Assert.assertEquals(2, successorResponseDeprecated.getSegmentsCount());
+
+        ResultObserver<SuccessorResponse> resultDeprecated2 = new ResultObserver<>();
+        this.controllerService.getSegmentsImmediatelyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 0),
+                resultDeprecated2);
+        final SuccessorResponse successorResponseDeprecated2 = result2.get();
+        Assert.assertEquals(0, successorResponseDeprecated2.getSegmentsCount());
     }
 
     @Test

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -24,7 +24,7 @@ service ControllerService {
     rpc deleteStream(StreamInfo) returns (DeleteStreamStatus);
     rpc getCurrentSegments(StreamInfo) returns (SegmentRanges);
     rpc getSegments(GetSegmentsRequest) returns (SegmentsAtTime);
-    rpc getSegmentsImmediatlyFollowing(SegmentId) returns(SuccessorResponse);
+    rpc getSegmentsImmediatelyFollowing(SegmentId) returns(SuccessorResponse);
     rpc getSegmentsBetween(StreamCutRange) returns (StreamCutRangeResponse);
     rpc scale(ScaleRequest) returns (ScaleResponse);
     rpc checkScale(ScaleStatusRequest) returns (ScaleStatusResponse);

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -24,6 +24,8 @@ service ControllerService {
     rpc deleteStream(StreamInfo) returns (DeleteStreamStatus);
     rpc getCurrentSegments(StreamInfo) returns (SegmentRanges);
     rpc getSegments(GetSegmentsRequest) returns (SegmentsAtTime);
+    /* Deprecated RPC: https://github.com/pravega/pravega/issues/3760 */
+    rpc getSegmentsImmediatlyFollowing(SegmentId) returns(SuccessorResponse);
     rpc getSegmentsImmediatelyFollowing(SegmentId) returns(SuccessorResponse);
     rpc getSegmentsBetween(StreamCutRange) returns (StreamCutRangeResponse);
     rpc scale(ScaleRequest) returns (ScaleResponse);


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**  
* Changes call from getSegmentsImmediatlyFollowing to getSegmentsImmediatelyFollowing to fix a typo.

* Retains the old call for compatibility, to be removed in the PR for #3760.

**Purpose of the change**  
Fixes #3758 

**What the code does**  
Changes the call name to fix a typo, but keeps the old call for compatibility. The changes affect the following files:

```
client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
shared/controller-api/src/main/proto/Controller.proto
```
**How to verify it**  
Build.