### PR TITLE
Issue 3830:  Fix flaky test testSegmentSealedFollowedbyConnectionDrop

### DIFF
--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -987,7 +987,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
         cf.setExecutor(executorService());
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
-        // Mock client connection that i`s returned for every invocation of ConnectionFactory#establishConnection.
+        // Mock client connection that is returned for every invocation of ConnectionFactory#establishConnection.
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
@@ -1015,7 +1015,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         // If the callback is not invoked the test will fail due to a timeout.
         callBackInvokedLatch.await();
 
-        // Now trigger a connection drop call back from netty and wait until it is executed.
+        // Now trigger a connection drop netty callback and wait until it is executed.
         executor.submit(() -> cf.getProcessor(uri).connectionDropped()).get();
         // close is invoked on the connection.
         order.verify(connection).close();

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -47,6 +47,7 @@ import lombok.Cleanup;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -301,7 +302,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
                 callback.complete(null);
                 return null;
             }
-        }).when(connection).sendAsync(Mockito.any(List.class), Mockito.any(CompletedCallback.class));
+        }).when(connection).sendAsync(ArgumentMatchers.<List<Append>>any(), Mockito.any(CompletedCallback.class));
     }
 
     private void sendAndVerifyEvent(UUID cid, ClientConnection connection, SegmentOutputStreamImpl output,
@@ -781,7 +782,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
                 }
                 return null;
             }
-        }).when(connection).sendAsync(Mockito.any(List.class), Mockito.any(CompletedCallback.class));
+        }).when(connection).sendAsync(ArgumentMatchers.<List<Append>>any(), Mockito.any(CompletedCallback.class));
 
         doAnswer(new Answer<Void>() {
             @Override


### PR DESCRIPTION
**Change log description**  
* Fix flaky junit test testSegmentSealedFollowedbyConnectionDrop

**Purpose of the change**  
Fixes #3830 

**What the code does**  
No changes to functionality.
The test now waits until the `connectionDrop()` netty callback execution is completed.
This also removes unchecked warnings while building the `SegmentOutputStreamTest` file.

**How to verify it**  
All the tests should continue to pass.
