### PR TITLE
Issue 3724: (SegmentStore) BugFix - Creating an already existing Segment in Tier 2

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -360,6 +360,11 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
         return this.handle.get();
     }
 
+    @Override
+    public String toString() {
+        return this.traceObjectId;
+    }
+
     /**
      * Executes the given Index Operation with retries. Retries are only performed in case of conditional update failures,
      * represented by BadOffsetException.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1177,7 +1177,9 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
                                 // of them managed to create the Segment (and write something to it), but the other still assumed
                                 // the Segment did not exist - so we end up in here. We need to get a handle of the segment
                                 // and continue with whatever we were doing. If there is a mismatch (length, sealed, etc.),
-                                // then the normal reconciliation algorithm will kick in once it is discovered.
+                                // then the normal reconciliation algorithm will kick in once it is discovered and if the
+                                // segment has already been fenced out, openWrite() will throw the appropriate exception
+                                // which will be handled upstream.
                                 log.info("{}: Segment did not exist in Storage when initialized() was called, but does now.", this.traceObjectId);
                                 return this.storage.openWrite(this.metadata.getName());
                             })

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1165,17 +1165,30 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         if (this.handle.get() == null) {
             // No handle so, the segment must not exist yet. Attempt to create it, then run what we wanted to.
             assert this.metadata.getStorageLength() == 0 : "no handle yet but metadata indicates Storage Segment not empty";
-            long rolloverSize = this.metadata.getAttributes().getOrDefault(Attributes.ROLLOVER_SIZE, -1L);
-            SegmentRollingPolicy rollingPolicy = rolloverSize < 0 ? SegmentRollingPolicy.NO_ROLLING : new SegmentRollingPolicy(rolloverSize);
+            long rolloverSize = this.metadata.getAttributes().getOrDefault(Attributes.ROLLOVER_SIZE, SegmentRollingPolicy.NO_ROLLING.getMaxLength());
             return Futures
                     .exceptionallyExpecting(
-                            this.storage.create(this.metadata.getName(), rollingPolicy, timeout),
+                            this.storage.create(this.metadata.getName(), new SegmentRollingPolicy(rolloverSize), timeout),
                             ex -> ex instanceof StreamSegmentExistsException,
                             null)
                     .thenComposeAsync(handle -> {
-                        this.handle.set(handle);
-                        return toRun.get();
-                    });
+                        if (handle == null) {
+                            // This happens if we have more than one concurrent instances of the owning SegmentContainer
+                            // running at the same time. Both SegmentAggregator instances were initialized when the Segment
+                            // did not exist, and both knew about an append that would eventually make it to Storage. One
+                            // of them managed to create the Segment (and write something to it), but the other still assumed
+                            // the Segment did not exist - so we end up in here. We need to get a handle of the segment
+                            // and continue with whatever we were doing. If there is a mismatch (length, sealed, etc.),
+                            // then the normal reconciliation algorithm will kick in once it is discovered.
+                            log.info("{}: Segment did not exist in Storage when initialized() was called, but does now.", this.traceObjectId);
+                            return this.storage.openWrite(this.metadata.getName()).thenAccept(this.handle::set);
+                        } else {
+                            this.handle.set(handle);
+                            return CompletableFuture.completedFuture(null);
+                        }
+                    }, this.executor)
+                    .thenComposeAsync(v -> toRun.get(), this.executor);
+
         } else {
             // Segment already exists. Execute what we were supposed to.
             return toRun.get();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1637,13 +1637,12 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
      * Tests the ability of the SegmentAggregator to recover from situations when a Segment did not exist in Storage
      * when {@link SegmentAggregator#initialize} was invoked, but exists when the first byte needs to be appended.
      * This can happen when there are concurrent instances of the same Segment Container running at the same time and
-     * one of the managed to create the Segment in Storage after the other one was initialized; when the second one tries
+     * one of them managed to create the Segment in Storage after the other one was initialized; when the second one tries
      * to do the same, it must gracefully recover from that situation.
      */
     @Test
     public void testReconcileCreateIfEmpty() throws Exception {
         final WriterConfig config = DEFAULT_CONFIG;
-        final int appendCount = 1;
 
         @Cleanup
         TestContext context = new TestContext(config);


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `SegmentAggregator` where it was not able to properly recover from a Segment being created behind the scenes.
- Fixes a minor nuisance in `SegmentAttributeBTreeIndex` where `toString()` was not implemented, hence making log parsing more difficult.

**Purpose of the change**  
Fixes #3724.

**What the code does**  
- Fixes the following bug: https://github.com/pravega/pravega/issues/3724#issuecomment-494099244
- If the `SegmentAggregator` gets a `StreamSegmentExistsException` while trying to create a new segment in Tier 2 Storage, it calls `openWrite` to get a handle to it. This will allow subsequent operations to continue executing.
    - Note 1: If there is a fencing event, `openWrite` will throw the appropriate exception and the upstream code will handle it as it does if it arose from other places.
    - Note 2: If there is a mismatch between the data in Tier 2 and what the metadata indicates, the `SegmentAggregator` will detect that upon executing the next operation and enter its usual `ReconciliationMode`.

**How to verify it**  
New unit test.
