### PR TITLE
Issue 3718: Fixed flaky unit tests in OperationProcessorTests.

### DIFF
--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -67,6 +67,28 @@ public class AssertExtensions {
     }
 
     /**
+     * Invokes `eval` in a loop over and over (with a small sleep) and asserts that the value eventually reaches `expected`.
+     *
+     * @param <T>                 The type of the value to compare.
+     * @param message             The message ot include.
+     * @param expected            The expected return value.
+     * @param eval                The function to test
+     * @param checkIntervalMillis The number of milliseconds to wait between two checks.
+     * @param timeoutMillis       The timeout in milliseconds after which an assertion error should be thrown.
+     * @throws Exception If the is an assertion error, and exception from `eval`, or the thread is interrupted.
+     */
+    public static <T> void assertEventuallyEquals(String message, T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
+        long remainingMillis = timeoutMillis;
+        while (remainingMillis > 0) {
+            if ((expected == null && eval.call() == null) || (expected != null && expected.equals(eval.call()))) {
+                return;
+            }
+            Thread.sleep(checkIntervalMillis);
+        }
+        assertEquals(message, expected, eval.call());
+    }
+
+    /**
      * Asserts that an exception of the Type provided is thrown.
      *
      * @param run  The Runnable to execute.


### PR DESCRIPTION
**Change log description**  
- Fixed a unit test that needed to wait on a condition to eventually become true.
- Added `AssertExtensions.assertEventuallyEquals(message, ...)` to include custom messages in failures.

**Purpose of the change**  
Fixes #3718.

**What the code does**  
- The unit test was relying on some value that was set asynchronously by the `OperationProcessor`. In some conditions, those values would either be delayed substantially or arrive out of order, so they would not be ready for reading when the test required them.
- Replacing `Assert.assertEquals` with `assertEventuallyEquals` changed the unit test to wait up to a specified amount of time for the condition to become true.

**How to verify it**  
Run these unit tests 20K+ times and verify they don't fail.
