### PR TITLE
Issue 3805: (SegmentStore) BugFix - StorageWriter not shutting down if Tier 2 fencing detected.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -30,6 +30,7 @@ import io.pravega.segmentstore.server.logs.operations.MetadataOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -412,8 +413,10 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     }
 
     private boolean isCriticalError(Throwable ex) {
+        ex = Exceptions.unwrap(ex);
         return Exceptions.mustRethrow(ex)
-                || Exceptions.unwrap(ex) instanceof DataCorruptionException;
+                || ex instanceof DataCorruptionException     // Data corruption - stop processing to prevent more damage.
+                || ex instanceof StorageNotPrimaryException; // Fenced out - another instance took over.
     }
 
     private boolean isShutdownException(Throwable ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -267,7 +267,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the StorageWriter in a configurable scenarion where the Storage component throws a critical (container-stopper)
+     * Tests the StorageWriter in a configurable scenario where the Storage component throws a critical (container-stopper)
      * exception and verifies its handling of the situation.
      *
      * @param createErrorInjector          Creates an ErrorInjector that will cause the Storage component to enter an
@@ -301,7 +301,6 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof IllegalStateException);
 
         ServiceListeners.awaitShutdown(context.writer, TIMEOUT, false);
-        System.out.println(context.writer.failureCause());
         Assert.assertTrue("Unexpected failure cause for StorageWriter.",
                 validatePostFailureException.test(Exceptions.unwrap(context.writer.failureCause())));
     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
@@ -41,7 +41,7 @@ public class StorageNotPrimaryException extends StreamSegmentException {
     }
 
     public StorageNotPrimaryException(String streamSegmentName, String message, Throwable cause) {
-        super(streamSegmentName, "The current instance is no longer the primary writer for this StreamSegment." + (message == null ? "" : " ") + message,
+        super(streamSegmentName, "The current instance is no longer the primary writer for this StreamSegment." + (message == null ? "" : " " + message),
                 cause);
     }
 }


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `StorageWriter` where it would not shut down (at all) if it detected `StorageNotPrimaryException`.

**Purpose of the change**  
Fixes #3805.

**What the code does**  
- Added `StorageNotPrimaryException` to the list of "critical" errors after which the `StorageWriter` must auto-shut down if it detects.
    - This is already thrown correctly by `SegmentAggregator` and a `StorageWriter` shutdown is already correctly handled upstream (triggering an entire container shutdown).

**How to verify it**  
Added unit test.
