### PR TITLE
Issue 3811: Fix SpotBugs error on Java 11 build.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -28,7 +28,8 @@ public class Connection {
     private final CompletableFuture<Void> connected;
     
     /**
-     * Returns the number of open flows on this connection. 
+     * Returns the number of open flows on this connection.
+     * @return Flow count.
      */
     public int getFlowCount() {
         return flowHandler.getOpenFlowCount();

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -98,6 +98,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
 
     /**
      * Returns the number of open flows.
+     * @return Flow count.
      */
     public int getOpenFlowCount() {
         return flowIdReplyProcessorMap.size();

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -54,7 +54,7 @@ public interface SegmentOutputStream extends AutoCloseable {
      * This is invoked by the segmentSealed callback to fetch the unackedEvents to be resent to the right
      * SegmentOutputStreams.
      *
-     * Returns a List of all the events that have been passed to write but have not yet been
+     * @return List of all the events that have been passed to write but have not yet been
      * acknowledged as written. The iteration order in the List is from oldest to newest.
      */
     public abstract List<PendingEvent> getUnackedEventsOnSeal();

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -222,7 +222,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                          .flatMap(map -> map.entrySet().stream())
                          .collect(Collectors.toMap(Entry::getKey,
                                                    // A value of -1L implies read until the end of the segment.
-                                                   entry -> (entry.getValue() == -1L) ? Long.MAX_VALUE : entry.getValue()));
+                                                   entry -> (entry.getValue() == -1L) ? (Long) Long.MAX_VALUE : entry.getValue()));
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -211,6 +211,7 @@ public class ReaderGroupState implements Revisioned {
 
     /**
      * Returns the number of segments currently being read from and that are unassigned within the reader group.
+     * @return Number of segments.
      */
     @Synchronized
     public int getNumberOfSegments() {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -59,7 +59,7 @@ import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
  * needed by calling {@link #findSegmentToReleaseIfRequired()}
  * 
  * Finally when a segment is sealed it may have one or more successors. So when a reader comes to the end of a
- * segment it should call {@link #handleEndOfSegment(Segment, boolean)}  so that it can continue reading from the
+ * segment it should call {@link #handleEndOfSegment(Segment)} so that it can continue reading from the
  * successor to that segment.
  */
 @Slf4j


### PR DESCRIPTION
**Change log description**  
* Fix `BX_UNBOXING_IMMEDIATELY_REBOXED` spotBugs error observed on Java 11 based build. 
* Remove java doc warnings in Pravega client build.

**Purpose of the change**  
Fixes #3811 

**What the code does**  
No changes in functionality. Fixes the spotbugs error observed with a Java 11 based build and java doc warnings.

**How to verify it**  
All the existing tests should continue to pass.
