### PR TITLE
Issue 3747: Always explicitly flush data AND metadata to device after each write.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -320,7 +320,8 @@ public class FileSystemStorage implements SyncStorage {
                 totalBytesWritten += bytesWritten;
                 length -= bytesWritten;
             }
-            channel.force(false);
+            // Wait for data and file metadata to be flushed to storage device.
+            channel.force(true);
         }
         FileSystemMetrics.WRITE_LATENCY.reportSuccessEvent(timer.getElapsed());
         FileSystemMetrics.WRITE_BYTES.add(totalBytesWritten);
@@ -378,7 +379,8 @@ public class FileSystemStorage implements SyncStorage {
                 offset += bytesTransferred;
                 length -= bytesTransferred;
             }
-            targetChannel.force(false);
+            // Wait for data and file metadata to be flushed to storage device.
+            targetChannel.force(true);
             Files.delete(sourcePath);
             LoggerHelpers.traceLeave(log, "concat", traceId);
             return null;


### PR DESCRIPTION


**Change log description**  
FileSystemStorage: Always explicitly flush data AND metadata to device after each write.

**Purpose of the change**  
Related to https://github.com/pravega/pravega/issues/3747

**What is problem/why we need change?**  

- Recently we added FileChannel.force(false); call to FileSystemStorage to flush the data to storage device after each tier-2 write to make sure data is actually persisted to disk before confirming write to segment store. This avoids data loss during system crash and offset mismatch/miscalculations in segment store after restart. 
- When boolean parameter to FileChannel.force is false, only data is flushed by calling underlying **fdatasync()** API. However in reality based on the description of  [fdatasync()](http://man7.org/linux/man-pages/man2/fdatasync.2.html ). It _actually also flushes modified metadata when that metadata is needed in order to allow a subsequent data retrieval to be correctly handled_
- **Note that this is exactly the behavior we wanted and we are expecting**. With append only writes whenever data is written to the to file, it also increases the file size and updates the file size on inode. Thus requiring _both file size metadata and data itself flushed to the device_. The aim of fdatasync() instead of fsync() is to reduce disk activity for applications that do not require all metadata to be synchronized with the disk.

- The segment store nfs tier 2 is mounted through [nfs-client-provisioner] which is a user level kubernetes storage provider/driver (https://github.com/helm/charts/tree/master/stable/nfs-client-provisioner)
- _While we are confident about Linux kernel and isilon nfs implementing intended/expected force semantics_, **we are not sure k8s actually correctly implements this behavior.**
- We have observed instances file size and data mismatch with longevity tests.
- We want to eliminate the ambiguity and always explicitly flush data AND metadata to device after each write.

**What the code does**  
calls FileChannel.force(true); To always explicitly flush data AND metadata to device after each write.

**How to verify it**  
System tests should pass. 


**Reference**
http://man7.org/linux/man-pages/man2/fdatasync.2.html

>  **fdatasync() is similar to fsync(), but does not flush modified
>        metadata unless that metadata is needed in order to allow a
>        subsequent data retrieval to be correctly handled.**  For example,
>        changes to st_atime or st_mtime (respectively, time of last access
>        and time of last modification; see inode(7)) do not require flushing
>        because they are not necessary for a subsequent data read to be
>        handled correctly.  **On the other hand, a change to the file size
>        (st_size, as made by say ftruncate(2)), would require a metadata
>        flush.**
> 