### PR TITLE
Issue 3867: RequestSweeper has incorrect exit check in doWhile loop 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
@@ -8,6 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.controller.task.Stream;
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.fault.FailoverSweeper;
 import io.pravega.controller.store.stream.StreamMetadataStore;
@@ -36,15 +37,25 @@ import static io.pravega.controller.util.RetryHelper.withRetriesAsync;
  */
 public class RequestSweeper implements FailoverSweeper {
 
+    public static final int LIMIT = 100;
+    
     private final StreamMetadataStore metadataStore;
     private final ScheduledExecutorService executor;
     private final StreamMetadataTasks streamMetadataTasks;
-
+    private final int limit;
+    
     public RequestSweeper(final StreamMetadataStore metadataStore,
                           final ScheduledExecutorService executor, final StreamMetadataTasks streamMetadataTasks) {
+        this(metadataStore, executor, streamMetadataTasks, LIMIT);
+    }
+    
+    public RequestSweeper(final StreamMetadataStore metadataStore,
+                          final ScheduledExecutorService executor, final StreamMetadataTasks streamMetadataTasks,
+                          final int limit) {
         this.metadataStore = metadataStore;
         this.executor = executor;
         this.streamMetadataTasks = streamMetadataTasks;
+        this.limit = limit;
     }
 
     @Override
@@ -77,13 +88,14 @@ public class RequestSweeper implements FailoverSweeper {
         log.info("Sweeping orphaned tasks for host {}", oldHostId);
         return withRetriesAsync(() -> Futures.doWhileLoop(
                 () -> postRequest(oldHostId),
-                List::isEmpty, executor).whenCompleteAsync((result, ex) ->
+                list -> !list.isEmpty(), executor).whenCompleteAsync((result, ex) ->
                         log.info("Sweeping orphaned tasks for host {} complete", oldHostId), executor),
                 RETRYABLE_PREDICATE, Integer.MAX_VALUE, executor);
     }
 
-    private CompletableFuture<List<String>> postRequest(final String oldHostId) {
-        return metadataStore.getPendingsTaskForHost(oldHostId, 100)
+    @VisibleForTesting
+    CompletableFuture<List<String>> postRequest(final String oldHostId) {
+        return metadataStore.getPendingsTaskForHost(oldHostId, limit)
                             .thenComposeAsync(tasks -> Futures.allOfWithResults(
                                     tasks.entrySet().stream().map(entry ->
                                             streamMetadataTasks.writeEvent(entry.getValue())

--- a/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
@@ -45,7 +45,7 @@ public class RequestSweeper implements FailoverSweeper {
     private final int limit;
 
     /**
-     * Constructor for RequestSweeper object
+     * Constructor for RequestSweeper object.
      * 
      * @param metadataStore stream metadata store
      * @param executor executor
@@ -57,7 +57,7 @@ public class RequestSweeper implements FailoverSweeper {
     }
 
     /**
-     * Constructor for RequestSweeper object
+     * Constructor for RequestSweeper object.
      *
      * @param metadataStore stream metadata store
      * @param executor executor

--- a/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/RequestSweeper.java
@@ -43,13 +43,29 @@ public class RequestSweeper implements FailoverSweeper {
     private final ScheduledExecutorService executor;
     private final StreamMetadataTasks streamMetadataTasks;
     private final int limit;
-    
+
+    /**
+     * Constructor for RequestSweeper object
+     * 
+     * @param metadataStore stream metadata store
+     * @param executor executor
+     * @param streamMetadataTasks stream metadata tasks
+     */
     public RequestSweeper(final StreamMetadataStore metadataStore,
                           final ScheduledExecutorService executor, final StreamMetadataTasks streamMetadataTasks) {
         this(metadataStore, executor, streamMetadataTasks, LIMIT);
     }
-    
-    public RequestSweeper(final StreamMetadataStore metadataStore,
+
+    /**
+     * Constructor for RequestSweeper object
+     *
+     * @param metadataStore stream metadata store
+     * @param executor executor
+     * @param streamMetadataTasks stream metadata tasks
+     * @param limit limit on number of requests to sweep for a host in one iteration.
+     */
+    @VisibleForTesting
+    RequestSweeper(final StreamMetadataStore metadataStore,
                           final ScheduledExecutorService executor, final StreamMetadataTasks streamMetadataTasks,
                           final int limit) {
         this.metadataStore = metadataStore;


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
RequestSweeper had incorrect check in do while loop whereby 
1) if all entities for a host had already been failed over, then it gets stuck in an infinite loop
2) if there are more than "limit" number of entities in the host, it exited prematurely. 

**Purpose of the change**  
Fixes #3867

**What the code does**  
Instead of `list.IsEmpty` we need to check `!list.isEmpty` to continue the doWhile loop. 
Added unit test to test the functionality. 
Parametrized the limit on number of entities to fetch from zookeeper in one pass. 

**How to verify it**  
Unit test added. 