### PR TITLE
Issue 3851: (SegmentStore) Bugfix for Segment Id assignment never completing

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -181,6 +181,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     @Override
     public void close() {
         if (this.closed.compareAndSet(false, true)) {
+            this.metadataStore.close();
             this.extensions.values().forEach(SegmentContainerExtension::close);
             Futures.await(Services.stopAsync(this, this.executor));
             this.metadataCleaner.close();


### PR DESCRIPTION
**Change log description**  
1. Fixed a bug in `MetadataStore` where a pending assignment would never complete a returned future if a sync exception is thrown.
2. Always closing the `MetadataStore` when shutting down the owning Segment Container.

**Purpose of the change**  
Fixes #3851.

**What the code does**  
- Context: 
    - Everything inside the Segment Container uses Segment Ids (not names) to operate.
    - A Segment Id is assigned the first time a segment is used, and is stored either in the in-memory metadata or in the Container Metadata Table.
    - If not in memory, the Segment Container delegates to the `MetadatStore` to get-or-assign its id, which is an async operation.
    - Multiple requests for the same segment may arrive at or around the same time (while the first one is executing), in which case subsequent ones are going to be piggybacked on the initial one.
- There was a bug in `MetadataStore.getOrAssignSegmentId` where it would never complete a returned future if the underlying calls to assign the id threw a synchronous exception (async exceptions were handled properly). In this case, whomever was waiting for this would never get any sort of completion.
    - This was triggered (in the system test that failed due to this) by the Segment Container shutting down immediately after an assignment was initiated. This was past the initial "close-check" but before downstream components performed theirs, hence a synchronous `ObjectClosedException` was thrown (and swallowed for eternity).
    - This was fixed by adding a `try-catch` block around the area of code that handled this.
- In addition, we are now closing the`MetadataStore` component when shutting down the Segment Container. This ensures that even if we have any lingering requests, those will be completed (exceptionally) instead of hanging around.

**How to verify it**  
New unit tests added to verify desired behavior.
