### PR TITLE
Issue 3847: Fix issues causing error in extracting client credentials 

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -122,20 +122,22 @@ public class ClientConfig implements Serializable {
         @VisibleForTesting
         ClientConfigBuilder extractCredentials(Properties properties, Map<String, String> env) {
             if (credentials != null) {
-                log.debug("Client credentials were specified by the caller.");
+                log.info("Client credentials were extracted using the explicitly supplied credentials object.");
                 return this;
             }
             if (properties != null) {
                 credentials = extractCredentialsFromProperties(properties);
                 if (credentials != null) {
-                    log.debug("Client credentials were extracted from system properties.");
+                    log.info("Client credentials were extracted from system properties. {}",
+                            "They weren't explicitly supplied as a Credentials object.");
                     return this;
                 }
             }
             if (env != null) {
                 credentials = extractCredentialsFromEnv(env);
                 if (credentials != null) {
-                    log.debug("Client credentials were extracted from environment variables");
+                    log.info("Client credentials were extracted from environment variables. {}",
+                            "They weren't explicitly supplied as a Credentials object or system properties.");
                     return this;
                 }
             }

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -122,12 +122,22 @@ public class ClientConfig implements Serializable {
         @VisibleForTesting
         ClientConfigBuilder extractCredentials(Properties properties, Map<String, String> env) {
             if (credentials != null) {
+                log.debug("Client credentials were specified by the caller.");
                 return this;
             }
-
-            credentials = extractCredentialsFromProperties(properties);
-            if (credentials == null) {
+            if (properties != null) {
+                credentials = extractCredentialsFromProperties(properties);
+                if (credentials != null) {
+                    log.debug("Client credentials were extracted from system properties.");
+                    return this;
+                }
+            }
+            if (env != null) {
                 credentials = extractCredentialsFromEnv(env);
+                if (credentials != null) {
+                    log.debug("Client credentials were extracted from environment variables");
+                    return this;
+                }
             }
             return this;
         }

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -10,83 +10,202 @@
 package io.pravega.client;
 
 import io.pravega.client.stream.impl.Credentials;
+
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class CredentialsExtractorTest {
+
     @Test
-    public void testextractCredentials() {
-        //No creds defined
-        ClientConfig config = ClientConfig.builder().build();
-        assertEquals("Empty list should return null", config.getCredentials(), null);
-
-        //Test custom creds
+    public void extractsCredentialsFromProperties() {
         Properties properties = new Properties();
-        properties.setProperty("pravega.client.auth.method", "temp");
-        properties.setProperty("pravega.client.auth.token", "mytoken");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
 
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
 
-        assertEquals("Method is not picked up from properties",
-                "temp", config.getCredentials().getAuthenticationType());
-
-        assertEquals("Token is not same",
-                "mytoken", config.getCredentials().getAuthenticationToken());
-
-        //If a credential is explicitly mentioned, do not override from properties
-        config = ClientConfig.builder().credentials(new Credentials() {
-            @Override
-            public String getAuthenticationType() {
-                return null;
-            }
-
-            @Override
-            public String getAuthenticationToken() {
-                return null;
-            }
-        }).build();
-
-        config = config.toBuilder().extractCredentials(properties, new HashMap<String, String>()).build();
-
-        assertNotEquals("Credentials should not be overridden",
-                config.getCredentials().getAuthenticationType(), "temp");
-
-        //In case dynamic creds system property is false, load the creds from properties
-        properties.setProperty("pravega.client.auth.loadDynamic", "false");
-
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        assertEquals("Method is not picked up from properties",
-                config.getCredentials().getAuthenticationType(), "temp");
-
-        //In case dynamic creds system property is true and class does not exist, the API should return null.
-        properties.setProperty("pravega.client.auth.loadDynamic", "true");
-
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        Assert.assertNull("Creds should not be picked up from properties",
-                config.getCredentials());
-
-        //In case dynamic creds system property is true, the correct class should be loaded.
-        properties.setProperty("pravega.client.auth.method", "DynamicallyLoadedCredsSecond");
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        Assert.assertEquals("Correct creds object should be loaded dynamically",
-                config.getCredentials().getAuthenticationType(), "DynamicallyLoadedCredsSecond");
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
     }
 
+    @Test
+    public void extractsCredentialsFromEnvVariables() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(null, authEnvVariables).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void explicitlySpecifiedCredentialsAreNotOverridden() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                .credentials(new Credentials() {
+                    @Override
+                    public String getAuthenticationType() {
+                        return "typeSpecifiedViaExplicitObject";
+                    }
+
+                    @Override
+                    public String getAuthenticationToken() {
+                        return "tokenSpecifiedViaExplicitObject";
+                    }
+                }).extractCredentials(properties, authEnvVariables)
+                .build();
+
+        assertEquals("Explicitly set credentials should not be overridden", "typeSpecifiedViaExplicitObject",
+                clientConfig.getCredentials().getAuthenticationType());
+
+        assertEquals("Explicitly set credentials should not be overridden", "tokenSpecifiedViaExplicitObject",
+                clientConfig.getCredentials().getAuthenticationToken());
+    }
+
+    @Test
+    public void credentialsSpecifiedViaPropertiesAreNotOverriddenByEnvVariables() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "bmethod");
+        authEnvVariables.put("pravega_client_auth_token", "btoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                .extractCredentials(properties, authEnvVariables)
+              .build();
+
+        assertEquals("amethod", clientConfig.getCredentials().getAuthenticationType());
+        assertEquals("atoken", clientConfig.getCredentials().getAuthenticationToken());
+    }
+
+    @Test
+    public void loadsCredentialsObjOfAGenericTypeFromPropertiesIfLoadDynamicIsFalse() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "false");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void loadsCredentialsObjOfAGenericTypeFromEnvVariablesIfLoadDynamicIsFalse() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "false");
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig =
+                ClientConfig.builder().extractCredentials(null, authEnvVariables).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void doesNotLoadCredentialsOfNonExistentClassIfLoadDynamicIsTrue() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "true");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                    .extractCredentials(properties, authEnvVariables)
+                .build();
+
+        // Expecting a null because there is no Credentials implementation in the classpath that registers an
+        // authentication type "amethod".
+        assertNull(clientConfig.getCredentials());
+    }
+
+    @Test
+    public void loadsCredentialsObjOfARegisteredTypeFromPropertiesIfLoadDynamicIsTrue() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "true");
+        properties.setProperty("pravega.client.auth.method", "Bearer");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull("Credentials is null", credentials);
+        assertNotNull(DynamicallyLoadedCreds.class.getName(), credentials.getClass());
+        assertEquals("Expected a different authentication type", "Bearer",
+                credentials.getAuthenticationType());
+    }
+
+    @Test
+    public void loadsCredentialsObjOfARegisteredTypeFromEnvVariablesIfLoadDynamicIsTrue() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
+        authEnvVariables.put("pravega_client_auth_method", "Bearer");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                   .extractCredentials(null, authEnvVariables)
+                .build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull("Credentials is null", credentials);
+        assertNotNull(DynamicallyLoadedCreds.class.getName(), credentials.getClass());
+        assertEquals("Expected a different authentication type", "Bearer",
+                credentials.getAuthenticationType());
+    }
+
+    /**
+     * A class representing Credentials. It is dynamically loaded using a {@link java.util.ServiceLoader} by
+     * the code under test, in the enclosing test class. For ServiceLoader to find it, it is configured in
+     * META-INF/services/io.pravega.client.stream.impl.Credentials.
+     */
     public static class DynamicallyLoadedCreds implements Credentials {
 
         @Override
         public String getAuthenticationType() {
-            return "DynamicallyLoadedCreds";
+            return "Bearer";
         }
 
         @Override
         public String getAuthenticationToken() {
-            return "DynamicallyLoadedCreds";
+            return "SomeToken";
         }
     }
 

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNull;
 public class CredentialsExtractorTest {
 
     @Test
-    public void extractsCredentialsFromProperties() {
+    public void testExtractsCredentialsFromProperties() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
@@ -39,7 +39,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void extractsCredentialsFromEnvVariables() {
+    public void testExtractsCredentialsFromEnvVariables() {
         Map authEnvVariables = new HashMap();
         authEnvVariables.put("pravega_client_auth_method", "amethod");
         authEnvVariables.put("pravega_client_auth_token", "atoken");
@@ -55,7 +55,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void explicitlySpecifiedCredentialsAreNotOverridden() {
+    public void testExplicitlySpecifiedCredentialsAreNotOverridden() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
@@ -86,7 +86,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void credentialsSpecifiedViaPropertiesAreNotOverriddenByEnvVariables() {
+    public void testCredentialsSpecifiedViaPropertiesAreNotOverriddenByEnvVariables() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
@@ -104,7 +104,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void loadsCredentialsObjOfAGenericTypeFromPropertiesIfLoadDynamicIsFalse() {
+    public void testLoadsCredentialsObjOfAGenericTypeFromPropertiesIfLoadDynamicIsFalse() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.loadDynamic", "false");
         properties.setProperty("pravega.client.auth.method", "amethod");
@@ -121,7 +121,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void loadsCredentialsObjOfAGenericTypeFromEnvVariablesIfLoadDynamicIsFalse() {
+    public void testLoadsCredentialsObjOfAGenericTypeFromEnvVariablesIfLoadDynamicIsFalse() {
         Map authEnvVariables = new HashMap();
         authEnvVariables.put("pravega_client_auth_loadDynamic", "false");
         authEnvVariables.put("pravega_client_auth_method", "amethod");
@@ -139,7 +139,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void doesNotLoadCredentialsOfNonExistentClassIfLoadDynamicIsTrue() {
+    public void testDoesNotLoadCredentialsOfNonExistentClassIfLoadDynamicIsTrue() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.loadDynamic", "true");
         properties.setProperty("pravega.client.auth.method", "amethod");
@@ -160,7 +160,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void loadsCredentialsObjOfARegisteredTypeFromPropertiesIfLoadDynamicIsTrue() {
+    public void testLoadsCredentialsObjOfARegisteredTypeFromPropertiesIfLoadDynamicIsTrue() {
         Properties properties = new Properties();
         properties.setProperty("pravega.client.auth.loadDynamic", "true");
         properties.setProperty("pravega.client.auth.method", "Bearer");
@@ -175,7 +175,7 @@ public class CredentialsExtractorTest {
     }
 
     @Test
-    public void loadsCredentialsObjOfARegisteredTypeFromEnvVariablesIfLoadDynamicIsTrue() {
+    public void testLoadsCredentialsObjOfARegisteredTypeFromEnvVariablesIfLoadDynamicIsTrue() {
         Map authEnvVariables = new HashMap();
         authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
         authEnvVariables.put("pravega_client_auth_method", "Bearer");


### PR DESCRIPTION
**Change log description**  
Adds null checks to prevent errors in extracting client credentials from environment variables. 

**Purpose of the change**  
Fixes #3847. 

**What the code does**  
* Adds null checks in ClientConfig `extractCredentials(...)` to prevent errors in extracting credentials from environment variables. It also adds some log statements for easier debugging. 
* Adds some tests and refactors existing one in `CredentialsExtractorTest` class for verifying client credentials extraction logic more comprehensively. 

**How to verify it**  
All tests must pass. 