### PR TITLE
Issue 3855: (SegmentStore) Bugfix for segment eviction in Read Index

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.containers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.function.Callbacks;
@@ -355,7 +356,8 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     /**
      * Marks this SegmentMetadata as inactive.
      */
-    synchronized void markInactive() {
+    @VisibleForTesting
+    public synchronized void markInactive() {
         this.active = false;
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -125,7 +125,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
 
     @Override
     public boolean isActive() {
-        throw new UnsupportedOperationException("isActive() is not supported on " + getClass().getName());
+        return true;
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -275,6 +275,15 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     }
 
     /**
+     * Gets a value indicating whether the Segment that this ReadIndex points to is still active (in memory) and not deleted.
+     *
+     * @return True if active, false otherwise.
+     */
+    boolean isActive() {
+        return this.metadata.isActive() && !this.metadata.isDeleted();
+    }
+
+    /**
      * Gets the length of the Segment this ReadIndex refers to.
      */
     long getSegmentLength() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -19,11 +19,13 @@ import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
 import io.pravega.segmentstore.server.CachePolicy;
+import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.TestCacheManager;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
+import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
 import io.pravega.segmentstore.storage.Cache;
 import io.pravega.segmentstore.storage.CacheFactory;
 import io.pravega.segmentstore.storage.Storage;
@@ -40,6 +42,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -773,10 +776,10 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
      * Tests the ability to evict entries from the ReadIndex under various conditions:
      * * If an entry is aged out
      * * If an entry is pushed out because of cache space pressure.
-     * <p>
+     *
      * This also verifies that certain entries, such as RedirectReadIndexEntries and entries after the Storage Offset are
      * not removed.
-     * <p>
+     *
      * The way this test goes is as follows (it's pretty subtle, because there aren't many ways to hook into the ReadIndex and see what it's doing)
      * 1. It creates a bunch of segments, and populates them in storage (each) up to offset N/2-1 (this is called pre-storage)
      * 2. It populates the ReadIndex for each of those segments from offset N/2 to offset N-1 (this is called post-storage)
@@ -949,6 +952,58 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             //1.25N..1.5N
             checkOffsets(segmentRemovedKeys, segmentId, entriesPerSegment + entriesPerSegment / 4, entriesPerSegment / 4, (int) (entriesPerSegment * appendSize * 1.25), appendSize);
         }
+    }
+
+    /**
+     * Tests the {@link ContainerReadIndex#cleanup} method as well as its handling of inactive segments.
+     */
+    @Test
+    public void testCleanup() throws Exception {
+        // Create all the segments in the metadata.
+        @Cleanup
+        TestContext context = new TestContext();
+        ArrayList<Long> segmentIds = createSegments(context);
+
+        final long activeSegmentId = segmentIds.get(0); // Always stays active.
+        final long inactiveSegmentId1 = segmentIds.get(1); // Becomes inactive - used for cleanup()
+        final long inactiveSegmentId2 = segmentIds.get(2); // Becomes inactive - used for getOrCreateIndex() (any op).
+        final long reactivatedSegmentId1 = segmentIds.get(3); // Becomes inactive and then active again (for cleanup)
+        final long reactivatedSegmentId2 = segmentIds.get(4); // Becomes inactive and then active again (for getOrCreateIndex()).
+
+        // Add a zero-byte append, which ensures the Segments' Read Indices are initialized.
+        for (val id : segmentIds) {
+            context.readIndex.append(id, 0, new byte[0]);
+        }
+
+        // Mark 2 segments as inactive, but do not evict them yet. We simulate a concurrent eviction, when the segment is
+        // first marked as inactive and the Read Index receives a request for it before it gets evicted.
+        markInactive(inactiveSegmentId1, context);
+        markInactive(inactiveSegmentId2, context);
+
+        // Evict 2 segments (which also marks them as inactive), then re-map them as active segments (which gives them
+        // new instances of their Segment Metadatas).
+        val reactivatedSegment2OldIndex = context.readIndex.getIndex(reactivatedSegmentId2);
+        evict(reactivatedSegmentId1, context);
+        evict(reactivatedSegmentId2, context);
+        createSegment(reactivatedSegmentId1, context);
+        createSegment(reactivatedSegmentId2, context);
+
+        // Test cleanup().
+        context.readIndex.cleanup(Arrays.asList(activeSegmentId, inactiveSegmentId1, reactivatedSegmentId1));
+        Assert.assertNotNull("Active segment's index removed during cleanup.", context.readIndex.getIndex(activeSegmentId));
+        Assert.assertNull("Inactive segment's index not removed during cleanup.", context.readIndex.getIndex(inactiveSegmentId1));
+        Assert.assertNull("Reactivated segment's index not removed during cleanup.", context.readIndex.getIndex(reactivatedSegmentId1));
+
+        // Test getOrCreateIndex() via append() (any other operation could be used for this, but this is the simplest to setup).
+        AssertExtensions.assertThrows(
+                "Appending to inactive segment succeeded.",
+                () -> context.readIndex.append(inactiveSegmentId2, 0, new byte[0]),
+                ex -> ex instanceof IllegalArgumentException);
+
+        // This should re-create the index.
+        context.readIndex.append(reactivatedSegmentId2, 0, new byte[0]);
+        Assert.assertNotEquals("Reactivated Segment's ReadIndex was not re-created.",
+                reactivatedSegment2OldIndex, context.readIndex.getIndex(reactivatedSegmentId2));
     }
 
     // region Scenario-based tests
@@ -1367,7 +1422,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         return segmentIds;
     }
 
-    private long createSegment(int id, TestContext context) {
+    private long createSegment(long id, TestContext context) {
         String name = getSegmentName(id);
         context.metadata.mapStreamSegmentId(name, id);
         initializeSegment(id, context);
@@ -1402,7 +1457,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         return transactionId;
     }
 
-    private String getSegmentName(int id) {
+    private String getSegmentName(long id) {
         return "Segment_" + id;
     }
 
@@ -1410,6 +1465,18 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         UpdateableSegmentMetadata metadata = context.metadata.getStreamSegmentMetadata(segmentId);
         metadata.setLength(0);
         metadata.setStorageLength(0);
+    }
+
+    private void markInactive(long segmentId, TestContext context) {
+        ((StreamSegmentMetadata) context.metadata.getStreamSegmentMetadata(segmentId)).markInactive();
+    }
+
+    private void evict(long segmentId, TestContext context) {
+        val candidates = Collections.singleton((SegmentMetadata) context.metadata.getStreamSegmentMetadata(segmentId));
+        val em = (EvictableMetadata) context.metadata;
+        val sn = context.metadata.getOperationSequenceNumber() + 1;
+        context.metadata.removeTruncationMarkers(sn);
+        em.cleanup(candidates, sn);
     }
 
     //endregion


### PR DESCRIPTION
**Change log description**  
Fixed a bug in `ContainerReadIndex` where it would incorrectly manage Segment Read Indices when those segments have been evicted or are in the process of being evicted.

**Purpose of the change**  
Fixes #3855.

**What the code does**  
- `ContainerReadIndex.cleanup()`
    - This method has been modified to check the `SegmentMetadata` that a candidate `SegmentReadIndex` actually points to (not the instance just served from `ContainerMetadata`). 
    - If this is no longer the case, then the Read Index is closed.
    - This ensures that if a segment has just been evicted and immediately reactivated, we won't have a case when the Read Index is in disagreement with the metadata.
- `ContainerReadIndex.getOrCreateIndex()`
    - This is used by every operation concerning the Read Index, and its job is to either fetch an already registered `SegmentReadIndex` or create and initialize a new one.
    - This method has been modified to check the `isActive` status of the `SegmentReadIndex` that was just fetched. If not active, it is closed and forcibly reinitialized. During reinitialization, further checks are performed (as before) to check the validity of the segment being requested.

**How to verify it**  
New unit test added to verify Read Index behavior during segment eviction.
