### PR TITLE
Issue 3790: Fix compatibility for deprecated Controller call in r0.5

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -218,6 +218,13 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 responseObserver);
     }
 
+    /* This deprecated call should be removed once we address: https://github.com/pravega/pravega/issues/3760 */
+    @Override
+    public void getSegmentsImmediatlyFollowing(SegmentId segmentId, StreamObserver<SuccessorResponse> responseObserver) {
+        log.info("getSegmentsImmediatlyFollowing called for segment {} ", segmentId);
+        getSegmentsImmediatelyFollowing(segmentId, responseObserver);
+    }
+
     @Override
     public void getSegmentsBetween(Controller.StreamCutRange request, StreamObserver<Controller.StreamCutRangeResponse> responseObserver) {
         log.info("getSegmentsBetweenStreamCuts called for stream {} for cuts from {} to {}", request.getStreamInfo(), request.getFromMap(), request.getToMap());

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -547,13 +547,13 @@ public abstract class ControllerServiceImplTest {
         /* https://github.com/pravega/pravega/issues/3760                            */
         ResultObserver<SuccessorResponse> resultDeprecated = new ResultObserver<>();
         this.controllerService.getSegmentsImmediatlyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 1), resultDeprecated);
-        final SuccessorResponse successorResponseDeprecated = result.get();
+        final SuccessorResponse successorResponseDeprecated = resultDeprecated.get();
         Assert.assertEquals(2, successorResponseDeprecated.getSegmentsCount());
 
         ResultObserver<SuccessorResponse> resultDeprecated2 = new ResultObserver<>();
-        this.controllerService.getSegmentsImmediatelyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 0),
+        this.controllerService.getSegmentsImmediatlyFollowing(ModelHelper.createSegmentId(SCOPE1, STREAM1, 0),
                 resultDeprecated2);
-        final SuccessorResponse successorResponseDeprecated2 = result2.get();
+        final SuccessorResponse successorResponseDeprecated2 = resultDeprecated2.get();
         Assert.assertEquals(0, successorResponseDeprecated2.getSegmentsCount());
     }
 


### PR DESCRIPTION
Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Adds missing implementation for deprecated Controller call "getSegmentsImmediatlyFollowing".
It fixes both `ControllerServiceImpl` and the associated test regarding the deprecated
`getSegmentsImmediatlyFollowing` method.

**Purpose of the change**  
Fixes #3790 

**What the code does**  
In PR #3759 we deprecated the method `getSegmentsImmediatlyFollowing` in favor of `getSegmentsImmediatelyFollowing`. However, that PR missed to add the deprecated method implementation in `ControllerServiceImpl`. This problem was not detected because a bug in the test code for the deprecated method, which was performing assertions over variables resulting from the new method name (in fact, the execution of `getSegmentsImmediatlyFollowing` was retrieving a response specifying that the method was unimplemented).

This PR fixes both `ControllerServiceImpl` and the associated test regarding the deprecated `getSegmentsImmediatlyFollowing` method.

**How to verify it**  
`ControllerServiceImplTest` should exercise the deprecated call and pass.
