### PR TITLE
Issue 3781: VersionedSerializer support for Compacted Signed Longs

### DIFF
--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
@@ -11,7 +11,6 @@ package io.pravega.common.io.serialization;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
-
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,8 +23,9 @@ import java.util.function.Supplier;
 /**
  * Extension to DataInput that adds support for a few new constructs. An instance of RevisionDataInput is created for each
  * Serialization Revision and closed when that Revision's serialization is fully consumed - it is not shared between multiple revisions.
- * <p>
- * This interface is designed to be used to consume data serialized using RevisionDataOutput.
+ *
+ * This interface is designed to be used to consume data serialized using {@link RevisionDataOutput}.
+ *
  */
 public interface RevisionDataInput extends DataInput {
     /**
@@ -36,36 +36,49 @@ public interface RevisionDataInput extends DataInput {
     InputStream getBaseStream();
 
     /**
-     * Decodes a Long that has been serialized using RevisionDataOutput.writeCompactLong(). After this method is complete,
+     * Decodes a Long that has been serialized using {@link RevisionDataOutput#writeCompactLong}. After this method is complete,
      * the underlying InputStream may have advanced by 1, 2, 4, or 8 bytes.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeCompactLong(). It may throw a SerializationException (after reading 1 byte) or it may produce
+     * {@link RevisionDataOutput#writeCompactLong}. It may throw a SerializationException (after reading 1 byte) or it may produce
      * a result that is not as expected.
      *
-     * @return The decoded compact Long. This number should be between 0 and 2^62-1, inclusive.
+     * @return The decoded compact Long. This number should be in the interval [0, 2^62).
      * @throws IOException If an IO Exception occurred.
      */
     long readCompactLong() throws IOException;
 
     /**
-     * Decodes an Integer that has been serialized using RevisionDataOutput.writeCompactInt(). After this method is complete,
+     * Decodes a Long that has been serialized using {@link RevisionDataOutput#writeCompactSignedLong}. After this method
+     * is complete, the underlying InputStream may have advanced by 1, 2, 4, or 8 bytes.
+     *
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * {@link RevisionDataOutput#writeCompactSignedLong}. It may throw a SerializationException (after reading 1 byte) or
+     * it may produce a result that is not as expected.
+     *
+     * @return The decoded compact signed Long. This number should be in the interval [-2^61, 2^61).
+     * @throws IOException If an IO Exception occurred.
+     */
+    long readCompactSignedLong() throws IOException;
+
+    /**
+     * Decodes an Integer that has been serialized using {@link RevisionDataOutput#writeCompactInt}. After this method is complete,
      * the underlying InputStream may have advanced by 1, 2, 3, or 4 bytes.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
      * RevisionDataOutput.writeCompactInt(). It may throw a SerializationException (after reading 1 byte) or it may produce
      * a result that is not as expected.
      *
-     * @return The decoded compact Long. This number should be between 0 and 2^30-1, inclusive.
+     * @return The decoded compact Integer. This number should be in the interval [0, 2^30).
      * @throws IOException If an IO Exception occurred.
      */
     int readCompactInt() throws IOException;
 
     /**
-     * Decodes a UUID that has been serialized using RevisionDataOutput.writeUUID().
+     * Decodes a UUID that has been serialized using {@link RevisionDataOutput#writeUUID}.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeUUID().
+     * {@link RevisionDataOutput#writeUUID}.
      *
      * @return A new UUID.
      * @throws IOException If an IO Exception occurred.
@@ -73,99 +86,103 @@ public interface RevisionDataInput extends DataInput {
     UUID readUUID() throws IOException;
 
     /**
-     * Decodes a generic Collection that has been serialized using RevisionDataOutput.writeCollection(). The underlying type
+     * Decodes a generic Collection that has been serialized using {@link RevisionDataOutput#writeCollection}. The underlying type
      * of the collection will be an ArrayList. Should a different type of Collection be desired, consider using the appropriate
      * overload of this method.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeCollection().
+     * {@link RevisionDataOutput#writeCollection}.
      *
      * @param elementDeserializer A Function that will decode a single element of the Collection from the given RevisionDataInput.
      * @param <T>                 Type of the elements in the Collection.
-     * @return A new Collection. If the original collection passed to RevisionDataOutput.writeCollection() was null, this
+     * @return A new Collection. If the original collection passed to {@link RevisionDataOutput#writeCollection} was null, this
      * will return an empty collection.
      * @throws IOException If an IO Exception occurred.
      */
     <T> Collection<T> readCollection(ElementDeserializer<T> elementDeserializer) throws IOException;
 
     /**
-     * Decodes a specific Collection that has been serialized using RevisionDataOutput.writeCollection().
+     * Decodes a specific Collection that has been serialized using {@link RevisionDataOutput#writeCollection}.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeCollection().
+     * {@link RevisionDataOutput#writeCollection}.
      *
      * @param elementDeserializer A Function that will decode a single element of the Collection from the given RevisionDataInput.
      * @param newCollection       A Supplier that will create a new instance of the Collection type desired.
      * @param <T>                 Type of the elements in the Collection.
      * @param <C>                 Type of the Collection desired to be instantiated and returned.
-     * @return A new Collection. If the original Collection passed to RevisionDataOutput.writeCollection() was null, this
+     * @return A new Collection. If the original Collection passed to {@link RevisionDataOutput#writeCollection} was null, this
      * will return an empty collection.
      * @throws IOException If an IO Exception occurred.
      */
     <T, C extends Collection<T>> C readCollection(ElementDeserializer<T> elementDeserializer, Supplier<C> newCollection) throws IOException;
 
     /**
-     * Decodes a specific Collection that has been serialized using RevisionDataOutput.writeCollection().
+     * Decodes a specific Collection that has been serialized using {@link RevisionDataOutput#writeCollection}.
      * It populates the supplied builder with the deserialized collection elements. 
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeCollection().
+     * {@link RevisionDataOutput#writeCollection}.
      *
-     * @param elementDeserializer A Function that will decode a single element of the Collection from the given RevisionDataInput.
-     * @param newCollectionBuilder A Builder that will create a new instance of the ImmutableCollection of desired type.
-     * @param <T>                 Type of the elements in the Collection.
-     * @param <C>                 Type of the Collection whose builder needs to be populated.
+     * @param elementDeserializer  A Function that will decode a single element of the Collection from the given RevisionDataInput.
+     * @param newCollectionBuilder A {@link ImmutableCollection.Builder} that will create a new instance of the
+     *                             {@link ImmutableCollection} of desired type.
+     * @param <T>                  Type of the elements in the Collection.
+     * @param <C>                  Type of the Collection whose builder needs to be populated.
      * @throws IOException If an IO Exception occurred.
      */
     <T, C extends ImmutableCollection<T>> void readCollection(
             ElementDeserializer<T> elementDeserializer, C.Builder<T> newCollectionBuilder) throws IOException;
-    
+
     /**
-     * Decodes a specific array that has been serialized using RevisionDataOutput.writeArray(T[], ElementSerializer).
+     * Decodes a specific array that has been serialized using
+     * {@link RevisionDataOutput#writeArray(Object[], RevisionDataOutput.ElementSerializer)}.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeArray(T[], ElementSerializer).
+     * {@link RevisionDataOutput#writeArray(Object[], RevisionDataOutput.ElementSerializer)}.
      *
      * @param elementDeserializer A Function that will decode a single element of the Collection from the given RevisionDataInput.
      * @param newArray            A Function that will create a new instance of the array type desired, with the specified length.
      * @param <T>                 Type of the elements in the array.
-     * @return A new array. If the original array passed to RevisionDataOutput.writeArray() was null, this
+     * @return A new array. If the original array passed to {@link RevisionDataOutput#writeArray} was null, this
      * will return an empty array.
      * @throws IOException If an IO Exception occurred.
      */
     <T> T[] readArray(ElementDeserializer<T> elementDeserializer, IntFunction<T[]> newArray) throws IOException;
 
     /**
-     * Decodes a byte array that has been serialized using RevisionDataOutput.writeArray(byte[]).
+     * Decodes a byte array that has been serialized using {@link RevisionDataOutput#writeArray(byte[])}.
      *
      * This method has undefined behavior if the data starting at the current position was not encoded using
-     * RevisionDataOutput.writeArray(byte[]).
+     * {@link RevisionDataOutput#writeArray(byte[])}.
      *
-     * @return A new byte array. If the original array passed to RevisionDataOutput.writeArray(byte[]) was null, this
+     * @return A new byte array. If the original array passed to {@link RevisionDataOutput#writeArray(byte[])} was null, this
      * will return an empty array.
      * @throws IOException If an IO Exception occurred.
      */
     byte[] readArray() throws IOException;
 
     /**
-     * Decodes a generic Map that has been serialized using RevisionDataOutput.writeMap(). The underlying type of the map
+     * Decodes a generic Map that has been serialized using {@link RevisionDataOutput#writeMap}. The underlying type of the map
      * will be a HashMap. Should a different type of Map be desired, consider using the appropriate overload of this method.
      *
-     * This method has undefined behavior if the data starting at the current position was not encoded using RevisionDataOutput.writeMap().
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * {@link RevisionDataOutput#writeMap}.
      *
      * @param keyDeserializer   A Function that will decode a single Key of the Map from the given RevisionDataInput.
      * @param valueDeserializer A Function that will decode a single Value of the Map from the given RevisionDataInput.
      * @param <K>               Type of the Keys in the Map.
      * @param <V>               Type of the Values in the Map.
-     * @return A new Map. If the original Map passed to RevisionDataOutput.writeMap() was null, this will return an empty map.
+     * @return A new Map. If the original Map passed to {@link RevisionDataOutput#writeMap} was null, this will return an empty map.
      * @throws IOException If an IOException occurred.
      */
     <K, V> Map<K, V> readMap(ElementDeserializer<K> keyDeserializer, ElementDeserializer<V> valueDeserializer) throws IOException;
 
     /**
-     * Decodes a specific Map that has been serialized using RevisionDataOutput.writeMap().
+     * Decodes a specific Map that has been serialized using {@link RevisionDataOutput#writeMap}.
      *
-     * This method has undefined behavior if the data starting at the current position was not encoded using RevisionDataOutput.writeMap().
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * {@link RevisionDataOutput#writeMap}.
      *
      * @param keyDeserializer   A Function that will decode a single Key of the Map from the given RevisionDataInput.
      * @param valueDeserializer A Function that will decode a single Value of the Map from the given RevisionDataInput.
@@ -173,20 +190,22 @@ public interface RevisionDataInput extends DataInput {
      * @param <K>               Type of the Keys in the Map.
      * @param <V>               Type of the Values in the Map.
      * @param <M>               Type of the Map desired to be instantiated and returned.
-     * @return A new Map. If the original Map passed to RevisionDataOutput.writeMap() was null, this will return an empty map.
+     * @return A new Map. If the original Map passed to {@link RevisionDataOutput#writeMap} was null, this will return an empty map.
      * @throws IOException If an IOException occurred.
      */
     <K, V, M extends Map<K, V>> M readMap(ElementDeserializer<K> keyDeserializer, ElementDeserializer<V> valueDeserializer, Supplier<M> newMap) throws IOException;
 
     /**
-     * Decodes a specific Map that has been serialized using RevisionDataOutput.writeMap() and populates the supplied 
+     * Decodes a specific Map that has been serialized using {@link RevisionDataOutput#writeMap} and populates the supplied
      * ImmutableMap builder and builds the immutable map. 
      *
-     * This method has undefined behavior if the data starting at the current position was not encoded using RevisionDataOutput.writeMap().
+     * This method has undefined behavior if the data starting at the current position was not encoded using
+     * {@link RevisionDataOutput#writeMap}.
      *
      * @param keyDeserializer   A Function that will decode a single Key of the Map from the given RevisionDataInput.
      * @param valueDeserializer A Function that will decode a single Value of the Map from the given RevisionDataInput.
-     * @param newMapBuilder     An ImmutableMapBuilder that will create a new instance of the ImmutableMap type desired.
+     * @param newMapBuilder     An {@link ImmutableMap.Builder} that will create a new instance of the {@link ImmutableMap}
+     *                          type desired.
      * @param <K>               Type of the Keys in the Map.
      * @param <V>               Type of the Values in the Map.
      * @param <M>               Type of Map whose builder needs to be populated. 

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
@@ -150,7 +150,7 @@ class RevisionDataInputStream extends DataInputStream implements RevisionDataInp
                         "Unable to deserialize compact signed long. Unrecognized header value %d.", header));
         }
 
-        if (value >= RevisionDataOutput.COMPACT_SIGNED_LONG_MAX) {
+        if (value > RevisionDataOutput.COMPACT_SIGNED_LONG_MAX) {
             throw new SerializationException(String.format(
                     "Unable to deserialize compact signed long. Resulting value (%d) is outside of permissible bounds.",
                     negative ? RevisionDataOutputStream.negateSignedNumber(value) : value));

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
@@ -15,7 +15,6 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.io.SerializationException;
 import io.pravega.common.util.BitConverter;
-
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,8 +28,8 @@ import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A DataInputStream that is used for deserializing Serialization Revisions. Instances of this class should be used to
- * read data that was serialized using an instance of RevisionDataOutput (i.e., NonSeekableRevisionDataOutput or
+ * A [@link DataInputStream} that is used for deserializing Serialization Revisions. Instances of this class should be used to
+ * read data that was serialized using an instance of {@link RevisionDataOutput} (i.e., NonSeekableRevisionDataOutput or
  * RandomRevisionDataOutput).
  */
 @NotThreadSafe
@@ -106,6 +105,58 @@ class RevisionDataInputStream extends DataInputStream implements RevisionDataInp
                 throw new SerializationException(String.format(
                         "Unable to deserialize compact long. Unrecognized header value %d.", header));
         }
+    }
+
+    @Override
+    public long readCompactSignedLong() throws IOException {
+        // This uses the DataInput APIs, which will handle throwing EOFExceptions for us, so we don't need to do any more checking.
+        // Read first byte and determine how many other bytes are used.
+        long b1 = readUnsignedByte();
+        int header = (byte) (b1 >>> 5);
+        b1 &= 0x1F;
+
+        // Determine if negative.
+        boolean negative = (header & 0x4) == 0x4;
+        if (negative) {
+            // Clear the first bit.
+            header &= 0x3;
+        }
+
+        long value;
+        switch (header) {
+            case 0:
+                // Only this byte.
+                value = b1;
+                break;
+            case 1:
+                // 2 bytes
+                value = (b1 << 8) + readUnsignedByte();
+                break;
+            case 2:
+                // 4 bytes
+                value = (b1 << 24)
+                        + ((long) readUnsignedByte() << 16)
+                        + readUnsignedShort();
+                break;
+            case 3:
+                // All 8 bytes
+                value = (b1 << 56)
+                        + ((long) readUnsignedByte() << 48)
+                        + ((long) readUnsignedShort() << 32)
+                        + (readInt() & 0xFFFF_FFFFL);
+                break;
+            default:
+                throw new SerializationException(String.format(
+                        "Unable to deserialize compact signed long. Unrecognized header value %d.", header));
+        }
+
+        if (value >= RevisionDataOutput.COMPACT_SIGNED_LONG_MAX) {
+            throw new SerializationException(String.format(
+                    "Unable to deserialize compact signed long. Resulting value (%d) is outside of permissible bounds.",
+                    negative ? RevisionDataOutputStream.negateSignedNumber(value) : value));
+        }
+
+        return negative ? RevisionDataOutputStream.negateSignedNumber(value) : value;
     }
 
     @Override

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -10,6 +10,7 @@
 package io.pravega.common.io.serialization;
 
 import io.pravega.common.util.ByteArraySegment;
+import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -23,26 +24,36 @@ import java.util.function.ToIntFunction;
  * An instance of a RevisionDataOutput is created for each Serialization Revision and closed when that Revision's serialization
  * is done - it is not shared between multiple revisions.
  *
- * This interface is designed to serialize data that can be consumed using RevisionDataInput.
+ * This interface is designed to serialize data that can be consumed using {@link RevisionDataInput}.
  */
 public interface RevisionDataOutput extends DataOutput {
     /**
-     * Maximum value that can be encoded using writeCompactLong().
+     * Maximum value that can be encoded using {@link #writeCompactLong).
      */
     long COMPACT_LONG_MAX = 0x3FFF_FFFF_FFFF_FFFFL;
 
     /**
-     * Minimum value that can be encoded using writeCompactLong().
+     * Minimum value that can be encoded using {@link #writeCompactLong}.
      */
     long COMPACT_LONG_MIN = 0L;
 
     /**
-     * Maximum value that can be encoded using writeCompactInt().
+     * Maximum value that can be encoded using {@link #writeCompactSignedLong}.
+     */
+    long COMPACT_SIGNED_LONG_MAX = 0x1FFF_FFFF_FFFF_FFFFL;
+
+    /**
+     * Minimum value that can be encoded using {@link #writeCompactSignedLong}.
+     */
+    long COMPACT_SIGNED_LONG_MIN = -0x1FFF_FFFF_FFFF_FFFFL;
+
+    /**
+     * Maximum value that can be encoded using {@link #writeCompactInt}.
      */
     int COMPACT_INT_MAX = 0x3FFF_FFFF;
 
     /**
-     * Minimum value that can be encoded using writeCompactInt().
+     * Minimum value that can be encoded using {@link #writeCompactInt}.
      */
     int COMPACT_INT_MIN = 0;
 
@@ -52,7 +63,7 @@ public interface RevisionDataOutput extends DataOutput {
     int UUID_BYTES = 2 * Long.BYTES;
 
     /**
-     * Gets a value indicating whether this instance of a RevisionDataOutput requires length() to be called prior to writing
+     * Gets a value indicating whether this instance of a RevisionDataOutput requires {@link #length) to be called prior to writing
      * anything to it.
      *
      * @return True if Length must be declared beforehand (by invoking length()) or not.
@@ -60,10 +71,10 @@ public interface RevisionDataOutput extends DataOutput {
     boolean requiresExplicitLength();
 
     /**
-     * If requiresExplicitLength() == true, this method will write 4 bytes at the current position representing the expected
+     * If {@link #requiresExplicitLength} == true, this method will write 4 bytes at the current position representing the expected
      * serialization length (via the argument). In this case, this method must be called prior to invoking any write method
      * on this object.
-     * If requiresExplicitLength() == false, this method will have no effect, since the length can be auto-calculated when
+     * If {@link #requiresExplicitLength} == false, this method will have no effect, since the length can be auto-calculated when
      * the RevisionDataOutput is closed.
      *
      * @param length The length to declare.
@@ -79,64 +90,89 @@ public interface RevisionDataOutput extends DataOutput {
     OutputStream getBaseStream();
 
     /**
-     * Calculates the length, in bytes, of the given String as serialized by using writeUTF(). Invoking this method will
+     * Calculates the length, in bytes, of the given String as serialized by using {@link #writeUTF}. Invoking this method will
      * not actually write the String.
      *
      * @param s The string to measure.
-     * @return The writeUTF() length of the String. Note that this may be different from s.length().
+     * @return The {@link #writeUTF} length of the String. Note that this may be different from s.length().
      */
     int getUTFLength(String s);
 
     /**
-     * Calculates the length, in bytes, of the given Long as serialized by using writeCompactLong(). Invoking this method
+     * Calculates the length, in bytes, of the given Long as serialized by using {@link #writeCompactLong}. Invoking this method
      * will not actually write the value.
      *
      * @param value The value to measure.
-     * @return The writeCompactLong() length of the value. This is a value between 1 and Long.BYTES (inclusive).
-     * @throws IllegalArgumentException If value is negative or greater than 2^62-1.
+     * @return The {@link #writeCompactLong} length of the value. This is a value between 1 and {@link Long#BYTES} (inclusive).
+     * @throws IllegalArgumentException If value is not in the interval [0, 2^62).
      */
     int getCompactLongLength(long value);
 
     /**
      * Encodes the given Long into a compact serialization of 1, 2, 4 or 8 bytes. The actual number of bytes can be
-     * calculated using getCompactLongLength(). The first two bits of the given value are ignored and will be reserved
+     * calculated using {@link #getCompactLongLength}. The first two bits of the given value are ignored and will be reserved
      * for serialization, hence this can only serialize values in the interval [0, 2^62).
-     * <p>
-     * This value must be read using RevisionDataInput.readCompactLong(). It cannot be read using DataInput.readLong().
+     *
+     * This value must be read using {@link RevisionDataInput#readCompactLong}. It cannot be read using {@link DataInput#readLong}
+     * or using {@link RevisionDataInput#readCompactSignedLong}.
      *
      * @param value The value to serialize.
      * @throws IOException              If an IO Exception occurred.
-     * @throws IllegalArgumentException If value is negative or greater than 2^62-1.
+     * @throws IllegalArgumentException If value is not in the interval [0, 2^62).
      */
     void writeCompactLong(long value) throws IOException;
 
     /**
-     * Calculates the length, in bytes, of the given Integer as serialized by using writeCompactInt(). Invoking this method
-     * will not actually write the value. The first two bits of the given value are ignored and will be reserved
-     * for serialization, hence this can only serialize values in the interval [0, 2^30).
+     * Calculates the length, in bytes, of the given signed Long as serialized by using {@link #writeCompactSignedLong}.
+     * Invoking this method will not actually write the value.
      *
      * @param value The value to measure.
-     * @return The writeCompactInt() length of the value. This is a value between 1 and Integer.BYTES (inclusive).
-     * @throws IllegalArgumentException If value is negative or greater than 2^30-1.
+     * @return The {@link #writeCompactSignedLong} length of the value. This is a value between 1 and {@link Long#BYTES} (inclusive).
+     * @throws IllegalArgumentException If value is not in the interval [-2^61, 2^61).
+     */
+    int getCompactSignedLongLength(long value);
+
+    /**
+     * Encodes the given signed Long into a compact serialization of 1, 2, 4 or 8 bytes. The actual number of bytes can be
+     * calculated using {@link #getCompactSignedLongLength}. The first three bits of the given value are ignored and will
+     * be reserved for serialization, hence this can only serialize values in the interval [-2^61, 2^61).
+     * <p>
+     * This value must be read using {@link RevisionDataInput#readCompactSignedLong}. It cannot be read using
+     * {@link DataInput#readLong} or using {@link RevisionDataInput#readCompactLong}.
+     *
+     * @param value The value to serialize.
+     * @throws IOException              If an IO Exception occurred.
+     * @throws IllegalArgumentException If value is not in the interval [-2^61, 2^61).
+     */
+    void writeCompactSignedLong(long value) throws IOException;
+
+    /**
+     * Calculates the length, in bytes, of the given Integer as serialized by using {@link #writeCompactInt}. Invoking this method
+     * will not actually write the value.
+     *
+     * @param value The value to measure.
+     * @return The {@link #writeCompactInt} length of the value. This is a value between 1 and {@link Integer#BYTES} (inclusive).
+     * @throws IllegalArgumentException If value is not in the interval [0, 2^30).
      */
     int getCompactIntLength(int value);
 
     /**
      * Encodes the given Integer into a compact serialization of 1, 2, 3 or 4 bytes. The actual number of bytes can be
-     * calculated using getCompactIntLength().
-     * <p>
-     * This value must be read using RevisionDataInput.readCompactInt(). It cannot be read using DataInput.readInt().
+     * calculated using {@link #getCompactIntLength}. The first two bits of the given value are ignored and will be reserved
+     * or serialization, hence this can only serialize values in the interval [0, 2^30).
+     *
+     * This value must be read using {@link RevisionDataInput#readCompactInt}. It cannot be read using {@link DataInput#readInt}.
      *
      * @param value The value to serialize.
      * @throws IOException              If an IO Exception occurred.
-     * @throws IllegalArgumentException If value is negative or greater than 2^60-1.
+     * @throws IllegalArgumentException If value is not in the interval [0, 2^30).
      */
     void writeCompactInt(int value) throws IOException;
 
     /**
      * Serializes the given UUID as two consecutive Long values.
-     * <p>
-     * This value must be read using RevisionDataInput.readUUID().
+     *
+     * This value must be read using {@link RevisionDataInput#readUUID}.
      *
      * @param uuid The UUID to serialize.
      * @throws IOException If an IO Exception occurred.
@@ -145,7 +181,7 @@ public interface RevisionDataOutput extends DataOutput {
 
     /**
      * Calculates the number of bytes required to serialize a Collection or array. This method can be used to estimate the
-     * serialization length of both writeCollection() and writeArray().
+     * serialization length of both {@link #writeCollection} and {@link #writeArray}.
      *
      * @param elementCount  The size of the collection.
      * @param elementLength The size (in bytes) of each element's serialization.
@@ -155,7 +191,7 @@ public interface RevisionDataOutput extends DataOutput {
 
     /**
      * Calculates the number of bytes required to serialize a Collection. This method can be used to estimate the
-     * serialization length of writeCollection().
+     * serialization length of {@link #writeCollection}.
      *
      * @param collection            The Collection to measure.
      * @param elementLengthProvider A Function that, given an Element of type T, will return its serialization length.
@@ -166,7 +202,7 @@ public interface RevisionDataOutput extends DataOutput {
 
     /**
      * Calculates the number of bytes required to serialize an array. This method can be used to estimate the
-     * serialization length of writeArray().
+     * serialization length of {@link #writeArray}.
      *
      * @param array                 The array to measure.
      * @param elementLengthProvider A Function that, given an Element of type T, will return its serialization length.
@@ -176,36 +212,36 @@ public interface RevisionDataOutput extends DataOutput {
     <T> int getCollectionLength(T[] array, ToIntFunction<T> elementLengthProvider);
 
     /**
-     * Serializes the given Collection using the given ElementSerializer. It first writes a Compact Integer representing
+     * Serializes the given Collection using the given {@link ElementSerializer}. It first writes a Compact Integer representing
      * the number of elements in the collection, followed by each element's serialization, in the same order as returned
      * by the Collection's iterator.
      *
      * @param collection        The Collection to serialize. Can be null (in which case an Empty Collection will be deserialized
-     *                          by RevisionDataInput.readCollection()).
-     * @param elementSerializer A Function that serializes a single element of the collection to a RevisionDataOutput.
+     *                          by {@link RevisionDataInput#readCollection}).
+     * @param elementSerializer A Function that serializes a single element of the collection to a {@link RevisionDataOutput}.
      * @param <T>               Type of the elements in the Collection.
      * @throws IOException If an IO Exception occurred.
      */
     <T> void writeCollection(Collection<T> collection, ElementSerializer<T> elementSerializer) throws IOException;
 
     /**
-     * Serializes the given array using the given ElementSerializer. It first writes a Compact Integer representing
+     * Serializes the given array using the given {@link ElementSerializer}. It first writes a Compact Integer representing
      * the number of elements in the array, followed by each element's serialization, in the order in which they appear in
      * the array.
      *
      * @param array             The array to serialize. Can be null (in which case an Empty array will be deserialized
-     *                          by RevisionDataInput.readArray()).
-     * @param elementSerializer A Function that serializes a single element of the array to a RevisionDataOutput.
+     *                          by {@link RevisionDataInput#readArray}).
+     * @param elementSerializer A Function that serializes a single element of the array to a {@link RevisionDataOutput}.
      * @param <T>               Type of the elements in the array.
      * @throws IOException If an IO Exception occurred.
      */
     <T> void writeArray(T[] array, ElementSerializer<T> elementSerializer) throws IOException;
 
     /**
-     * Serializes the given byte array. Equivalent to calling writeArray(array, 0, array.length).
+     * Serializes the given byte array. Equivalent to calling {@link #writeArray}(array, 0, array.length)}.
      *
      * @param array The array to serialize. Can be null (in which case an Empty array will be deserialized
-     *              by RevisionDataInput.readArray()).
+     *              by {@link RevisionDataInput#readArray}).
      * @throws IOException If an IO Exception occurred.
      */
     default void writeArray(byte[] array) throws IOException {
@@ -213,10 +249,10 @@ public interface RevisionDataOutput extends DataOutput {
     }
 
     /**
-     * Serializes the given byte array segment. Equivalent to calling writeArray(segment, segment.arrayOffset(), segment.getLength()).
+     * Serializes the given byte array segment. Equivalent to calling {@link #writeArray}(segment, segment.arrayOffset(), segment.getLength()).
      *
      * @param segment The byte array segment to serialize. Can be null (in which case an Empty array will be deserialized
-     *                by RevisionDataInput.readArray()).
+     *                by {@link RevisionDataInput#readArray})).
      * @throws IOException If an IO Exception occurred.
      */
     default void writeArray(ByteArraySegment segment) throws IOException {
@@ -232,7 +268,7 @@ public interface RevisionDataOutput extends DataOutput {
      * by the actual array elements being written.
      *
      * @param array  The array to serialize. Can be null (in which case an Empty array will be deserialized
-     *               by RevisionDataInput.readArray()).
+     *               by {@link RevisionDataInput#readArray})).
      * @param offset The offset within the array to begin serializing at. This is ignored if array == null.
      * @param length The number of elements to serialize. This is ignored if array == null.
      * @throws IOException If an IO Exception occurred.
@@ -262,14 +298,14 @@ public interface RevisionDataOutput extends DataOutput {
     <K, V> int getMapLength(Map<K, V> map, ToIntFunction<K> keyLengthProvider, ToIntFunction<V> valueLengthProvider);
 
     /**
-     * Serializes the given Map using the given ElementSerializers (one for Key and one for Value). It first writes a
+     * Serializes the given Map using the given {@link ElementSerializer}s (one for Key and one for Value). It first writes a
      * Compact Integer representing the number of elements in the Map, followed by each pair's serialization (first the key,
      * then the value), in the same order as returned by the Map's iterator.
      *
      * @param map             The Map to serialize. Can be null (in which case an Empty Map will be deserialized
-     *                        by RevisionDataInput.readMap()).
-     * @param keySerializer   A Function that serializes a single Key of the Map to a RevisionDataOutput.
-     * @param valueSerializer A Function that serializes a single Value of the Map to a RevisionDataOutput.
+     *                        by {@link RevisionDataInput#readMap}).
+     * @param keySerializer   A Function that serializes a single Key of the Map to a {@link RevisionDataOutput}.
+     * @param valueSerializer A Function that serializes a single Value of the Map to a {@link RevisionDataOutput}.
      * @param <K>             Type of the Map's Keys.
      * @param <V>             Type of the Map's Values.
      * @throws IOException If an IO Exception occurred.
@@ -277,7 +313,7 @@ public interface RevisionDataOutput extends DataOutput {
     <K, V> void writeMap(Map<K, V> map, ElementSerializer<K> keySerializer, ElementSerializer<V> valueSerializer) throws IOException;
 
     /**
-     * Defines a Function signature that can serialize an element to a RevisionDataOutput.
+     * Defines a Function signature that can serialize an element to a {@link RevisionDataOutput}.
      *
      * @param <T> Type of the element to serialize.
      */

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -30,7 +30,7 @@ public interface RevisionDataOutput extends DataOutput {
     /**
      * Maximum value that can be encoded using {@link #writeCompactLong).
      */
-    long COMPACT_LONG_MAX = 0x3FFF_FFFF_FFFF_FFFFL;
+    long COMPACT_LONG_MAX = 0x3FFF_FFFF_FFFF_FFFFL - 1;
 
     /**
      * Minimum value that can be encoded using {@link #writeCompactLong}.
@@ -40,7 +40,7 @@ public interface RevisionDataOutput extends DataOutput {
     /**
      * Maximum value that can be encoded using {@link #writeCompactSignedLong}.
      */
-    long COMPACT_SIGNED_LONG_MAX = 0x1FFF_FFFF_FFFF_FFFFL;
+    long COMPACT_SIGNED_LONG_MAX = 0x1FFF_FFFF_FFFF_FFFFL - 1;
 
     /**
      * Minimum value that can be encoded using {@link #writeCompactSignedLong}.
@@ -50,7 +50,7 @@ public interface RevisionDataOutput extends DataOutput {
     /**
      * Maximum value that can be encoded using {@link #writeCompactInt}.
      */
-    int COMPACT_INT_MAX = 0x3FFF_FFFF;
+    int COMPACT_INT_MAX = 0x3FFF_FFFF - 1;
 
     /**
      * Minimum value that can be encoded using {@link #writeCompactInt}.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
@@ -74,7 +74,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
 
     @Override
     public int getCompactLongLength(long value) {
-        if (value < COMPACT_LONG_MIN || value >= COMPACT_LONG_MAX) {
+        if (value < COMPACT_LONG_MIN || value > COMPACT_LONG_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactLong", "longs", "[0, 2^62)", value));
         } else if (value > 0x3FFF_FFFF) {
             return 8;
@@ -99,7 +99,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
      */
     @Override
     public void writeCompactLong(long value) throws IOException {
-        if (value < COMPACT_LONG_MIN || value >= COMPACT_LONG_MAX) {
+        if (value < COMPACT_LONG_MIN || value > COMPACT_LONG_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactLong", "longs", "[0, 2^62)", value));
         } else if (value > 0x3FFF_FFFF) {
             // All 8 bytes
@@ -119,7 +119,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
 
     @Override
     public int getCompactSignedLongLength(long value) {
-        if (value < COMPACT_SIGNED_LONG_MIN || value >= COMPACT_SIGNED_LONG_MAX) {
+        if (value < COMPACT_SIGNED_LONG_MIN || value > COMPACT_SIGNED_LONG_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactSignedLong", "longs", "[-2^61, 2^61)", value));
         }
 
@@ -151,7 +151,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
      */
     @Override
     public void writeCompactSignedLong(long value) throws IOException {
-        if (value < COMPACT_SIGNED_LONG_MIN || value >= COMPACT_SIGNED_LONG_MAX) {
+        if (value < COMPACT_SIGNED_LONG_MIN || value > COMPACT_SIGNED_LONG_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactSignedLong", "longs", "[-2^61, 2^61)", value));
         } else {
             boolean negative = value < 0;
@@ -182,7 +182,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
 
     @Override
     public int getCompactIntLength(int value) {
-        if (value < COMPACT_INT_MIN || value >= COMPACT_INT_MAX) {
+        if (value < COMPACT_INT_MIN || value > COMPACT_INT_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactInt", "ints", "[0, 2^30)", value));
         } else if (value > 0x3FFF) {
             return 4;
@@ -207,7 +207,7 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
         // MSB: 0  -> 1 byte with the remaining 7 bits
         // MSB: 10 -> 2 bytes with the remaining 6+8 bits
         // MSB: 11 -> 4 bytes with the remaining 6+8+8+8 bits
-        if (value < COMPACT_INT_MIN || value >= COMPACT_INT_MAX) {
+        if (value < COMPACT_INT_MIN || value > COMPACT_INT_MAX) {
             throw new IllegalArgumentException(badArgRange("writeCompactInt", "ints", "[0, 2^30)", value));
         } else if (value > 0x3FFF) {
             // All 4 bytes

--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
@@ -121,27 +121,30 @@ public class RevisionDataStreamCommonTests {
                 .put(0x3FL + 1, 2).put(0x3FFFL, 2)
                 .put(0x3FFFL + 1, 4).put(0x3FFF_FFFFL, 4)
                 .put(0x3FFF_FFFFL + 1, 8).build();
-        @Cleanup
-        val rdos = RevisionDataOutputStream.wrap(new ByteArrayOutputStream());
-        for (val e : expectedValues.entrySet()) {
-            if (e.getValue() < 0) {
-                AssertExtensions.assertThrows(
-                        "getCompactLongLength accepted invalid input: " + e.getKey(),
-                        () -> rdos.getCompactLongLength(e.getKey()),
-                        ex -> ex instanceof IllegalArgumentException);
-            } else {
-                // Verify what it should be.
-                int actualValue = rdos.getCompactLongLength(e.getKey());
-                Assert.assertEquals("Unexpected result for " + e.getKey(), (int) e.getValue(), actualValue);
-
-                // Verify that it is the case in practice.
-                testLength(RevisionDataOutputStream::writeCompactLong, RevisionDataOutputStream::getCompactLongLength, e.getKey());
-            }
-        }
+        testGetCompactLength(expectedValues, RevisionDataOutputStream::getCompactLongLength, RevisionDataOutputStream::writeCompactLong);
     }
 
     /**
-     * Tests the getCompactLongLength() method.
+     * Tests the getCompactSignedLongLength() method.
+     */
+    @Test
+    public void testGetCompactSignedLongLength() throws Exception {
+        val expectedValues = ImmutableMap.<Long, Integer>builder()
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN - 1, -1)
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX, -1)
+                .put(-0x1FL - 1, 1).put(0x1FL, 1)
+                .put(-0x1FL - 2, 2).put(0x1FFFL, 2)
+                .put(-0x1FFFL - 2, 4).put(0x1FFF_FFFFL, 4)
+                .put(-0x1FFF_FFFFL - 2, 8).put(0x1FFF_FFFFL + 1, 8)
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN, 8)
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX - 1, 8)
+                .put(0L, 1).put(-1L, 1)
+                .build();
+        testGetCompactLength(expectedValues, RevisionDataOutputStream::getCompactSignedLongLength, RevisionDataOutputStream::writeCompactSignedLong);
+    }
+
+    /**
+     * Tests the getCompactIntLength() method.
      */
     @Test
     public void testGetCompactIntLength() throws Exception {
@@ -151,23 +154,7 @@ public class RevisionDataStreamCommonTests {
                 .put(0, 1).put(0x7F, 1)
                 .put(0x7F + 1, 2).put(0x3FFF, 2)
                 .put(0x3FFF + 1, 4).build();
-        @Cleanup
-        val rdos = RevisionDataOutputStream.wrap(new ByteArrayOutputStream());
-        for (val e : expectedValues.entrySet()) {
-            if (e.getValue() < 0) {
-                AssertExtensions.assertThrows(
-                        "getCompactIntLength accepted invalid input: " + e.getKey(),
-                        () -> rdos.getCompactIntLength(e.getKey()),
-                        ex -> ex instanceof IllegalArgumentException);
-            } else {
-                // Verify what it should be.
-                int actualValue = rdos.getCompactIntLength(e.getKey());
-                Assert.assertEquals("Unexpected result for " + e.getKey(), (int) e.getValue(), actualValue);
-
-                // Verify that it is the case in practice.
-                testLength(RevisionDataOutputStream::writeCompactInt, RevisionDataOutputStream::getCompactIntLength, e.getKey());
-            }
-        }
+        testGetCompactLength(expectedValues, RevisionDataOutputStream::getCompactIntLength, RevisionDataOutputStream::writeCompactInt);
     }
 
     /**
@@ -186,6 +173,30 @@ public class RevisionDataStreamCommonTests {
         val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_LONG_MIN - 1, RevisionDataOutput.COMPACT_LONG_MAX);
         testCompact(RevisionDataOutputStream::writeCompactLong, RevisionDataInputStream::readCompactLong,
                 RevisionDataOutputStream::getCompactLongLength, toTest, shouldFail, Long::equals);
+    }
+
+    /**
+     * Tests the ability to encode and decode a Compact Signed Long.
+     */
+    @Test
+    public void testCompactSignedLong() throws Exception {
+        val toTest = new ArrayList<Long>();
+
+        // Boundary tests.
+        toTest.addAll(Arrays.asList(-0x1FL - 1, 0x1FL, -0x1FL - 2, 0x1FFFL, -0x1FFFL - 2, 0x1FFF_FFFFL, -0x1FFF_FFFFL - 2, 0x1FFF_FFFFL + 1, 0L, -1L));
+
+        // We want to test that when we split up the Long into smaller numbers, we won't be tripping over unsigned bytes/shorts/ints.
+        toTest.addAll(getAllOneBitNumbers(Long.SIZE - 3));
+
+        // Add the negatives of all the numbers so far.
+        toTest.addAll(toTest.stream().mapToLong(l -> -l).boxed().collect(Collectors.toList()));
+
+        // Add extremes.
+        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX - 1));
+
+        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN - 1, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX);
+        testCompact(RevisionDataOutputStream::writeCompactSignedLong, RevisionDataInputStream::readCompactSignedLong,
+                RevisionDataOutputStream::getCompactSignedLongLength, toTest, shouldFail, Long::equals);
     }
 
     /**
@@ -296,6 +307,26 @@ public class RevisionDataStreamCommonTests {
                     (s, v) -> s.getMapLength(v, e -> Long.BYTES, s::getUTFLength),
                     value,
                     this::mapsEqual);
+        }
+    }
+
+    private <T> void testGetCompactLength(Map<T, Integer> expectedValues, BiFunction<RevisionDataOutputStream, T, Integer> getLength, BiConsumerWithException<RevisionDataOutputStream, T> writeNumber) throws Exception {
+        @Cleanup
+        val rdos = RevisionDataOutputStream.wrap(new ByteArrayOutputStream());
+        for (val e : expectedValues.entrySet()) {
+            if (e.getValue() < 0) {
+                AssertExtensions.assertThrows(
+                        "getCompactIntLength accepted invalid input: " + e.getKey(),
+                        () -> getLength.apply(rdos, e.getKey()),
+                        ex -> ex instanceof IllegalArgumentException);
+            } else {
+                // Verify what it should be.
+                int actualValue = getLength.apply(rdos, e.getKey());
+                Assert.assertEquals("Unexpected result for " + e.getKey(), (int) e.getValue(), actualValue);
+
+                // Verify that it is the case in practice.
+                testLength(writeNumber, getLength, e.getKey());
+            }
         }
     }
 

--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
@@ -116,7 +116,7 @@ public class RevisionDataStreamCommonTests {
     public void testGetCompactLongLength() throws Exception {
         val expectedValues = ImmutableMap.<Long, Integer>builder()
                 .put(RevisionDataOutput.COMPACT_LONG_MIN - 1, -1)
-                .put(RevisionDataOutput.COMPACT_LONG_MAX, -1)
+                .put(RevisionDataOutput.COMPACT_LONG_MAX + 1, -1)
                 .put(0L, 1).put(0x3FL, 1)
                 .put(0x3FL + 1, 2).put(0x3FFFL, 2)
                 .put(0x3FFFL + 1, 4).put(0x3FFF_FFFFL, 4)
@@ -131,13 +131,13 @@ public class RevisionDataStreamCommonTests {
     public void testGetCompactSignedLongLength() throws Exception {
         val expectedValues = ImmutableMap.<Long, Integer>builder()
                 .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN - 1, -1)
-                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX, -1)
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX + 1, -1)
                 .put(-0x1FL - 1, 1).put(0x1FL, 1)
                 .put(-0x1FL - 2, 2).put(0x1FFFL, 2)
                 .put(-0x1FFFL - 2, 4).put(0x1FFF_FFFFL, 4)
                 .put(-0x1FFF_FFFFL - 2, 8).put(0x1FFF_FFFFL + 1, 8)
                 .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN, 8)
-                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX - 1, 8)
+                .put(RevisionDataOutput.COMPACT_SIGNED_LONG_MAX, 8)
                 .put(0L, 1).put(-1L, 1)
                 .build();
         testGetCompactLength(expectedValues, RevisionDataOutputStream::getCompactSignedLongLength, RevisionDataOutputStream::writeCompactSignedLong);
@@ -150,7 +150,7 @@ public class RevisionDataStreamCommonTests {
     public void testGetCompactIntLength() throws Exception {
         val expectedValues = ImmutableMap.<Integer, Integer>builder()
                 .put(RevisionDataOutput.COMPACT_INT_MIN - 1, -1)
-                .put(RevisionDataOutput.COMPACT_INT_MAX, -1)
+                .put(RevisionDataOutput.COMPACT_INT_MAX + 1, -1)
                 .put(0, 1).put(0x7F, 1)
                 .put(0x7F + 1, 2).put(0x3FFF, 2)
                 .put(0x3FFF + 1, 4).build();
@@ -164,13 +164,13 @@ public class RevisionDataStreamCommonTests {
     public void testCompactLong() throws Exception {
         val toTest = new ArrayList<Long>();
         // Boundary tests.
-        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_LONG_MIN, RevisionDataOutput.COMPACT_LONG_MAX - 1,
+        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_LONG_MIN, RevisionDataOutput.COMPACT_LONG_MAX,
                 0x3FL, 0x3FL + 1, 0x3FFFL, 0x3FFFL + 1, 0x3FFF_FFFFL, 0x3FFF_FFFFL + 1));
 
         // We want to test that when we split up the Long into smaller numbers, we won't be tripping over unsigned bytes/shorts/ints.
         toTest.addAll(getAllOneBitNumbers(Long.SIZE - 2));
 
-        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_LONG_MIN - 1, RevisionDataOutput.COMPACT_LONG_MAX);
+        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_LONG_MIN - 1, RevisionDataOutput.COMPACT_LONG_MAX + 1);
         testCompact(RevisionDataOutputStream::writeCompactLong, RevisionDataInputStream::readCompactLong,
                 RevisionDataOutputStream::getCompactLongLength, toTest, shouldFail, Long::equals);
     }
@@ -192,9 +192,9 @@ public class RevisionDataStreamCommonTests {
         toTest.addAll(toTest.stream().mapToLong(l -> -l).boxed().collect(Collectors.toList()));
 
         // Add extremes.
-        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX - 1));
+        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX));
 
-        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN - 1, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX);
+        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_SIGNED_LONG_MIN - 1, RevisionDataOutput.COMPACT_SIGNED_LONG_MAX + 1);
         testCompact(RevisionDataOutputStream::writeCompactSignedLong, RevisionDataInputStream::readCompactSignedLong,
                 RevisionDataOutputStream::getCompactSignedLongLength, toTest, shouldFail, Long::equals);
     }
@@ -206,13 +206,13 @@ public class RevisionDataStreamCommonTests {
     public void testCompactInt() throws Exception {
         val toTest = new ArrayList<Integer>();
         // Boundary tests.
-        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_INT_MIN, RevisionDataOutput.COMPACT_INT_MAX - 1,
+        toTest.addAll(Arrays.asList(RevisionDataOutput.COMPACT_INT_MIN, RevisionDataOutput.COMPACT_INT_MAX,
                 0x7F, 0x7F + 1, 0x3FFF, 0x3FFF + 1, 0x3F_FFFF, 0x3F_FFFF + 1));
 
         // We want to test that when we split up the Long into smaller numbers, we won't be tripping over unsigned bytes/shorts/ints.
         getAllOneBitNumbers(Integer.SIZE - 2).forEach(n -> toTest.add((int) (long) n));
 
-        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_INT_MIN - 1, RevisionDataOutput.COMPACT_INT_MAX);
+        val shouldFail = Arrays.asList(RevisionDataOutput.COMPACT_INT_MIN - 1, RevisionDataOutput.COMPACT_INT_MAX + 1);
         testCompact(RevisionDataOutputStream::writeCompactInt, RevisionDataInputStream::readCompactInt, RevisionDataOutputStream::getCompactIntLength,
                 toTest, shouldFail, Integer::equals);
     }


### PR DESCRIPTION
**Change log description**  
- Added `RevisionDataOutput.writeCompactSignedLong()` and `RevisionDataInput.readCompactSignedLong()`.
- Improved Javadoc in `RevisionDataOutput` and `RevisionDataInput` by adding Javadoc links and fixing various references.

**Purpose of the change**  
Fixes #3781.

**What the code does**  
- `writeCompactLong`/`readCompactLong` only supported non-negative numbers up to 2^62-1. This change adds support for negative numbers as well.
- Negative numbers require an extra bit to store the sign, as such only numbers within the range [2^61, 2^61) can be encoded (3 bits are reserved for sign and length).

**How to verify it**  
New unit tests added.