### PR TITLE
Issue 3670: Service side Grpc implementation for watermarking related apis

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -314,12 +314,12 @@ public interface Controller extends AutoCloseable {
     /**
      * Notifies the controller that the specified writer is shutting down gracefully and no longer
      * needs to be considered for calculating entries for the marks segment. This may not be called
-     * in the event that writer crashes.
+     * in the event that writer crashes. 
      * 
      * @param writerId The name of the writer. (User defined)
      * @param stream The stream the writer was on.
      */
-    CompletableFuture<Void> writerShutdown(String writerId, Stream stream);
+    CompletableFuture<Void> removeWriter(String writerId, Stream stream);
 
     /**
      * Closes controller client.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -73,8 +73,8 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.TxnRequest;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnState;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.WriterShutdownRequest;
-import io.pravega.controller.stream.api.grpc.v1.Controller.WriterShutdownResponse;
+import io.pravega.controller.stream.api.grpc.v1.Controller.RemoveWriterRequest;
+import io.pravega.controller.stream.api.grpc.v1.Controller.RemoveWriterResponse;
 import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc;
 import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc.ControllerServiceStub;
 import io.pravega.shared.controller.tracing.RPCTracingHelpers;
@@ -1003,14 +1003,14 @@ public class ControllerImpl implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> writerShutdown(String writerId, Stream stream) {
+    public CompletableFuture<Void> removeWriter(String writerId, Stream stream) {
         Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkNotNull(writerId, "writerId");
         long traceId = LoggerHelpers.traceEnter(log, "writerShutdown", writerId, stream);
-        final CompletableFuture<WriterShutdownResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<WriterShutdownResponse> callback = new RPCAsyncCallback<>(traceId, "writerShutdown");
-            client.writerShutdown(WriterShutdownRequest.newBuilder()
+        final CompletableFuture<RemoveWriterResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<RemoveWriterResponse> callback = new RPCAsyncCallback<>(traceId, "writerShutdown");
+            client.removeWriter(RemoveWriterRequest.newBuilder()
                                                        .setWriter(writerId)
                                                        .setStream(ModelHelper.createStreamInfo(stream.getScope(),
                                                                                                stream.getStreamName()))
@@ -1019,8 +1019,8 @@ public class ControllerImpl implements Controller {
             return callback.getFuture();
         }, this.executor);
         return Futures.toVoidExpecting(result,
-                                       WriterShutdownResponse.newBuilder()
-                                                             .setResult(WriterShutdownResponse.Status.SUCCESS)
+                                       RemoveWriterResponse.newBuilder()
+                                                             .setResult(RemoveWriterResponse.Status.SUCCESS)
                                                              .build(),
                                        RuntimeException::new)
                       .whenComplete((x, e) -> {

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -547,7 +547,7 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Void> writerShutdown(String writerId, Stream stream) {
+    public CompletableFuture<Void> removeWriter(String writerId, Stream stream) {
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -510,8 +510,8 @@ public class ControllerService {
         }
     }
 
-    public CompletableFuture<Controller.TimestampResponse> noteTimestampFromWriter(String scope, String stream, String writer, long timestamp, Map<Long, Long> streamCut) {
-        return streamStore.noteWriterMark(scope, stream, writer, timestamp, streamCut, null, executor)
+    public CompletableFuture<Controller.TimestampResponse> noteTimestampFromWriter(String scope, String stream, String writerId, long timestamp, Map<Long, Long> streamCut) {
+        return streamStore.noteWriterMark(scope, stream, writerId, timestamp, streamCut, null, executor)
                 .handle((r, e) -> {
                     Controller.TimestampResponse.Builder response = Controller.TimestampResponse.newBuilder();
                     if (e != null) {

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -537,12 +537,12 @@ public class ControllerService {
     }
  
     public CompletableFuture<Controller.WriterShutdownResponse> shutdownWriter(String scope, String stream, String writer) {
-        return streamStore.removeWriter(scope, stream, writer, null, executor)
+        return streamStore.shutdownWriter(scope, stream, writer, null, executor)
                 .handle((r, e) -> {
                     Controller.WriterShutdownResponse.Builder response = Controller.WriterShutdownResponse.newBuilder();
                     if (e != null) {
                         if (Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException) {
-                            response.setResult(Controller.WriterShutdownResponse.Status.STREAM_DOES_NOT_EXIST);
+                            response.setResult(Controller.WriterShutdownResponse.Status.UNKNOWN_WRITER);
                         } else {
                             response.setResult(Controller.WriterShutdownResponse.Status.INTERNAL_ERROR);
                         }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -536,18 +536,18 @@ public class ControllerService {
                 });
     }
  
-    public CompletableFuture<Controller.WriterShutdownResponse> shutdownWriter(String scope, String stream, String writer) {
+    public CompletableFuture<Controller.RemoveWriterResponse> removeWriter(String scope, String stream, String writer) {
         return streamStore.shutdownWriter(scope, stream, writer, null, executor)
                 .handle((r, e) -> {
-                    Controller.WriterShutdownResponse.Builder response = Controller.WriterShutdownResponse.newBuilder();
+                    Controller.RemoveWriterResponse.Builder response = Controller.RemoveWriterResponse.newBuilder();
                     if (e != null) {
                         if (Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException) {
-                            response.setResult(Controller.WriterShutdownResponse.Status.UNKNOWN_WRITER);
+                            response.setResult(Controller.RemoveWriterResponse.Status.UNKNOWN_WRITER);
                         } else {
-                            response.setResult(Controller.WriterShutdownResponse.Status.INTERNAL_ERROR);
+                            response.setResult(Controller.RemoveWriterResponse.Status.INTERNAL_ERROR);
                         }
                     } else {
-                        response.setResult(Controller.WriterShutdownResponse.Status.SUCCESS);
+                        response.setResult(Controller.RemoveWriterResponse.Status.SUCCESS);
                     }
                     return response.build();
                 });

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -331,7 +331,7 @@ public class LocalController implements Controller {
     @Override
     public CompletableFuture<Void> commitTransaction(Stream stream, final String writerId, final Long timestamp, UUID txnId) {
         return controller
-                .commitTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId))
+                .commitTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId), writerId, timestamp)
                 .thenApply(x -> null);
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -431,13 +431,12 @@ public class LocalController implements Controller {
     @Override
     public CompletableFuture<Void> noteTimestampFromWriter(String writer, Stream stream, long timestamp,
                                                            Position lastWrittenPosition) {
-        // TODO watermarking: Implement this feature in the controller and call the method here.
-        return null;
+        Map<Long, Long> map = ModelHelper.createStreamCut(stream, lastWrittenPosition.asImpl()).getCutMap();
+        return Futures.toVoid(controller.noteTimestampFromWriter(stream.getScope(), stream.getStreamName(), writer, timestamp, map));
     }
 
     @Override
-    public CompletableFuture<Void> writerShutdown(String writerId, Stream stream) {
-        // TODO watermarking: Implement this feature in the controller and call the method here.
-        return null;
+    public CompletableFuture<Void> removeWriter(String writerId, Stream stream) {
+        return Futures.toVoid(controller.removeWriter(stream.getScope(), stream.getStreamName(), writerId));
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -330,8 +331,9 @@ public class LocalController implements Controller {
 
     @Override
     public CompletableFuture<Void> commitTransaction(Stream stream, final String writerId, final Long timestamp, UUID txnId) {
+        long time = Optional.ofNullable(timestamp).orElse(Long.MIN_VALUE);
         return controller
-                .commitTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId), writerId, timestamp)
+                .commitTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId), writerId, time)
                 .thenApply(x -> null);
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -293,7 +293,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                     // Note: if its a rerun, transaction commit offsets may have been updated already in previous iteration
                     // so this will not update/modify it. 
                     .thenCompose(v -> streamMetadataTasks.notifyTxnCommit(scope, stream, segments, txnId))
-                    .thenCompose(v -> streamMetadataTasks.getCurrentSegmentsSize(scope, stream, segments))
+                    .thenCompose(v -> streamMetadataTasks.getCurrentSegmentSizes(scope, stream, segments))
                     .thenCompose(map -> streamMetadataStore.recordCommitOffsets(scope, stream, txnId, map, context, executor));
         }
         return future;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -288,6 +288,10 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                     // primary id is taken for creation of txn-segment name and secondary part is erased and replaced with
                     // transaction's epoch.
                     // And we are creating duplicates of txn epoch keeping the primary same.
+                    // After committing transactions, we collect the current sizes of segments and update the offset 
+                    // at which the transaction was committed into ActiveTxnRecord in an idempotent fashion. 
+                    // Note: if its a rerun, transaction commit offsets may have been updated already in previous iteration
+                    // so this will not update/modify it. 
                     .thenCompose(v -> streamMetadataTasks.notifyTxnCommit(scope, stream, segments, txnId))
                     .thenCompose(v -> streamMetadataTasks.getCurrentSegmentsSize(scope, stream, segments))
                     .thenCompose(map -> streamMetadataStore.recordCommitOffsets(scope, stream, txnId, map, context, executor));

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
@@ -139,7 +139,7 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
                             return streamMetadataTasks.notifyNewSegments(scope, stream, segmentIds, context, delegationToken, requestId)
                                     .thenCompose(x -> streamMetadataStore.scaleCreateNewEpochs(scope, stream, record, context, executor))
                                     .thenCompose(x -> streamMetadataTasks.notifySealedSegments(scope, stream, segmentsToSeal, delegationToken, requestId))
-                                    .thenCompose(x -> streamMetadataTasks.getSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
+                                    .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
                                     .thenCompose(map -> streamMetadataStore.scaleSegmentsSealed(scope, stream, map, record, context, executor))
                                     .thenCompose(x -> streamMetadataStore.completeScale(scope, stream, record, context, executor))
                                     .thenCompose(x -> streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updatedState, context, executor))

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
@@ -139,7 +139,7 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
                             return streamMetadataTasks.notifyNewSegments(scope, stream, segmentIds, context, delegationToken, requestId)
                                     .thenCompose(x -> streamMetadataStore.scaleCreateNewEpochs(scope, stream, record, context, executor))
                                     .thenCompose(x -> streamMetadataTasks.notifySealedSegments(scope, stream, segmentsToSeal, delegationToken, requestId))
-                                    .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
+                                    .thenCompose(x -> streamMetadataTasks.getSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
                                     .thenCompose(map -> streamMetadataStore.scaleSegmentsSealed(scope, stream, map, record, context, executor))
                                     .thenCompose(x -> streamMetadataStore.completeScale(scope, stream, record, context, executor))
                                     .thenCompose(x -> streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updatedState, context, executor))

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -448,14 +448,14 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void writerShutdown(Controller.WriterShutdownRequest request, StreamObserver<Controller.WriterShutdownResponse> responseObserver) {
+    public void removeWriter(Controller.RemoveWriterRequest request, StreamObserver<Controller.RemoveWriterResponse> responseObserver) {
         StreamInfo streamInfo = request.getStream();
         log.info("writerShutdown called for stream {}/{}, writer={}", streamInfo.getScope(),
                 streamInfo.getStream(), request.getWriter());
         authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(streamInfo.getScope(), streamInfo.getStream()),
                 AuthHandler.Permissions.READ_UPDATE),
-                delegationToken  -> controllerService.shutdownWriter(streamInfo.getScope(),
+                delegationToken  -> controllerService.removeWriter(streamInfo.getScope(),
                         streamInfo.getStream(), request.getWriter()),
                 responseObserver);
     }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -433,20 +433,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     // region watermarking apis
-
-    @Override
-    public void writerShutdown(Controller.WriterShutdownRequest request, StreamObserver<Controller.WriterShutdownResponse> responseObserver) {
-        StreamInfo streamInfo = request.getStream();
-        log.info("writerShutdown called for stream {}/{}, writer={}", streamInfo.getScope(),
-                streamInfo.getStream(), request.getWriter());
-        authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
-                AuthResourceRepresentation.ofStreamInScope(streamInfo.getScope(), streamInfo.getStream()),
-                AuthHandler.Permissions.READ_UPDATE),
-                delegationToken  -> controllerService.shutdownWriter(streamInfo.getScope(),
-                        streamInfo.getStream(), request.getWriter()),
-                responseObserver);
-    }
-
+    
     @Override
     public void noteTimestampFromWriter(Controller.TimestampFromWriter request, StreamObserver<Controller.TimestampResponse> responseObserver) {
         StreamInfo streamInfo = request.getPosition().getStreamInfo();
@@ -460,7 +447,18 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 responseObserver);
     }
 
-
+    @Override
+    public void writerShutdown(Controller.WriterShutdownRequest request, StreamObserver<Controller.WriterShutdownResponse> responseObserver) {
+        StreamInfo streamInfo = request.getStream();
+        log.info("writerShutdown called for stream {}/{}, writer={}", streamInfo.getScope(),
+                streamInfo.getStream(), request.getWriter());
+        authenticateExecuteAndProcessResults(() -> this.authHelper.checkAuthorization(
+                AuthResourceRepresentation.ofStreamInScope(streamInfo.getScope(), streamInfo.getStream()),
+                AuthHandler.Permissions.READ_UPDATE),
+                delegationToken  -> controllerService.shutdownWriter(streamInfo.getScope(),
+                        streamInfo.getStream(), request.getWriter()),
+                responseObserver);
+    }
     // endregion
     
     // Convert responses from CompletableFuture to gRPC's Observer pattern.

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -798,9 +798,9 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks(String scope, String stream, 
-                                                                         OperationContext context, Executor executor) {
-        return withCompletion(getStream(scope, stream, context).getAllWritersMarks(), executor);
+    public CompletableFuture<Map<String, WriterMark>> getAllWriterMarks(String scope, String stream,
+                                                                        OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, stream, context).getAllWriterMarks(), executor);
     }
 
     protected Stream getStream(String scope, final String name, OperationContext context) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -780,9 +780,15 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
-    public CompletableFuture<Void> removeWriter(String scope, String stream, String writer,
+    public CompletableFuture<Void> shutdownWriter(String scope, String stream, String writer,
                                                        OperationContext context, Executor executor) {
-        return withCompletion(getStream(scope, stream, context).removeWriter(writer), executor);
+        return withCompletion(getStream(scope, stream, context).shutdownWriter(writer), executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeWriter(String scope, String stream, String writer, WriterMark writerMark,
+                                                OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, stream, context).removeWriter(writer, writerMark), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -981,7 +981,7 @@ public class InMemoryStream extends PersistentStreamBase {
             }
         }
         
-        return CompletableFuture.completedFuture(null);
+        return result;
     }
 
     @Override
@@ -990,6 +990,7 @@ public class InMemoryStream extends PersistentStreamBase {
         
         synchronized (writersLock) {
             writerMarks.remove(writer);
+            result.complete(null);
         }
         
         return result;
@@ -1031,7 +1032,7 @@ public class InMemoryStream extends PersistentStreamBase {
             } else if (!Objects.equals(existing.getVersion(), version)) {
                 result.completeExceptionally(StoreException.create(StoreException.Type.WRITE_CONFLICT, "writer mark version mismatch"));
             } else {
-                this.writerMarks.put(writer, existing);
+                this.writerMarks.put(writer, updatedCopy);
                 result.complete(null);
             }
         }

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -13,6 +13,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.stream.records.ActiveTxnRecord;
@@ -28,6 +29,7 @@ import io.pravega.controller.store.stream.records.StateRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.controller.store.stream.records.WriterMark;
 import io.pravega.controller.util.Config;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -98,6 +100,11 @@ public class InMemoryStream extends PersistentStreamBase {
      */
     @GuardedBy("txnsLock")
     private final Map<Integer, Set<UUID>> epochTxnMap = new HashMap<>();
+
+    private final Object writersLock = new Object();
+
+    @GuardedBy("writersLock")
+    private final Map<String, VersionedMetadata<WriterMark>> writerMarks = new HashMap<>();
 
     InMemoryStream(String scope, String name) {
         this(scope, name, Duration.ofHours(Config.COMPLETED_TRANSACTION_TTL_IN_HOURS).toMillis());
@@ -710,7 +717,7 @@ public class InMemoryStream extends PersistentStreamBase {
                     activeTxns.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, x -> x.getValue().getObject()))));
         }
     }
-
+    
     @Override
     CompletableFuture<List<Map.Entry<UUID, ActiveTxnRecord>>> getOrderedCommittingTxnInLowestEpoch() {
         List<Long> toPurge = new ArrayList<>();
@@ -957,6 +964,78 @@ public class InMemoryStream extends PersistentStreamBase {
             this.waitingRequestNode = null;
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    CompletableFuture<Void> createWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        WriterMark mark = new WriterMark(timestamp, position);
+
+        synchronized (writersLock) {
+            VersionedMetadata<WriterMark> existing = writerMarks.get(writer);
+            if (existing != null) {
+                result.completeExceptionally(StoreException.create(StoreException.Type.DATA_EXISTS, "writer mark exists"));
+            } else {
+                writerMarks.put(writer, new VersionedMetadata<>(mark, new Version.IntVersion(0)));
+                result.complete(null);
+            }
+        }
+        
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeWriter(String writer) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        
+        synchronized (writersLock) {
+            writerMarks.remove(writer);
+        }
+        
+        return result;
+    }
+
+    @Override
+    CompletableFuture<VersionedMetadata<WriterMark>> getWriterMarkRecord(String writer) {
+        CompletableFuture<VersionedMetadata<WriterMark>> result = new CompletableFuture<>();
+        
+        synchronized (writersLock) {
+            VersionedMetadata<WriterMark> mark = writerMarks.get(writer);
+            if (mark == null) {
+                result.completeExceptionally(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "writer mark not found"));
+            } else {
+                result.complete(mark);
+            }
+        }
+        
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks() {
+        Map<String, WriterMark> result;
+        synchronized (writersLock) {
+            result = writerMarks.entrySet().stream().collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue().getObject()));
+        }
+        return CompletableFuture.completedFuture(result);
+    }
+
+    @Override
+    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, Version version) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        VersionedMetadata<WriterMark> updatedCopy = updatedCopy(new VersionedMetadata<>(new WriterMark(timestamp, position), version));
+        synchronized (writersLock) {
+            VersionedMetadata<WriterMark> existing = writerMarks.get(writer);
+            if (existing == null) {
+                result.completeExceptionally(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "writer mark not found"));
+            } else if (!Objects.equals(existing.getVersion(), version)) {
+                result.completeExceptionally(StoreException.create(StoreException.Type.WRITE_CONFLICT, "writer mark version mismatch"));
+            } else {
+                this.writerMarks.put(writer, existing);
+                result.complete(null);
+            }
+        }
+        return result;
     }
 
     private <T> VersionedMetadata<T> updatedCopy(VersionedMetadata<T> input) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -968,20 +968,17 @@ public class InMemoryStream extends PersistentStreamBase {
 
     @Override
     CompletableFuture<Void> createWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position) {
-        CompletableFuture<Void> result = new CompletableFuture<>();
         WriterMark mark = new WriterMark(timestamp, position);
 
         synchronized (writersLock) {
             VersionedMetadata<WriterMark> existing = writerMarks.get(writer);
             if (existing != null) {
-                result.completeExceptionally(StoreException.create(StoreException.Type.DATA_EXISTS, "writer mark exists"));
+                return Futures.failedFuture(StoreException.create(StoreException.Type.DATA_EXISTS, "writer mark exists"));
             } else {
                 writerMarks.put(writer, new VersionedMetadata<>(mark, new Version.IntVersion(0)));
-                result.complete(null);
+                return CompletableFuture.completedFuture(null);
             }
         }
-        
-        return result;
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -1011,7 +1011,7 @@ public class InMemoryStream extends PersistentStreamBase {
     }
 
     @Override
-    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks() {
+    public CompletableFuture<Map<String, WriterMark>> getAllWriterMarks() {
         Map<String, WriterMark> result;
         synchronized (writersLock) {
             result = writerMarks.entrySet().stream().collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue().getObject()));

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -986,14 +986,11 @@ public class InMemoryStream extends PersistentStreamBase {
 
     @Override
     public CompletableFuture<Void> removeWriter(String writer) {
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        
         synchronized (writersLock) {
             writerMarks.remove(writer);
-            result.complete(null);
         }
-        
-        return result;
+
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -2052,12 +2052,41 @@ public abstract class PersistentStreamBase implements Stream {
     // endregion
 
     // region watermarking
+    /**
+     * Method to create new writer mark record. 
+     * @param writer writer id
+     * @param timestamp timestamp
+     * @param position position
+     * @return CompletableFuture which when completed will have writer mark created.  
+     * Implementation should throw DataExistsException if data exists
+     */
     abstract CompletableFuture<Void> createWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position);
 
+    /**
+     * Method to get writer mark record. 
+     * @param writer writer id
+     * @return CompletableFuture which when completed will contain writer's last reported mark.  
+     */
     abstract CompletableFuture<VersionedMetadata<WriterMark>> getWriterMarkRecord(String writer);
 
+    /**
+     * Method to update existing writer mark record. 
+     * @param writer writer id
+     * @param timestamp timestamp
+     * @param position position
+     * @param isAlive whether writer is shutdown or not
+     * @param version version of last record
+     * @return CompletableFuture which when completed will have writer mark updated.  
+     */
     abstract CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, boolean isAlive, Version version);
-    
+
+    /**
+     * Method to delete existing writer mark record conditionally. 
+     * @param writer writer id
+     * @param version version of last record
+     * @return CompletableFuture which when completed will have writer mark deleted.
+     * Can throw Write Conflict if delete version mismatches.
+     */
     abstract CompletableFuture<Void> removeWriterRecord(String writer, Version version);
     // endregion
     // endregion

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1209,7 +1209,9 @@ public abstract class PersistentStreamBase implements Stream {
 
     /**
      * This method takes the list of transactions in the committing transactions record, and tries to report marks
-     * for writers for these transactions, if they exist. 
+     * for writers for these transactions, if the information about writer is present in the record. The information 
+     * about writer and commit time is optionally provided by the client. A client not interested in watermarking may not 
+     * report writer id and time during commit request. Similarly older clients will not report writer id and time either.  
      * WriterId, commit time and commit offsets are recorded in ActiveTxnRecord for each transaction. 
      * For transactions where above fields are present, a mark is recorded for them. 
      * This method will ignore any INVALID_TIME or INVALID_POSITION related failures in noting marks for writers.
@@ -1589,7 +1591,7 @@ public abstract class PersistentStreamBase implements Stream {
                             });
         } 
         
-        return compareMaxes;
+        return false;
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1228,7 +1228,7 @@ public abstract class PersistentStreamBase implements Stream {
             // Ignore data not found exceptions. DataNotFound Exceptions can be thrown because transaction record no longer 
             // exists and this is an idempotent case. DataNotFound can also be thrown because writer's mark was deleted 
             // as we attempted to update an existing record. Note: Delete can be triggered by writer explicitly calling
-            // shutdownWriter api. 
+            // removeWriter api. 
             CompletableFuture<Void> future = getActiveTx(epoch, txId).thenCompose(txnRecord -> {
                 if (txnRecord != null && !Strings.isNullOrEmpty(txnRecord.getObject().getWriterId())
                         && txnRecord.getObject().getCommitTime() >= 0L && !txnRecord.getObject().getCommitOffsets().isEmpty()) {
@@ -2062,7 +2062,7 @@ public abstract class PersistentStreamBase implements Stream {
      * @param timestamp timestamp
      * @param position position
      * @return CompletableFuture which when completed will have writer mark created.  
-     * Implementation should throw DataExistsException if data exists
+     * Implementation should throw DataExistsException if data exists.
      */
     abstract CompletableFuture<Void> createWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position);
 
@@ -2075,17 +2075,21 @@ public abstract class PersistentStreamBase implements Stream {
 
     /**
      * Method to update existing writer mark record. 
+     * 
      * @param writer writer id
      * @param timestamp timestamp
      * @param position position
      * @param isAlive whether writer is shutdown or not
      * @param version version of last record
-     * @return CompletableFuture which when completed will have writer mark updated.  
+     * @return CompletableFuture which when completed will have writer mark updated. 
+     * @throws DataNotFoundException if while attempting to update a writer mark, its previous mark was removed by 
+     * watermarking workflow.
      */
     abstract CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, boolean isAlive, Version version);
 
     /**
      * Method to delete existing writer mark record conditionally. 
+     * 
      * @param writer writer id
      * @param version version of last record
      * @return CompletableFuture which when completed will have writer mark deleted.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1228,7 +1228,8 @@ public abstract class PersistentStreamBase implements Stream {
             // shutdownWriter api. 
             return Futures.exceptionallyExpecting(getActiveTx(epoch, txId)
                           .thenCompose(txnRecord -> {
-                              if (txnRecord != null && !Strings.isNullOrEmpty(txnRecord.getObject().getWriterId())) {
+                              if (txnRecord != null && !Strings.isNullOrEmpty(txnRecord.getObject().getWriterId()) 
+                                      && txnRecord.getObject().getCommitTime() >= 0L && !txnRecord.getObject().getCommitOffsets().isEmpty()) {
                                   ActiveTxnRecord record = txnRecord.getObject();
                                   return Futures.toVoid(noteWriterMark(record.getWriterId(), record.getCommitTime(), record.getCommitOffsets()));
                               } else {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
@@ -303,9 +303,22 @@ public class PravegaTablesStoreHelper {
      * It ignores DataNotFound exception. 
      */
     public CompletableFuture<Void> removeEntry(String tableName, String key) {
-        log.trace("remove entry called for : {} key : {}", tableName, key);
+        return removeEntry(tableName, key, null);
+    }
 
-        List<TableKey<byte[]>> keys = Collections.singletonList(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), null));
+    /**
+     * Method to remove entry from the store. 
+     * @param tableName tableName
+     * @param key key
+     * @param ver version for conditional removal
+     * @return CompletableFuture which when completed will indicate successful deletion of entry from the table. 
+     * It ignores DataNotFound exception. 
+     */
+    public CompletableFuture<Void> removeEntry(String tableName, String key, Version ver) {
+        log.trace("remove entry called for : {} key : {}", tableName, key);
+        KeyVersionImpl version = ver == null ? null : new KeyVersionImpl(ver.asLongVersion().getLongValue());
+
+        List<TableKey<byte[]>> keys = Collections.singletonList(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), version));
         return expectingDataNotFound(withRetries(() -> segmentHelper.removeTableKeys(
                 tableName, keys, authToken.get(), RequestTag.NON_EXISTENT_ID), 
                 () -> String.format("remove entry: key: %s table: %s", key, tableName)), null)

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -198,7 +198,7 @@ class PravegaTablesStream extends PersistentStreamBase {
                 .thenCompose(x -> Futures.toVoid(updateCommittingTxnRecord(new VersionedMetadata<>(CommittingTransactionsRecord.EMPTY,
                         record.getVersion()))));
     }
-    
+
     @Override
     CompletableFuture<Void> createStreamMetadata() {
         return getId().thenCompose(id -> {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -925,7 +925,7 @@ class PravegaTablesStream extends PersistentStreamBase {
     }
 
     @Override
-    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks() {
+    public CompletableFuture<Map<String, WriterMark>> getAllWriterMarks() {
         Map<String, WriterMark> result = new ConcurrentHashMap<>();
 
         return getWritersTable()

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -188,7 +188,7 @@ class PravegaTablesStream extends PersistentStreamBase {
         if (record.getObject().getTransactionsToCommit().size() == 0) {
             future = CompletableFuture.completedFuture(null);
         } else {
-            future = generateMarksForTransactions(record.getObject().getTransactionsToCommit())
+            future = generateMarksForTransactions(record.getObject())
                 .thenCompose(v -> createCompletedTxEntries(completedRecords))
                     .thenCompose(x -> getTransactionsInEpochTable(record.getObject().getEpoch())
                             .thenCompose(table -> storeHelper.removeEntries(table, completedRecords.keySet())))

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -905,9 +905,9 @@ class PravegaTablesStream extends PersistentStreamBase {
     }
 
     @Override
-    public CompletableFuture<Void> removeWriter(String writer) {
+    public CompletableFuture<Void> removeWriterRecord(String writer, Version version) {
         return getWritersTable()
-                .thenCompose(table -> storeHelper.removeEntry(table, writer));
+                .thenCompose(table -> storeHelper.removeEntry(table, writer, version));
     }
 
     @Override
@@ -917,8 +917,9 @@ class PravegaTablesStream extends PersistentStreamBase {
     }
 
     @Override
-    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, Version version) {
-        WriterMark mark = new WriterMark(timestamp, position);
+    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, 
+                                                   boolean isAlive, Version version) {
+        WriterMark mark = new WriterMark(timestamp, position, isAlive);
         return Futures.toVoid(getWritersTable()
                 .thenCompose(table -> storeHelper.updateEntry(table, writer, mark.toBytes(), version)));
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -581,11 +581,21 @@ interface Stream {
     CompletableFuture<WriterTimestampResponse> noteWriterMark(String writer, long timestamp, Map<Long, Long> position);
 
     /**
-     * Method to remove writer specific metadata from the metadata store. Remove method is idempotent. 
+     * Method to set a writer to be shutting down for its writer mark record.
+     * 
      * @param writer writer id
+     * @return A completableFuture, which when completed, will have shutdown the writer.  
+     */
+    CompletableFuture<Void> shutdownWriter(String writer);
+
+    /**
+     * Method to remove writer specific metadata from the metadata store if existing writermark matches given writermark. 
+     * Remove method is idempotent. So if writer doesnt exist, this method will declare success. 
+     * @param writer writer id
+     * @param writerMark writer mark
      * @return A completableFuture, which when completed, will have removed writer metadata. 
      */
-    CompletableFuture<Void> removeWriter(String writer);
+    CompletableFuture<Void> removeWriter(String writer, WriterMark writerMark);
 
     /**
      * Method to retrieve writer's latest recorded mark.  

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -608,7 +608,7 @@ interface Stream {
      * Method to retrieve latest recorded mark for all known writers.  
      * @return A completableFuture, which when completed, will contain map of writer to respective marks.  
      */
-    CompletableFuture<Map<String, WriterMark>> getAllWritersMarks();
+    CompletableFuture<Map<String, WriterMark>> getAllWriterMarks();
 
     /**
      * Refresh the stream object. Typically to be used to invalidate any caches.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -1150,5 +1150,5 @@ public interface StreamMetadataStore extends AutoCloseable {
      * @param executor executor
      * @return A completableFuture, which when completed, will contain map of writer to respective marks.  
      */
-    CompletableFuture<Map<String, WriterMark>> getAllWritersMarks(String scope, String stream, OperationContext context, Executor executor);
+    CompletableFuture<Map<String, WriterMark>> getAllWriterMarks(String scope, String stream, OperationContext context, Executor executor);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -1108,7 +1108,9 @@ public interface StreamMetadataStore extends AutoCloseable {
                                                               OperationContext context, Executor executor);
 
     /**
-     * Method to mark a writer for shutdown. A shutdown writer can be revived if newer marks are reported for it. 
+     * Method to mark a writer for shutdown. A shutdown writer can be revived if newer marks are reported for it.
+     * A writer which is marked for shutdown is removed asynchronously after its latest reported mark is included for 
+     * a watermarking computation. 
      * 
      * @param scope scope name
      * @param stream stream name
@@ -1120,7 +1122,9 @@ public interface StreamMetadataStore extends AutoCloseable {
     CompletableFuture<Void> shutdownWriter(String scope, String stream, String writer, OperationContext context, Executor executor);
 
     /**
-     * Method to remove writer specific metadata from the metadata store. Remove method is idempotent. 
+     * Method to remove writer specific metadata conditionally from the metadata store.  
+     * A writer is removed only if the writer mark in the store matches the given writer mark. Remove method is idempotent, 
+     * so if writer is not found, its considered removed. 
      * @param scope scope name
      * @param stream stream name
      * @param writer writer id

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -20,6 +20,7 @@ import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.controller.store.stream.records.WriterMark;
 import io.pravega.controller.store.task.TxnResource;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateScopeStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteScopeStatus;
@@ -706,6 +707,8 @@ public interface StreamMetadataStore extends AutoCloseable {
      * @param txId     transaction id
      * @param commit   Boolean indicating whether to change txn state to committing or aborting.
      * @param version  Expected version of the transaction record in the store.
+     * @param writerId writer id. Used only if commit is set to true. 
+     * @param timestamp commit timestamp. Valid only when commit flag is true.
      * @param context  operation context
      * @param executor callers executor
      * @return         Pair containing the transaction status after sealing and transaction epoch.
@@ -713,6 +716,8 @@ public interface StreamMetadataStore extends AutoCloseable {
     CompletableFuture<SimpleEntry<TxnStatus, Integer>> sealTransaction(final String scope, final String stream,
                                                                        final UUID txId, final boolean commit,
                                                                        final Optional<Version> version,
+                                                                       final String writerId,
+                                                                       final long timestamp,
                                                                        final OperationContext context,
                                                                        final Executor executor);
 
@@ -1034,6 +1039,21 @@ public interface StreamMetadataStore extends AutoCloseable {
     CompletableFuture<Void> completeCommitTransactions(final String scope, final String stream, final VersionedMetadata<CommittingTransactionsRecord> record,
                                                        final OperationContext context, final ScheduledExecutorService executor);
 
+
+    /**
+     * Method to record commit offset for a transaction. This method stores the commit offset in ActiveTransaction record. 
+     * Its behaviour is idempotent and if a transaction already has commitOffsets set earlier, they are not overwritten. 
+     * @param scope scope name
+     * @param stream stream name
+     * @param txnId transaction id
+     * @param commitOffsets segment to offset position where transaction was committed
+     * @param context operation context
+     * @param executor executor
+     * @return A completableFuture which, when completed, will have transaction commit offset recorded successfully.
+     */
+    CompletableFuture<Void> recordCommitOffsets(final String scope, final String stream, final UUID txnId, final Map<Long, Long> commitOffsets,
+                                                final OperationContext context, final ScheduledExecutorService executor);
+    
     /**
      * This method attempts to create a new Waiting Request node and set the processor's name in the node.
      * If a node already exists, this attempt is ignored.
@@ -1070,4 +1090,52 @@ public interface StreamMetadataStore extends AutoCloseable {
      * @return CompletableFuture which indicates completion of processing.
      */
     CompletableFuture<Void> deleteWaitingRequestConditionally(String scope, String stream, String processorName, OperationContext context, ScheduledExecutorService executor);
+
+    /**
+     * Method to record writer's mark in the metadata store. If this is a known writer, its mark is updated if it advances 
+     * both time and position from the previously recorded position.    
+     * @param scope scope name
+     * @param stream stream name
+     * @param writer writer id
+     * @param timestamp mark timestamp
+     * @param position writer position 
+     * @param context operation context
+     * @param executor executor
+     * @return A completableFuture, which when completed, will have recorded the new mark for the writer. 
+     */
+    CompletableFuture<WriterTimestampResponse> noteWriterMark(String scope, String stream, String writer,
+                                                              long timestamp, Map<Long, Long> position,
+                                                              OperationContext context, Executor executor);
+
+    /**
+     * Method to remove writer specific metadata from the metadata store. Remove method is idempotent. 
+     * @param scope scope name
+     * @param stream stream name
+     * @param writer writer id
+     * @param context operation context
+     * @param executor executor
+     * @return A completableFuture, which when completed, will have removed writer metadata. 
+     */
+    CompletableFuture<Void> removeWriter(String scope, String stream, String writer, OperationContext context, Executor executor);
+
+    /**
+     * Method to retrieve writer's latest recorded mark.  
+     * @param scope scope name
+     * @param stream stream name
+     * @param writer writer id
+     * @param context operation context
+     * @param executor executor
+     * @return A completableFuture, which when completed, will contain writer's mark.  
+     */
+    CompletableFuture<WriterMark> getWriterMark(String scope, String stream, String writer, OperationContext context, Executor executor);
+
+    /**
+     * Method to retrieve latest recorded mark for all known writers.  
+     * @param scope scope name
+     * @param stream stream name
+     * @param context operation context
+     * @param executor executor
+     * @return A completableFuture, which when completed, will contain map of writer to respective marks.  
+     */
+    CompletableFuture<Map<String, WriterMark>> getAllWritersMarks(String scope, String stream, OperationContext context, Executor executor);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -1108,15 +1108,28 @@ public interface StreamMetadataStore extends AutoCloseable {
                                                               OperationContext context, Executor executor);
 
     /**
-     * Method to remove writer specific metadata from the metadata store. Remove method is idempotent. 
+     * Method to mark a writer for shutdown. A shutdown writer can be revived if newer marks are reported for it. 
+     * 
      * @param scope scope name
      * @param stream stream name
      * @param writer writer id
      * @param context operation context
      * @param executor executor
+     * @return A completableFuture, which when completed, will have shutdown writer. 
+     */
+    CompletableFuture<Void> shutdownWriter(String scope, String stream, String writer, OperationContext context, Executor executor);
+
+    /**
+     * Method to remove writer specific metadata from the metadata store. Remove method is idempotent. 
+     * @param scope scope name
+     * @param stream stream name
+     * @param writer writer id
+     * @param writerMark writer mark to match for removal
+     * @param context operation context
+     * @param executor executor
      * @return A completableFuture, which when completed, will have removed writer metadata. 
      */
-    CompletableFuture<Void> removeWriter(String scope, String stream, String writer, OperationContext context, Executor executor);
+    CompletableFuture<Void> removeWriter(String scope, String stream, String writer, WriterMark writerMark, OperationContext context, Executor executor);
 
     /**
      * Method to retrieve writer's latest recorded mark.  

--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.store.stream;
 
+import com.google.common.collect.ImmutableMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -21,7 +22,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class VersionedTransactionData {
     public static final VersionedTransactionData EMPTY = new VersionedTransactionData(Integer.MIN_VALUE, new UUID(0, 0), null,
-            TxnStatus.UNKNOWN, Long.MIN_VALUE, Long.MIN_VALUE, "", Long.MIN_VALUE, Long.MIN_VALUE);
+            TxnStatus.UNKNOWN, Long.MIN_VALUE, Long.MIN_VALUE, "", Long.MIN_VALUE, Long.MIN_VALUE, ImmutableMap.of());
 
     private final int epoch;
     private final UUID id;
@@ -32,4 +33,5 @@ public class VersionedTransactionData {
     private final String writerId;
     private final Long commitTime;
     private final Long position;
+    private final ImmutableMap<Long, Long> commitOffsets;
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/WriterTimestampResponse.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/WriterTimestampResponse.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+public enum WriterTimestampResponse {
+    SUCCESS,
+    INVALID_TIME,
+    INVALID_POSITION
+}

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -84,6 +84,24 @@ public class ZKStoreHelper {
         return result;
     }
 
+    CompletableFuture<Void> deleteNode(final String path, final Version version) {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        try {
+            client.delete().withVersion(version.asIntVersion().getIntValue()).inBackground(
+                    callback(x -> result.complete(null),
+                            e -> {
+                                if (e instanceof StoreException.DataNotFoundException) { // deleted already
+                                    result.complete(null);
+                                } else {
+                                    result.completeExceptionally(e);
+                                }
+                            }, path), executor).forPath(path);
+        } catch (Exception e) {
+            result.completeExceptionally(StoreException.create(StoreException.Type.UNKNOWN, e, path));
+        }
+        return result;
+    }
+
     // region curator client store access
 
     CompletableFuture<Void> deletePath(final String path, final boolean deleteEmptyContainer) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -680,9 +680,9 @@ class ZKStream extends PersistentStreamBase {
     }
 
     @Override
-    public CompletableFuture<Void> removeWriter(String writer) {
+    public CompletableFuture<Void> removeWriterRecord(String writer, Version version) {
         String writerPath = getWriterPath(writer);
-        return store.deletePath(writerPath, false);
+        return store.deleteNode(writerPath, version);
     }
 
     @Override
@@ -692,9 +692,10 @@ class ZKStream extends PersistentStreamBase {
     }
 
     @Override
-    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, Version version) {
+    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position,
+                                                   boolean isAlive, Version version) {
         String writerPath = getWriterPath(writer);
-        WriterMark mark = new WriterMark(timestamp, position);
+        WriterMark mark = new WriterMark(timestamp, position, isAlive);
 
         return Futures.toVoid(store.setData(writerPath, mark.toBytes(), version));
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -705,7 +705,7 @@ class ZKStream extends PersistentStreamBase {
     }
 
     @Override
-    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks() {
+    public CompletableFuture<Map<String, WriterMark>> getAllWriterMarks() {
         return store.getChildren(writerPositionsPath)
                 .thenCompose(children -> {
                     return Futures.allOfWithResults(children.stream().collect(Collectors.toMap(writer -> writer, 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -708,7 +708,7 @@ class ZKStream extends PersistentStreamBase {
         return store.getChildren(writerPositionsPath)
                 .thenCompose(children -> {
                     return Futures.allOfWithResults(children.stream().collect(Collectors.toMap(writer -> writer, 
-                            writer -> Futures.exceptionallyExpecting(getWriterMark(getWriterPath(writer)), 
+                            writer -> Futures.exceptionallyExpecting(getWriterMark(writer), 
                                     DATA_NOT_FOUND_PREDICATE, WriterMark.EMPTY))))
                             .thenApply(map -> map.entrySet().stream().filter(x -> !x.getValue().equals(WriterMark.EMPTY))
                                                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -470,7 +470,7 @@ class ZKStream extends PersistentStreamBase {
                                       });
                     });
     }
-    
+
     @Override
     public CompletableFuture<Map<UUID, ActiveTxnRecord>> getTxnInEpoch(int epoch) {
         VersionedMetadata<ActiveTxnRecord> empty = getEmptyData();

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -11,6 +11,7 @@ package io.pravega.controller.store.stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -27,6 +28,7 @@ import io.pravega.controller.store.stream.records.StateRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.controller.store.stream.records.WriterMark;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +50,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import static io.pravega.controller.store.stream.AbstractStreamMetadataStore.DATA_NOT_FOUND_PREDICATE;
 
 /**
  * ZK Stream. It understands the following.
@@ -74,6 +78,7 @@ class ZKStream extends PersistentStreamBase {
     private static final String SEGMENTS_SEALED_SIZE_MAP_SHARD_PATH = STREAM_PATH + "/segmentsSealedSizeMapShardPath";
     private static final String SEGMENT_SEALED_EPOCH_PATH = STREAM_PATH + "/segmentSealedEpochPath";
     private static final String COMMITTING_TXNS_PATH = STREAM_PATH + "/committingTxns";
+    private static final String WRITER_POSITIONS_PATH = STREAM_PATH + "/writerPositions";
     private static final String WAITING_REQUEST_PROCESSOR_PATH = STREAM_PATH + "/waitingRequestProcessor";
     private static final String MARKER_PATH = STREAM_PATH + "/markers";
     private static final String ID_PATH = STREAM_PATH + "/id";
@@ -102,6 +107,7 @@ class ZKStream extends PersistentStreamBase {
     private final String historyTimeSeriesChunkPathFormat;
     private final String segmentSealedEpochPathFormat;
     private final String segmentsSealedSizeMapShardPathFormat;
+    private final String writerPositionsPath;
 
     private final Supplier<Integer> currentBatchSupplier;
     private final Executor executor;
@@ -149,7 +155,7 @@ class ZKStream extends PersistentStreamBase {
         historyTimeSeriesChunkPathFormat = String.format(HISTORY_TIMESERIES_CHUNK_PATH, scopeName, streamName) + "/%d";
         segmentSealedEpochPathFormat = String.format(SEGMENT_SEALED_EPOCH_PATH, scopeName, streamName) + "/%d";
         segmentsSealedSizeMapShardPathFormat = String.format(SEGMENTS_SEALED_SIZE_MAP_SHARD_PATH, scopeName, streamName) + "/%d";
-
+        writerPositionsPath = String.format(WRITER_POSITIONS_PATH, scopeName, streamName);
         idRef = new AtomicReference<>();
         this.currentBatchSupplier = currentBatchSupplier;
         this.executor = executor;
@@ -464,7 +470,7 @@ class ZKStream extends PersistentStreamBase {
                                       });
                     });
     }
-
+    
     @Override
     public CompletableFuture<Map<UUID, ActiveTxnRecord>> getTxnInEpoch(int epoch) {
         VersionedMetadata<ActiveTxnRecord> empty = getEmptyData();
@@ -664,6 +670,49 @@ class ZKStream extends PersistentStreamBase {
     @Override
     CompletableFuture<Void> deleteWaitingRequestNode() {
         return store.deletePath(waitingRequestProcessorPath, false);
+    }
+
+    @Override
+    CompletableFuture<Void> createWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position) {
+        String writerPath = getWriterPath(writer);
+        WriterMark mark = new WriterMark(timestamp, position);
+        return Futures.toVoid(store.createZNode(writerPath, mark.toBytes()));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeWriter(String writer) {
+        String writerPath = getWriterPath(writer);
+        return store.deletePath(writerPath, false);
+    }
+
+    @Override
+    CompletableFuture<VersionedMetadata<WriterMark>> getWriterMarkRecord(String writer) {
+        String writerPath = getWriterPath(writer);
+        return store.getData(writerPath, WriterMark::fromBytes);
+    }
+
+    @Override
+    CompletableFuture<Void> updateWriterMarkRecord(String writer, long timestamp, ImmutableMap<Long, Long> position, Version version) {
+        String writerPath = getWriterPath(writer);
+        WriterMark mark = new WriterMark(timestamp, position);
+
+        return Futures.toVoid(store.setData(writerPath, mark.toBytes(), version));
+    }
+
+    private String getWriterPath(String writer) {
+        return ZKPaths.makePath(writerPositionsPath, writer);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, WriterMark>> getAllWritersMarks() {
+        return store.getChildren(writerPositionsPath)
+                .thenCompose(children -> {
+                    return Futures.allOfWithResults(children.stream().collect(Collectors.toMap(writer -> writer, 
+                            writer -> Futures.exceptionallyExpecting(getWriterMark(getWriterPath(writer)), 
+                                    DATA_NOT_FOUND_PREDICATE, WriterMark.EMPTY))))
+                            .thenApply(map -> map.entrySet().stream().filter(x -> !x.getValue().equals(WriterMark.EMPTY))
+                                                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                });
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/WriterMark.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/WriterMark.java
@@ -22,6 +22,12 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+/**
+ * This is a data class that represents a writer's mark. 
+ * A writer sends a time and its position corresponding to the time.
+ * This is data object where the information sent by the writer is recorded and serialized to be stored in underlying 
+ * metadata store. 
+ */
 @Data
 public class WriterMark {
     public static final WriterMarkSerializer SERIALIZER = new WriterMarkSerializer();

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/WriterMark.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/WriterMark.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream.records;
+
+import com.google.common.collect.ImmutableMap;
+import io.pravega.common.ObjectBuilder;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.common.io.serialization.VersionedSerializer;
+import lombok.Builder;
+import lombok.Data;
+import lombok.SneakyThrows;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+@Data
+public class WriterMark {
+    public static final WriterMarkSerializer SERIALIZER = new WriterMarkSerializer();
+    public static final WriterMark EMPTY = new WriterMark(Long.MIN_VALUE, ImmutableMap.of());
+    private final long timestamp;
+    private final ImmutableMap<Long, Long> position;
+
+    @Builder
+    public WriterMark(long timestamp, ImmutableMap<Long, Long> position) {
+        this.timestamp = timestamp;
+        this.position = position;
+    }
+
+    public static class WriterMarkBuilder implements ObjectBuilder<WriterMark> {
+
+    }
+    
+    @SneakyThrows(IOException.class)
+    public static WriterMark fromBytes(final byte[] data) {
+        return SERIALIZER.deserialize(data);
+    }
+
+    @SneakyThrows(IOException.class)
+    public byte[] toBytes() {
+        return SERIALIZER.serialize(this).getCopy();
+    }
+
+    private static class WriterMarkSerializer
+            extends VersionedSerializer.WithBuilder<WriterMark, WriterMark.WriterMarkBuilder> {
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        private void read00(RevisionDataInput revisionDataInput,
+                            WriterMark.WriterMarkBuilder builder) throws IOException {
+            builder.timestamp(revisionDataInput.readLong());
+
+            ImmutableMap.Builder<Long, Long> mapBuilder = ImmutableMap.builder();
+            revisionDataInput.readMap(DataInput::readLong, DataInput::readLong, mapBuilder);
+            builder.position(mapBuilder.build());
+        }
+        
+        private void write00(WriterMark writerMark, RevisionDataOutput revisionDataOutput) throws IOException {
+            revisionDataOutput.writeLong(writerMark.timestamp);
+            revisionDataOutput.writeMap(writerMark.position, DataOutput::writeLong, DataOutput::writeLong);
+        }
+
+        @Override
+        protected WriterMark.WriterMarkBuilder newBuilder() {
+            return WriterMark.builder();
+        }
+    }
+
+}

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -798,7 +798,7 @@ public class StreamMetadataTasks extends TaskBase {
                 segmentCut.getValue(), delegationToken, requestId), executor));
     }
 
-    public CompletableFuture<Map<Long, Long>> getSealedSegmentsSize(String scope, String stream, List<Long> sealedSegments, String delegationToken) {
+    public CompletableFuture<Map<Long, Long>> getSegmentsSize(String scope, String stream, List<Long> sealedSegments, String delegationToken) {
         return Futures.allOfWithResults(
                 sealedSegments
                         .stream()

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -797,10 +797,10 @@ public class StreamMetadataTasks extends TaskBase {
         return Futures.toVoid(withRetries(() -> segmentHelper.truncateSegment(scope, stream, segmentCut.getKey(),
                 segmentCut.getValue(), delegationToken, requestId), executor));
     }
-
-    public CompletableFuture<Map<Long, Long>> getSegmentsSize(String scope, String stream, List<Long> sealedSegments, String delegationToken) {
+    
+    public CompletableFuture<Map<Long, Long>> getSealedSegmentsSize(String scope, String stream, List<Long> segments, String delegationToken) {
         return Futures.allOfWithResults(
-                sealedSegments
+                segments
                         .stream()
                         .parallel()
                         .collect(Collectors.toMap(x -> x, x -> getSegmentOffset(scope, stream, x, delegationToken))));
@@ -917,6 +917,11 @@ public class StreamMetadataTasks extends TaskBase {
                 segmentNumber,
                 txnId,
                 this.retrieveDelegationToken()), executor);
+    }
+
+    public CompletableFuture<Map<Long, Long>> getCurrentSegmentsSize(String scope, String stream, List<Long> segments) {
+        return Futures.allOfWithResults(segments.stream().collect(
+                Collectors.toMap(x -> x, x -> getSegmentOffset(scope, stream, x, this.retrieveDelegationToken()))));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -797,7 +797,7 @@ public class StreamMetadataTasks extends TaskBase {
         return Futures.toVoid(withRetries(() -> segmentHelper.truncateSegment(scope, stream, segmentCut.getKey(),
                 segmentCut.getValue(), delegationToken, requestId), executor));
     }
-    
+
     public CompletableFuture<Map<Long, Long>> getSealedSegmentsSize(String scope, String stream, List<Long> segments, String delegationToken) {
         return Futures.allOfWithResults(
                 segments

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -919,7 +919,7 @@ public class StreamMetadataTasks extends TaskBase {
                 this.retrieveDelegationToken()), executor);
     }
 
-    public CompletableFuture<Map<Long, Long>> getCurrentSegmentsSize(String scope, String stream, List<Long> segments) {
+    public CompletableFuture<Map<Long, Long>> getCurrentSegmentSizes(String scope, String stream, List<Long> segments) {
         return Futures.allOfWithResults(segments.stream().collect(
                 Collectors.toMap(x -> x, x -> getSegmentOffset(scope, stream, x, this.retrieveDelegationToken()))));
     }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
@@ -62,4 +62,9 @@ public class EventStreamReaderMock<T> implements EventStreamReader<T> {
     @Override
     public void closeAt(Position position) {
     }
+    
+    @Override  
+    public TimeWindow getCurrentTimeWindow() {
+        return null;
+    }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
@@ -62,9 +62,4 @@ public class EventStreamReaderMock<T> implements EventStreamReader<T> {
     @Override
     public void closeAt(Position position) {
     }
-    
-    @Override  
-    public TimeWindow getCurrentTimeWindow() {
-        return null;
-    }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
@@ -142,7 +142,7 @@ public abstract class ControllerEventProcessorTest {
         Assert.assertNotNull(txnData);
         checkTransactionState(SCOPE, STREAM, txnId, TxnStatus.OPEN);
 
-        streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
         checkTransactionState(SCOPE, STREAM, txnData.getId(), TxnStatus.COMMITTING);
 
         CommitRequestHandler commitEventProcessor = new CommitRequestHandler(streamStore, streamMetadataTasks, streamTransactionMetadataTasks, executor);
@@ -166,7 +166,7 @@ public abstract class ControllerEventProcessorTest {
         Assert.assertNotNull(txnData0);
         checkTransactionState(SCOPE, stream, txnOnEpoch0, TxnStatus.OPEN);
 
-        streamStore.sealTransaction(SCOPE, stream, txnData0.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(SCOPE, stream, txnData0.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
         checkTransactionState(SCOPE, stream, txnData0.getId(), TxnStatus.COMMITTING);
 
         // scale stream
@@ -180,7 +180,7 @@ public abstract class ControllerEventProcessorTest {
         Assert.assertNotNull(txnData1);
         checkTransactionState(SCOPE, stream, txnOnEpoch1, TxnStatus.OPEN);
 
-        streamStore.sealTransaction(SCOPE, stream, txnData1.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(SCOPE, stream, txnData1.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
         checkTransactionState(SCOPE, stream, txnData1.getId(), TxnStatus.COMMITTING);
 
         // set the stream to SEALING
@@ -340,7 +340,7 @@ public abstract class ControllerEventProcessorTest {
             Assert.assertNotNull(txnData);
             checkTransactionState(SCOPE, STREAM, txnId, TxnStatus.OPEN);
 
-            streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), true, Optional.empty(), null, executor).join();
+            streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
             checkTransactionState(SCOPE, STREAM, txnData.getId(), TxnStatus.COMMITTING);
 
             retVal.add(txnData);
@@ -356,7 +356,7 @@ public abstract class ControllerEventProcessorTest {
         Assert.assertNotNull(txnData);
         checkTransactionState(SCOPE, STREAM, txnId, TxnStatus.OPEN);
 
-        streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), false, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(SCOPE, STREAM, txnData.getId(), false, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
         checkTransactionState(SCOPE, STREAM, txnData.getId(), TxnStatus.ABORTING);
 
         AbortRequestHandler abortRequestHandler = new AbortRequestHandler(streamStore, streamMetadataTasks, executor);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -203,7 +203,7 @@ public abstract class RequestHandlersTest {
         // create txn on epoch 0 and set it to committing
         UUID txnId = streamStore1.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnEpoch0 = streamStore1.createTransaction(scope, stream, txnId, 1000L, 10000L, null, executor).join();
-        streamStore1.sealTransaction(scope, stream, txnId, true, Optional.of(txnEpoch0.getVersion()), null, executor).join();
+        streamStore1.sealTransaction(scope, stream, txnId, true, Optional.of(txnEpoch0.getVersion()), "", Long.MIN_VALUE, null, executor).join();
 
         // regular commit
         // start commit transactions
@@ -307,7 +307,7 @@ public abstract class RequestHandlersTest {
         // create txn on epoch 0 and set it to committing
         UUID txnId = streamStore1.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnEpoch0 = streamStore1.createTransaction(scope, stream, txnId, 1000L, 10000L, null, executor).join();
-        streamStore1.sealTransaction(scope, stream, txnId, true, Optional.of(txnEpoch0.getVersion()), null, executor).join();
+        streamStore1.sealTransaction(scope, stream, txnId, true, Optional.of(txnEpoch0.getVersion()), "", Long.MIN_VALUE, null, executor).join();
         // perform scale
         ScaleOpEvent event = new ScaleOpEvent(scope, stream, Lists.newArrayList(0L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), false, System.currentTimeMillis(),
@@ -722,7 +722,7 @@ public abstract class RequestHandlersTest {
                 System.currentTimeMillis()).join();
 
         UUID txn = streamTransactionMetadataTasks.createTxn(fairness, fairness, 30000, null).join().getKey().getId();
-        streamStore.sealTransaction(fairness, fairness, txn, true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(fairness, fairness, txn, true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
         
         // 1. set segment helper mock to throw exception
         doAnswer(x -> Futures.failedFuture(new RuntimeException()))

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -283,7 +283,7 @@ public abstract class ScaleRequestHandlerTest {
         UUID txnIdOldEpoch = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnData = streamStore.createTransaction(scope, stream, txnIdOldEpoch, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         EpochRecord epochZero = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
         assertEquals(0, epochZero.getEpoch());
@@ -303,7 +303,7 @@ public abstract class ScaleRequestHandlerTest {
         UUID txnIdNewEpoch = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnDataNew = streamStore.createTransaction(scope, stream, txnIdNewEpoch, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnDataNew.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnDataNew.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         // 5. commit on old epoch. this should roll over
         assertTrue(Futures.await(commitRequestHandler.processEvent(new CommitEvent(scope, stream, txnData.getEpoch()))));
@@ -354,12 +354,12 @@ public abstract class ScaleRequestHandlerTest {
         UUID txnIdOldEpoch = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnData = streamStore.createTransaction(scope, stream, txnIdOldEpoch, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         UUID txnIdOldEpoch2 = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnData2 = streamStore.createTransaction(scope, stream, txnIdOldEpoch2, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnData2.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnData2.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         EpochRecord epochZero = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
         assertEquals(0, epochZero.getEpoch());
@@ -412,12 +412,12 @@ public abstract class ScaleRequestHandlerTest {
         UUID txnIdOldEpoch = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnData = streamStore.createTransaction(scope, stream, txnIdOldEpoch, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnData.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         UUID txnIdOldEpoch2 = streamStore.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData txnData2 = streamStore.createTransaction(scope, stream, txnIdOldEpoch2, 10000, 10000,
                 null, executor).join();
-        streamStore.sealTransaction(scope, stream, txnData2.getId(), true, Optional.empty(), null, executor).join();
+        streamStore.sealTransaction(scope, stream, txnData2.getId(), true, Optional.empty(), "", Long.MIN_VALUE, null, executor).join();
 
         EpochRecord epochZero = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
         assertEquals(0, epochZero.getEpoch());

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -735,18 +735,18 @@ public abstract class ControllerServiceImplTest {
         this.controllerService.noteTimestampFromWriter(request, resultObserver);
         assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.INVALID_POSITION);
 
-        Controller.WriterShutdownRequest writerShutdownRequest = Controller.WriterShutdownRequest
+        Controller.RemoveWriterRequest writerShutdownRequest = Controller.RemoveWriterRequest
                 .newBuilder().setStream(streamInfo).setWriter(writer1).build();
-        ResultObserver<Controller.WriterShutdownResponse> shutdownResultObserver = new ResultObserver<>();
-        this.controllerService.writerShutdown(writerShutdownRequest, shutdownResultObserver);
-        assertEquals(shutdownResultObserver.get().getResult(), Controller.WriterShutdownResponse.Status.SUCCESS);
+        ResultObserver<Controller.RemoveWriterResponse> shutdownResultObserver = new ResultObserver<>();
+        this.controllerService.removeWriter(writerShutdownRequest, shutdownResultObserver);
+        assertEquals(shutdownResultObserver.get().getResult(), Controller.RemoveWriterResponse.Status.SUCCESS);
 
         // shutdown request for unknown writer
-        writerShutdownRequest = Controller.WriterShutdownRequest
+        writerShutdownRequest = Controller.RemoveWriterRequest
                 .newBuilder().setStream(streamInfo).setWriter("unknown writer").build();
         shutdownResultObserver = new ResultObserver<>();
-        this.controllerService.writerShutdown(writerShutdownRequest, shutdownResultObserver);
-        assertEquals(shutdownResultObserver.get().getResult(), Controller.WriterShutdownResponse.Status.UNKNOWN_WRITER);
+        this.controllerService.removeWriter(writerShutdownRequest, shutdownResultObserver);
+        assertEquals(shutdownResultObserver.get().getResult(), Controller.RemoveWriterResponse.Status.UNKNOWN_WRITER);
     }
 
     protected void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -649,6 +649,93 @@ public abstract class ControllerServiceImplTest {
                 e -> checkGRPCException(e, IllegalArgumentException.class));
     }
 
+    @Test(timeout = 30000L)
+    public void testWriterMark() {
+        String writer1 = "writer1";
+        String stream = "mark";
+        StreamInfo streamInfo = ModelHelper.createStreamInfo(SCOPE1, stream);
+        
+        createScopeAndStream(SCOPE1, stream, ScalingPolicy.fixed(2));
+        
+        // call note for new writer
+        Controller.StreamCut.Builder position = Controller.StreamCut.newBuilder()
+                                               .setStreamInfo(streamInfo)
+                                               .putCut(0L, 0L).putCut(1L, 0L);
+        Controller.TimestampFromWriter request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(1L)
+                                     .setPosition(position)
+                                     .build();
+
+        ResultObserver<Controller.TimestampResponse> resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.SUCCESS);
+
+        // call note for existing writer with advancing time and advancing position
+        position = Controller.StreamCut.newBuilder()
+                            .setStreamInfo(streamInfo)
+                            .putCut(0L, 1L).putCut(1L, 1L);
+        request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(2L)
+                                     .setPosition(position)
+                                     .build();
+        resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        resultObserver.get();
+
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.SUCCESS);
+
+        // call note for existing writer with advancing time but same position
+        request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(3L)
+                                     .setPosition(position)
+                                     .build();
+        resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.SUCCESS);
+        
+        // call note for existing writer with same time but advancing position
+        position = Controller.StreamCut.newBuilder()
+                            .setStreamInfo(streamInfo)
+                            .putCut(0L, 2L).putCut(1L, 2L);
+        request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(3L)
+                                     .setPosition(position)
+                                     .build();
+        resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.SUCCESS);
+        
+        // call note for existing writer with lower time
+        position = Controller.StreamCut.newBuilder()
+                            .setStreamInfo(streamInfo)
+                            .putCut(0L, 2L).putCut(1L, 2L);
+        request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(2L)
+                                     .setPosition(position)
+                                     .build();
+        resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.INVALID_TIME);
+        
+        // call note for existing writer with lower position
+        position = Controller.StreamCut.newBuilder()
+                            .setStreamInfo(streamInfo)
+                            .putCut(0L, 2L).putCut(1L, 1L);
+        request = Controller.TimestampFromWriter.newBuilder()
+                                     .setWriter(writer1)
+                                     .setTimestamp(4L)
+                                     .setPosition(position)
+                                     .build();
+        resultObserver = new ResultObserver<>();
+        this.controllerService.noteTimestampFromWriter(request, resultObserver);
+        assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.INVALID_POSITION);
+    }
+
     protected void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {
         final StreamConfiguration configuration1 =
                 StreamConfiguration.builder().scalingPolicy(scalingPolicy).build();

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -734,6 +734,19 @@ public abstract class ControllerServiceImplTest {
         resultObserver = new ResultObserver<>();
         this.controllerService.noteTimestampFromWriter(request, resultObserver);
         assertEquals(resultObserver.get().getResult(), Controller.TimestampResponse.Status.INVALID_POSITION);
+
+        Controller.WriterShutdownRequest writerShutdownRequest = Controller.WriterShutdownRequest
+                .newBuilder().setStream(streamInfo).setWriter(writer1).build();
+        ResultObserver<Controller.WriterShutdownResponse> shutdownResultObserver = new ResultObserver<>();
+        this.controllerService.writerShutdown(writerShutdownRequest, shutdownResultObserver);
+        assertEquals(shutdownResultObserver.get().getResult(), Controller.WriterShutdownResponse.Status.SUCCESS);
+
+        // shutdown request for unknown writer
+        writerShutdownRequest = Controller.WriterShutdownRequest
+                .newBuilder().setStream(streamInfo).setWriter("unknown writer").build();
+        shutdownResultObserver = new ResultObserver<>();
+        this.controllerService.writerShutdown(writerShutdownRequest, shutdownResultObserver);
+        assertEquals(shutdownResultObserver.get().getResult(), Controller.WriterShutdownResponse.Status.UNKNOWN_WRITER);
     }
 
     protected void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {

--- a/controller/src/test/java/io/pravega/controller/server/v1/PravegaTablesControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/PravegaTablesControllerServiceImplTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server.v1;
+
+import io.pravega.common.cluster.Cluster;
+import io.pravega.common.cluster.ClusterType;
+import io.pravega.common.cluster.Host;
+import io.pravega.common.cluster.zkImpl.ClusterZKImpl;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.tracing.RequestTracker;
+import io.pravega.controller.mocks.ControllerEventStreamWriterMock;
+import io.pravega.controller.mocks.EventStreamWriterMock;
+import io.pravega.controller.mocks.SegmentHelperMock;
+import io.pravega.controller.server.ControllerService;
+import io.pravega.controller.server.SegmentHelper;
+import io.pravega.controller.server.eventProcessor.requesthandlers.AutoScaleTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.DeleteStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.ScaleOperationTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.SealStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.StreamRequestHandler;
+import io.pravega.controller.server.eventProcessor.requesthandlers.TruncateStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.UpdateStreamTask;
+import io.pravega.controller.server.rpc.auth.AuthHelper;
+import io.pravega.controller.server.rpc.grpc.v1.ControllerServiceImpl;
+import io.pravega.controller.store.client.StoreClient;
+import io.pravega.controller.store.client.StoreClientFactory;
+import io.pravega.controller.store.host.HostControllerStore;
+import io.pravega.controller.store.host.HostStoreFactory;
+import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
+import io.pravega.controller.store.stream.BucketStore;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import io.pravega.controller.store.task.TaskMetadataStore;
+import io.pravega.controller.store.task.TaskStoreFactory;
+import io.pravega.controller.task.Stream.StreamMetadataTasks;
+import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+import io.pravega.test.common.TestingServerStarter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Zookeeper stream store configuration.
+ */
+public class PravegaTablesControllerServiceImplTest extends ControllerServiceImplTest {
+
+    private TestingServer zkServer;
+    private CuratorFramework zkClient;
+    private StoreClient storeClient;
+    private StreamMetadataTasks streamMetadataTasks;
+    private StreamRequestHandler streamRequestHandler;
+
+    private ScheduledExecutorService executorService;
+    private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
+    private Cluster cluster;
+    private StreamMetadataStore streamStore;
+
+    @Override
+    public void setup() throws Exception {
+        final HostControllerStore hostStore;
+        final TaskMetadataStore taskMetadataStore;
+        final SegmentHelper segmentHelper;
+        final RequestTracker requestTracker = new RequestTracker(true);
+
+        zkServer = new TestingServerStarter().start();
+        zkServer.start();
+        zkClient = CuratorFrameworkFactory.newClient(zkServer.getConnectString(),
+                new ExponentialBackoffRetry(200, 10, 5000));
+        zkClient.start();
+
+        storeClient = StoreClientFactory.createZKStoreClient(zkClient);
+        executorService = ExecutorServiceHelpers.newScheduledThreadPool(20, "testpool");
+        segmentHelper = SegmentHelperMock.getSegmentHelperMockForTables(executorService);
+        taskMetadataStore = TaskStoreFactory.createStore(storeClient, executorService);
+        hostStore = HostStoreFactory.createInMemoryStore(HostMonitorConfigImpl.dummyConfig());
+        streamStore = StreamStoreFactory.createPravegaTablesStore(segmentHelper, AuthHelper.getDisabledAuthHelper(), 
+                zkClient, executorService);
+        BucketStore bucketStore = StreamStoreFactory.createZKBucketStore(zkClient, executorService);
+
+        streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, taskMetadataStore, segmentHelper,
+                executorService, "host", AuthHelper.getDisabledAuthHelper(), requestTracker);
+        streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, segmentHelper,
+                executorService, "host", AuthHelper.getDisabledAuthHelper());
+        this.streamRequestHandler = new StreamRequestHandler(new AutoScaleTask(streamMetadataTasks, streamStore, executorService),
+                new ScaleOperationTask(streamMetadataTasks, streamStore, executorService),
+                new UpdateStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
+                new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executorService),
+                new DeleteStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
+                new TruncateStreamTask(streamMetadataTasks, streamStore, executorService),
+                streamStore,
+                executorService);
+
+        streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));
+
+        streamTransactionMetadataTasks.initializeStreamWriters(new EventStreamWriterMock<>(), new EventStreamWriterMock<>());
+
+        cluster = new ClusterZKImpl(zkClient, ClusterType.CONTROLLER);
+        final CountDownLatch latch = new CountDownLatch(1);
+        cluster.addListener((type, host) -> latch.countDown());
+        cluster.registerHost(new Host("localhost", 9090, null));
+        latch.await();
+
+        ControllerService controller = new ControllerService(streamStore, streamMetadataTasks,
+                streamTransactionMetadataTasks, segmentHelper, executorService, cluster);
+        controllerService = new ControllerServiceImpl(controller, AuthHelper.getDisabledAuthHelper(), requestTracker, true, 2);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (executorService != null) {
+            ExecutorServiceHelpers.shutdown(executorService);
+        }
+        if (streamMetadataTasks != null) {
+            streamMetadataTasks.close();
+        }
+        if (streamTransactionMetadataTasks != null) {
+            streamTransactionMetadataTasks.close();
+        }
+        streamStore.close();
+        if (cluster != null) {
+            cluster.close();
+        }
+        storeClient.close();
+        zkClient.close();
+        zkServer.close();
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -752,8 +752,8 @@ public abstract class StreamMetadataStoreTest {
         // third transaction created after new epoch created
         txnId = store.generateTransactionId(scope, stream, null, executor).join();
 
-        store.sealTransaction(scope, stream, tx02.getId(), true, Optional.of(tx02.getVersion()), null, executor).get();
-        store.sealTransaction(scope, stream, tx01.getId(), true, Optional.of(tx01.getVersion()), null, executor).get();
+        store.sealTransaction(scope, stream, tx02.getId(), true, Optional.of(tx02.getVersion()), "", Long.MIN_VALUE, null, executor).get();
+        store.sealTransaction(scope, stream, tx01.getId(), true, Optional.of(tx01.getVersion()), "", Long.MIN_VALUE, null, executor).get();
 
         store.scaleSegmentsSealed(scope, stream, scale1SealedSegments.stream().collect(Collectors.toMap(x -> x, x -> 0L)), versioned,
                 null, executor).join();
@@ -799,7 +799,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(store.transactionStatus(scope, stream, tx01.getId(), null, executor).join(), TxnStatus.COMMITTED);
         assertEquals(store.transactionStatus(scope, stream, tx02.getId(), null, executor).join(), TxnStatus.COMMITTED);
         assertEquals(store.transactionStatus(scope, stream, tx03.getId(), null, executor).join(), TxnStatus.OPEN);
-        store.sealTransaction(scope, stream, tx03.getId(), true, Optional.of(tx03.getVersion()), null, executor).get();
+        store.sealTransaction(scope, stream, tx03.getId(), true, Optional.of(tx03.getVersion()), "", Long.MIN_VALUE, null, executor).get();
         // endregion
 
         // region verify migrate request for manual scale
@@ -818,7 +818,7 @@ public abstract class StreamMetadataStoreTest {
                 100, 100, null, executor).get();
         assertEquals(1, tx14.getEpoch());
 
-        store.sealTransaction(scope, stream, tx14.getId(), true, Optional.of(tx14.getVersion()), null, executor).get();
+        store.sealTransaction(scope, stream, tx14.getId(), true, Optional.of(tx14.getVersion()), "", Long.MIN_VALUE, null, executor).get();
 
         // verify that new txns can be created and are created on original epoch
         txnId = store.generateTransactionId(scope, stream, null, executor).join();
@@ -835,7 +835,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(4, activeEpoch.getEpoch());
         assertEquals(4, activeEpoch.getReferenceEpoch());
 
-        store.sealTransaction(scope, stream, tx15.getId(), true, Optional.of(tx15.getVersion()), null, executor).get();
+        store.sealTransaction(scope, stream, tx15.getId(), true, Optional.of(tx15.getVersion()), "", Long.MIN_VALUE, null, executor).get();
 
         record = store.startCommitTransactions(scope, stream, null, executor).join();
         store.setState(scope, stream, State.COMMITTING_TXN, null, executor).get();
@@ -867,7 +867,7 @@ public abstract class StreamMetadataStoreTest {
         UUID txnId = store.generateTransactionId(scope, stream, null, executor).join();
         VersionedTransactionData tx1 = store.createTransaction(scope, stream, txnId,
                 100, 100, null, executor).get();
-        store.sealTransaction(scope, stream, txnId, true, Optional.of(tx1.getVersion()), null, executor).get();
+        store.sealTransaction(scope, stream, txnId, true, Optional.of(tx1.getVersion()), "", Long.MIN_VALUE, null, executor).get();
 
         long scaleTs = System.currentTimeMillis();
         List<Long> scale1SealedSegments = Collections.singletonList(0L);
@@ -949,10 +949,10 @@ public abstract class StreamMetadataStoreTest {
 
         // committing
         store.sealTransaction(scope, stream, tx00, true, Optional.empty(),
-                null, executor).get();
+                "", Long.MIN_VALUE, null, executor).get();
         // aborting
         store.sealTransaction(scope, stream, tx01, false, Optional.empty(),
-                null, executor).get();
+                "", Long.MIN_VALUE, null, executor).get();
 
         PersistentStreamBase streamObj = (PersistentStreamBase) ((AbstractStreamMetadataStore) store).getStream(scope, stream, null);
         // duplicate for tx00
@@ -997,11 +997,11 @@ public abstract class StreamMetadataStoreTest {
                 100, 100, null, executor).get();
         // set all three transactions to committing
         store.sealTransaction(scope, stream, tx10, true, Optional.empty(),
-                null, executor).get();
+                "", Long.MIN_VALUE, null, executor).get();
         store.sealTransaction(scope, stream, tx11, true, Optional.empty(),
-                null, executor).get();
+                "", Long.MIN_VALUE, null, executor).get();
         store.sealTransaction(scope, stream, tx12, true, Optional.empty(),
-                null, executor).get();
+                "", Long.MIN_VALUE, null, executor).get();
         
         // verify that we still get tx00 only 
         orderedRecords = streamObj.getOrderedCommittingTxnInLowestEpoch().join();

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1419,7 +1419,7 @@ public abstract class StreamMetadataStoreTest {
         WriterMark writerMark = store.getWriterMark(scope, stream, writer1, null, executor).join();
         assertTrue(writerMark.isAlive());
 
-        Map<String, WriterMark> marks = store.getAllWritersMarks(scope, stream, null, executor).join();
+        Map<String, WriterMark> marks = store.getAllWriterMarks(scope, stream, null, executor).join();
         assertTrue(marks.containsKey(writer1));
 
         store.shutdownWriter(scope, stream, writer1, null, executor).join();
@@ -1440,7 +1440,7 @@ public abstract class StreamMetadataStoreTest {
         AssertExtensions.assertFutureThrows("", store.getWriterMark(scope, stream, writer1, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
 
-        marks = store.getAllWritersMarks(scope, stream, null, executor).join();
+        marks = store.getAllWriterMarks(scope, stream, null, executor).join();
         assertTrue(marks.isEmpty());
 
         String writer2 = "writer2";
@@ -1450,7 +1450,7 @@ public abstract class StreamMetadataStoreTest {
         String writer4 = "writer4";
         store.noteWriterMark(scope, stream, writer4, 1L, Collections.singletonMap(0L, 1L), null, executor).join();
 
-        marks = store.getAllWritersMarks(scope, stream, null, executor).join();
+        marks = store.getAllWriterMarks(scope, stream, null, executor).join();
         assertFalse(marks.containsKey(writer1));
         assertTrue(marks.containsKey(writer2));
         assertTrue(marks.containsKey(writer3));

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -1463,8 +1463,8 @@ public abstract class StreamTestBase {
         timestamp = 1L;
         position = Collections.singletonMap(0L, 2L);
 
-        stream.noteWriterMark(writer, timestamp, position).join();
-
+        AssertExtensions.assertFutureThrows("Expecting WriteConflict", stream.noteWriterMark(writer, timestamp, position),
+            e -> Exceptions.unwrap(e) instanceof StoreException.WriteConflictException);
     }
 
     @Test(timeout = 30000L)

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -97,7 +97,7 @@ public abstract class StreamTestBase {
     private UUID createAndCommitTransaction(Stream stream, int msb, long lsb) {
         return stream.generateNewTxnId(msb, lsb)
                      .thenCompose(x -> stream.createTransaction(x, 1000L, 1000L))
-                     .thenCompose(y -> stream.sealTransaction(y.getId(), true, Optional.empty())
+                     .thenCompose(y -> stream.sealTransaction(y.getId(), true, Optional.empty(), "", Long.MIN_VALUE)
                                              .thenApply(z -> y.getId())).join();
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -1399,7 +1399,7 @@ public abstract class StreamTestBase {
     public void testWriterMark() {
         PersistentStreamBase stream = spy(createStream("writerMark", "writerMark", System.currentTimeMillis(), 3, 0));
 
-        Map<String, WriterMark> marks = stream.getAllWritersMarks().join();
+        Map<String, WriterMark> marks = stream.getAllWriterMarks().join();
         assertTrue(marks.isEmpty());
 
         // call noteWritermark --> this should call createMarkerRecord
@@ -1410,7 +1410,7 @@ public abstract class StreamTestBase {
 
         stream.noteWriterMark(writer, timestamp, position).join();
 
-        marks = stream.getAllWritersMarks().join();
+        marks = stream.getAllWriterMarks().join();
         assertEquals(marks.size(), 1);
         verify(stream, times(1)).createWriterMarkRecord(writer, timestamp, immutablePos);
 
@@ -1419,7 +1419,7 @@ public abstract class StreamTestBase {
 
         // call noteWritermark --> this should call update
         stream.noteWriterMark(writer, timestamp, position).join();
-        marks = stream.getAllWritersMarks().join();
+        marks = stream.getAllWriterMarks().join();
         assertEquals(marks.size(), 1);
         mark = stream.getWriterMarkRecord(writer).join();
         assertNotEquals(mark.getVersion(), version);
@@ -1441,7 +1441,7 @@ public abstract class StreamTestBase {
 
         // update deleted writer --> data not found
         stream.removeWriter(writer, mark.getObject()).join();
-        marks = stream.getAllWritersMarks().join();
+        marks = stream.getAllWriterMarks().join();
         assertEquals(marks.size(), 0);
         AssertExtensions.assertFutureThrows("", stream.updateWriterMarkRecord(writer, timestamp, immutablePos, true, mark.getVersion()),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -409,7 +409,7 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
     private CompletableFuture<TxnStatus> createAndCommitTxn(UUID txnId, String scope, String stream) {
         return store.createTransaction(scope, stream, txnId, 100, 100, null, executor)
              .thenCompose(x -> store.setState(scope, stream, State.COMMITTING_TXN, null, executor))
-             .thenCompose(x -> store.sealTransaction(scope, stream, txnId, true, Optional.empty(), null, executor))
+             .thenCompose(x -> store.sealTransaction(scope, stream, txnId, true, Optional.empty(), "", Long.MIN_VALUE, null, executor))
              .thenCompose(x -> ((AbstractStreamMetadataStore) store).commitTransaction(scope, stream, txnId, null, executor));
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -462,14 +462,14 @@ public class ZkStreamTest {
                 context, executor).get();
         Assert.assertEquals(txnId2, tx2.getId());
 
-        store.sealTransaction(SCOPE, streamName, tx.getId(), true, Optional.empty(),
+        store.sealTransaction(SCOPE, streamName, tx.getId(), true, Optional.empty(), "", Long.MIN_VALUE,
                 context, executor).get();
         assert store.transactionStatus(SCOPE, streamName, tx.getId(), context, executor)
                 .get().equals(TxnStatus.COMMITTING);
 
         // Test to ensure that sealTransaction is idempotent.
         Assert.assertEquals(TxnStatus.COMMITTING, store.sealTransaction(SCOPE, streamName, tx.getId(), true,
-                Optional.empty(), context, executor).join().getKey());
+                Optional.empty(), "", Long.MIN_VALUE, context, executor).join().getKey());
 
         // Test to ensure that COMMITTING_TXN transaction cannot be aborted.
         testAbortFailure(store, SCOPE, streamName, tx.getEpoch(), tx.getId(), context, operationNotAllowedPredicate);
@@ -479,13 +479,13 @@ public class ZkStreamTest {
         store.setState(SCOPE, streamName, State.ACTIVE, context, executor).join();
 
         store.sealTransaction(SCOPE, streamName, tx2.getId(), false, Optional.empty(),
-                context, executor).get();
+                "", Long.MIN_VALUE, context, executor).get();
         assert store.transactionStatus(SCOPE, streamName, tx2.getId(), context, executor)
                 .get().equals(TxnStatus.ABORTING);
 
         // Test to ensure that sealTransaction is idempotent.
         Assert.assertEquals(TxnStatus.ABORTING, store.sealTransaction(SCOPE, streamName, tx2.getId(), false,
-                Optional.empty(), context, executor).join().getKey());
+                Optional.empty(), "", Long.MIN_VALUE, context, executor).join().getKey());
 
         // Test to ensure that ABORTING transaction cannot be committed.
         testCommitFailure(store, SCOPE, streamName, tx2.getEpoch(), tx2.getId(), context, operationNotAllowedPredicate);
@@ -501,7 +501,7 @@ public class ZkStreamTest {
 
         // Test to ensure that sealTransaction, to commit it, on committed transaction does not throw an error.
         Assert.assertEquals(TxnStatus.COMMITTED, store.sealTransaction(SCOPE, streamName, tx.getId(), true,
-                Optional.empty(), context, executor).join().getKey());
+                Optional.empty(), "", Long.MIN_VALUE, context, executor).join().getKey());
 
         // Test to ensure that commitTransaction is idempotent.
         store.setState(SCOPE, streamName, State.COMMITTING_TXN, context, executor).join();
@@ -514,7 +514,7 @@ public class ZkStreamTest {
 
         // Test to ensure that sealTransaction, to abort it, on aborted transaction does not throw an error.
         Assert.assertEquals(TxnStatus.ABORTED, store.sealTransaction(SCOPE, streamName, tx2.getId(), false,
-                Optional.empty(), context, executor).join().getKey());
+                Optional.empty(), "", Long.MIN_VALUE, context, executor).join().getKey());
 
         // Test to ensure that abortTransaction is idempotent.
         Assert.assertEquals(TxnStatus.ABORTED,
@@ -647,7 +647,7 @@ public class ZkStreamTest {
                                    OperationContext context,
                                    Predicate<Throwable> checker) {
         AssertExtensions.assertSuppliedFutureThrows("Seal txn to commit it failure",
-                () -> store.sealTransaction(scope, stream, txnId, true, Optional.empty(), context, executor),
+                () -> store.sealTransaction(scope, stream, txnId, true, Optional.empty(), "", Long.MIN_VALUE, context, executor),
                 checker);
 
         AssertExtensions.assertSuppliedFutureThrows("Commit txn failure",
@@ -659,7 +659,7 @@ public class ZkStreamTest {
                                   OperationContext context,
                                   Predicate<Throwable> checker) {
         AssertExtensions.assertSuppliedFutureThrows("Seal txn to abort it failure",
-                () -> store.sealTransaction(scope, stream, txnId, false, Optional.empty(), context, executor),
+                () -> store.sealTransaction(scope, stream, txnId, false, Optional.empty(), "", Long.MIN_VALUE, context, executor),
                 checker);
 
         AssertExtensions.assertSuppliedFutureThrows("Abort txn failure",

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -960,7 +960,8 @@ public abstract class StreamMetadataTasksTest {
                 .get().getKey();
 
         // set transaction to committing
-        streamStorePartialMock.sealTransaction(SCOPE, streamWithTxn, committingTxn.getId(), true, Optional.empty(), null, executor).join();
+        streamStorePartialMock.sealTransaction(SCOPE, streamWithTxn, committingTxn.getId(), true, Optional.empty(), 
+                "", Long.MIN_VALUE, null, executor).join();
 
         // Mock getActiveTransactions call such that we return committing txn as OPEN txn.
         Map<UUID, ActiveTxnRecord> activeTxns = streamStorePartialMock.getActiveTxns(SCOPE, streamWithTxn, null, executor).join();

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -296,12 +296,12 @@ public class StreamTransactionMetadataTasksTest {
 
         // Change state of one txn to COMMITTING.
         TxnStatus txnStatus2 = streamStore.sealTransaction(SCOPE, STREAM, tx2.getId(), true, Optional.empty(),
-                null, executor).thenApply(AbstractMap.SimpleEntry::getKey).join();
+                "", Long.MIN_VALUE, null, executor).thenApply(AbstractMap.SimpleEntry::getKey).join();
         Assert.assertEquals(TxnStatus.COMMITTING, txnStatus2);
 
         // Change state of another txn to ABORTING.
         TxnStatus txnStatus3 = streamStore.sealTransaction(SCOPE, STREAM, tx3.getId(), false, Optional.empty(),
-                null, executor).thenApply(AbstractMap.SimpleEntry::getKey).join();
+                "", Long.MIN_VALUE, null, executor).thenApply(AbstractMap.SimpleEntry::getKey).join();
         Assert.assertEquals(TxnStatus.ABORTING, txnStatus3);
 
         // Create transaction tasks for sweeping txns from failedHost.

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -40,7 +40,7 @@ service ControllerService {
     rpc listStreamsInScope(StreamsInScopeRequest) returns (StreamsInScopeResponse);
     rpc deleteScope(ScopeInfo) returns (DeleteScopeStatus);
     rpc getDelegationToken(StreamInfo) returns (DelegationToken);
-    rpc writerShutdown(WriterShutdownRequest) returns (WriterShutdownResponse);
+    rpc removeWriter(RemoveWriterRequest) returns (RemoveWriterResponse);
     rpc noteTimestampFromWriter(TimestampFromWriter) returns (TimestampResponse);
 }
 
@@ -329,12 +329,12 @@ message DelegationToken {
     string delegationToken = 1;
 }
 
-message WriterShutdownRequest {
+message RemoveWriterRequest {
     string writer = 1;
     StreamInfo stream = 2;
 }
 
-message WriterShutdownResponse {
+message RemoveWriterResponse {
     enum Status {
         SUCCESS = 0;
         UNKNOWN_WRITER = 1;

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -102,7 +102,6 @@ public class EndToEndTransactionOrderTest {
 
         controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), port);
         controller = controllerWrapper.getController();
-        controllerWrapper.getControllerService().createScope(NameUtils.INTERNAL_SCOPE_NAME).get();
 
         connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
 
@@ -112,6 +111,8 @@ public class EndToEndTransactionOrderTest {
         serviceBuilder.initialize();
         StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
         TableStore tableStore = serviceBuilder.createTableStoreService();
+
+        controllerWrapper.getControllerService().createScope(NameUtils.INTERNAL_SCOPE_NAME).get();
 
         autoScaleMonitor = new AutoScaleMonitor(store,
                 internalCF,


### PR DESCRIPTION
**Change log description**  
Controller grpc api implementation and metadata support for watermarking. 

**Purpose of the change**  
Fixes  #3670 

**What the code does** 
This PR adds an implementation for grpc apis `noteTimeForWriter` and `removeWriter`.  Also, it updates `commitTxn` api to take writerId, time and position. 

We have added new metadata for the writer mark. For PravegaTables, the writer mark for a stream go into a new table called `_system/_tables/stream/WritersMarkTable.#<id>`.

The key is `writerId` and the value is the mark for the writer with `writerId`. The writer mark is a new metadata record type that is introduced in this change set. It has the timestamp and the position of the writer. 

The writer mark can be updated via explicit request from the writer or during a transaction commit. 
For transaction commits, whenever we merge a transaction segment into its parent segment, we record the segment offset after the merge completes. The segment offset is stored in the metadata record of the active transaction. 

When all transactions in a batch are merged and before marking transactions as committed, we report marks for each transaction where its record contains commit offsets, then it invokes `store.noteTimeForWriter(writerId, time, commitOffsets)`. 

It is important to note that it is possible that a writer calls `removeWriter`, and that there are attempts to `noteTimeForWriter` after the writer is removed. This situation can arise in at least two ways:

1-  Writer calls `noteTimeForWriter` explicitly, in which case we will create a new record.
2- Transaction commits after remove-writer call completes.  

We do not handle this in any special way and let the marks be reported for writers. 

The responsibility for removing stale writers from known writers set will lie with watermarking periodic workflow implementation and will be tackled in a subsequent PR. 

**How to verify it**  
New unit tests added to test new metadata records. 