### PR TITLE
Issue 3768: Increase timeout for pod/task-pv-pod creation

### DIFF
--- a/test/system/kubernetes/setupTestPod.sh
+++ b/test/system/kubernetes/setupTestPod.sh
@@ -92,7 +92,7 @@ spec:
         - mountPath: "/data"
           name: task-pv-storage
 EOF
-kubectl wait --for=condition=Ready pod/task-pv-pod
+kubectl wait --timeout=1m --for=condition=Ready pod/task-pv-pod
 
 #Step 7: Compute the checksum of the local test artifact and the artifact on the persistent volume. Copy test artifact only if required.
 checksum="$(kubectl exec task-pv-pod md5sum '/data/test-collection.jar' | awk '{ print $1 }' || true)"


### PR DESCRIPTION


**Change log description**  
- Increase timeout for test pod (`pod/task-pv-pod`) creation from 30 seconds (default value) to 1 minute

**Purpose of the change**  
Fix #3768 

**What the code does**  
Applies the changes to the `test/system/kubernetes/setupTestPod.sh` script.

**How to verify it**  
System test should pass consistently. 

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>