### PR TITLE
Issue 3651: Handle ZooKeeper Restart with Different IP in Segment Store

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ allprojects {
             force "com.google.guava:guava:" + guavaVersion
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
+            force "org.apache.zookeeper:zookeeper:" + apacheZookeeperVersion
             dependencySubstitution {
                 substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -542,6 +542,10 @@ project('controller') {
         test.resources.srcDirs += "$rootDir/config"
     }
 
+    compileJava {
+        options.compilerArgs.remove("-Werror")
+    }
+
     apply plugin: 'application'
     applicationName = "pravega-controller"
     mainClassName = "io.pravega.controller.server.Main"

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        maven {
+            url "https://repository.apache.org"
+        }
     }
     dependencies {
         classpath group: 'com.google.protobuf', name:'protobuf-gradle-plugin', version: protobufGradlePlugin

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,11 @@ allprojects {
             force "org.glassfish.jersey.core:jersey-common:" + jerseyVersion
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
             force "org.apache.zookeeper:zookeeper:" + apacheZookeeperVersion
+            force "io.netty:netty-transport:"+ nettyVersion
+            force "io.netty:netty-handler:" + nettyVersion
+            force "io.netty:netty-transport-native-epoll:" + nettyVersion
+            force "io.netty:netty-all:" + nettyVersion
+            force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
             dependencySubstitution {
                 substitute module("javax.ws.rs:jsr311-api") with module("javax.ws.rs:javax.ws.rs-api:" + javaxwsrsApiVersion)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -543,10 +543,6 @@ project('controller') {
         test.resources.srcDirs += "$rootDir/config"
     }
 
-    compileJava {
-        options.compilerArgs.remove("-Werror")
-    }
-
     apply plugin: 'application'
     applicationName = "pravega-controller"
     mainClassName = "io.pravega.controller.server.Main"

--- a/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
+++ b/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
@@ -17,8 +17,10 @@ public class ZKTLSUtils {
     public static void setSecureZKClientProperties(String trustStorePath, String trustStorePassword) {
         System.setProperty("zookeeper.client.secure", "true");
         System.setProperty("zookeeper.clientCnxnSocket", "org.apache.zookeeper.ClientCnxnSocketNetty");
-        System.setProperty("zookeeper.ssl.trustStore.location", trustStorePath);
-        System.setProperty("zookeeper.ssl.trustStore.password", trustStorePassword);
+        System.setProperty("zookeeper.ssl.trustStore.location", "/home/raul/Documents/workspace/mine/pravega/config/client.truststore.jks");
+        System.setProperty("zookeeper.ssl.trustStore.password", "1111_aaaa");
+        System.setProperty("zookeeper.ssl.keyStore.location", "/home/raul/Documents/workspace/mine/pravega/config/server.keystore.jks");
+        System.setProperty("zookeeper.ssl.keyStore.password", "1111_aaaa");
     }
 
     public static void unsetSecureZKClientProperties() {
@@ -26,6 +28,8 @@ public class ZKTLSUtils {
         System.clearProperty("zookeeper.clientCnxnSocket");
         System.clearProperty("zookeeper.ssl.trustStore.location");
         System.clearProperty("zookeeper.ssl.trustStore.password");
+        System.clearProperty("zookeeper.ssl.keyStore.location");
+        System.clearProperty("zookeeper.ssl.keyStore.password");
     }
 
 }

--- a/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
+++ b/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
@@ -9,6 +9,9 @@
  */
 package io.pravega.common.auth;
 
+/**
+ * Utility class to set and unset the SSL-related configuration parameters in a Zookeeper client.
+ */
 public class ZKTLSUtils {
 
     public static void setSecureZKClientProperties(String trustStorePath, String trustStorePassword) {

--- a/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
+++ b/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
@@ -17,10 +17,8 @@ public class ZKTLSUtils {
     public static void setSecureZKClientProperties(String trustStorePath, String trustStorePassword) {
         System.setProperty("zookeeper.client.secure", "true");
         System.setProperty("zookeeper.clientCnxnSocket", "org.apache.zookeeper.ClientCnxnSocketNetty");
-        System.setProperty("zookeeper.ssl.trustStore.location", "/home/raul/Documents/workspace/mine/pravega/config/client.truststore.jks");
-        System.setProperty("zookeeper.ssl.trustStore.password", "1111_aaaa");
-        System.setProperty("zookeeper.ssl.keyStore.location", "/home/raul/Documents/workspace/mine/pravega/config/server.keystore.jks");
-        System.setProperty("zookeeper.ssl.keyStore.password", "1111_aaaa");
+        System.setProperty("zookeeper.ssl.trustStore.location", trustStorePath);
+        System.setProperty("zookeeper.ssl.trustStore.password", trustStorePassword);
     }
 
     public static void unsetSecureZKClientProperties() {
@@ -28,8 +26,6 @@ public class ZKTLSUtils {
         System.clearProperty("zookeeper.clientCnxnSocket");
         System.clearProperty("zookeeper.ssl.trustStore.location");
         System.clearProperty("zookeeper.ssl.trustStore.password");
-        System.clearProperty("zookeeper.ssl.keyStore.location");
-        System.clearProperty("zookeeper.ssl.keyStore.password");
     }
 
 }

--- a/config/standalone-config.properties
+++ b/config/standalone-config.properties
@@ -33,33 +33,33 @@
 # Whether to enable authentication/authorization.
 # Valid values: 'true' or 'false'
 # Default value: false
-#singlenode.enableAuth=false
+singlenode.enableAuth=true
 
 # Username for default password handler implementation.
-#singlenode.userName=admin
+singlenode.userName=admin
 
 # Password associated with the default user
-#singlenode.passwd=1111_aaaa
+singlenode.passwd=1111_aaaa
 
 # Password file for default password handler
-#singlenode.passwdFile=../config/passwd
+singlenode.passwdFile=../config/passwd
 
 # Whether to enable TLS for segmentstore and controller.
 # Valid values: 'true' or 'false'
 # Default value: false
-#singlenode.enableTls=false
+singlenode.enableTls=true
 
 # Location of server's key file for TLS communication.
-#singlenode.keyFile=../config/server-key.key
+singlenode.keyFile=../config/server-key.key
 
 # Location of server's certificate file for TLS communication.
-#singlenode.certFile=../config/server-cert.crt
+singlenode.certFile=../config/server-cert.crt
 
 # Location of keystore for TLS-enabled communications
-#singlenode.keyStoreJKS=../config/server.keystore.jks
+singlenode.keyStoreJKS=../config/server.keystore.jks
 
 # Location of file containing keystore password
-#singlenode.keyStoreJKSPasswordFile=../config/server.keystore.jks.passwd
+singlenode.keyStoreJKSPasswordFile=../config/server.keystore.jks.passwd
 
 # Location of truststore for TLS-enabled communications
-#singlenode.trustStoreJKS=../config/client.truststore.jks
+singlenode.trustStoreJKS=../config/client.truststore.jks

--- a/config/standalone-config.properties
+++ b/config/standalone-config.properties
@@ -33,33 +33,33 @@
 # Whether to enable authentication/authorization.
 # Valid values: 'true' or 'false'
 # Default value: false
-singlenode.enableAuth=true
+#singlenode.enableAuth=false
 
 # Username for default password handler implementation.
-singlenode.userName=admin
+#singlenode.userName=admin
 
 # Password associated with the default user
-singlenode.passwd=1111_aaaa
+#singlenode.passwd=1111_aaaa
 
 # Password file for default password handler
-singlenode.passwdFile=../config/passwd
+#singlenode.passwdFile=../config/passwd
 
 # Whether to enable TLS for segmentstore and controller.
 # Valid values: 'true' or 'false'
 # Default value: false
-singlenode.enableTls=true
+#singlenode.enableTls=false
 
 # Location of server's key file for TLS communication.
-singlenode.keyFile=../config/server-key.key
+#singlenode.keyFile=../config/server-key.key
 
 # Location of server's certificate file for TLS communication.
-singlenode.certFile=../config/server-cert.crt
+#singlenode.certFile=../config/server-cert.crt
 
 # Location of keystore for TLS-enabled communications
-singlenode.keyStoreJKS=../config/server.keystore.jks
+#singlenode.keyStoreJKS=../config/server.keystore.jks
 
 # Location of file containing keystore password
-singlenode.keyStoreJKSPasswordFile=../config/server.keystore.jks.passwd
+#singlenode.keyStoreJKSPasswordFile=../config/server.keystore.jks.passwd
 
 # Location of truststore for TLS-enabled communications
-singlenode.trustStoreJKS=../config/client.truststore.jks
+#singlenode.trustStoreJKS=../config/client.truststore.jks

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ dockerExecutable=/usr/bin/docker
 
 #3rd party Versions
 apacheCommonsCsvVersion=1.5
-apacheCuratorVersion=4.0.1
+apacheCuratorVersion=4.0.1-SNAPSHOT
 checkstyleToolVersion=8.2
 bookKeeperVersion=4.7.3
 commonsioVersion=2.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,8 @@ dockerExecutable=/usr/bin/docker
 
 #3rd party Versions
 apacheCommonsCsvVersion=1.5
-apacheCuratorVersion=4.0.1-SNAPSHOT
+apacheCuratorVersion=4.0.1
+apacheZookeeperVersion=3.5.5
 checkstyleToolVersion=8.2
 bookKeeperVersion=4.7.3
 commonsioVersion=2.6

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
@@ -178,6 +178,8 @@ public class BookKeeperServiceRunner implements AutoCloseable {
 
         if (this.secureZK) {
             ZKTLSUtils.setSecureZKClientProperties(this.tlsTrustStore, JKSHelper.loadPasswordFrom(this.tLSKeyStorePasswordPath));
+        } else {
+            ZKTLSUtils.unsetSecureZKClientProperties();
         }
 
         @Cleanup

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -13,12 +13,8 @@ import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.auth.JKSHelper;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.KeyManagementException;
@@ -32,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -176,10 +176,11 @@ public class InProcPravegaCluster implements AutoCloseable {
     @Synchronized
     public void start() throws Exception {
 
+        zkPort = secureZK ? 2281 : 2181;
         /*Start the ZK*/
         if (isInProcZK) {
             zkUrl = "localhost:" + zkPort;
-            startLocalZK();
+            //startLocalZK();
         } else {
             URI zkUri = new URI("temp://" + zkUrl);
             zkHost = zkUri.getHost();
@@ -258,7 +259,7 @@ public class InProcPravegaCluster implements AutoCloseable {
     private void startLocalSegmentStore(int segmentStoreId) throws Exception {
         Properties authProps = new Properties();
         authProps.setProperty("pravega.client.auth.method", "Default");
-        authProps.setProperty("pravega.client.auth.userName", "arvind");
+        authProps.setProperty("pravega.client.auth.userName", "admin");
         authProps.setProperty("pravega.client.auth.password", "1111_aaaa");
 
         ServiceBuilderConfig.Builder configBuilder = ServiceBuilderConfig

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -176,11 +176,10 @@ public class InProcPravegaCluster implements AutoCloseable {
     @Synchronized
     public void start() throws Exception {
 
-        zkPort = secureZK ? 2281 : 2181;
         /*Start the ZK*/
         if (isInProcZK) {
             zkUrl = "localhost:" + zkPort;
-            //startLocalZK();
+            startLocalZK();
         } else {
             URI zkUri = new URI("temp://" + zkUrl);
             zkHost = zkUri.getHost();


### PR DESCRIPTION
**Change log description**  
Added a ZooKeeper client factory in the Curator client used in the Segment Store to ensure resolving the host name of ZooKeeper instances. Upgraded the ZooKeeper library version to version 3.5.5 as it contains an important fix to correctly retry hostname resolution.

**Purpose of the change**  
Fixes #3651.

**What the code does**  
In a container execution environment (e.g., Kubernetes), it is very frequent to observe restarts of service instances, normally using different IPs across restarts. This is particularly important in the coordination service in Pravega depends on: ZooKeeper. 

In the event of a ZooKeeper instance restart, the Controller basically performs an internal, graceful restart and re-creates the Curator client used to connect to Zookeeper. This, jointly with the usage of the "headless" endpoints has been an effective way to tackle the churn of ZooKeeper instances. However, the Segment Store does not re-create the Curator client upon a session expiration, therefore exhibiting problems to handle ZooKeeper restarts.
 
This PR contains 2 main fixes for improving the handling of restarts of ZooKeeper instances in the Segment Store:
- _Always resolve ZooKeeper instances by hostname_: One of the problems we found is that the Curator client was using the previously resolved IP address from the ZooKeeper instance to re-connect. This is incorrect, as the restarted instance may have a different IP address. To avoid this problem, we used a custom `ZookeeperFactory` in the Curator client of the Segment Store.

- _Re-resolve the hostname if the server is not yet available_: The system may assign a new IP to the hostname of the new ZooKeeper instance, but the instance may not be available until the server starts. In this situation, the Curator client is expected to re-resolve and retry the connection to the new ZooKeeper instance. However, this is not the actual behavior for `zookeeper-3.5.4-beta` (the default ZooKeeper version imported by `curator-4.0.1`). This problem has been fixed in `zookeeper-3.5.5` via [ZOOKEEPER-2184](https://issues.apache.org/jira/browse/ZOOKEEPER-2184), so this PR forces the import of that version of the ZooKeeper library. Moreover, we also force specific versions of Netty and BoringSSL, as they are also used by `zookeeper-3.5.5` with slightly different versions.

Apart from that, the upgrade to `zookeeper-3.5.5` required a small change to make `ZookeeperServiceRunner` (used in Pravega standalone) to work with SSL enabled.

**How to verify it**  
Complete build passes locally.
Executed experiments in Kubernetes with a single ZooKeeper instance that has been intentionally restarted and the Segment Store is able to re-connect and resume its operation.
