### PR TITLE
Issue 3508: Delete the year in the license header across all files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/HEADER
+++ b/HEADER
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SegmentHandle.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SegmentHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemMetrics.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSegmentHandle.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSegmentHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/FileNameFormatException.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/FileNameFormatException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSExceptionHelpers.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSExceptionHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSMetrics.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSegmentHandle.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSegmentHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
+++ b/bindings/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/IdempotentStorageTestBase.java
+++ b/bindings/src/test/java/io/pravega/storage/IdempotentStorageTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/AclSize.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/AclSize.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3FileSystemImpl.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3FileSystemImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3ImplBase.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3ImplBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3JerseyClientWrapper.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3JerseyClientWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemStorageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSClusterHelpers.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSClusterHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/MockFileSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.jvm.Jvm
 
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ByteStreamClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/ClientFactory.java
+++ b/client/src/main/java/io/pravega/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/EventStreamClientFactory.java
+++ b/client/src/main/java/io/pravega/client/EventStreamClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
+++ b/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/StreamInfo.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamCutHelper.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamCutHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/BatchClient.java
+++ b/client/src/main/java/io/pravega/client/batch/BatchClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/SegmentRange.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentRange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/StreamInfo.java
+++ b/client/src/main/java/io/pravega/client/batch/StreamInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/StreamSegmentsIterator.java
+++ b/client/src/main/java/io/pravega/client/batch/StreamSegmentsIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/batch/impl/StreamSegmentsInfoImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/StreamSegmentsInfoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/AppendBatchSizeTrackerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnectionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/Connection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Connection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactory.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/Flow.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Flow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/RawClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/EndOfSegmentException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EndOfSegmentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/NoSuchEventException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/NoSuchEventException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/NoSuchSegmentException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/NoSuchSegmentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/Segment.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/Segment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentAttribute.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentAttribute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInfo.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentSealedException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentSealedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentTruncatedException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentTruncatedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/InitialUpdate.java
+++ b/client/src/main/java/io/pravega/client/state/InitialUpdate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/Revision.java
+++ b/client/src/main/java/io/pravega/client/state/Revision.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/Revisioned.java
+++ b/client/src/main/java/io/pravega/client/state/Revisioned.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
+++ b/client/src/main/java/io/pravega/client/state/StateSynchronizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
+++ b/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/Update.java
+++ b/client/src/main/java/io/pravega/client/state/Update.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/CorruptedStateException.java
+++ b/client/src/main/java/io/pravega/client/state/impl/CorruptedStateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/UpdateOrInit.java
+++ b/client/src/main/java/io/pravega/client/state/impl/UpdateOrInit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/state/impl/UpdateOrInitSerializer.java
+++ b/client/src/main/java/io/pravega/client/state/impl/UpdateOrInitSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Checkpoint.java
+++ b/client/src/main/java/io/pravega/client/stream/Checkpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/EventPointer.java
+++ b/client/src/main/java/io/pravega/client/stream/EventPointer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/EventRead.java
+++ b/client/src/main/java/io/pravega/client/stream/EventRead.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/IdempotentEventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/IdempotentEventStreamWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/InvalidStreamException.java
+++ b/client/src/main/java/io/pravega/client/stream/InvalidStreamException.java
@@ -1,5 +1,5 @@
 /**
-  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/PingFailedException.java
+++ b/client/src/main/java/io/pravega/client/stream/PingFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Position.java
+++ b/client/src/main/java/io/pravega/client/stream/Position.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReaderConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupMetrics.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderNotInReaderGroupException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ReinitializationRequiredException.java
+++ b/client/src/main/java/io/pravega/client/stream/ReinitializationRequiredException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/RetentionPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Sequence.java
+++ b/client/src/main/java/io/pravega/client/stream/Sequence.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Serializer.java
+++ b/client/src/main/java/io/pravega/client/stream/Serializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Stream.java
+++ b/client/src/main/java/io/pravega/client/stream/Stream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamCut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/Transaction.java
+++ b/client/src/main/java/io/pravega/client/stream/Transaction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/TruncatedDataException.java
+++ b/client/src/main/java/io/pravega/client/stream/TruncatedDataException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/TxnFailedException.java
+++ b/client/src/main/java/io/pravega/client/stream/TxnFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ByteArraySerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ByteArraySerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ByteBufferSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/CancellableRequest.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CancellableRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointFailedException.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ConnectionClosedException.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ConnectionClosedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerFailureException.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerFailureException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImplConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerResolverFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Credentials.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/EventPointerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventPointerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/EventPointerInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventPointerInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/EventReadImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventReadImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/JavaSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/JavaSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/MaxNumberOfCheckpointsExceededException.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/MaxNumberOfCheckpointsExceededException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PendingEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/PositionImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PositionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PositionInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/PravegaCredentialsWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentTransaction.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentTransaction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentTransactionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentWithRange.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentWithRange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCutInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCutInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamInternal.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegmentSuccessors.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegmentSuccessors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegmentsWithPredecessors.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegmentsWithPredecessors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/TxnSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TxnSegments.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/impl/UTF8StringSerializer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/UTF8StringSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/EndOfDataNotification.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/EndOfDataNotification.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/Listener.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/Listener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/Notification.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/Notification.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/NotificationSystem.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/NotificationSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/NotifierFactory.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/NotifierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/Observable.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/Observable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/ReaderGroupNotificationListener.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/ReaderGroupNotificationListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/SegmentNotification.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/SegmentNotification.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractPollingNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/AbstractPollingNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/EndOfDataNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/EndOfDataNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
+++ b/client/src/main/java/io/pravega/client/stream/notifications/notifier/SegmentNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/ConditionalTableUpdateException.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/ConditionalTableUpdateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/IteratorState.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/IteratorState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/IteratorStateImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/IteratorStateImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyVersionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableEntry.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableEntryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableKeyImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/FlowTest.java
+++ b/client/src/test/java/io/pravega/client/FlowTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/batch/StreamSegmentsInfoTest.java
+++ b/client/src/test/java/io/pravega/client/batch/StreamSegmentsInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentRangeImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/netty/impl/ConnectionFactoryImplTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/ConnectionFactoryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/netty/impl/ConnectionPoolingTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/ConnectionPoolingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/RawClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/client/src/test/java/io/pravega/client/netty/impl/SecureConnectionFactoryImplTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/SecureConnectionFactoryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentAttributeTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentAttributeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/state/examples/MembershipSynchronizer.java
+++ b/client/src/test/java/io/pravega/client/state/examples/MembershipSynchronizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/state/examples/SetSynchronizer.java
+++ b/client/src/test/java/io/pravega/client/state/examples/SetSynchronizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/ScalingPolicyTest.java
+++ b/client/src/test/java/io/pravega/client/stream/ScalingPolicyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamCutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/CancellableRequestTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CancellableRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplLBTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/EventPointerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventPointerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/JavaSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/JavaSerializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ModelHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/SecureControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SecureControllerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentTransactionTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentTransactionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/StreamSegmentsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/UTF8StringSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/UTF8StringSerializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockClientFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockConnectionFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/notifications/CustomNotification.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/CustomNotification.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/notifications/CustomNotifier.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/CustomNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/notifications/EndOfDataNotifierTest.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/EndOfDataNotifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/notifications/NotificationFrameworkTest.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/NotificationFrameworkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/notifications/SegmentNotifierTest.java
+++ b/client/src/test/java/io/pravega/client/stream/notifications/SegmentNotifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyVersionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/resources/META-INF/services/io.pravega.client.stream.impl.Credentials
+++ b/client/src/test/resources/META-INF/services/io.pravega.client.stream.impl.Credentials
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/client/src/test/resources/logback-test.xml
+++ b/client/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/client/src/test/resources/logback.xml
+++ b/client/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/AbstractTimer.java
+++ b/common/src/main/java/io/pravega/common/AbstractTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/Exceptions.java
+++ b/common/src/main/java/io/pravega/common/Exceptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/ExponentialMovingAverage.java
+++ b/common/src/main/java/io/pravega/common/ExponentialMovingAverage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/LoggerHelpers.java
+++ b/common/src/main/java/io/pravega/common/LoggerHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/MathHelpers.java
+++ b/common/src/main/java/io/pravega/common/MathHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/ObjectBuilder.java
+++ b/common/src/main/java/io/pravega/common/ObjectBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/ObjectClosedException.java
+++ b/common/src/main/java/io/pravega/common/ObjectClosedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/SimpleMovingAverage.java
+++ b/common/src/main/java/io/pravega/common/SimpleMovingAverage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/TimeoutTimer.java
+++ b/common/src/main/java/io/pravega/common/TimeoutTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/Timer.java
+++ b/common/src/main/java/io/pravega/common/Timer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/auth/JKSHelper.java
+++ b/common/src/main/java/io/pravega/common/auth/JKSHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
+++ b/common/src/main/java/io/pravega/common/auth/ZKTLSUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/AbstractThreadPoolService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/AbstractThreadPoolService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/CancellationToken.java
+++ b/common/src/main/java/io/pravega/common/concurrent/CancellationToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/Futures.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Futures.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/MultiKeySequentialProcessor.java
+++ b/common/src/main/java/io/pravega/common/concurrent/MultiKeySequentialProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/NewestReference.java
+++ b/common/src/main/java/io/pravega/common/concurrent/NewestReference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/SequentialProcessor.java
+++ b/common/src/main/java/io/pravega/common/concurrent/SequentialProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/concurrent/Services.java
+++ b/common/src/main/java/io/pravega/common/concurrent/Services.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/function/Callbacks.java
+++ b/common/src/main/java/io/pravega/common/function/Callbacks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/function/RunnableWithException.java
+++ b/common/src/main/java/io/pravega/common/function/RunnableWithException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/hash/HashHelper.java
+++ b/common/src/main/java/io/pravega/common/hash/HashHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/hash/RandomFactory.java
+++ b/common/src/main/java/io/pravega/common/hash/RandomFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/BoundedInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/BoundedInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/EnhancedByteArrayOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/EnhancedByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/FileHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/FileHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/FixedByteArrayOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/FixedByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/SerializationException.java
+++ b/common/src/main/java/io/pravega/common/io/SerializationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/StreamHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/StreamHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/RandomAccessOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RandomAccessOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/lang/AtomicInt96.java
+++ b/common/src/main/java/io/pravega/common/lang/AtomicInt96.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/lang/Int96.java
+++ b/common/src/main/java/io/pravega/common/lang/Int96.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
+++ b/common/src/main/java/io/pravega/common/lang/ProcessStarter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/tracing/RequestTag.java
+++ b/common/src/main/java/io/pravega/common/tracing/RequestTag.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/tracing/RequestTracker.java
+++ b/common/src/main/java/io/pravega/common/tracing/RequestTracker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/tracing/TagLogger.java
+++ b/common/src/main/java/io/pravega/common/tracing/TagLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ArrayView.java
+++ b/common/src/main/java/io/pravega/common/util/ArrayView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/AsyncIterator.java
+++ b/common/src/main/java/io/pravega/common/util/AsyncIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/AsyncMap.java
+++ b/common/src/main/java/io/pravega/common/util/AsyncMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/AvlTreeIndex.java
+++ b/common/src/main/java/io/pravega/common/util/AvlTreeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/BitConverter.java
+++ b/common/src/main/java/io/pravega/common/util/BitConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/BlockingAsyncIterator.java
+++ b/common/src/main/java/io/pravega/common/util/BlockingAsyncIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/BlockingDrainingQueue.java
+++ b/common/src/main/java/io/pravega/common/util/BlockingDrainingQueue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ByteBufferUtils.java
+++ b/common/src/main/java/io/pravega/common/util/ByteBufferUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/CircularBuffer.java
+++ b/common/src/main/java/io/pravega/common/util/CircularBuffer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/CloseableIterator.java
+++ b/common/src/main/java/io/pravega/common/util/CloseableIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/CollectionHelpers.java
+++ b/common/src/main/java/io/pravega/common/util/CollectionHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ConfigBuilder.java
+++ b/common/src/main/java/io/pravega/common/util/ConfigBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ConfigurationException.java
+++ b/common/src/main/java/io/pravega/common/util/ConfigurationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ContinuationTokenAsyncIterator.java
+++ b/common/src/main/java/io/pravega/common/util/ContinuationTokenAsyncIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/DelimitedStringParser.java
+++ b/common/src/main/java/io/pravega/common/util/DelimitedStringParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/EnumHelpers.java
+++ b/common/src/main/java/io/pravega/common/util/EnumHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/HashedArray.java
+++ b/common/src/main/java/io/pravega/common/util/HashedArray.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/IllegalDataFormatException.java
+++ b/common/src/main/java/io/pravega/common/util/IllegalDataFormatException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ImmutableDate.java
+++ b/common/src/main/java/io/pravega/common/util/ImmutableDate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/InvalidPropertyValueException.java
+++ b/common/src/main/java/io/pravega/common/util/InvalidPropertyValueException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/MissingPropertyException.java
+++ b/common/src/main/java/io/pravega/common/util/MissingPropertyException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
+++ b/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/Property.java
+++ b/common/src/main/java/io/pravega/common/util/Property.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/RedBlackTreeIndex.java
+++ b/common/src/main/java/io/pravega/common/util/RedBlackTreeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ResourcePool.java
+++ b/common/src/main/java/io/pravega/common/util/ResourcePool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/RetriesExhaustedException.java
+++ b/common/src/main/java/io/pravega/common/util/RetriesExhaustedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableFutureLatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ReusableLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableLatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/SequencedItemList.java
+++ b/common/src/main/java/io/pravega/common/util/SequencedItemList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/SortedIndex.java
+++ b/common/src/main/java/io/pravega/common/util/SortedIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/ToStringUtils.java
+++ b/common/src/main/java/io/pravega/common/util/ToStringUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/TypedProperties.java
+++ b/common/src/main/java/io/pravega/common/util/TypedProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
+++ b/common/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/BTreePage.java
+++ b/common/src/main/java/io/pravega/common/util/btree/BTreePage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
+++ b/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/EntryIterator.java
+++ b/common/src/main/java/io/pravega/common/util/btree/EntryIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/PageCollection.java
+++ b/common/src/main/java/io/pravega/common/util/btree/PageCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/PageEntry.java
+++ b/common/src/main/java/io/pravega/common/util/btree/PageEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/PagePointer.java
+++ b/common/src/main/java/io/pravega/common/util/btree/PagePointer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/PageWrapper.java
+++ b/common/src/main/java/io/pravega/common/util/btree/PageWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/io/pravega/common/util/btree/UpdateablePageCollection.java
+++ b/common/src/main/java/io/pravega/common/util/btree/UpdateablePageCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/ExceptionsTests.java
+++ b/common/src/test/java/io/pravega/common/ExceptionsTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/ExponentialMovingAverageTest.java
+++ b/common/src/test/java/io/pravega/common/ExponentialMovingAverageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/SimpleMovingAverageTests.java
+++ b/common/src/test/java/io/pravega/common/SimpleMovingAverageTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/TimeoutTimerTest.java
+++ b/common/src/test/java/io/pravega/common/TimeoutTimerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/AbstractThreadPoolServiceTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/AbstractThreadPoolServiceTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/AsyncIteratorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/AsyncIteratorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/CancellationTokenTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/CancellationTokenTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/FuturesTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/MultiKeySequentialProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/MultiKeySequentialProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/concurrent/SequentialProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/SequentialProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/function/CallbacksTests.java
+++ b/common/src/test/java/io/pravega/common/function/CallbacksTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/hash/HashHelperTest.java
+++ b/common/src/test/java/io/pravega/common/hash/HashHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/BoundedInputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/BoundedInputStreamTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/FixedByteArrayOutputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/FixedByteArrayOutputStreamTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/RandomAccessOutputStreamTestBase.java
+++ b/common/src/test/java/io/pravega/common/io/RandomAccessOutputStreamTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/RandomOutputTestBase.java
+++ b/common/src/test/java/io/pravega/common/io/RandomOutputTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataOutputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataOutputStreamTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/RevisionDataStreamCommonTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/io/serialization/VersionedSerializerTests.java
+++ b/common/src/test/java/io/pravega/common/io/serialization/VersionedSerializerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/lang/Int96Test.java
+++ b/common/src/test/java/io/pravega/common/lang/Int96Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/lang/ProcessStarterTests.java
+++ b/common/src/test/java/io/pravega/common/lang/ProcessStarterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/tracing/RequestTrackerTest.java
+++ b/common/src/test/java/io/pravega/common/tracing/RequestTrackerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/BitConverterTests.java
+++ b/common/src/test/java/io/pravega/common/util/BitConverterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/BlockingDrainingQueueTests.java
+++ b/common/src/test/java/io/pravega/common/util/BlockingDrainingQueueTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/CircularBufferTests.java
+++ b/common/src/test/java/io/pravega/common/util/CircularBufferTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/CollectionHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/util/CollectionHelpersTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ConfigBuilderTests.java
+++ b/common/src/test/java/io/pravega/common/util/ConfigBuilderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/DelimitedStringParserTests.java
+++ b/common/src/test/java/io/pravega/common/util/DelimitedStringParserTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/HashedArrayTests.java
+++ b/common/src/test/java/io/pravega/common/util/HashedArrayTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/IteratorTest.java
+++ b/common/src/test/java/io/pravega/common/util/IteratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/OrderedItemProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/util/OrderedItemProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ResourcePoolTest.java
+++ b/common/src/test/java/io/pravega/common/util/ResourcePoolTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/RetryTests.java
+++ b/common/src/test/java/io/pravega/common/util/RetryTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableFutureLatchTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/SequencedItemListTests.java
+++ b/common/src/test/java/io/pravega/common/util/SequencedItemListTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/SortedIndexTestBase.java
+++ b/common/src/test/java/io/pravega/common/util/SortedIndexTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ToStringUtilsTest.java
+++ b/common/src/test/java/io/pravega/common/util/ToStringUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
+++ b/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
+++ b/common/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/btree/BTreePageTests.java
+++ b/common/src/test/java/io/pravega/common/util/btree/BTreePageTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/btree/ByteArrayComparatorTests.java
+++ b/common/src/test/java/io/pravega/common/util/btree/ByteArrayComparatorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config.properties
+++ b/config/config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/standalone-config.properties
+++ b/config/standalone-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controller/src/conf/controller.config.properties
+++ b/controller/src/conf/controller.config.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/CheckpointConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/CheckpointConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorGroup.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorGroupConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorGroupConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorInitException.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorInitException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorReinitException.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorReinitException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventSerializer.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/ExceptionHandler.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/RequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/RequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorHelper.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorSystemImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorSystemImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/ContainerBalancer.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ContainerBalancer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/FailoverSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/fault/FailoverSweeper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/SegmentContainerMonitor.java
+++ b/controller/src/main/java/io/pravega/controller/fault/SegmentContainerMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
+++ b/controller/src/main/java/io/pravega/controller/fault/SegmentMonitorLeader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/fault/UniformContainerBalancer.java
+++ b/controller/src/main/java/io/pravega/controller/fault/UniformContainerBalancer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/metrics/AbstractControllerMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/AbstractControllerMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/metrics/HostContainerMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/HostContainerMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/metrics/TransactionMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/TransactionMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/ZookeeperMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/retryable/RetryableException.java
+++ b/controller/src/main/java/io/pravega/controller/retryable/RetryableException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/AuthResourceRepresentation.java
+++ b/controller/src/main/java/io/pravega/controller/server/AuthResourceRepresentation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServerException.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceMain.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/SegmentStoreConnectionManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentStoreConnectionManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/WireCommandFailedException.java
+++ b/controller/src/main/java/io/pravega/controller/server/WireCommandFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/BucketManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/BucketManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/BucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/BucketService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/BucketServiceFactory.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/BucketServiceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/BucketWork.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/BucketWork.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/InMemoryBucketManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/InMemoryBucketManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/InMemoryBucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/InMemoryBucketService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicRetention.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicRetention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbortRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbortRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AutoScaleTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/DeleteStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/DeleteStreamTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestUnsupportedException.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestUnsupportedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TaskExceptions.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TaskExceptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/TruncateStreamTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/ControllerApplication.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/ControllerApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/CustomObjectMapperProvider.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/CustomObjectMapperProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/RESTServer.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/RESTServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/RESTServerConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/RESTServerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/impl/RESTServerConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/impl/RESTServerConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/PingImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/PingImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PasswordAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaAuthManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/PravegaInterceptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/RESTAuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/RESTAuthHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/StrongPasswordProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/StrongPasswordProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/TestAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/UserPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/GRPCServer.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/GRPCServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/GRPCServerConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/GRPCServerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStoreException.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStoreException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStoreFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStoreFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/InMemoryCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/InMemoryCheckpointStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/InMemoryStoreClient.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/InMemoryStoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/PravegaTableStoreClient.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/PravegaTableStoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClient.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClientConfig.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClientConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/StoreType.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/ZKClientConfig.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/ZKClientConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/ZKStoreClient.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/ZKStoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/impl/StoreClientConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/impl/StoreClientConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/client/impl/ZKClientConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/impl/ZKClientConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/HostControllerStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/HostControllerStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/HostMonitorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/HostMonitorConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/HostStoreException.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/HostStoreException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/HostStoreFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/HostStoreFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/InMemoryHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/InMemoryHostStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/host/impl/HostMonitorConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/impl/HostMonitorConfigImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/index/HostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/HostIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/index/InMemoryHostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/InMemoryHostIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/BucketStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Cache.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Cache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/CreateStreamResponse.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/CreateStreamResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/EpochTransitionOperationExceptions.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/EpochTransitionOperationExceptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryBucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryBucketStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryScope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/OperationContext.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/OperationContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/OperationContextImpl.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/OperationContextImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesScope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ScaleMetadata.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ScaleMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Scope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Scope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Segment.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Segment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/State.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/State.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StoreException.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StoreException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/TxnStatus.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/TxnStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/Version.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Version.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedMetadata.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/VersionedTransactionData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZkInt96Counter.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZkInt96Counter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZkOrderedStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZkOrderedStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/ActiveTxnRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/ActiveTxnRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/CommittingTransactionsRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/CommittingTransactionsRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/CompletedTxnRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/CompletedTxnRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/EpochRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/EpochRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/EpochTransitionRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/EpochTransitionRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/HistoryTimeSeries.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/HistoryTimeSeries.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/HistoryTimeSeriesRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/HistoryTimeSeriesRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/RecordHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/RecordHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/RetentionSet.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/RetentionSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/SealedSegmentsMapShard.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/SealedSegmentsMapShard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StateRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StateRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamConfigurationRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamConfigurationRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutReferenceRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutReferenceRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamSegmentRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamSegmentRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamTruncationRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamTruncationRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/VersionMismatchException.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/VersionMismatchException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/AbstractTaskMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/AbstractTaskMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/InMemoryTaskMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/InMemoryTaskMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/LockData.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/LockData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/LockFailedException.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/LockFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/Resource.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/Resource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/TaggedResource.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/TaggedResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/TaskMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/TaskMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/TaskStoreFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/TaskStoreFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/TxnResource.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/TxnResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/UnlockFailedException.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/UnlockFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/store/task/ZKTaskMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/ZKTaskMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/DuplicateTaskAnnotationException.java
+++ b/controller/src/main/java/io/pravega/controller/task/DuplicateTaskAnnotationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/TaskStepsRetryHelper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/TaskStepsRetryHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/TestTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/TestTasks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/TxnSweeper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/WriteFailedException.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/WriteFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/Task.java
+++ b/controller/src/main/java/io/pravega/controller/task/Task.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/TaskAnnotationNotFoundException.java
+++ b/controller/src/main/java/io/pravega/controller/task/TaskAnnotationNotFoundException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/TaskBase.java
+++ b/controller/src/main/java/io/pravega/controller/task/TaskBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/TaskData.java
+++ b/controller/src/main/java/io/pravega/controller/task/TaskData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/task/TaskSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/TaskSweeper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/timeout/TimeoutService.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimeoutService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/timeout/TimeoutServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimeoutServiceConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
+++ b/controller/src/main/java/io/pravega/controller/timeout/TimerWheelTimeoutService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/util/RetryHelper.java
+++ b/controller/src/main/java/io/pravega/controller/util/RetryHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/util/ZKUtils.java
+++ b/controller/src/main/java/io/pravega/controller/util/ZKUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/main/resources/META-INF/services/io.pravega.auth.AuthHandler
+++ b/controller/src/main/resources/META-INF/services/io.pravega.auth.AuthHandler
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/auth/AuthFileUtils.java
+++ b/controller/src/test/java/io/pravega/controller/auth/AuthFileUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/auth/PasswordEncryptorTool.java
+++ b/controller/src/test/java/io/pravega/controller/auth/PasswordEncryptorTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java
+++ b/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/auth/PasswordValidatorTool.java
+++ b/controller/src/test/java/io/pravega/controller/auth/PasswordValidatorTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/CheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/CheckpointStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEPSerializedRHTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEPSerializedRHTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/InMemoryCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/InMemoryCheckpointStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/fault/UniformContainerBalancerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/UniformContainerBalancerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamReaderMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/mocks/FakeAuthHandler.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/FakeAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/Failing403StreamMetaDataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/SecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/SecureStreamMetaDataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/rest/v1/UserSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/UserSecureStreamMetaDataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/AuthResourceRepresentationTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/AuthResourceRepresentationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceConfigTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceMainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithPravegaTablesStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithPravegaTablesStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithZKStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithZKStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/InMemoryControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/InMemoryControllerServiceMainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/InMemoryControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/InMemoryControllerServiceStarterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceMainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/PravegaTablesControllerServiceStarterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/SecureInMemoryControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SecureInMemoryControllerServiceStarterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/SegmentStoreConnectionManagerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentStoreConnectionManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceMainTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceMainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ZKControllerServiceStarterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/bucket/InMemoryStoreRetentionTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/InMemoryStoreRetentionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/bucket/PravegaTablesStoreRetentionTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/PravegaTablesStoreRetentionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/bucket/ZkStoreRetentionTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/ZkStoreRetentionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorPravegaTablesStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorPravegaTablesStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorZkStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesRequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesRequestHandlersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesScaleRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/SecureLocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/SecureLocalControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ZkRequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ZkRequestHandlersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ZkScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ZkScaleRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithInMemoryStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorWithZkStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rest/impl/RESTServerConfigImplTests.java
+++ b/controller/src/test/java/io/pravega/controller/server/rest/impl/RESTServerConfigImplTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/PravegaAuthManagerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/PravegaAuthManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/RESTAuthHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/RESTAuthHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/StrongPasswordProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/StrongPasswordProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/UserPrincipalTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/UserPrincipalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/impl/GRPCServerConfigImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/InMemoryControllerServiceImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ZKControllerServiceImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/client/impl/ZKClientConfigImplTests.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/impl/ZKClientConfigImplTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/InMemoryStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/VersionTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/VersionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKCounterTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKCounterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZooKeeperStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/records/ControllerMetadataRecordSerializerTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/records/ControllerMetadataRecordSerializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/store/stream/records/RecordHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/records/RecordHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/InMemoryTaskMetadataStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/task/InMemoryTaskMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/PravegaTableTaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/PravegaTableTaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/PravegaTablesRequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/PravegaTablesRequestSweeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/PravegaTablesStreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/PravegaTablesStreamMetadataTasksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/SecureStreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/SecureStreamMetadataTasksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/ZkRequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/ZkRequestSweeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/Stream/ZkStreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/ZkStreamMetadataTasksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/TaskMetadataStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/ZKTaskMetadataStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/task/ZKTaskMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/task/ZkTaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/ZkTaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServicePravegaTableStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServicePravegaTableStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceZkStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceZkStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/util/ConfigTest.java
+++ b/controller/src/test/java/io/pravega/controller/util/ConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/util/RetryHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/test/resources/META-INF/services/io.pravega.auth.AuthHandler
+++ b/controller/src/test/resources/META-INF/services/io.pravega.auth.AuthHandler
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controller/src/test/resources/controller.config.properties
+++ b/controller/src/test/resources/controller.config.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controller/src/test/resources/logback.xml
+++ b/controller/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/deployment/aws/aws.tf
+++ b/deployment/aws/aws.tf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/aws/bootstrap.sh
+++ b/deployment/aws/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/ansible.cfg
+++ b/deployment/aws/installer/ansible.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/data/variable_template.yml
+++ b/deployment/aws/installer/data/variable_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/entry_point_template.yml
+++ b/deployment/aws/installer/entry_point_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-bk/files/install-bk.sh
+++ b/deployment/aws/installer/roles/install-bk/files/install-bk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-bk/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-bk/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-controller/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-controller/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-hosts/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-hosts/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-prereqs/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-prereqs/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-zk/defaults/main.yml
+++ b/deployment/aws/installer/roles/install-zk/defaults/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-zk/tasks/main.yml
+++ b/deployment/aws/installer/roles/install-zk/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/installer/roles/install-zk/templates/zoo.cfg.j2
+++ b/deployment/aws/installer/roles/install-zk/templates/zoo.cfg.j2
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployment/aws/variable.tf
+++ b/deployment/aws/variable.tf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/Readme.md
+++ b/docker/compose/Readme.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker/compose/docker-compose-extendeds3.yml
+++ b/docker/compose/docker-compose-extendeds3.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/docker-compose-nfs-mount.yml
+++ b/docker/compose/docker-compose-nfs-mount.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/docker-compose-nfs.yml
+++ b/docker/compose/docker-compose-nfs.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/swarm/Readme.md
+++ b/docker/compose/swarm/Readme.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker/compose/swarm/hdfs.yml
+++ b/docker/compose/swarm/hdfs.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/swarm/pravega.yml
+++ b/docker/compose/swarm/pravega.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/compose/swarm/zookeeper.yml
+++ b/docker/compose/swarm/zookeeper.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/entrypoint.sh
+++ b/docker/pravega/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/init_controller.sh
+++ b/docker/pravega/scripts/init_controller.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/init_segmentstore.sh
+++ b/docker/pravega/scripts/init_segmentstore.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/init_standalone.sh
+++ b/docker/pravega/scripts/init_standalone.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/pravega/scripts/wait_for
+++ b/docker/pravega/scripts/wait_for
@@ -1,6 +1,6 @@
 #!/usr/bin/python -u
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/documentation/src/docs/auth/auth-plugin.md
+++ b/documentation/src/docs/auth/auth-plugin.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/auth/client-auth.md
+++ b/documentation/src/docs/auth/client-auth.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/basic-reader-and-writer.md
+++ b/documentation/src/docs/basic-reader-and-writer.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/connectors.md
+++ b/documentation/src/docs/connectors.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/contributing.md
+++ b/documentation/src/docs/contributing.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/controller-service.md
+++ b/documentation/src/docs/controller-service.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/aws-install.md
+++ b/documentation/src/docs/deployment/aws-install.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/dcos-install.md
+++ b/documentation/src/docs/deployment/dcos-install.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/deployment.md
+++ b/documentation/src/docs/deployment/deployment.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/docker-swarm.md
+++ b/documentation/src/docs/deployment/docker-swarm.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/kubernetes-install.md
+++ b/documentation/src/docs/deployment/kubernetes-install.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/manual-install.md
+++ b/documentation/src/docs/deployment/manual-install.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/deployment/run-local.md
+++ b/documentation/src/docs/deployment/run-local.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/faq.md
+++ b/documentation/src/docs/faq.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/getting-started.md
+++ b/documentation/src/docs/getting-started.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/index.md
+++ b/documentation/src/docs/index.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/javadoc.md
+++ b/documentation/src/docs/javadoc.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/join-community.md
+++ b/documentation/src/docs/join-community.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/key-features.md
+++ b/documentation/src/docs/key-features.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/metrics.md
+++ b/documentation/src/docs/metrics.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/pravega-concepts.md
+++ b/documentation/src/docs/pravega-concepts.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/reader-group-design.md
+++ b/documentation/src/docs/reader-group-design.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/reader-group-notifications.md
+++ b/documentation/src/docs/reader-group-notifications.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/roadmap.md
+++ b/documentation/src/docs/roadmap.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/security/pravega-security-authorization-authentication.md
+++ b/documentation/src/docs/security/pravega-security-authorization-authentication.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/security/pravega-security-configurations.md
+++ b/documentation/src/docs/security/pravega-security-configurations.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/security/pravega-security-encryption.md
+++ b/documentation/src/docs/security/pravega-security-encryption.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/security/securing-distributed-mode-cluster.md
+++ b/documentation/src/docs/security/securing-distributed-mode-cluster.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/segment-containers.md
+++ b/documentation/src/docs/segment-containers.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/segment-store-service.md
+++ b/documentation/src/docs/segment-store-service.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/state-synchronizer-design.md
+++ b/documentation/src/docs/state-synchronizer-design.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/state-synchronizer.md
+++ b/documentation/src/docs/state-synchronizer.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/streamcuts.md
+++ b/documentation/src/docs/streamcuts.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/terminology.md
+++ b/documentation/src/docs/terminology.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/transactions.md
+++ b/documentation/src/docs/transactions.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/docs/wire-protocol.md
+++ b/documentation/src/docs/wire-protocol.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/documentation/src/mkdocs.yml
+++ b/documentation/src/mkdocs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/mkdocs.gradle
+++ b/gradle/mkdocs.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/protobuf.gradle
+++ b/gradle/protobuf.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 ##############################################################################
 
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -6,7 +6,7 @@
 @rem ##########################################################################
 
 @rem
-@rem  Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+@rem  Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 @rem
 @rem  Licensed under the Apache License, Version 2.0 (the "License");
 @rem  you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdate.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/AttributeUpdateType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadAttributeUpdateException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadAttributeUpdateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadOffsetException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadOffsetException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadSegmentTypeException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/BadSegmentTypeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ContainerException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ContainerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ContainerNotFoundException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ContainerNotFoundException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntry.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntryContents.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntryContents.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntryType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResultEntryType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentProperties.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentExistsException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentExistsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentInformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentMergedException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentMergedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentNotExistsException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentNotExistsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentNotSealedException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentNotSealedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentSealedException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentSealedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentTruncatedException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentTruncatedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamingException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamingException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/TooManyActiveSegmentsException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/TooManyActiveSegmentsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/BadKeyVersionException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/BadKeyVersionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/ConditionalTableUpdateException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/ConditionalTableUpdateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/IteratorItem.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/IteratorItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/KeyNotExistsException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/KeyNotExistsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableAttributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableAttributes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableEntry.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableKey.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableKeyTooLongException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableKeyTooLongException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableSegmentNotEmptyException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableSegmentNotEmptyException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableValueTooLongException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableValueTooLongException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/config/logback.xml
+++ b/segmentstore/server/host/src/config/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/Playground.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/Playground.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/StorageLoader.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/StorageLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/AdminRunner.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/AdminRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/Parser.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/Parser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/AdminCommandState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/AdminCommandState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperCleanupCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperCleanupCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperDetailsCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperDetailsCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperDisableCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperDisableCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperEnableCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperEnableCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperListCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/BookKeeperListCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/Command.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/Command.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/CommandArgs.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/CommandArgs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigListCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigListCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigSetCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ConfigSetCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ContainerCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ContainerCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ContainerRecoverCommand.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/admin/commands/ContainerRecoverCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/DelegationTokenVerifier.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/DelegationTokenVerifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/PassingTokenVerifier.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/PassingTokenVerifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/TokenVerifierImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/delegationtoken/TokenVerifierImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorder.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorder.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperIntegrationTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperRunner.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/BookKeeperRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/S3ClientWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/delegationtoken/TokenVerifierImplTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/delegationtoken/TokenVerifierImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorAuthFailedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/load/AttributeLoadTests.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/load/AttributeLoadTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfigTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScalerConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/SegmentAggregatesTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/SegmentAggregatesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/TableSegmentStatsRecorderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeIterator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/AttributeIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Container.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Container.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerHandle.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerOfflineException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerOfflineException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DataCorruptionException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DataCorruptionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DirectSegmentAccess.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DirectSegmentAccess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/EvictableMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/EvictableMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/IllegalContainerStateException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/IllegalContainerStateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLogFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/OperationLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndexFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndexFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/RecoverableMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/RecoverableMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerExtension.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/TruncationMarkerRepository.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/TruncationMarkerRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableContainerMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/UpdateableSegmentMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Writer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/Writer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterSegmentProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterSegmentProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/AttributeIndexConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/AttributeIndexConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/AttributeIndexFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/AttributeIndexFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/CacheKey.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/CacheKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexFactoryImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/ContainerAttributeIndexImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentAttributeIterator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/SegmentAttributeIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameRecord.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DebugRecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DebugRecoveryProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MetadataUpdateException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MetadataUpdateException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdater.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Serializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Serializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/AttributeUpdaterOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/AttributeUpdaterOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationBase.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CompletableOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CompletableOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeSegmentOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MergeSegmentOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MetadataCheckpointOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MetadataCheckpointOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MetadataOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/MetadataOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/Operation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/Operation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/OperationSerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/OperationSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageMetadataCheckpointOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageMetadataCheckpointOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StorageOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentAppendOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentAppendOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentSealOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentSealOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentTruncateOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentTruncateOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/UpdateAttributesOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/UpdateAttributesOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/LocalSegmentContainerManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/LocalSegmentContainerManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheIndexEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheIndexEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheKey.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CacheReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndexFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndexFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/EndOfStreamSegmentReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/EndOfStreamSegmentReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/MergedIndexEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/MergedIndexEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/PendingMerge.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/PendingMerge.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadResultEntryBase.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadResultEntryBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectIndexEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectIndexEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/TruncatedReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/TruncatedReadResultEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/SegmentContainerCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/SegmentContainerCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/BucketUpdate.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/BucketUpdate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/CacheBucketOffset.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/CacheBucketOffset.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtension.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IteratorState.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IteratorState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyHasher.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyHasher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyUpdateCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucket.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableIterator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableKeyBatch.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableKeyBatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AckCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AckCalculator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AggregatorState.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AggregatorState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/ReconciliationFailureException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/ReconciliationFailureException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriterFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterDataSource.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterState.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/ManualTimer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/ManualTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/MetadataBuilder.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/MetadataBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/ServiceListeners.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/ServiceListeners.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TableStoreMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TableStoreMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLogFactory.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/CacheKeyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/CacheKeyTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentAttributeIteratorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/SegmentAttributeIteratorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameBuilderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameOutputStreamTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameReaderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTestHelpers.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTestHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MetadataCheckpointPolicyTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationMetadataUpdaterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogAddress.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogItem.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestLogItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestSerializer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/TestSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CheckpointOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CompletableOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/CompletableOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/MergeSegmentOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/MergeSegmentOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationComparer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationTestsBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentAppendOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentAppendOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentMapOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentSealOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentSealOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentTruncateOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/StreamSegmentTruncateOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/UpdateAttributesOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/UpdateAttributesOperationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStoreTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/CacheKeyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/CacheKeyTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/PendingMergeTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/PendingMergeTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntryTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReadManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReadManagerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReaderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/TestReadResultHandler.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/TestReadResultHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceConfigTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/BucketUpdateTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/BucketUpdateTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/CacheBucketOffsetTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/CacheBucketOffsetTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/IndexReaderWriterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyHashers.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyHashers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyUpdateCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/KeyUpdateCollectionTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableIteratorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableIteratorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableServiceTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableServiceTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/AckCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/AckCalculatorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/server/src/test/resources/logback-test.xml
+++ b/segmentstore/server/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperMetrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/HierarchyUtils.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/HierarchyUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerAddress.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogReader.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ReadOnlyLogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ReadOnlyLogMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/SequentialAsyncProcessor.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/SequentialAsyncProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Write.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Write.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteLedger.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteLedger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheFactory.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/HierarchyUtilsTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/HierarchyUtilsTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerAddressTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerAddressTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadataTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/LogMetadataTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/SequentialAsyncProcessorTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/SequentialAsyncProcessorTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCacheTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/impl/src/test/resources/logback.xml
+++ b/segmentstore/storage/impl/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Cache.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Cache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/CacheException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/CacheException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/CacheFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/CacheFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ConfigSetup.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ConfigSetup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogDisabledException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogDisabledException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogInitializationException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogInitializationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogNotAvailableException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogNotAvailableException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogWriterNotPrimaryException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DataLogWriterNotPrimaryException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLogException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLogException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLogFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/LogAddress.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/LogAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/QueueStats.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/QueueStats.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ReadOnlyStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ReadOnlyStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SegmentHandle.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SegmentHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SegmentRollingPolicy.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SegmentRollingPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageNotPrimaryException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteFailureException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteFailureException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteTooLongException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteTooLongException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryCache.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/HandleSerializer.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/HandleSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingSegmentHandle.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingSegmentHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/SegmentChunk.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/SegmentChunk.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
+++ b/segmentstore/storage/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/CacheTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/CacheTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryCacheTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/HandleSerializerTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/HandleSerializerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingSegmentHandleTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingSegmentHandleTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/test/resources/logback.xml
+++ b/segmentstore/storage/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthConstants.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthException.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthenticationException.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthenticationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthorizationException.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthorizationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/authplugin/src/main/java/io/pravega/auth/ServerConfig.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/ServerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/Cluster.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/Cluster.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterException.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterListener.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterType.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/ClusterType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/ContainerSet.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/ContainerSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/Host.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/Host.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/HostContainerMap.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/HostContainerMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/test/java/io/pravega/common/cluster/SerializationTest.java
+++ b/shared/cluster/src/test/java/io/pravega/common/cluster/SerializationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/cluster/src/test/java/io/pravega/common/cluster/zkImpl/ClusterZKTest.java
+++ b/shared/cluster/src/test/java/io/pravega/common/cluster/zkImpl/ClusterZKTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/AbortEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/AbortEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/AutoScaleEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/AutoScaleEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CommitEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CommitEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ControllerEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ControllerEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ControllerEventSerializer.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ControllerEventSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/DeleteStreamEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/DeleteStreamEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/RequestProcessor.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/RequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/ScaleOpEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/SealStreamEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/SealStreamEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/TruncateStreamEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/TruncateStreamEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/UpdateStreamEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/UpdateStreamEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/tracing/RPCTracingHelpers.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/tracing/RPCTracingHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/swagger/Controller.yaml
+++ b/shared/controller-api/src/main/swagger/Controller.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/main/swagger/README.md
+++ b/shared/controller-api/src/main/swagger/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/tracing/RPCTracingHelpersTest.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/tracing/RPCTracingHelpersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Counter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/CounterProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Gauge.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/GaugeProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Meter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MeterProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/Metric.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/Metric.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsProvider.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullDynamicLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullDynamicLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsProvider.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/NullStatsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsData.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/OpStatsLoggerProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/RegistryConfigUtil.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/RegistryConfigUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLogger.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsLoggerProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProvider.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/BasicMetricTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/BasicMetricTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricRegistryUtils.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricRegistryUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/RegistryConfigUtilTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/RegistryConfigUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsLoggerProxyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendBatchSizeTracker.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendBatchSizeTracker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ConnectionFailedException.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ConnectionFailedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingReplyProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ExceptionLoggingHandler.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ExceptionLoggingHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/InvalidMessageException.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/InvalidMessageException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/PravegaNodeUri.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/PravegaNodeUri.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Reply.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Reply.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommand.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/segment/ScaleType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/ScaleType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/segment/SegmentToContainerMapper.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/SegmentToContainerMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/SegmentToContainerMapperTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/SegmentToContainerMapperTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/StreamSegmentNameUtilsTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/main/java/io/pravega/local/LocalHDFSEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalHDFSEmulator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
+++ b/standalone/src/main/java/io/pravega/local/LocalPravegaEmulator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
+++ b/standalone/src/main/java/io/pravega/local/SingleNodeConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleDownTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleDownTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndTransactionTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndTransactionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/NotDoneException.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/NotDoneException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/ScaleTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/ScaleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartLocalService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/StartWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Actor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Consumer.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Consumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ConsumerOperationType.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ConsumerOperationType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Event.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Event.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/EventGenerator.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/EventGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/OperationType.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/OperationType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Producer.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Producer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerDataSource.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerOperation.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerOperationType.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerOperationType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerUpdate.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ProducerUpdate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTestRunner.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/SelfTestRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/StreamProducerDataSource.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/StreamProducerDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TableConsumer.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TableConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TableProducerDataSource.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TableProducerDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TableUpdate.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TableUpdate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestConfig.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestLogger.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/TestState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationException.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationResult.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationSource.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/ValidationSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/BookKeeperAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/BookKeeperAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientAdapterBase.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientAdapterBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ClientReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ExternalAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/ExternalAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessListenerWithRealStoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessListenerWithRealStoreAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/InProcessMockClientAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/OutOfProcessAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/OutOfProcessAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/SegmentStoreReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/StoreAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/StoreAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/StoreReader.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/StoreReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/utils/IntegerSerializer.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/utils/IntegerSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/main/resources/logback-test.xml
+++ b/test/integration/src/main/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/AutoCheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AutoCheckpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BoundedStreamReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerBootstrapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerFailoverTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerStreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerStreamMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MultiReadersEndToEndTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadFromDeletedStreamTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadFromDeletedStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadWriteTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadWriteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadWriteUtils.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadWriteUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupNotificationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupStreamCutUpdateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamCutsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/UnreadBytesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/DebugStreamSegmentsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/DebugStreamSegmentsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/AbstractEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/AbstractEndToEndTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndWithScaleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/ScopeTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/ScopeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/resources/controller.config.properties
+++ b/test/integration/src/test/resources/controller.config.properties
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/src/test/resources/logback.xml
+++ b/test/integration/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017 Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test/system/Change_Docker_Config_Master.sh
+++ b/test/system/Change_Docker_Config_Master.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/Change_Docker_Config_Slave.sh
+++ b/test/system/Change_Docker_Config_Slave.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/logCollectionScript.sh
+++ b/test/system/aws/logCollectionScript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/master_script.sh
+++ b/test/system/aws/master_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/output.tf
+++ b/test/system/aws/output.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/aws/postTestScript.sh
+++ b/test/system/aws/postTestScript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/pravega.tf
+++ b/test/system/aws/pravega.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/aws/preTestScript.sh
+++ b/test/system/aws/preTestScript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/slave_script.sh
+++ b/test/system/aws/slave_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/aws/variable.tf
+++ b/test/system/aws/variable.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/kubernetes/setupTestPod.sh
+++ b/test/system/kubernetes/setupTestPod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/preTestScript.sh
+++ b/test/system/preTestScript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/SingleJUnitTestRunner.java
+++ b/test/system/src/main/java/io/pravega/test/system/SingleJUnitTestRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/DockerBasedTestExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/DockerBasedTestExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/Environment.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/Environment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/LoginClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/LoginClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/SystemTestRunner.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/SystemTestRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/TestExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/TestExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/TestExecutorFactory.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/TestExecutorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/TestFrameworkException.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/TestFrameworkException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/TrustingSSLSocketFactory.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/TrustingSSLSocketFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/ClientFactory.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/ClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/kubernetes/K8sClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/marathon/AuthEnabledMarathonClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/marathon/AuthEnabledMarathonClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/AuthEnabledMetronomeClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/AuthEnabledMetronomeClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/Metronome.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/Metronome.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/MetronomeClient.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/MetronomeClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/MetronomeException.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/MetronomeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/ModelUtils.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/ModelUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/ActiveRun.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/ActiveRun.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Artifact.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Artifact.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/History.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/History.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Job.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Job.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Restart.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Restart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Run.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Run.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Task.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/metronome/model/v1/Task.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/Service.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/Service.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/BookkeeperDockerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/HDFSDockerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaControllerDockerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/PravegaSegmentStoreDockerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/ZookeeperDockerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/BookkeeperK8sService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaControllerK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaControllerK8sService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/PravegaSegmentStoreK8sService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/BookkeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/BookkeeperService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/MarathonBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/MarathonBasedService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaControllerService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaControllerService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaSegmentStoreService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/PravegaSegmentStoreService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/ZookeeperService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/marathon/ZookeeperService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractFailoverTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractScaleTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractSystemTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AutoScaleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookkeeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ByteClientTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ByteClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ControllerRestApiTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeNumSegmentsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityLargeScalesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MetadataScalabilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiSegmentStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/OffsetTruncationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaSegmentStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/PravegaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteScaleWithFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWithAutoScaleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReaderCheckpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/RetentionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamCutsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/StreamsAndScopesManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ZookeeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/resources/logback-test.xml
+++ b/test/system/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/testcommon/resources/logback-test.xml
+++ b/test/testcommon/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/ErrorInjector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/InlineExecutor.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/InlineExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/IntentionalException.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/IntentionalException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestingServerStarter.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestingServerStarter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/main/java/io/pravega/test/common/ThreadPooledTestSuite.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/ThreadPooledTestSuite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testcommon/src/test/java/io/pravega/test/common/UtilityMethodsTest.java
+++ b/test/testcommon/src/test/java/io/pravega/test/common/UtilityMethodsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**  
* Removed year from copyright header from all files according to legal guidance.

**Purpose of the change**  
Fixes #3508 

**What the code does**  
There is no code change, it only removes the year from the copyright.

**How to verify it**  
It must build regularly as there is no code change.
