### PR TITLE
Issue 3786: improved the gauge handling to prevent gauge object loss

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -136,27 +136,18 @@ public class DynamicLoggerImpl implements DynamicLogger {
     public <T extends Number> void reportGaugeValue(String name, T value, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(value);
-        Gauge newGauge = null;
         MetricsNames.MetricKey keys = metricKey(name, tags);
 
-        if (value instanceof Float) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::floatValue, tags);
-        } else if (value instanceof Double) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::doubleValue, tags);
-        } else if (value instanceof Byte) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::byteValue, tags);
-        } else if (value instanceof Short) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::shortValue, tags);
-        } else if (value instanceof Integer) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::intValue, tags);
-        } else if (value instanceof Long) {
-            newGauge = underlying.registerGauge(keys.getRegistryKey(), value::longValue);
-        }
-
-        if (null == newGauge) {
-            log.error("Unsupported Number type: {}.", value.getClass().getName());
+        Gauge gauge = gaugesCache.getIfPresent(keys.getCacheKey());
+        if (gauge == null) {
+            Gauge newGauge = underlying.registerGauge(keys.getRegistryKey(), value::doubleValue, tags);
+            if (newGauge == null) {
+                log.error("Unsupported Number type: {}.", value.getClass().getName());
+            } else {
+                gaugesCache.put(keys.getCacheKey(), newGauge);
+            }
         } else {
-            gaugesCache.put(keys.getCacheKey(), newGauge);
+            gauge.supplierReference().set(value::doubleValue);
         }
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.shared.metrics;
 
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -18,8 +17,14 @@ import java.util.function.Supplier;
 public interface Gauge extends Metric {
 
     /**
-     * Return an AtomicReference pointing to the supplier of gauge value.
-     * @return an AtomicReference pointing to the Supplier of gauge value.
+     * Set the supplier of gauge value.
+     * @param supplier the supplier of gauge value.
      */
-    AtomicReference<Supplier<Number>> supplierReference();
+    void setSupplier(Supplier<Number> supplier);
+
+    /**
+     * Get the supplier of gauge value.
+     * @return the supplier of gauge value.
+     */
+    Supplier<Number> getSupplier();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
@@ -9,8 +9,17 @@
  */
 package io.pravega.shared.metrics;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 /**
  * Defines a Gauge, which will wrap a gauge instance and its name.
  */
 public interface Gauge extends Metric {
+
+    /**
+     * Return an AtomicReference pointing to the supplier of gauge value.
+     * @return an AtomicReference pointing to the Supplier of gauge value.
+     */
+    AtomicReference<Supplier<Number>> supplierReference();
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -9,17 +9,18 @@
  */
 package io.pravega.shared.metrics;
 
-import com.google.common.base.Preconditions;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import lombok.Getter;
 
 class GaugeProxy extends MetricProxy<Gauge> implements Gauge {
-    @Getter
-    private final Supplier<? extends Number> valueSupplier;
 
-    GaugeProxy(Gauge gauge, String proxyName, Supplier<? extends Number> valueSupplier, Consumer<String> closeCallback) {
+    GaugeProxy(Gauge gauge, String proxyName, Consumer<String> closeCallback) {
         super(gauge, proxyName, closeCallback);
-        this.valueSupplier = Preconditions.checkNotNull(valueSupplier, "valueSupplier");
+    }
+
+    @Override
+    public AtomicReference<Supplier<Number>> supplierReference() {
+        return getInstance().supplierReference();
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.shared.metrics;
 
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -20,7 +19,12 @@ class GaugeProxy extends MetricProxy<Gauge> implements Gauge {
     }
 
     @Override
-    public AtomicReference<Supplier<Number>> supplierReference() {
-        return getInstance().supplierReference();
+    public void setSupplier(Supplier<Number> supplier) {
+        getInstance().setSupplier(supplier);
+    }
+
+    @Override
+    public Supplier<Number> getSupplier() {
+        return getInstance().getSupplier();
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
@@ -11,7 +11,6 @@ package io.pravega.shared.metrics;
 
 import java.time.Duration;
 import java.util.EnumMap;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import io.micrometer.core.instrument.Meter.Id;
 
@@ -41,8 +40,13 @@ public class NullStatsLogger implements StatsLogger {
         }
 
         @Override
-        public AtomicReference<Supplier<Number>> supplierReference() {
-            return new AtomicReference<>();
+        public Supplier<Number> getSupplier() {
+            return null;
+        }
+
+        @Override
+        public void setSupplier(Supplier<Number> supplier) {
+            // no-op
         }
 
         @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
@@ -11,6 +11,7 @@ package io.pravega.shared.metrics;
 
 import java.time.Duration;
 import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import io.micrometer.core.instrument.Meter.Id;
 
@@ -40,13 +41,18 @@ public class NullStatsLogger implements StatsLogger {
         }
 
         @Override
+        public AtomicReference<Supplier<Number>> supplierReference() {
+            return new AtomicReference<>();
+        }
+
+        @Override
         public void close() {
             // nop
         }
     }
 
     @Override
-    public <T extends Number> Gauge registerGauge(String name, Supplier<T> value, String... tags) {
+    public Gauge registerGauge(String name, Supplier<Number> value, String... tags) {
         return NULLGAUGE;
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLogger.java
@@ -47,13 +47,12 @@ public interface StatsLogger {
      * Register gauge.
      * <i>value</i> is usually get of Number: AtomicInteger::get, AtomicLong::get
      *
-     * @param <T>   the type of value
-     * @param name  the name of gauge
-     * @param tags  the tags associated with the Gauge.
-     * @param value the supplier to provide value through get()
+     * @param name          the name of gauge
+     * @param tags          the tags associated with the Gauge.
+     * @param valueSupplier the supplier to provide value through get()
      */
-    <T extends Number> Gauge registerGauge(String name, Supplier<T> value, String... tags);
-
+    Gauge registerGauge(String name, Supplier<Number> valueSupplier, String... tags);
+    
     /**
      * Create the stats logger under scope <i>scope</i>.
      *

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -135,8 +135,13 @@ public class StatsLoggerImpl implements StatsLogger {
         }
 
         @Override
-        public AtomicReference<Supplier<Number>> supplierReference() {
-            return supplierReference;
+        public void setSupplier(Supplier<Number> supplier) {
+            supplierReference.set(supplier);
+        }
+
+        @Override
+        public Supplier<Number> getSupplier() {
+            return supplierReference.get();
         }
 
         @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -124,7 +124,6 @@ public class StatsLoggerImpl implements StatsLogger {
     private class GaugeImpl<T extends Number> implements Gauge {
         @Getter
         private final Id id;
-        @Getter
         private final AtomicReference<Supplier<Number>> supplierReference = new AtomicReference<>();
 
         GaugeImpl(String statName, Supplier<Number> valueSupplier, String... tagPairs) {

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -135,7 +135,7 @@ public class StatsLoggerImpl implements StatsLogger {
 
         @Override
         public void setSupplier(Supplier<Number> supplier) {
-            supplierReference.set(supplier);
+            supplierReference.set(Preconditions.checkNotNull(supplier));
         }
 
         @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
@@ -37,7 +37,7 @@ public class StatsLoggerProxy implements StatsLogger {
         this.opStatsLoggers.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createStats(v.getProxyName())));
         this.counters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createCounter(v.getProxyName())));
         this.meters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createMeter(v.getProxyName())));
-        this.gauges.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().registerGauge(v.getProxyName(), v.supplierReference().get())));
+        this.gauges.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().registerGauge(v.getProxyName(), v.getSupplier())));
     }
 
     @Override

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
@@ -37,7 +37,7 @@ public class StatsLoggerProxy implements StatsLogger {
         this.opStatsLoggers.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createStats(v.getProxyName())));
         this.counters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createCounter(v.getProxyName())));
         this.meters.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().createMeter(v.getProxyName())));
-        this.gauges.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().registerGauge(v.getProxyName(), v.getValueSupplier())));
+        this.gauges.values().forEach(v -> v.updateInstance(this.statsLoggerRef.get().registerGauge(v.getProxyName(), v.supplierReference().get())));
     }
 
     @Override
@@ -59,10 +59,10 @@ public class StatsLoggerProxy implements StatsLogger {
     }
 
     @Override
-    public <T extends Number> Gauge registerGauge(String name, Supplier<T> value, String... tags) {
+    public Gauge registerGauge(String name, Supplier<Number> supplier, String... tags) {
         return getOrSet(this.gauges, name,
-                metricName -> this.statsLoggerRef.get().registerGauge(metricName, value, tags),
-                (metric, proxyName, c) -> new GaugeProxy(metric, proxyName, value, c), tags);
+                metricName -> this.statsLoggerRef.get().registerGauge(metricName, supplier, tags),
+                (metric, proxyName, c) -> new GaugeProxy(metric, proxyName, c), tags);
     }
 
     @Override

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/BasicMetricTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/BasicMetricTest.java
@@ -77,8 +77,16 @@ public class BasicMetricTest {
     }
 
     @Test (expected = Exception.class)
-    public void testGaugeCreationException() {
-        statsLogger.registerGauge("testGauge", () -> 5, "tagName1", "tagValue1", "tagName2");
+    public void testGaugeCreationTagException() {
+        statsLogger.registerGauge("testGauge", () -> 5, "tagKey1", "tagValue1", "tagKey2");
+    }
+
+    @Test
+    public void testGaugeCreationFunctionException() {
+        Gauge noopGauge = statsLogger.registerGauge("testGauge", null, "tagKey", "tagValue");
+        assertTrue(noopGauge.getId() == null);
+        noopGauge.close();
+
     }
 
     @Test

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -173,6 +173,18 @@ public class MetricsProviderTest {
      */
     @Test
     public void testGauge() {
+
+        // test gauge value supplier
+        String[] tags1 = {"tagKey", "tagValue"};
+        Gauge gauge1 = statsLogger.registerGauge("testGaugeFunctionNoTag", () -> 23);
+        Gauge gauge2 = statsLogger.registerGauge("testGaugeFunction", () -> 52, tags1);
+        assertEquals(23, (int) MetricRegistryUtils.getGauge("testGaugeFunctionNoTag").value());
+        assertEquals(52, (int) MetricRegistryUtils.getGauge("testGaugeFunction", tags1).value());
+        gauge1.setSupplier(() -> 32);
+        gauge2.setSupplier(() -> 25);
+        assertEquals(32, (int) MetricRegistryUtils.getGauge("testGaugeFunctionNoTag").value());
+        assertEquals(25, (int) MetricRegistryUtils.getGauge("testGaugeFunction", tags1).value());
+
         AtomicInteger value = new AtomicInteger(1);
         AtomicInteger value1 = new AtomicInteger(100);
         AtomicInteger value2 = new AtomicInteger(200);

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
@@ -13,7 +13,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.Getter;
@@ -236,11 +235,13 @@ public class StatsLoggerProxyTest {
         }
 
         @Override
-        public AtomicReference<Supplier<Number>> supplierReference() {
-            AtomicReference<Supplier<Number>> reference = new AtomicReference<>();
-            Supplier<Number> supplier = () -> 5;
-            reference.set(supplier);
-            return reference;
+        public Supplier<Number> getSupplier() {
+            return () -> 5;
+        }
+
+        @Override
+        public void setSupplier(Supplier<Number> supplier) {
+
         }
         //endregion
     }

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.Getter;
@@ -138,7 +139,7 @@ public class StatsLoggerProxyTest {
         }
 
         @Override
-        public <T extends Number> Gauge registerGauge(String name, Supplier<T> value, String... tags) {
+        public Gauge registerGauge(String name, Supplier<Number> supplier, String... tags) {
             return create(name, tags);
         }
 
@@ -234,6 +235,13 @@ public class StatsLoggerProxyTest {
 
         }
 
+        @Override
+        public AtomicReference<Supplier<Number>> supplierReference() {
+            AtomicReference<Supplier<Number>> reference = new AtomicReference<>();
+            Supplier<Number> supplier = () -> 5;
+            reference.set(supplier);
+            return reference;
+        }
         //endregion
     }
 }


### PR DESCRIPTION
**Change log description**  
Gauge handling is different than other metrics type because it passes a function into metrics registry. Because the function is immutable, in order to update gauge, the legacy code just delete existing gauge and insert a new one.
Hence a race condition is introduced - if the gauge value is retrieved after the old object is deleted but before the new object is registered, the gauge will report 0 or NaN.
This change is to add an AtomicReference into Gauge which points to a function. To update Gauge value, simply replace the function inside the reference.

**Purpose of the change**  
Fixes #3786

**What the code does**  
(Detailed description of the code changes)
Added an AtomicReference into Gauge object to hold a reference to a Supplier<Number>.
Changed the Gauge interface to expose the reference.
Changes test codes to adopt the new interface.
When to update gauge, instead of removing old object, now just replace the function(Supplier<Number>).
Since Gauge object can now be "reused", put Gauge into cache.

**How to verify it**  
All the tests should pass.
