### PR TITLE
Issue 3296: Fix auth failure in internal communications in Standalone Mode server

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -10,6 +10,8 @@
 package io.pravega.local;
 
 import com.google.common.base.Preconditions;
+import io.pravega.client.stream.impl.Credentials;
+import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.common.auth.ZKTLSUtils;
 import com.google.common.base.Strings;
 import io.pravega.controller.server.ControllerServiceConfig;
@@ -40,7 +42,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.UUID;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.Builder;
@@ -256,15 +257,13 @@ public class InProcPravegaCluster implements AutoCloseable {
      * @param segmentStoreId id of the SegmentStore.
      */
     private void startLocalSegmentStore(int segmentStoreId) throws Exception {
-        Properties authProps = new Properties();
-        authProps.setProperty("pravega.client.auth.method", "Default");
-        authProps.setProperty("pravega.client.auth.userName", "arvind");
-        authProps.setProperty("pravega.client.auth.password", "1111_aaaa");
+        if (this.enableAuth) {
+            setAuthSystemProperties();
+        }
 
         ServiceBuilderConfig.Builder configBuilder = ServiceBuilderConfig
                 .builder()
                 .include(System.getProperties())
-                .include(authProps)
                 .include(ServiceConfig.builder()
                         .with(ServiceConfig.CONTAINER_COUNT, containerCount)
                         .with(ServiceConfig.THREAD_POOL_SIZE, THREADPOOL_SIZE)
@@ -302,6 +301,27 @@ public class InProcPravegaCluster implements AutoCloseable {
 
         nodeServiceStarter[segmentStoreId] = new ServiceStarter(configBuilder.build());
         nodeServiceStarter[segmentStoreId].start();
+    }
+
+    private void setAuthSystemProperties() {
+        if (authPropertiesAlreadySet()) {
+            log.debug("Auth params already specified via system properties or environment variables.");
+        } else {
+            if (!Strings.isNullOrEmpty(this.userName)) {
+                Credentials credentials = new DefaultCredentials(this.passwd, this.userName);
+                System.setProperty("pravega.client.auth.loadDynamic", "false");
+                System.setProperty("pravega.client.auth.method", credentials.getAuthenticationType());
+                System.setProperty("pravega.client.auth.token", credentials.getAuthenticationToken());
+                log.debug("Done setting auth params via system properties.");
+            } else {
+                log.debug("Cannot set auth params as username is null or empty");
+            }
+        }
+    }
+
+    private boolean authPropertiesAlreadySet() {
+        return !Strings.isNullOrEmpty(System.getProperty("pravega.client.auth.method"))
+                || !Strings.isNullOrEmpty(System.getenv("pravega_client_auth_method"));
     }
 
     private void startLocalControllers() {


### PR DESCRIPTION
**Change log description**  
Fix the condition that leads to auth failure in internal communications from AutoScaleProcessor in standalone mode server. 

**Purpose of the change**  
Fixes #3296.

**What the code does**  
The code sets the correct auth params via system properties so that that the CientConfig used in `AutoScaleProcessor` has the specified credentials to work with. Previously, wrong params were being set and the params were not propagated, so the `ClientConfig` used there could not obtain credentials. 

**How to verify it**  
* All tests should pass. 
* If you run Standalone mode server with auth enabled, you should not encounter the exception mentioned in the issue description. 