### PR TITLE
Issue 3816: Sporadic failure of BookieFailoverTest in Docker Swarm system tests

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -74,7 +74,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=false";
+        String env5 = "BK_useHostNameAsBookieID=true";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);
@@ -84,7 +84,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
-                        .hostname("{{.Node.ID}}-{{.Service.Name}}")
+                        .hostname("{{.Task.Name}}-{{.Node.ID}}-{{.Service.Name}}")
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -72,7 +72,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=false";
+        String env5 = "BK_useHostNameAsBookieID=true";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -66,9 +66,6 @@ public class BookkeeperDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.service.name", serviceName);
 
-        Mount mount2 = Mount.builder().type("volume").source("bookkeeper-logs")
-                .target("/opt/dl_all/distributedlog-service/logs/")
-                .build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         List<String> stringList = new ArrayList<>();
         String env1 = "ZK_URL=" + zk;
@@ -89,7 +86,6 @@ public class BookkeeperDockerService extends DockerBasedService {
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())
-                        .mounts(Arrays.asList(mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -74,7 +74,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=false";
+        String env5 = "BK_useHostNameAsBookieID=true";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -77,7 +77,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         stringList.add(env5);
 
         final TaskSpec taskSpec = TaskSpec
-                .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
+                .builder().restartPolicy(RestartPolicy.builder().maxAttempts(3).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
                         .hostname(serviceName)
                         .labels(labels)

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -72,7 +72,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=true";
+        String env5 = "BK_useHostNameAsBookieID=false";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -74,7 +74,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=true";
+        String env5 = "BK_useHostNameAsBookieID=false";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);
@@ -84,7 +84,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
-                        .hostname(serviceName)
+                        .hostname("{{.Node.ID}}-{{.Service.Name}}")
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -10,7 +10,6 @@
 package io.pravega.test.system.framework.services.docker;
 
 import com.spotify.docker.client.messages.ContainerConfig;
-import com.spotify.docker.client.messages.mount.Mount;
 import com.spotify.docker.client.messages.swarm.ContainerSpec;
 import com.spotify.docker.client.messages.swarm.EndpointSpec;
 import com.spotify.docker.client.messages.swarm.NetworkAttachmentConfig;
@@ -21,17 +20,15 @@ import com.spotify.docker.client.messages.swarm.RestartPolicy;
 import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
-import io.pravega.common.hash.RandomFactory;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
-import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 import static com.spotify.docker.client.messages.swarm.RestartPolicy.RESTART_POLICY_ANY;
+import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 
 @Slf4j
 public class BookkeeperDockerService extends DockerBasedService {
@@ -72,7 +69,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=true";
+        String env5 = "BK_useHostNameAsBookieID=false";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);
@@ -82,7 +79,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
-                        .hostname(serviceName + "-" + Math.abs(RandomFactory.getSeed()))
+                        .hostname(serviceName)
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -21,6 +21,7 @@ import com.spotify.docker.client.messages.swarm.RestartPolicy;
 import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
+import io.pravega.common.hash.RandomFactory;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,7 +85,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
-                        .hostname("{{.Task.Name}}-{{.Node.ID}}-{{.Service.Name}}")
+                        .hostname(serviceName + "-" + RandomFactory.getSeed())
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -75,7 +75,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         String env2 = "ZK=" + zk;
         String env3 = "bookiePort=" + String.valueOf(BK_PORT);
         String env4 = "DLOG_EXTRA_OPTS=-Xms512m";
-        String env5 = "BK_useHostNameAsBookieID=true";
+        String env5 = "BK_useHostNameAsBookieID=false";
         stringList.add(env1);
         stringList.add(env2);
         stringList.add(env3);
@@ -85,7 +85,7 @@ public class BookkeeperDockerService extends DockerBasedService {
         final TaskSpec taskSpec = TaskSpec
                 .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
-                        .hostname(serviceName + "-" + RandomFactory.getSeed())
+                        .hostname(serviceName + "-" + Math.abs(RandomFactory.getSeed()))
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -28,7 +28,7 @@ import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 @Slf4j
 public class ZookeeperDockerService extends DockerBasedService {
 
-    private static final String ZK_IMAGE = "jplock/zookeeper:3.5.1-alpha";
+    private static final String ZK_IMAGE = "zookeeper:3.5.4-beta";
     private final long instances = 1;
     private final double cpu = 1.0 * Math.pow(10.0, 9.0);
     private final long mem = 1024 * 1024 * 1024L;

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -36,6 +36,7 @@ import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -45,6 +46,7 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
+@Ignore
 public class BookieFailoverTest extends AbstractFailoverTests  {
 
     private static final String STREAM = "testBookieFailoverStream";

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -36,7 +36,6 @@ import mesosphere.marathon.client.MarathonException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -46,7 +45,6 @@ import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @RunWith(SystemTestRunner.class)
-@Ignore
 public class BookieFailoverTest extends AbstractFailoverTests  {
 
     private static final String STREAM = "testBookieFailoverStream";


### PR DESCRIPTION
**Change log description**  
Fixes a sporadic problem in BookieFailoverTest (Docker Swarm system tests) that prevented the Bookkeeper service to scale up from 2 to 3 replicas.

**Purpose of the change**  
Fixes #3816.

**What the code does**  
This PR contains 2 changes that improve the situation of the Bookkeeper service in Docker Swarm:
- _Increase retries in the Bookkeeper restart policy_: Before, the `RestartPolicy` of Bookkeeper tasks was set to `maxAttempts=1`. However, in an unfortunate case, a Bookie may fail more than once to get started. We increased restart retries to `3`, which seems to be enough in most cases.
- _Remove unused volume for Bookies_: `BookkeeperDockerService` was mounting a volume referring to a non-existing location in the Bookkeeper image (`/opt/dl_all/distributedlog-service/logs/`). We just removed that useless volume.

Apart from that, we also upgraded the Zookeeper image used in Docker Swarm system tests (`jplock/zookeeper:3.5.1-alpha`) to the same one used in Kubernetes tests (`zookeeper:3.5.4-beta`). 

**How to verify it**  
We have seen 4 successful `BookieFailoverTest` executions in a row with these changes (including a green build).
