### PR TITLE
Issue 3826: Cherry-pick commits from master to r0.5

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -290,7 +290,11 @@ class HDFSStorage implements SyncStorage {
             } else if (fileStatus.getLen() != offset) {
                 throw new BadOffsetException(target.getSegmentName(), fileStatus.getLen(), offset);
             }
+        } catch (IOException ex) {
+            throw HDFSExceptionHelpers.convertException(target.getSegmentName(), ex);
+        }
 
+        try {
             FileStatus sourceFile = findStatusForSegment(sourceSegment, true);
             Preconditions.checkState(isSealed(sourceFile.getPath()),
                     "Cannot concat segment '%s' into '%s' because it is not sealed.", sourceSegment, target.getSegmentName());

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -28,7 +28,8 @@ public class Connection {
     private final CompletableFuture<Void> connected;
     
     /**
-     * Returns the number of open flows on this connection. 
+     * Returns the number of open flows on this connection.
+     * @return Flow count.
      */
     public int getFlowCount() {
         return flowHandler.getOpenFlowCount();

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -98,6 +98,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
 
     /**
      * Returns the number of open flows.
+     * @return Flow count.
      */
     public int getOpenFlowCount() {
         return flowIdReplyProcessorMap.size();

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -54,7 +54,7 @@ public interface SegmentOutputStream extends AutoCloseable {
      * This is invoked by the segmentSealed callback to fetch the unackedEvents to be resent to the right
      * SegmentOutputStreams.
      *
-     * Returns a List of all the events that have been passed to write but have not yet been
+     * @return List of all the events that have been passed to write but have not yet been
      * acknowledged as written. The iteration order in the List is from oldest to newest.
      */
     public abstract List<PendingEvent> getUnackedEventsOnSeal();

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -131,9 +131,9 @@ public class ClientFactoryImpl implements ClientFactory, EventStreamClientFactor
     public <T> EventStreamWriter<T> createEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {
         log.info("Creating writer for stream: {} with configuration: {}", streamName, config);
         Stream stream = new StreamImpl(scope, streamName);
-        ThreadPoolExecutor executor = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"
+        ThreadPoolExecutor retransmitPool = ExecutorServiceHelpers.getShrinkingExecutor(1, 100, "ScalingRetransmition-"
                 + stream.getScopedName());
-        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, executor);
+        return new EventStreamWriterImpl<T>(stream, controller, outFactory, s, config, retransmitPool, connectionFactory.getInternalExecutor());
     }
     
     @Override
@@ -141,7 +141,7 @@ public class ClientFactoryImpl implements ClientFactory, EventStreamClientFactor
     public <T> TransactionalEventStreamWriter<T> createTransactionalEventWriter(String streamName, Serializer<T> s, EventWriterConfig config) {
         log.info("Creating transactional writer for stream: {} with configuration: {}", streamName, config);
         Stream stream = new StreamImpl(scope, streamName);
-        return new TransactionalEventStreamWriterImpl<T>(stream, controller, outFactory, s, config);
+        return new TransactionalEventStreamWriterImpl<T>(stream, controller, outFactory, s, config, connectionFactory.getInternalExecutor());
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.GuardedBy;
@@ -81,7 +82,8 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
     private final Pinger pinger;
     
     EventStreamWriterImpl(Stream stream, Controller controller, SegmentOutputStreamFactory outputStreamFactory,
-            Serializer<Type> serializer, EventWriterConfig config, ExecutorService retransmitPool) {
+                          Serializer<Type> serializer, EventWriterConfig config, ExecutorService retransmitPool,
+                          ScheduledExecutorService internalExecutor) {
         this.stream = Preconditions.checkNotNull(stream);
         this.controller = Preconditions.checkNotNull(controller);
         this.segmentSealedCallBack = this::handleLogSealed;
@@ -90,7 +92,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         this.serializer = Preconditions.checkNotNull(serializer);
         this.config = config;
         this.retransmitPool = Preconditions.checkNotNull(retransmitPool);
-        this.pinger = new Pinger(config, stream, controller);
+        this.pinger = new Pinger(config, stream, controller, internalExecutor);
         List<PendingEvent> failedEvents = selector.refreshSegmentEventWriters(segmentSealedCallBack);
         assert failedEvents.isEmpty() : "There should not be any events to have failed";
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
@@ -12,16 +12,21 @@ package io.pravega.client.stream.impl;
 import com.google.common.annotations.VisibleForTesting;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Stream;
-import io.pravega.common.concurrent.ExecutorServiceHelpers;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import io.pravega.client.stream.Transaction;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Synchronized;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.GuardedBy;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import static io.pravega.common.Exceptions.unwrap;
 
 /**
  * Pinger is used to send pings to renew the transaction lease for active transactions.
@@ -32,54 +37,58 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Pinger implements AutoCloseable {
     private static final double PING_INTERVAL_FACTOR = 0.5; //ping interval = factor * txn lease time.
+    private static final long MINIMUM_PING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
 
     private final Stream stream;
     private final Controller controller;
     private final long txnLeaseMillis;
     private final long pingIntervalMillis;
-    private ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(1,
-            "pingTxnThread");
-    private final List<UUID> txnList = Collections.synchronizedList(new ArrayList<>());
+    private final ScheduledExecutorService executor;
+    private final Object lock = new Object();
+    @GuardedBy("lock")
+    private final Set<UUID> txnList = new HashSet<>();
+    @Getter(value = AccessLevel.PACKAGE)
+    @VisibleForTesting
+    @GuardedBy("lock")
+    private final Set<UUID> completedTxns = new HashSet<>();
     private final AtomicBoolean isStarted = new AtomicBoolean();
+    private final AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>();
 
-    Pinger(EventWriterConfig config, Stream stream, Controller controller) {
+    Pinger(EventWriterConfig config, Stream stream, Controller controller, ScheduledExecutorService executor) {
         this.txnLeaseMillis = config.getTransactionTimeoutTime();
         this.pingIntervalMillis = getPingInterval(txnLeaseMillis);
         this.stream = stream;
         this.controller = controller;
-    }
-
-    @VisibleForTesting
-    Pinger(EventWriterConfig config, Stream stream, Controller controller, ScheduledExecutorService executor) {
-      this(config, stream, controller);
-      this.executor = executor;
+        this.executor = executor;
     }
 
     void startPing(UUID txnID) {
-        txnList.add(txnID);
+        synchronized (lock) {
+            txnList.add(txnID);
+        }
         startPeriodicPingTxn();
     }
 
     void stopPing(UUID txnID) {
-        txnList.remove(txnID);
+        synchronized (lock) {
+            txnList.remove(txnID);
+        }
     }
 
     private long getPingInterval(long txnLeaseMillis) {
         double pingInterval = txnLeaseMillis * PING_INTERVAL_FACTOR;
-        if (pingInterval < TimeUnit.SECONDS.toMillis(5)) {
+        if (pingInterval < MINIMUM_PING_INTERVAL_MS) {
             log.warn("Transaction ping interval is less than 10 seconds(lower bound)");
         }
         //Ping interval cannot be less than KeepAlive task interval of 10seconds.
-        return Math.max(TimeUnit.SECONDS.toMillis(5), (long) pingInterval);
+        return Math.max(MINIMUM_PING_INTERVAL_MS, (long) pingInterval);
     }
 
-    @Synchronized
     private void startPeriodicPingTxn() {
-        if (!isStarted.get()) {
+        if (!isStarted.getAndSet(true)) {
             log.info("Starting Pinger at an interval of {}ms ", this.pingIntervalMillis);
-            executor.scheduleAtFixedRate(this::pingTransactions, 10, this.pingIntervalMillis,
-                    TimeUnit.MILLISECONDS);
-            isStarted.set(true);
+            // scheduleAtFixedRate ensure that there are no concurrent executions of the command, pingTransactions()
+            scheduledFuture.set(executor.scheduleAtFixedRate(this::pingTransactions, 10, this.pingIntervalMillis, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -89,25 +98,35 @@ public class Pinger implements AutoCloseable {
      */
     private void pingTransactions() {
         log.info("Start sending transaction pings.");
-        txnList.stream().forEach(uuid -> {
-            try {
-                log.debug("Sending ping request for txn ID: {} with lease: {}", uuid, txnLeaseMillis);
-                controller.pingTransaction(stream, uuid, txnLeaseMillis)
-                .exceptionally(e -> {
-                    log.warn("Ping Transaction for txn ID:{} failed", uuid, e);
-                    return null;
-                });
-            } catch (Exception e) {
-                // Suppressing exception to prevent future pings from not being executed. 
-                log.warn("Encountered exception when attepting to ping transactions", e);
-            }
-        });
+        synchronized (lock) {
+            txnList.removeAll(completedTxns);  // remove completed transactions from the pingable transaction list.
+            completedTxns.clear();
+            txnList.forEach(uuid -> {
+                try {
+                    log.debug("Sending ping request for txn ID: {} with lease: {}", uuid, txnLeaseMillis);
+                    controller.pingTransaction(stream, uuid, txnLeaseMillis)
+                              .whenComplete((status, e) -> {
+                                  if (e != null) {
+                                      log.warn("Ping Transaction for txn ID:{} failed", uuid, unwrap(e));
+                                  } else if (Transaction.PingStatus.ABORTED.equals(status) || Transaction.PingStatus.COMMITTED.equals(status)) {
+                                      completedTxns.add(uuid);
+                                  }
+                              });
+                } catch (Exception e) {
+                    // Suppressing exception to prevent future pings from not being executed.
+                    log.warn("Encountered exception when attempting to ping transactions", e);
+                }
+            });
+        }
         log.trace("Completed sending transaction pings.");
     }
 
     @Override
     public void close() {
         log.info("Closing Pinger periodic task");
-        ExecutorServiceHelpers.shutdown(executor);
+        ScheduledFuture<?> future = scheduledFuture.getAndSet(null);
+        if (future != null) {
+            future.cancel(false);
+        }
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -222,7 +222,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                          .flatMap(map -> map.entrySet().stream())
                          .collect(Collectors.toMap(Entry::getKey,
                                                    // A value of -1L implies read until the end of the segment.
-                                                   entry -> (entry.getValue() == -1L) ? Long.MAX_VALUE : entry.getValue()));
+                                                   entry -> (entry.getValue() == -1L) ? (Long) Long.MAX_VALUE : entry.getValue()));
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -211,6 +211,7 @@ public class ReaderGroupState implements Revisioned {
 
     /**
      * Returns the number of segments currently being read from and that are unassigned within the reader group.
+     * @return Number of segments.
      */
     @Synchronized
     public int getNumberOfSegments() {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -59,7 +59,7 @@ import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
  * needed by calling {@link #findSegmentToReleaseIfRequired()}
  * 
  * Finally when a segment is sealed it may have one or more successors. So when a reader comes to the end of a
- * segment it should call {@link #handleEndOfSegment(Segment, boolean)}  so that it can continue reading from the
+ * segment it should call {@link #handleEndOfSegment(Segment)} so that it can continue reading from the
  * successor to that segment.
  */
 @Slf4j

--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -23,6 +23,7 @@ import io.pravega.client.stream.TxnFailedException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -49,13 +50,13 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
     private final Pinger pinger;
     
     TransactionalEventStreamWriterImpl(Stream stream, Controller controller, SegmentOutputStreamFactory outputStreamFactory,
-            Serializer<Type> serializer, EventWriterConfig config) {
+                                       Serializer<Type> serializer, EventWriterConfig config, ScheduledExecutorService executor) {
         this.stream = Preconditions.checkNotNull(stream);
         this.controller = Preconditions.checkNotNull(controller);
         this.outputStreamFactory = Preconditions.checkNotNull(outputStreamFactory);
         this.serializer = Preconditions.checkNotNull(serializer);
         this.config = config;
-        this.pinger = new Pinger(config, stream, controller);
+        this.pinger = new Pinger(config, stream, controller, executor);
     }
 
     @RequiredArgsConstructor

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -81,7 +81,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         MockSegmentIoStreams outputStream = new MockSegmentIoStreams(segment);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
-                new JavaSerializer<>(), config, executorService());
+                new JavaSerializer<>(), config, executorService(), executorService());
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
         writer.close();
@@ -122,7 +122,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         SegmentOutputStream outputStream = Mockito.mock(SegmentOutputStream.class);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory,
-                new JavaSerializer<>(), config, executorService());
+                new JavaSerializer<>(), config, executorService(), executorService());
         Mockito.doThrow(new RuntimeException("Intentional exception")).when(outputStream).close();
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
@@ -279,7 +279,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
                .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -330,7 +330,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
                 .thenReturn(getSegmentsFuture(segment2));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
 
         writer.writeEvent(routingKey, "Foo");
 
@@ -384,7 +384,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         Transaction<String> txn = writer.beginTxn();
         txn.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
@@ -419,7 +419,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         Transaction<String> txn = writer.beginTxn();
         outputStream.invokeSealedCallBack();
         try {
@@ -448,7 +448,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.unacked.size() > 0);
@@ -483,7 +483,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertEquals(1, outputStream1.unacked.size());
@@ -516,7 +516,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.unacked.size() > 0);
@@ -555,7 +555,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -601,7 +601,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
 
@@ -647,7 +647,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream.getUnackedEventsOnSeal().size() > 0);
@@ -692,7 +692,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent("Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertTrue(outputStream1.unacked.size() > 0);
@@ -747,7 +747,7 @@ public class EventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config, executorService());
+                config, executorService(), executorService());
         writer.writeEvent(routingKey, "Foo");
         Mockito.verify(controller).getCurrentSegments(any(), any());
         assertEquals(1, outputStream1.unacked.size());

--- a/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
@@ -13,6 +13,7 @@ import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.Transaction;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.test.common.InlineExecutor;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,9 +30,11 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -93,8 +96,8 @@ public class PingerTest {
         Pinger pinger = new Pinger(smallTxnLeaseTime, stream, controller, executor);
         pinger.startPing(txnID);
 
-            verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(),
-                eq(SECONDS.toMillis(5)), eq(TimeUnit.MILLISECONDS));
+        verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(),
+                eq(SECONDS.toMillis(10)), eq(TimeUnit.MILLISECONDS));
         verify(controller, times(1)).pingTransaction(eq(stream), eq(txnID),
                 eq(smallTxnLeaseTime.getTransactionTimeoutTime()));
     }
@@ -129,5 +132,43 @@ public class PingerTest {
         long expectedKeepAliveInterval = (long) (PING_INTERVAL_FACTOR * config.getTransactionTimeoutTime());
         verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(),
                 eq(expectedKeepAliveInterval), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testPingWithStatus() {
+
+        config = EventWriterConfig.builder().transactionTimeoutTime(500).build();
+        final UUID txnID1 = UUID.randomUUID();
+        final UUID txnID2 = UUID.randomUUID();
+        final UUID txnID3 = UUID.randomUUID();
+        final UUID txnID4 = UUID.randomUUID();
+
+        @Cleanup("shutdown")
+        InlineExecutor pingExecutor = new InlineExecutor();
+
+        //Setup mock to return different
+        when(controller.pingTransaction(any(Stream.class), eq(txnID1), anyLong()))
+                .thenReturn(CompletableFuture.<Transaction.PingStatus>completedFuture(Transaction.PingStatus.ABORTED));
+        when(controller.pingTransaction(any(Stream.class), eq(txnID2), anyLong()))
+                .thenReturn(CompletableFuture.<Transaction.PingStatus>completedFuture(Transaction.PingStatus.COMMITTED));
+        when(controller.pingTransaction(any(Stream.class), eq(txnID3), anyLong()))
+                .thenReturn(CompletableFuture.<Transaction.PingStatus>completedFuture(Transaction.PingStatus.OPEN));
+        CompletableFuture<Transaction.PingStatus> failedPingFuture = new CompletableFuture<>();
+        failedPingFuture.completeExceptionally(new RuntimeException("error"));
+        when(controller.pingTransaction(any(Stream.class), eq(txnID4), anyLong()))
+                .thenReturn(failedPingFuture);
+        @Cleanup
+        Pinger pinger = new Pinger(config, stream, controller, pingExecutor);
+
+        pinger.startPing(txnID1);
+        pinger.startPing(txnID2);
+        pinger.startPing(txnID3);
+        pinger.startPing(txnID4);
+
+        verify(controller, timeout(1000)).pingTransaction(eq(stream), eq(txnID1), eq(config.getTransactionTimeoutTime()));
+        verify(controller, timeout(1000)).pingTransaction(eq(stream), eq(txnID2), eq(config.getTransactionTimeoutTime()));
+        verify(controller, timeout(1000)).pingTransaction(eq(stream), eq(txnID3), eq(config.getTransactionTimeoutTime()));
+        verify(controller, timeout(1000)).pingTransaction(eq(stream), eq(txnID4), eq(config.getTransactionTimeoutTime()));
+        assertEquals(2, pinger.getCompletedTxns().size());
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -68,7 +68,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         TransactionalEventStreamWriter<String> writer = new TransactionalEventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config);
+                config, executorService());
         Transaction<String> txn = writer.beginTxn();
         txn.writeEvent("Foo");
         assertTrue(bad.unacked.isEmpty());
@@ -101,7 +101,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         TransactionalEventStreamWriter<String> writer = new TransactionalEventStreamWriterImpl<>(stream, controller, streamFactory, serializer,
-                config);
+                config, executorService());
         Transaction<String> txn = writer.beginTxn();
         outputStream.invokeSealedCallBack();
         try {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -360,6 +360,11 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
         return this.handle.get();
     }
 
+    @Override
+    public String toString() {
+        return this.traceObjectId;
+    }
+
     /**
      * Executes the given Index Operation with retries. Retries are only performed in case of conditional update failures,
      * represented by BadOffsetException.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1165,17 +1165,29 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         if (this.handle.get() == null) {
             // No handle so, the segment must not exist yet. Attempt to create it, then run what we wanted to.
             assert this.metadata.getStorageLength() == 0 : "no handle yet but metadata indicates Storage Segment not empty";
-            long rolloverSize = this.metadata.getAttributes().getOrDefault(Attributes.ROLLOVER_SIZE, -1L);
-            SegmentRollingPolicy rollingPolicy = rolloverSize < 0 ? SegmentRollingPolicy.NO_ROLLING : new SegmentRollingPolicy(rolloverSize);
+            long rolloverSize = this.metadata.getAttributes().getOrDefault(Attributes.ROLLOVER_SIZE, SegmentRollingPolicy.NO_ROLLING.getMaxLength());
             return Futures
-                    .exceptionallyExpecting(
-                            this.storage.create(this.metadata.getName(), rollingPolicy, timeout),
+                    .exceptionallyComposeExpecting(
+                            this.storage.create(this.metadata.getName(), new SegmentRollingPolicy(rolloverSize), timeout),
                             ex -> ex instanceof StreamSegmentExistsException,
-                            null)
+                            () -> {
+                                // This happens if we have more than one concurrent instances of the owning SegmentContainer
+                                // running at the same time. Both SegmentAggregator instances were initialized when the Segment
+                                // did not exist, and both knew about an append that would eventually make it to Storage. One
+                                // of them managed to create the Segment (and write something to it), but the other still assumed
+                                // the Segment did not exist - so we end up in here. We need to get a handle of the segment
+                                // and continue with whatever we were doing. If there is a mismatch (length, sealed, etc.),
+                                // then the normal reconciliation algorithm will kick in once it is discovered and if the
+                                // segment has already been fenced out, openWrite() will throw the appropriate exception
+                                // which will be handled upstream.
+                                log.info("{}: Segment did not exist in Storage when initialized() was called, but does now.", this.traceObjectId);
+                                return this.storage.openWrite(this.metadata.getName());
+                            })
                     .thenComposeAsync(handle -> {
                         this.handle.set(handle);
                         return toRun.get();
-                    });
+                    }, this.executor);
+
         } else {
             // Segment already exists. Execute what we were supposed to.
             return toRun.get();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -30,6 +30,7 @@ import io.pravega.segmentstore.server.logs.operations.MetadataOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -412,8 +413,10 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     }
 
     private boolean isCriticalError(Throwable ex) {
+        ex = Exceptions.unwrap(ex);
         return Exceptions.mustRethrow(ex)
-                || Exceptions.unwrap(ex) instanceof DataCorruptionException;
+                || ex instanceof DataCorruptionException     // Data corruption - stop processing to prevent more damage.
+                || ex instanceof StorageNotPrimaryException; // Fenced out - another instance took over.
     }
 
     private boolean isShutdownException(Throwable ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1634,6 +1634,50 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
     //region Unknown outcome operation reconciliation
 
     /**
+     * Tests the ability of the SegmentAggregator to recover from situations when a Segment did not exist in Storage
+     * when {@link SegmentAggregator#initialize} was invoked, but exists when the first byte needs to be appended.
+     * This can happen when there are concurrent instances of the same Segment Container running at the same time and
+     * one of them managed to create the Segment in Storage after the other one was initialized; when the second one tries
+     * to do the same, it must gracefully recover from that situation.
+     */
+    @Test
+    public void testReconcileCreateIfEmpty() throws Exception {
+        final WriterConfig config = DEFAULT_CONFIG;
+
+        @Cleanup
+        TestContext context = new TestContext(config);
+
+        // Initialize the Segment Aggregator, but do not yet create the segment.
+        context.segmentAggregator.initialize(TIMEOUT).join();
+
+        // Write one operation.
+        @Cleanup
+        ByteArrayOutputStream writtenData = new ByteArrayOutputStream();
+        StorageOperation appendOp = generateAppendAndUpdateMetadata(0, SEGMENT_ID, context);
+        context.segmentAggregator.add(appendOp);
+        getAppendData(appendOp, writtenData, context);
+
+        // Create the segment in Storage.
+        context.storage.create(SEGMENT_NAME, TIMEOUT).join();
+
+        // Flush the data. The SegmentAggregator thinks the Segment does not exist in Storage, so this verifies that it
+        // handles this situation elegantly.
+        context.increaseTime(config.getFlushThresholdTime().toMillis() + 1); // Force a flush by incrementing the time by a lot.
+        Assert.assertTrue("Expecting mustFlush() == true.", context.segmentAggregator.mustFlush());
+        val flushResult = context.segmentAggregator.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected number of flushed bytes.", writtenData.size(), flushResult.getFlushedBytes());
+
+        // Verify data.
+        byte[] expectedData = writtenData.toByteArray();
+        byte[] actualData = new byte[expectedData.length];
+        long storageLength = context.storage.getStreamSegmentInfo(context.segmentAggregator.getMetadata().getName(), TIMEOUT).join().getLength();
+        Assert.assertEquals("Unexpected number of bytes flushed to Storage.", expectedData.length, storageLength);
+        context.storage.read(readHandle(context.segmentAggregator.getMetadata().getName()), 0, actualData, 0, actualData.length, TIMEOUT).join();
+        checkAttributes(context);
+        Assert.assertArrayEquals("Unexpected data written to storage.", expectedData, actualData);
+    }
+
+    /**
      * Tests the ability of the SegmentAggregator to reconcile AppendOperations (Cached/NonCached).
      */
     @Test

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -38,6 +38,7 @@ import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentTruncateOperation;
 import io.pravega.segmentstore.server.logs.operations.UpdateAttributesOperation;
 import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.common.AssertExtensions;
@@ -63,6 +64,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -232,6 +234,49 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testWithStorageCorruptionErrors() throws Exception {
+        AtomicBoolean corruptionHappened = new AtomicBoolean();
+        Function<TestContext, ErrorInjector<Exception>> createErrorInjector = context -> {
+            byte[] corruptionData = "foo".getBytes();
+            SegmentHandle corruptedSegmentHandle = InMemoryStorage.newHandle(context.metadata.getStreamSegmentMetadata(0).getName(), false);
+            Supplier<Exception> exceptionSupplier = () -> {
+                // Corrupt data. We use an internal method (append) to atomically write data at the end of the segment.
+                // GetLength+Write would not work well because there may be concurrent writes that modify the data between
+                // requesting the length and attempting to write, thus causing the corruption to fail.
+                // NOTE: this is a synchronous call, but append() is also a sync method. If append() would become async,
+                // care must be taken not to block a thread while waiting for it.
+                context.storage.append(corruptedSegmentHandle, new ByteArrayInputStream(corruptionData), corruptionData.length);
+
+                // Return some other kind of exception.
+                return new TimeoutException("Intentional");
+            };
+            return new ErrorInjector<>(c -> !corruptionHappened.getAndSet(true), exceptionSupplier);
+        };
+
+        testWithStorageCriticalErrors(createErrorInjector, ex -> ex instanceof ReconciliationFailureException);
+    }
+
+    /**
+     * Tests the StorageWriter in a Scenario where the Storage component reports that it is no longer the primary owner
+     * of a particular segment (it was fenced out).
+     */
+    @Test
+    public void testWithStorageNotPrimaryErrors() throws Exception {
+        testWithStorageCriticalErrors(
+                context -> new ErrorInjector<>(c -> true, () -> new StorageNotPrimaryException("intentional")),
+                ex -> ex instanceof StorageNotPrimaryException);
+    }
+
+    /**
+     * Tests the StorageWriter in a configurable scenario where the Storage component throws a critical (container-stopper)
+     * exception and verifies its handling of the situation.
+     *
+     * @param createErrorInjector          Creates an ErrorInjector that will cause the Storage component to enter an
+     *                                     errored state and throw an exception back at the StorageWriter.
+     * @param validatePostFailureException Validates that the {@link StorageWriter#failureCause()} is set correctly after
+     *                                     the StorageWriter terminates with failure.
+     */
+    private void testWithStorageCriticalErrors(Function<TestContext, ErrorInjector<Exception>> createErrorInjector,
+                                               Predicate<Throwable> validatePostFailureException) throws Exception {
         @Cleanup
         TestContext context = new TestContext(DEFAULT_CONFIG);
 
@@ -242,29 +287,12 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
         HashMap<Long, ByteArrayOutputStream> segmentContents = new HashMap<>();
         appendDataBreadthFirst(segmentIds, segmentContents, context);
 
-        // Corrupt (one segment should suffice).
-        byte[] corruptionData = "foo".getBytes();
-        SegmentHandle corruptedSegmentHandle = InMemoryStorage.newHandle(context.metadata.getStreamSegmentMetadata(segmentIds.get(0)).getName(), false);
-        Supplier<Exception> exceptionSupplier = () -> {
-            // Corrupt data. We use an internal method (append) to atomically write data at the end of the segment.
-            // GetLength+Write would not work well because there may be concurrent writes that modify the data between
-            // requesting the length and attempting to write, thus causing the corruption to fail.
-            // NOTE: this is a synchronous call, but append() is also a sync method. If append() would become async,
-            // care must be taken not to block a thread while waiting for it.
-            context.storage.append(corruptedSegmentHandle, new ByteArrayInputStream(corruptionData), corruptionData.length);
-
-            // Return some other kind of exception.
-            return new TimeoutException("Intentional");
-        };
-
         // We only try to corrupt data once.
-        AtomicBoolean corruptionHappened = new AtomicBoolean();
-        context.storage.setWriteAsyncErrorInjector(new ErrorInjector<>(c -> !corruptionHappened.getAndSet(true), exceptionSupplier));
-
+        context.storage.setWriteAsyncErrorInjector(createErrorInjector.apply(context));
         AssertExtensions.assertThrows(
-                "StorageWriter did not fail when a fatal data corruption error occurred.",
+                "StorageWriter did not fail when critical error occurred.",
                 () -> {
-                    // The Corruption may happen early enough so the "awaitRunning" isn't complete yet. In that case,
+                    // The critical error may happen early enough so the "awaitRunning" isn't complete yet. In that case,
                     // the writer will never reach its 'Running' state. As such, we need to make sure at least one of these
                     // will throw (either start or, if the failure happened after start, make sure it eventually fails and shuts down).
                     context.writer.startAsync().awaitRunning();
@@ -273,7 +301,8 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof IllegalStateException);
 
         ServiceListeners.awaitShutdown(context.writer, TIMEOUT, false);
-        Assert.assertTrue("Unexpected failure cause for StorageWriter.", Exceptions.unwrap(context.writer.failureCause()) instanceof ReconciliationFailureException);
+        Assert.assertTrue("Unexpected failure cause for StorageWriter.",
+                validatePostFailureException.test(Exceptions.unwrap(context.writer.failureCause())));
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
@@ -41,7 +41,7 @@ public class StorageNotPrimaryException extends StreamSegmentException {
     }
 
     public StorageNotPrimaryException(String streamSegmentName, String message, Throwable cause) {
-        super(streamSegmentName, "The current instance is no longer the primary writer for this StreamSegment." + (message == null ? "" : " ") + message,
+        super(streamSegmentName, "The current instance is no longer the primary writer for this StreamSegment." + (message == null ? "" : " " + message),
                 cause);
     }
 }

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -10,7 +10,6 @@
 package io.pravega.test.system.framework.services.docker;
 
 import com.spotify.docker.client.messages.ContainerConfig;
-import com.spotify.docker.client.messages.mount.Mount;
 import com.spotify.docker.client.messages.swarm.ContainerSpec;
 import com.spotify.docker.client.messages.swarm.EndpointSpec;
 import com.spotify.docker.client.messages.swarm.NetworkAttachmentConfig;
@@ -23,14 +22,13 @@ import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
-import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 import static com.spotify.docker.client.messages.swarm.RestartPolicy.RESTART_POLICY_ANY;
+import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 
 @Slf4j
 public class BookkeeperDockerService extends DockerBasedService {
@@ -65,9 +63,6 @@ public class BookkeeperDockerService extends DockerBasedService {
         Map<String, String> labels = new HashMap<>();
         labels.put("com.docker.swarm.service.name", serviceName);
 
-        Mount mount2 = Mount.builder().type("volume").source("bookkeeper-logs")
-                .target("/opt/dl_all/distributedlog-service/logs/")
-                .build();
         String zk = zkUri.getHost() + ":" + ZKSERVICE_ZKPORT;
         List<String> stringList = new ArrayList<>();
         String env1 = "ZK_URL=" + zk;
@@ -82,13 +77,12 @@ public class BookkeeperDockerService extends DockerBasedService {
         stringList.add(env5);
 
         final TaskSpec taskSpec = TaskSpec
-                .builder().restartPolicy(RestartPolicy.builder().maxAttempts(1).condition(RESTART_POLICY_ANY).build())
+                .builder().restartPolicy(RestartPolicy.builder().maxAttempts(3).condition(RESTART_POLICY_ANY).build())
                 .containerSpec(ContainerSpec.builder()
                         .hostname(serviceName)
                         .labels(labels)
                         .image(IMAGE_PATH + "nautilus/bookkeeper:" + PRAVEGA_VERSION)
                         .healthcheck(ContainerConfig.Healthcheck.builder().test(defaultHealthCheck(BK_PORT)).build())
-                        .mounts(Arrays.asList(mount2))
                         .env(stringList).build())
                 .networks(NetworkAttachmentConfig.builder().target(DOCKER_NETWORK).aliases(serviceName).build())
                 .resources(ResourceRequirements.builder()

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -28,7 +28,7 @@ import static io.pravega.test.system.framework.Utils.DOCKER_NETWORK;
 @Slf4j
 public class ZookeeperDockerService extends DockerBasedService {
 
-    private static final String ZK_IMAGE = "jplock/zookeeper:3.5.1-alpha";
+    private static final String ZK_IMAGE = "zookeeper:3.5.4-beta";
     private final long instances = 1;
     private final double cpu = 1.0 * Math.pow(10.0, 9.0);
     private final long mem = 1024 * 1024 * 1024L;


### PR DESCRIPTION
**Change log description**  
* Cherry-picks recent commits fixing bugs from master to r0.5.

**Purpose of the change**  
Fixes #3826

**What the code does**  
Cherry-picks the following commits:

```
Issue 3823: Fix incorrect segment name in exception thrown. (#3824)
Issue 3816: Sporadic failure of BookieFailoverTest in Docker Swarm system tests (#3818)
Issue 3811: Fix SpotBugs error on Java 11 build (#3812)
Issue 3724: (SegmentStore) BugFix - Creating an already existing Segment in Tier 2 (#3804)
Issue 3463: Ensure completed transactions are not pinged by the client. (#3767)
Issue 3805: (SegmentStore) BugFix - StorageWriter not shutting down if Tier 2 fencing detected. (#3806)
```

**How to verify it**  
Check the git log to make sure it contains the expected set of commits and make sure that the Travis build succeeds.