### PR TITLE
Issue 3774:  make AppendBatchSizeTracker per writer/reader  and disable the flowids for segment append paths

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactory.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactory.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.netty.impl;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -24,21 +25,23 @@ public interface ConnectionFactory extends AutoCloseable {
     /**
      * Establishes a connection between server and client with given parameters.
      *
+     * @param id       identifier
      * @param endpoint The Pravega Node URI.
      * @param rp       Reply Processor instance.
      * @return An instance of client connection.
      */
-    CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri endpoint, ReplyProcessor rp);
+    CompletableFuture<ClientConnection> establishConnection(UUID id, PravegaNodeUri endpoint, ReplyProcessor rp);
 
     /**
      * This method is used to establish a client connection using a {@link Flow} on the underlying Connection
      * pool.
      * @param flow  Flow to be used to create a client connection.
+     * @param id     identifier
      * @param endpoint The Pravega Node URI.
      * @param rp Reply Processor instance.
      * @return An instance of client connection.
      */
-    CompletableFuture<ClientConnection> establishConnection(Flow flow, PravegaNodeUri endpoint, ReplyProcessor rp);
+    CompletableFuture<ClientConnection> establishConnection(Flow flow, UUID id, PravegaNodeUri endpoint, ReplyProcessor rp);
 
     /**
      * Get the internal executor which is used by the client.

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -15,15 +15,17 @@ import io.pravega.client.ClientConfig;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
+
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * A Connection factory implementation used to create {@link ClientConnection}s by creating new Flow over existing connection pool.
- *
  */
 @Slf4j
 public final class ConnectionFactoryImpl implements ConnectionFactory {
@@ -54,13 +56,13 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
     }
 
     @Override
-    public CompletableFuture<ClientConnection> establishConnection(Flow flow, PravegaNodeUri endpoint, ReplyProcessor rp) {
-        return connectionPool.getClientConnection(flow, endpoint, rp);
+    public CompletableFuture<ClientConnection> establishConnection(Flow flow, UUID id, PravegaNodeUri endpoint, ReplyProcessor rp) {
+        return connectionPool.getClientConnection(flow, id, endpoint, rp);
     }
 
     @Override
-    public CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri endpoint, ReplyProcessor rp) {
-        return connectionPool.getClientConnection(endpoint, rp);
+    public CompletableFuture<ClientConnection> establishConnection(UUID id, PravegaNodeUri endpoint, ReplyProcessor rp) {
+        return connectionPool.getClientConnection(id, endpoint, rp);
     }
 
     @Override
@@ -79,7 +81,7 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
 
     @VisibleForTesting
     public int getActiveChannelCount() {
-       return connectionPool.getActiveChannelCount();
+        return connectionPool.getActiveChannelCount();
     }
 
     private int getThreadPoolSize(Integer threadCount) {

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
@@ -11,6 +11,8 @@ package io.pravega.client.netty.impl;
 
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
+
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -27,7 +29,7 @@ public interface ConnectionPool extends AutoCloseable {
      * @param rp ReplyProcessor instance.
      * @return An instance of client connection.
      */
-    CompletableFuture<ClientConnection> getClientConnection(Flow flow, PravegaNodeUri uri, ReplyProcessor rp);
+    CompletableFuture<ClientConnection> getClientConnection(Flow flow, UUID id, PravegaNodeUri uri, ReplyProcessor rp);
 
     /**
      * This is used to create a {@link ClientConnection} where flows are disabled. This implies that only one ClientConnection
@@ -37,7 +39,7 @@ public interface ConnectionPool extends AutoCloseable {
      * @param rp ReplyProcessor instance.
      * @return An instance of client connection.
      */
-    CompletableFuture<ClientConnection> getClientConnection(PravegaNodeUri uri, ReplyProcessor rp);
+    CompletableFuture<ClientConnection> getClientConnection(UUID id, PravegaNodeUri uri, ReplyProcessor rp);
 
     /**
      * Fetch the current active {@link io.netty.channel.Channel} count, which represents the number of active connections being

--- a/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
@@ -22,13 +22,16 @@ import io.pravega.shared.protocol.netty.Request;
 import io.pravega.shared.protocol.netty.WireCommand;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.Hello;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.GuardedBy;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -83,7 +86,7 @@ public class RawClient implements AutoCloseable {
     public RawClient(Controller controller, ConnectionFactory connectionFactory, Segment segmentId) {
         this.segmentId = segmentId;
         this.connection = controller.getEndpointForSegment(segmentId.getScopedName())
-                                    .thenCompose((PravegaNodeUri uri) -> connectionFactory.establishConnection(flow, uri, responseProcessor));
+                .thenCompose((PravegaNodeUri uri) -> connectionFactory.establishConnection(flow, UUID.randomUUID(), uri, responseProcessor));
         Futures.exceptionListener(connection, e -> closeConnection(e));
     }
 

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -547,7 +547,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                         log.info("Fetching endpoint for segment {}, writer {}", segmentName, writerId);
                         return controller.getEndpointForSegment(segmentName).thenComposeAsync((PravegaNodeUri uri) -> {
                             log.info("Establishing connection to {} for {}, writerID: {}", uri, segmentName, writerId);
-                            return connectionFactory.establishConnection(Flow.from(requestId), writerId, uri, responseProcessor);
+                            return connectionFactory.establishConnection(writerId, uri, responseProcessor);
                         }, connectionFactory.getInternalExecutor()).thenComposeAsync(connection -> {
                             CompletableFuture<Void> connectionSetupFuture = state.newConnection(connection);
                             SetupAppend cmd = new SetupAppend(requestId, writerId, segmentName, delegationToken);

--- a/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
@@ -16,10 +16,13 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
+
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Synchronized;
@@ -33,7 +36,7 @@ public class MockConnectionFactoryImpl implements ConnectionFactory {
 
     @Override
     @Synchronized
-    public CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri location, ReplyProcessor rp) {
+    public CompletableFuture<ClientConnection> establishConnection(UUID id, PravegaNodeUri location, ReplyProcessor rp) {
         ClientConnection connection = connections.get(location);
         Preconditions.checkState(connection != null, "Unexpected Endpoint");
         processors.put(location, rp);
@@ -42,8 +45,8 @@ public class MockConnectionFactoryImpl implements ConnectionFactory {
 
     @Override
     @Synchronized
-    public CompletableFuture<ClientConnection> establishConnection(Flow flow, PravegaNodeUri location, ReplyProcessor rp) {
-      return establishConnection(location, rp);
+    public CompletableFuture<ClientConnection> establishConnection(Flow flow, UUID id, PravegaNodeUri location, ReplyProcessor rp) {
+        return establishConnection(id, location, rp);
     }
 
     @Override


### PR DESCRIPTION
**Change log description**  
Currently there performance drop performance drop due the connection pooling implementation.
https://github.com/pravega/pravega/commit/02f1c0036da29e2db34cc319714d99fd08da941a. 
It is also identified that AppendBatchSizeTracker was used by multiple connections and thus last append number and ack numbers were incorrect. This PR fixes this AppendBatchSizeTracker  bug .
Another issue identified that  in the command encoder , whenever the segment and writer id changes, the appends are broken and thus causing performance drop.  So, This PR improves the performance of writer by disabling flowid for append path.

**Purpose of the change**  
fixes #3774 

**What the code does**  
1. The AppendBatchSizeTracker  is maintained as per writer id (for append paths) and tracker ids as for segment read paths in the netty handler.
2. The flowids are disabled for append only paths and thus there will be dedicated netty channel for segment writes and avoids the append breaks. this improves the latency and throughput.

**How to verify it**  
1. Pravega is tested with bare-metal deployment with 1 controller and 3 segment nodes on Lgaunitas (white cluster).
2. Benchmark mark tool : https://github.com/pravega/pravega-benchmark is used for performance bench-marking and ensured that the write performance is re gained and improved.

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>
