### PR TITLE
Issue 3785: Fixes bug inside AssertExtensions

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.test.integration;
 
-import io.micrometer.core.instrument.Metrics;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
@@ -207,7 +206,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
             assertEquals(bytesWritten, (long) MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags).count());
 
             //Wait for cache eviction to happen
-            TestUtils.awaitFirst(() -> MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags) != null, 4000, 12000);
+            Thread.sleep(5000);
 
             String readerGroupName2 = readerGroupName + "2";
             log.info("Creating Reader group : {}", readerGroupName2);

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -100,7 +100,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
         MetricsConfig metricsConfig = MetricsConfig.builder()
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
-        metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(5));
+        metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(3));
 
         MetricsProvider.initialize(metricsConfig);
         statsProvider = MetricsProvider.getMetricsProvider();
@@ -206,7 +206,10 @@ public class MetricsTest extends ThreadPooledTestSuite {
             AssertExtensions.assertEventuallyEquals(bytesWritten, () -> {
                 return MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags) == null
                         ? -1 : (long) MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags).count();
-            }, 10000);
+            }, 2000);
+
+            //Wait for cache eviction to happen
+            Thread.sleep(5000);
 
             String readerGroupName2 = readerGroupName + "2";
             log.info("Creating Reader group : {}", readerGroupName2);
@@ -229,7 +232,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
             AssertExtensions.assertEventuallyEquals(bytesWritten, () -> {
                 return MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags) == null
                         ? -1 : (long) MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags).count();
-            }, 10000);
+            }, 1000);
 
             Map<Double, Double> map = new HashMap<>();
             map.put(0.0, 1.0);
@@ -253,7 +256,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
             AssertExtensions.assertEventuallyEquals(bytesWritten, () -> {
                 return MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags2nd) == null
                         ? -1 : (long) MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags2nd).count();
-            }, 10000);
+            }, 1000);
 
             readerGroupManager.deleteReaderGroup(readerGroupName1);
             readerGroupManager.deleteReaderGroup(readerGroupName2);

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.test.integration;
 
+import io.micrometer.core.instrument.Metrics;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
@@ -206,7 +207,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
             assertEquals(bytesWritten, (long) MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags).count());
 
             //Wait for cache eviction to happen
-            Thread.sleep(4000);
+            TestUtils.awaitFirst(() -> MetricRegistryUtils.getCounter(SEGMENT_READ_BYTES, streamTags) != null, 4000, 12000);
 
             String readerGroupName2 = readerGroupName + "2";
             log.info("Creating Reader group : {}", readerGroupName2);

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -36,23 +36,36 @@ public class AssertExtensions {
 
     /**
      * Invokes `eval` in a loop over and over (with a small sleep) and asserts that the value eventually reaches `expected`.
-     * @param <T> The type of the value to compare.
-     * @param eval The function to test
-     * @param expected the expected return value.
-     * @param timeout the timeout after which an assertion error should be thrown.
-     * @throws Exception If the is an assertion error, and exception from `eval`, or the thread is interrupted.
+     * @param <T>                   The type of the value to compare.
+     * @param expected              The expected return value.
+     * @param eval                  The function to test
+     * @param timeoutMillis         The timeout in milliseconds after which an assertion error should be thrown.
+     * @throws Exception            If the is an assertion error, and exception from `eval`, or the thread is interrupted.
      */
-    public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, long timeout) throws Exception {
-        long endTime = System.currentTimeMillis() + timeout;
-        while (endTime > System.currentTimeMillis()) {
+    public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, long timeoutMillis) throws Exception {
+        assertEventuallyEquals(expected, eval, 10, timeoutMillis);
+    }
+
+    /**
+     * Invokes `eval` in a loop over and over (with a small sleep) and asserts that the value eventually reaches `expected`.
+     * @param <T>                   The type of the value to compare.
+     * @param expected              The expected return value.
+     * @param eval                  The function to test
+     * @param checkIntervalMillis   The number of milliseconds to wait between two checks.
+     * @param timeoutMillis         The timeout in milliseconds after which an assertion error should be thrown.
+     * @throws Exception            If the is an assertion error, and exception from `eval`, or the thread is interrupted.
+     */
+    public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
+        long remainingMillis = timeoutMillis;
+        while (remainingMillis > 0) {
             if ((expected == null && eval.call() == null) || (expected != null && expected.equals(eval.call()))) {
                 return;
             }
-            Thread.sleep(10);
+            Thread.sleep(checkIntervalMillis);
         }
         assertEquals(expected, eval.call());
     }
-    
+
     /**
      * Asserts that an exception of the Type provided is thrown.
      *

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -45,8 +45,14 @@ public class AssertExtensions {
     public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, long timeout) throws Exception {
         long endTime = System.currentTimeMillis() + timeout;
         while (endTime > System.currentTimeMillis()) {
-            if (expected == eval.call()) {
-                return;
+            if (expected == null) {
+                if (eval.call() == null) {
+                    return;
+                }
+            } else {
+                if (expected.equals(eval.call())) {
+                    return;
+                }
             }
             Thread.sleep(10);
         }

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -49,10 +49,8 @@ public class AssertExtensions {
                 if (eval.call() == null) {
                     return;
                 }
-            } else {
-                if (expected.equals(eval.call())) {
-                    return;
-                }
+            } else if (expected.equals(eval.call())) {
+                return;
             }
             Thread.sleep(10);
         }

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -45,11 +45,7 @@ public class AssertExtensions {
     public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, long timeout) throws Exception {
         long endTime = System.currentTimeMillis() + timeout;
         while (endTime > System.currentTimeMillis()) {
-            if (expected == null) {
-                if (eval.call() == null) {
-                    return;
-                }
-            } else if (expected.equals(eval.call())) {
+            if ((expected == null && eval.call() == null) || (expected != null && expected.equals(eval.call()))) {
                 return;
             }
             Thread.sleep(10);

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -57,7 +57,7 @@ public class TestUtils {
     }
 
     /**
-     * Check whether the given condition is true and then await.
+     * Awaits the given condition to become true.
      *
      * @param condition            A Supplier that indicates when the condition is true. When this happens, this method will return.
      * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
@@ -71,27 +71,6 @@ public class TestUtils {
             Thread.sleep(checkFrequencyMillis);
             remainingMillis -= checkFrequencyMillis;
         }
-
-        if (!condition.get() && remainingMillis <= 0) {
-            throw new TimeoutException("Timeout expired prior to the condition becoming true.");
-        }
-    }
-
-    /**
-     * Awaits first and then check whether the given condition becomes true.
-     *
-     * @param condition            A Supplier that indicates when the condition is true. When this happens, this method will return.
-     * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
-     * @param timeoutMillis        The maximum amount of time to wait.
-     * @throws TimeoutException If the condition was not met during the allotted time.
-     */
-    @SneakyThrows(InterruptedException.class)
-    public static void awaitFirst(Supplier<Boolean> condition, int checkFrequencyMillis, long timeoutMillis) throws TimeoutException {
-        long remainingMillis = timeoutMillis;
-        do {
-            Thread.sleep(checkFrequencyMillis);
-            remainingMillis -= checkFrequencyMillis;
-        } while (!condition.get() && remainingMillis > 0);
 
         if (!condition.get() && remainingMillis <= 0) {
             throw new TimeoutException("Timeout expired prior to the condition becoming true.");

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -57,7 +57,7 @@ public class TestUtils {
     }
 
     /**
-     * Awaits the given condition to become true.
+     * Check whether the given condition is true and then await.
      *
      * @param condition            A Supplier that indicates when the condition is true. When this happens, this method will return.
      * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
@@ -71,6 +71,27 @@ public class TestUtils {
             Thread.sleep(checkFrequencyMillis);
             remainingMillis -= checkFrequencyMillis;
         }
+
+        if (!condition.get() && remainingMillis <= 0) {
+            throw new TimeoutException("Timeout expired prior to the condition becoming true.");
+        }
+    }
+
+    /**
+     * Awaits first and then check whether the given condition becomes true.
+     *
+     * @param condition            A Supplier that indicates when the condition is true. When this happens, this method will return.
+     * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
+     * @param timeoutMillis        The maximum amount of time to wait.
+     * @throws TimeoutException If the condition was not met during the allotted time.
+     */
+    @SneakyThrows(InterruptedException.class)
+    public static void awaitFirst(Supplier<Boolean> condition, int checkFrequencyMillis, long timeoutMillis) throws TimeoutException {
+        long remainingMillis = timeoutMillis;
+        do {
+            Thread.sleep(checkFrequencyMillis);
+            remainingMillis -= checkFrequencyMillis;
+        } while (!condition.get() && remainingMillis > 0);
 
         if (!condition.get() && remainingMillis <= 0) {
             throw new TimeoutException("Timeout expired prior to the condition becoming true.");


### PR DESCRIPTION
**Change log description**  
There is a bug inside AssertExtension::assertEventuallyEquals() - when compare two incoming objects, it uses == (address comparison) which fails in most cases unless the two objects are the same. Then it keeps trying until timed out and eventually hands it over to org.junit.Assert.assertEquals which correctly uses objA.equals(objB). 
The effect of this bug is that it will hold things up to timeout and then call assertEquals.

**Purpose of the change**  
Fixes #3785 

**What the code does**  
This PR fixes a bug in `AssertExtensions`, by testing null equals and then call equals of object, instead of using address comparison.

With the fix above, the test inside `MetricsTest` still failed because there's no more holding so the cache eviction didn't get chance to run; Thread.sleep is added for cache eviction to happen.

**How to verify it**  
All tests should pass.