### PR TITLE
Issue 3801, 3803: (SegmentStore) Do not keep checkpoint operations' serializations in memory

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -27,6 +27,7 @@ import io.pravega.segmentstore.server.SegmentOperation;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
+import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.DeleteSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
@@ -370,9 +371,15 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             }
         }
 
-        if (operation instanceof MetadataCheckpointOperation) {
-            // A MetadataCheckpointOperation represents a valid truncation point. Record it as such.
-            this.newTruncationPoints.add(operation.getSequenceNumber());
+        if (operation instanceof CheckpointOperationBase) {
+            if (operation instanceof MetadataCheckpointOperation) {
+                // A MetadataCheckpointOperation represents a valid truncation point. Record it as such.
+                this.newTruncationPoints.add(operation.getSequenceNumber());
+            }
+
+            // Checkpoint operation has been serialized and we no longer need its contents. Clear it and release any
+            // memory it used.
+            ((CheckpointOperationBase) operation).clearContents();
         } else if (operation instanceof StreamSegmentMapOperation) {
             acceptMetadataOperation((StreamSegmentMapOperation) operation);
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationBase.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationBase.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * Base Log Operation for any operation wishing to store a checkpoint.
  */
-abstract class CheckpointOperationBase extends MetadataOperation {
+public abstract class CheckpointOperationBase extends MetadataOperation {
     //region Members
 
     private ByteArraySegment contents;
@@ -28,7 +28,7 @@ abstract class CheckpointOperationBase extends MetadataOperation {
     //region CheckpointOperationBase Implementation
 
     /**
-     * Sets the Contents of this MetadataCheckpointOperation.
+     * Sets the Contents of this Checkpoint Operation.
      *
      * @param contents The contents to set.
      */
@@ -39,8 +39,16 @@ abstract class CheckpointOperationBase extends MetadataOperation {
     }
 
     /**
-     * Gets the contents of this CheckpointOperationBase.
-     * @return the contents of this CheckpointOperationBase.
+     * Clears the Contents of this Checkpoint Operation. This should only be invoked after this Operation has been serialized
+     * and/or processed, otherwise all information stored in it will be lost.
+     */
+    public void clearContents() {
+        this.contents = null;
+    }
+
+    /**
+     * Gets the contents of this Checkpoint Operation.
+     * @return the contents of this Checkpoint Operation.
      */
     public ByteArraySegment getContents() {
         return this.contents;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -32,6 +32,7 @@ import io.pravega.segmentstore.server.TestDurableDataLogFactory;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
+import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationComparer;
@@ -1423,9 +1424,14 @@ public class DurableLogTests extends OperationLogTestBase {
         for (int i = 0; i < expected.size(); i++) {
             Operation expectedItem = expected.get(i);
             Operation actualItem = actual.get(i);
-            OperationComparer.DEFAULT.assertEquals(
-                    String.format("Recovered operations do not match original ones. Elements at index %d differ. Expected '%s', found '%s'.", i, expectedItem, actualItem),
-                    expectedItem, actualItem);
+            if (expectedItem instanceof CheckpointOperationBase) {
+                Assert.assertNull("Recovered Checkpoint Operation did not have contents cleared up.", ((CheckpointOperationBase) actualItem).getContents());
+                Assert.assertEquals(" Unexpected Sequence Number", expectedItem.getSequenceNumber(), actualItem.getSequenceNumber());
+            } else {
+                OperationComparer.DEFAULT.assertEquals(
+                        String.format("Recovered operations do not match original ones. Elements at index %d differ. Expected '%s', found '%s'.", i, expectedItem, actualItem),
+                        expectedItem, actualItem);
+            }
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationTests.java
@@ -10,8 +10,11 @@
 package io.pravega.segmentstore.server.logs.operations;
 
 import io.pravega.common.util.ByteArraySegment;
+import io.pravega.test.common.AssertExtensions;
 import java.util.Random;
+import lombok.val;
 import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Unit tests for all classes derived from the CheckpointOperationBase class.
@@ -46,5 +49,21 @@ public abstract class CheckpointOperationTests extends OperationTestsBase<Checkp
         } else if (isPreSerializationConfigRequired(operation)) {
             Assert.fail("isPreSerializationConfigRequired returned true but there is nothing to be done.");
         }
+    }
+
+    @Test
+    public void testSetClearContents() {
+        val rnd = new Random(0);
+        val op = createOperation(rnd);
+        byte[] data = new byte[10245];
+        rnd.nextBytes(data);
+        op.setContents(new ByteArraySegment(data));
+        AssertExtensions.assertThrows(
+                "setContents() allowed double-setting the contents.",
+                () -> op.setContents(new ByteArraySegment(data)),
+                ex -> ex instanceof IllegalStateException);
+        Assert.assertNotNull("setContents() did not set contents.", op.getContents());
+        op.clearContents();
+        Assert.assertNull("clearContents() did not clear the contents.", op.getContents());
     }
 }


### PR DESCRIPTION
**Change log description**  
- `MetadataCheckpointOperation`s and `StorageMetadataCheckpointOperation`s no longer keep a reference to their serialized contents after being serialized and/or processed.

**Purpose of the change**  
Fixes #3801.
Fixes #3803.

**What the code does**  
- Anything inheriting from `CheckpointOperationBase` will have its contents cleared after processing, as there is no need for these byte serializations after writing them to Tier 1.
- Checkpoint operations are used to snapshot the in-memory metadata to Tier 1. 
    - They are queued just like any other operation.
    - During pre-processing, they are assigned a byte array containing the serialization of everything in the container metadata
    - After pre-processing, they are serialized to Tier 1 (just like any other op)
    - After serialization (the acceptance), their contents is removed from memory, as it would not have served any further purpose.
- During recovery, these operations are still deserialized from Tier 1, but after they've been processed, their contents is also removed as it serves no purpose anymore.

**How to verify it**  
Unit tests updated.
