### PR TITLE
Issue 3853: (SegmentStore) Bugfix for ConcurrentModificationException in SegmentAttributeIterator

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -10,6 +10,9 @@
 package io.pravega.segmentstore.server;
 
 import io.pravega.segmentstore.contracts.SegmentProperties;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiPredicate;
 
 /**
  * Defines an immutable StreamSegment Metadata.
@@ -89,4 +92,12 @@ public interface SegmentMetadata extends SegmentProperties {
      * @return True if pinned, false otherwise.
      */
     boolean isPinned();
+
+    /**
+     * Gets new Map containing all the Attributes for this Segment that match the given filter.
+     *
+     * @param filter The Key-Value filter that will be used.
+     * @return A new Map containing the result.
+     */
+    Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -109,6 +109,7 @@ public interface SegmentMetadata extends SegmentProperties {
      *
      * @return The map.
      */
+    @Override
     Map<UUID, Long> getAttributes();
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -76,7 +76,8 @@ public interface SegmentMetadata extends SegmentProperties {
      * Creates a new SegmentProperties instance with current information from this SegmentMetadata object.
      *
      * @return The new SegmentProperties instance. This object is completely detached from the SegmentMetadata from which
-     * it was created (changes to the base object will not be reflected in the result).
+     * it was created (changes to the base object will not be reflected in the result). The returned object will have a copy
+     * of this instance's Attributes which would make it safe for iterating over without holding any locks.
      */
     SegmentProperties getSnapshot();
 
@@ -94,10 +95,28 @@ public interface SegmentMetadata extends SegmentProperties {
     boolean isPinned();
 
     /**
+     * Gets a read-only Map of AttributeId-Values for this Segment. The returned object is a View combining both Core
+     * and Extended attributes and provides direct read-only access to all this Segment's Attributes.
+     *
+     * Notes on concurrency:
+     * - All retrieval methods are thread-safe and can be invoked from any context.
+     * - Iterating over this Map's elements ({@link Map#keySet(), {@link Map#values()}, {@link Map#entrySet()}) is not
+     * thread safe and should only be done in an (external) synchronized context (while holding the same lock that is
+     * used to update this {@link SegmentMetadata} instance).
+     * - Consider using {@link #getSnapshot()} if you need a thread-safe way of iterating over the current set of Attributes.
+     * - Consider using {@link #getAttributes(BiPredicate)} if you need to get a subset of the attributes and can provide
+     * a filter.
+     *
+     * @return The map.
+     */
+    Map<UUID, Long> getAttributes();
+
+    /**
      * Gets new Map containing all the Attributes for this Segment that match the given filter.
      *
      * @param filter The Key-Value filter that will be used.
-     * @return A new Map containing the result.
+     * @return A new Map containing the result. This is a new object, detached from this {@link SegmentMetadata} instance
+     * and can be safely accessed and iterated over from any thread.
      */
     Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -185,6 +186,13 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     }
 
     @Override
+    public synchronized Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+        return getAttributes().entrySet().stream()
+                              .filter(e -> filter.test(e.getKey(), e.getValue()))
+                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "Id = %d, Start = %d, Length = %d, StorageLength = %d, Sealed(M/S) = %s/%s, Deleted = %s, Name = %s",
@@ -275,7 +283,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     @Override
     public synchronized void setLastModified(ImmutableDate date) {
         this.lastModified = date;
-        log.trace("{}: LastModified = {}.", this.lastModified);
+        log.trace("{}: LastModified = {}.", this.traceObjectId, this.lastModified);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiPredicate;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
 
@@ -131,6 +132,11 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Override
     public SegmentProperties getSnapshot() {
         throw new UnsupportedOperationException("getSnapshot() is not supported on " + getClass().getName());
+    }
+
+    @Override
+    public Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+        throw new UnsupportedOperationException("getAttributes(BiPredicate) is not supported on " + getClass().getName());
     }
 
     @Override


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `SegmentAttributeIterator` where the `StreamSegmentMetadata` attribute iteration was not thread safe and was prone to `ConcurrentModificationException`s.

**Purpose of the change**  
Fixes #3853.

**What the code does**  
- Created `StreamSegmentMetadata.getAttributes(Filter)` which iterates and filters while holding the same lock used for modifying its contents.
- Updated `SegmentAttributeIterator` to use this method for retrieving desired attributes.

**How to verify it**  
- Concurrency cannot be easily tested in unit tests.
- Updated a `StreamSegmentMetadata` unit test to verify new method.
