### PR TITLE
Issue 3809: Add unit tests for shared/segment classes

### DIFF
--- a/shared/protocol/src/test/java/io/pravega/shared/segment/ScaleTypeTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/ScaleTypeTests.java
@@ -16,33 +16,14 @@ import org.junit.Test;
 public class ScaleTypeTests {
 
     @Test
-    public void testToValue() {
-        ScaleType noScaling = ScaleType.NoScaling;
-        ScaleType throughput = ScaleType.Throughput;
-        ScaleType eventRate = ScaleType.EventRate;
-
-        Assert.assertTrue(noScaling.name().equals(ScaleType.NoScaling.name()));
-        Assert.assertTrue(throughput.name().equals(ScaleType.Throughput.name()));
-        Assert.assertTrue(eventRate.name().equals(ScaleType.EventRate.name()));
-
-        Assert.assertTrue(noScaling.getValue() == ScaleType.NoScaling.getValue());
-        Assert.assertTrue(throughput.getValue() == ScaleType.Throughput.getValue());
-        Assert.assertTrue(eventRate.getValue() == ScaleType.EventRate.getValue());
-    }
-
-    @Test
     public void testFromValue() {
         ScaleType noScaling = ScaleType.fromValue(ScaleType.NoScaling.getValue());
         ScaleType throughput = ScaleType.fromValue(ScaleType.Throughput.getValue());
         ScaleType eventRate = ScaleType.fromValue(ScaleType.EventRate.getValue());
 
-        Assert.assertTrue(noScaling.name().equals(ScaleType.NoScaling.name()));
-        Assert.assertTrue(throughput.name().equals(ScaleType.Throughput.name()));
-        Assert.assertTrue(eventRate.name().equals(ScaleType.EventRate.name()));
-
-        Assert.assertTrue(noScaling.getValue() == ScaleType.NoScaling.getValue());
-        Assert.assertTrue(throughput.getValue() == ScaleType.Throughput.getValue());
-        Assert.assertTrue(eventRate.getValue() == ScaleType.EventRate.getValue());
+        Assert.assertEquals(noScaling, ScaleType.NoScaling);
+        Assert.assertEquals(throughput, ScaleType.Throughput);
+        Assert.assertEquals(eventRate, ScaleType.EventRate);
     }
 
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/ScaleTypeTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/ScaleTypeTests.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.shared.segment;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScaleTypeTests {
+
+    @Test
+    public void testToValue() {
+        ScaleType noScaling = ScaleType.NoScaling;
+        ScaleType throughput = ScaleType.Throughput;
+        ScaleType eventRate = ScaleType.EventRate;
+
+        Assert.assertTrue(noScaling.name().equals(ScaleType.NoScaling.name()));
+        Assert.assertTrue(throughput.name().equals(ScaleType.Throughput.name()));
+        Assert.assertTrue(eventRate.name().equals(ScaleType.EventRate.name()));
+
+        Assert.assertTrue(noScaling.getValue() == ScaleType.NoScaling.getValue());
+        Assert.assertTrue(throughput.getValue() == ScaleType.Throughput.getValue());
+        Assert.assertTrue(eventRate.getValue() == ScaleType.EventRate.getValue());
+    }
+
+    @Test
+    public void testFromValue() {
+        ScaleType noScaling = ScaleType.fromValue(ScaleType.NoScaling.getValue());
+        ScaleType throughput = ScaleType.fromValue(ScaleType.Throughput.getValue());
+        ScaleType eventRate = ScaleType.fromValue(ScaleType.EventRate.getValue());
+
+        Assert.assertTrue(noScaling.name().equals(ScaleType.NoScaling.name()));
+        Assert.assertTrue(throughput.name().equals(ScaleType.Throughput.name()));
+        Assert.assertTrue(eventRate.name().equals(ScaleType.EventRate.name()));
+
+        Assert.assertTrue(noScaling.getValue() == ScaleType.NoScaling.getValue());
+        Assert.assertTrue(throughput.getValue() == ScaleType.Throughput.getValue());
+        Assert.assertTrue(eventRate.getValue() == ScaleType.EventRate.getValue());
+    }
+
+}

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
@@ -134,4 +134,83 @@ public class StreamSegmentNameUtilsTests {
         AssertExtensions.assertThrows("No tokens supplied", () -> StreamSegmentNameUtils.getQualifiedTableName("scope"), 
                 e -> e instanceof IllegalArgumentException);
     }
+
+    @Test
+    public void testGetAttributeSegmentName() {
+       String name = StreamSegmentNameUtils.getAttributeSegmentName("foo");
+        AssertExtensions.assertThrows(
+                "getAttributeSegmentName did not add the attribute suffix",
+                () -> StreamSegmentNameUtils.getAttributeSegmentName(name),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testGetHeaderSegmentName() {
+        String name = StreamSegmentNameUtils.getHeaderSegmentName("foo");
+        AssertExtensions.assertThrows(
+                "getAttributeSegmentName did not add the header suffix",
+                () -> StreamSegmentNameUtils.getHeaderSegmentName(name),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testGetSegmentNameFromHeader() {
+        String name = StreamSegmentNameUtils.getSegmentNameFromHeader(StreamSegmentNameUtils.getHeaderSegmentName("foo"));
+        AssertExtensions.assertThrows(
+                "getAttributeSegmentName did not add the attribute suffix",
+                () -> StreamSegmentNameUtils.getSegmentNameFromHeader("foo"),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testGetSegmentNameChunkName() {
+        String name = StreamSegmentNameUtils.getSegmentChunkName("foo", 0);
+        AssertExtensions.assertThrows(
+                "getAttributeSegmentName did not add the attribute suffix",
+                () -> StreamSegmentNameUtils.getSegmentChunkName(name, 0),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testGetScopedStreamName() {
+        String name = StreamSegmentNameUtils.getScopedStreamName("scope", "stream");
+        Assert.assertTrue(name.equals("scope/stream"));
+        name = StreamSegmentNameUtils.getScopedStreamName("", "stream");
+        Assert.assertTrue(name.equals("stream"));
+        name = StreamSegmentNameUtils.getScopedStreamName(null, "stream");
+        Assert.assertTrue(name.equals("stream"));
+    }
+
+    @Test
+    public void testComputeSegmentId() {
+        long sid = StreamSegmentNameUtils.computeSegmentId(1, 1);
+        Assert.assertEquals(sid, (long) (0x1L << 32) + 1);
+
+        AssertExtensions.assertThrows(
+                "Accepted a negative epoch",
+                () -> StreamSegmentNameUtils.computeSegmentId(1, -1),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testExtractSegmentTokens() {
+        String name  = StreamSegmentNameUtils.getQualifiedStreamSegmentName("scope", "stream", 0);
+        List<String> tokens = StreamSegmentNameUtils.extractSegmentTokens(name);
+        Assert.assertEquals(tokens.size(), 3);
+        Assert.assertTrue(tokens.get(0).equals("scope"));
+        Assert.assertTrue(tokens.get(1).equals("stream"));
+        Assert.assertTrue(tokens.get(2).equals("0"));
+
+        name  = StreamSegmentNameUtils.getQualifiedStreamSegmentName("", "stream", 0);
+        tokens = StreamSegmentNameUtils.extractSegmentTokens(name);
+        Assert.assertEquals(tokens.size(), 2);
+        Assert.assertTrue(tokens.get(0).equals("stream"));
+        Assert.assertTrue(tokens.get(1).equals("0"));
+
+        name  = StreamSegmentNameUtils.getQualifiedStreamSegmentName(null, "stream", 0);
+        tokens = StreamSegmentNameUtils.extractSegmentTokens(name);
+        Assert.assertEquals(tokens.size(), 2);
+        Assert.assertTrue(tokens.get(0).equals("stream"));
+        Assert.assertTrue(tokens.get(1).equals("0"));
+    }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
@@ -148,7 +148,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetHeaderSegmentName() {
         String name = StreamSegmentNameUtils.getHeaderSegmentName("foo");
         AssertExtensions.assertThrows(
-                "getAttributeSegmentName did not add the header suffix",
+                "getHeaderSegmentName did not add the header suffix",
                 () -> StreamSegmentNameUtils.getHeaderSegmentName(name),
                 ex -> ex instanceof IllegalArgumentException);
     }
@@ -157,7 +157,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetSegmentNameFromHeader() {
         String name = StreamSegmentNameUtils.getSegmentNameFromHeader(StreamSegmentNameUtils.getHeaderSegmentName("foo"));
         AssertExtensions.assertThrows(
-                "getAttributeSegmentName did not add the attribute suffix",
+                "getSegmentNameFromHeader did not remove the header suffix",
                 () -> StreamSegmentNameUtils.getSegmentNameFromHeader("foo"),
                 ex -> ex instanceof IllegalArgumentException);
     }
@@ -166,7 +166,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetSegmentNameChunkName() {
         String name = StreamSegmentNameUtils.getSegmentChunkName("foo", 0);
         AssertExtensions.assertThrows(
-                "getAttributeSegmentName did not add the attribute suffix",
+                "getSegmentChunkName did not concatenate segment name and suffix",
                 () -> StreamSegmentNameUtils.getSegmentChunkName(name, 0),
                 ex -> ex instanceof IllegalArgumentException);
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
@@ -139,7 +139,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetAttributeSegmentName() {
        String name = StreamSegmentNameUtils.getAttributeSegmentName("foo");
         AssertExtensions.assertThrows(
-                "getAttributeSegmentName did not fail to add attribute suffix.",
+                "getAttributeSegmentName did not fail to add the attribute suffix.",
                 () -> StreamSegmentNameUtils.getAttributeSegmentName(name),
                 ex -> ex instanceof IllegalArgumentException);
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
@@ -139,7 +139,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetAttributeSegmentName() {
        String name = StreamSegmentNameUtils.getAttributeSegmentName("foo");
         AssertExtensions.assertThrows(
-                "getAttributeSegmentName did not add the attribute suffix",
+                "getAttributeSegmentName did not fail to add attribute suffix.",
                 () -> StreamSegmentNameUtils.getAttributeSegmentName(name),
                 ex -> ex instanceof IllegalArgumentException);
     }
@@ -148,7 +148,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetHeaderSegmentName() {
         String name = StreamSegmentNameUtils.getHeaderSegmentName("foo");
         AssertExtensions.assertThrows(
-                "getHeaderSegmentName did not add the header suffix",
+                "getHeaderSegmentName did not fail to add the header suffix.",
                 () -> StreamSegmentNameUtils.getHeaderSegmentName(name),
                 ex -> ex instanceof IllegalArgumentException);
     }
@@ -157,7 +157,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetSegmentNameFromHeader() {
         String name = StreamSegmentNameUtils.getSegmentNameFromHeader(StreamSegmentNameUtils.getHeaderSegmentName("foo"));
         AssertExtensions.assertThrows(
-                "getSegmentNameFromHeader did not remove the header suffix",
+                "getSegmentNameFromHeader did not fail to remove the header suffix.",
                 () -> StreamSegmentNameUtils.getSegmentNameFromHeader("foo"),
                 ex -> ex instanceof IllegalArgumentException);
     }
@@ -166,7 +166,7 @@ public class StreamSegmentNameUtilsTests {
     public void testGetSegmentNameChunkName() {
         String name = StreamSegmentNameUtils.getSegmentChunkName("foo", 0);
         AssertExtensions.assertThrows(
-                "getSegmentChunkName did not concatenate segment name and suffix",
+                "getSegmentChunkName did not fail to concatenate the offset.",
                 () -> StreamSegmentNameUtils.getSegmentChunkName(name, 0),
                 ex -> ex instanceof IllegalArgumentException);
     }


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**  
* Adds some simple unit tests to classes in shared/segment to improve code coverage.
* Specifically, adds tests for ScaleType and StreamSegmentNameUtils
 
**Purpose of the change**  
Fixes #3809 

**What the code does**  
This PR adds new unit test cases to improve the test coverage in the shared/segment package. Codecov is declaring that the package has low coverage and there are two classed only primarily contributing to the low coverage. 

**How to verify it**  
New unit tests must pass and code coverage must go up.
