### PR TITLE
Issue 3823: Fix incorrect segment name in exception thrown.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -290,7 +290,11 @@ class HDFSStorage implements SyncStorage {
             } else if (fileStatus.getLen() != offset) {
                 throw new BadOffsetException(target.getSegmentName(), fileStatus.getLen(), offset);
             }
+        } catch (IOException ex) {
+            throw HDFSExceptionHelpers.convertException(target.getSegmentName(), ex);
+        }
 
+        try {
             FileStatus sourceFile = findStatusForSegment(sourceSegment, true);
             Preconditions.checkState(isSealed(sourceFile.getPath()),
                     "Cannot concat segment '%s' into '%s' because it is not sealed.", sourceSegment, target.getSegmentName());


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Fixing exception thrown from concat as it always has source segment name instead of target.

**Purpose of the change**  
Fixes #3823

**What the code does**  
Uses separate try catch blocks for validating target and source so correct exception with correct message can be thrown.

**How to verify it**  
All tests should continue to pass.
