### PR TITLE
Issue 3859: Fix scale_segmentStore script for external access

### DIFF
--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -17,7 +17,7 @@ try:
         "docker service inspect pravega_segmentstore --format='{{.Spec.TaskTemplate.ContainerSpec.Env}}'", shell=True)
 
     def get_config(name):
-        return re.findall(name + "=(.+?)( |])", env)[0][0]
+        return re.findall(name + "=(.+?)( |]|\n)", env)[0][0]
 
     published_address = get_config("publishedIPAddress")
     hdfs_url = get_config("HDFS_URL")

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -17,7 +17,7 @@ try:
         "docker service inspect pravega_segmentstore --format='{{.Spec.TaskTemplate.ContainerSpec.Env}}'", shell=True)
 
     def get_config(name):
-        return re.findall(name + "=(.+?)( |]|\n)", env)[0][0]
+        return re.findall(name + "=(.+?)( |]|\r\n|\n)", env)[0][0]
 
     published_address = get_config("publishedIPAddress")
     hdfs_url = get_config("HDFS_URL")

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -17,7 +17,7 @@ try:
         "docker service inspect pravega_segmentstore --format='{{.Spec.TaskTemplate.ContainerSpec.Env}}'", shell=True)
 
     def get_config(name):
-        return re.findall(name + "=(.+?)( |]|\r\n|\n)", env)[0][0]
+        return re.findall(name + "=(.+//)?(.+?)( |]|\r\n|\n)", env)[0][1]
 
     published_address = get_config("publishedIPAddress")
     hdfs_url = get_config("HDFS_URL")
@@ -59,6 +59,8 @@ for instance in to_create:
           --label com.docker.stack.namespace='pravega' \
           -p '{port}:{port}' \
           -e HDFS_URL={hdfs_url} \
+          -e TIER2_STORAGE=HDFS \
+          -e HDFS_REPLICATION=1 \
           -e ZK_URL={zk_url} \
           -e CONTROLLER_URL=tcp://controller:9090 \
           -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Dbookkeeper.bkEnsembleSize=2 -Dbookkeeper.bkAckQuorumSize=2 -Dbookkeeper.bkWriteQuorumSize=2 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \


### PR DESCRIPTION
**Change log description**  
* Ensures `publishedIPAddress` configuration is read from the docker configuration.
* Adds missing configuration for HDFS.

**Purpose of the change**  
Fixes #3859 #3874 

**What the code does**  
`scale_segmentStore ` is a helper script which is used to scale segment stores (with HDFS as tier2) instances with external access. This enables Pravega to be accessed by clients outside the docker swarm cluster. The user uses the system property `PUBLISHED_ADDRESS` to convey the ip to be used by the external clients to access Pravega.

The script ensures it reads the configuration from the running segment store docker service 
via `docker service inspect pravega_segmentstore` and uses the same properties to create newer segment store service instances.



**How to verify it**  
Verified it by testing it on a docker swarm setup.
