### PR TITLE
Issue 3843 : Add missing config values required for for HDFS system tests to test/resources/pravega.properties file.

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -132,20 +132,6 @@ public abstract class AbstractService implements Service {
 
         // generate Pravega Spec.
         final Map<String, Object> pravegaPersistentVolumeSpec = getPersistentVolumeClaimSpec("20Gi", "standard");
-        final ImmutableMap<String, String> options = ImmutableMap.<String, String>builder()
-                // Segment store properties.
-                .put("autoScale.muteInSeconds", "120")
-                .put("autoScale.cooldownInSeconds", "120")
-                .put("autoScale.cacheExpiryInSeconds", "120")
-                .put("autoScale.cacheCleanUpInSeconds", "120")
-                .put("curator-default-session-timeout", "10000")
-                .put("bookkeeper.bkAckQuorumSize", "3")
-                .put("hdfs.replaceDataNodesOnFailure", "false")
-                // Controller properties.
-                .put("controller.transaction.maxLeaseValue", "60000")
-                .put("controller.retention.frequencyMinutes", "2")
-                .put("log.level", "DEBUG")
-                .build();
 
         final Map<String, Object> pravegaSpec = ImmutableMap.<String, Object>builder().put("controllerReplicas", controllerCount)
                                                                                       .put("segmentStoreReplicas", segmentStoreCount)

--- a/test/system/src/test/resources/pravega.properties
+++ b/test/system/src/test/resources/pravega.properties
@@ -14,3 +14,4 @@ bookkeeper.bkAckQuorumSize=3
 controller.transaction.maxLeaseValue=60000
 controller.retention.frequencyMinutes=2
 log.level=DEBUG
+hdfs.replaceDataNodesOnFailure=false

--- a/test/system/src/test/resources/pravega_withAuth.properties
+++ b/test/system/src/test/resources/pravega_withAuth.properties
@@ -14,6 +14,7 @@ bookkeeper.bkAckQuorumSize=3
 controller.transaction.maxLeaseValue=60000
 controller.retention.frequencyMinutes=2
 log.level=DEBUG
+hdfs.replaceDataNodesOnFailure=false
 controller.auth.enabled=true
 controller.auth.userPasswordFile=/opt/pravega/conf/passwd
 controller.auth.tokenSigningKey=secret


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Recently we made a change that requires config values being passed through pravega.properties file.
This broke existing system tests for HDFS as config values for segment store were no more getting passed.
fixing it.

**Purpose of the change**  
Fixes #3843

**What the code does**  

- add config values to this file 

- delete options from AbstractService.java as it is no more needed. 

**How to verify it**  
Hdfs system tests should see  hdfs.replaceDataNodesOnFailure=false passed to segment store.


**Recent failures that were caused by this issue**
io.pravega.test.system.AutoScaleTest.scaleTests
io.pravega.test.system.BookieFailoverTest.bookieFailoverTest
io.pravega.test.system.ByteClientTest.byteClientTest
io.pravega.test.system.MultiReaderWriterWithFailOverTest.multiReaderWriterWithFailOverTest
io.pravega.test.system.MultiSegmentStoreTest.testMultiSegmentStores
io.pravega.test.system.PravegaTest.simpleTest
io.pravega.test.system.ReadTxnWriteAutoScaleWithFailoverTest.readTxnWriteAutoScaleWithFailoverTest
io.pravega.test.system.ReadWithAutoScaleTest.scaleTestsWithReader
io.pravega.test.system.ReadWriteAndAutoScaleWithFailoverTest.readWriteAndAutoScaleWithFailoverTest
io.pravega.test.system.ReaderCheckpointTest.generateStreamCutsTest
io.pravega.test.system.ReaderCheckpointTest.readerCheckpointTest
io.pravega.test.system.RetentionTest.retentionTest
io.pravega.test.system.ReadWriteAndScaleWithFailoverTest.readWriteAndScaleWithFailoverTest
io.pravega.test.system.BatchClientSimpleTest.batchClientSimpleTest
io.pravega.test.system.MetadataScalabilityLargeNumSegmentsTest.largeNumSegmentsScalability
io.pravega.test.system.MultiReaderTxnWriterWithFailoverTest.multiReaderTxnWriterWithFailOverTest
io.pravega.test.system.ReadTxnWriteScaleWithFailoverTest.readTxnWriteScaleWithFailoverTest