### PR TITLE
Issue 3832: (SegmentStore) Lazily creating the Attribute Index only on the first write.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1180,14 +1180,13 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
                                 // then the normal reconciliation algorithm will kick in once it is discovered and if the
                                 // segment has already been fenced out, openWrite() will throw the appropriate exception
                                 // which will be handled upstream.
-                                log.info("{}: Segment did not exist in Storage when initialized() was called, but does now.", this.traceObjectId);
+                                log.info("{}: Segment did not exist in Storage when initialize() was called, but does now.", this.traceObjectId);
                                 return this.storage.openWrite(this.metadata.getName());
                             })
                     .thenComposeAsync(handle -> {
                         this.handle.set(handle);
                         return toRun.get();
                     }, this.executor);
-
         } else {
             // Segment already exists. Execute what we were supposed to.
             return toRun.get();


### PR DESCRIPTION
**Change log description**  
- The Segment Attribute Index is now created only when writing to it for the first time.

**Purpose of the change**  
Fixes #3832.

**What the code does**  
- #3148 ensured that all segments are created in Tier 2 only when we transfer the first byte to them, however that did not address Attribute Segments (which reside only in Tier 2 and cannot be accessed from the outside). Furthermore, these were created even if we did not intend to write anything to them (when we want to get the value of an attribute, for example), which significantly increased the latency of certain external operations that relied on attributes (file creates (some cases) and setting up appends for new segments).
- The `SegmentAttributeBTreeIndex` has been modified in a similar fashion to `SegmentAggregator` to only create the sub-segment in Tier 2 when we execute the first write. Any reads or getInfo's will treat inexistent segments as a zero-length segment, and sealing an inexistent attribute segment will have no effect (it will not create it just for the sake of sealing an empty file).

**How to verify it**  
New unit tests added, existing unit test(s) updated.
All unit tests and system tests must pass.
