### PR TITLE
Issue 3624: BugFix - Segment Seal and reconnect race causes io.netty.util.IllegalReferenceCountException

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 
@@ -33,6 +34,7 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
  *
  * @see CommandEncoder For details about handling of PartialEvents
  */
+@Slf4j
 public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
 
     private final HashMap<UUID, Segment> appendingSegments = new HashMap<>();
@@ -61,6 +63,7 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
     @VisibleForTesting
     public Request processCommand(WireCommand command) throws Exception {
         if (currentBlock != null && command.getType() != WireCommandType.APPEND_BLOCK_END) {
+            log.warn("Invalid message received {}. CurrentBlock {}", command, currentBlock);
             throw new InvalidMessageException("Unexpected " + command.getType() + " following a append block.");
         }
         Request result;
@@ -99,6 +102,7 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
         case APPEND_BLOCK_END:
             WireCommands.AppendBlockEnd blockEnd = (WireCommands.AppendBlockEnd) command;
             if (currentBlock == null) {
+                log.warn("Received AppendBlockEnd {} without AppendBlock", blockEnd);
                 throw new InvalidMessageException("AppendBlockEnd without AppendBlock.");
             }
             UUID writerId = blockEnd.getWriterId();

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -99,6 +99,36 @@ public class AppendEncodeDecodeTest {
         ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         append(streamName, writerId, 0, 1, size, fakeNetwork);
     }
+
+    @Test(expected = InvalidMessageException.class)
+    public void testAppendDecoderMissingAppendBlockEnd() throws Exception {
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        WireCommands.AppendBlock appendBlock = new WireCommands.AppendBlock(writerId, Unpooled.wrappedBuffer(content));
+
+        // Simulate Setup append
+        appendDecoder.processCommand(setupAppend);
+        // Simulate receiving an appendBlock
+        appendDecoder.processCommand((WireCommand) appendBlock);
+        // Simulate a missing appendBlockEnd by sending an appendBlock
+        appendDecoder.processCommand((WireCommand) appendBlock);
+    }
+
+    @Test(expected = InvalidMessageException.class)
+    public void testAppendDecoderInvalidAppendBlockEnd() throws Exception {
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        WireCommands.AppendBlockEnd appendBlock = new WireCommands.AppendBlockEnd(writerId, 1024, null,  10, 2, 123L);
+
+        // Simulate Setup append
+        appendDecoder.processCommand(setupAppend);
+        // Simulate an error by directly sending AppendBlockEnd.
+        appendDecoder.processCommand((WireCommand) appendBlock);
+    }
     
     @Test
     public void testVerySmallBlockSize() throws Exception {


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Fixes in r0.5 a bug in event writers to prevent connections from being established to sealed / truncated segments.
* Fixes flaky junit test testSegmentSealedFollowedbyConnectionDrop

**Purpose of the change**  
Fixes #3828

**What the code does**  
See PR #3820 and #3831. 

**How to verify it**
It should contain the commits for PRs #3820 and #3831, and should build correctly.