### PR TITLE
Issue 3882: ControllerClusterListener test mocks invoke the method once with null/empty values

### DIFF
--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -136,7 +136,7 @@ public class ControllerClusterListener extends AbstractIdleService {
         return Futures.allOf(sweepers.stream().map(sweeper -> RetryHelper.withIndefiniteRetriesAsync(() -> {
             if (!sweeper.isReady()) {
                 log.trace("sweeper not ready, retrying with exponential backoff");
-                throw new RuntimeException("sweeper not ready");
+                throw new RuntimeException(String.format("sweeper %s not ready", sweeper.getClass()));
             }
             return sweeper.sweepFailedProcesses(processes);
         }, e -> log.warn(e.getMessage()), executor)).collect(Collectors.toList()));

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -183,14 +183,14 @@ public class ControllerClusterListenerTest {
         TaskSweeper taskSweeper = spy(new TaskSweeper(taskStore, host.getHostId(), executor,
                 new TestTasks(taskStore, executor, host.getHostId())));
 
-        when(taskSweeper.sweepFailedProcesses(any(Supplier.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!taskSweep.isDone()) {
                 // we complete the future when this method is called for the first time.
                 taskSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(taskSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(taskSweeper).sweepFailedProcesses(any(Supplier.class));
+        doAnswer(invocation -> {
             if (!taskHostSweep1.isDone()) {
                 // we complete this future when task sweeper for a failed host is called for the first time.
                 taskHostSweep1.complete(null);
@@ -199,7 +199,7 @@ public class ControllerClusterListenerTest {
                 taskHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(taskSweeper).handleFailedProcess(anyString());
 
         // Create txn sweeper.
         StreamMetadataStore streamStore = StreamStoreFactory.createInMemoryStore(executor);
@@ -216,18 +216,19 @@ public class ControllerClusterListenerTest {
             return false;
         }).when(txnSweeper).isReady();
 
-        when(txnSweeper.sweepFailedProcesses(any())).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!txnSweep.isDone()) {
                 txnSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(txnSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(txnSweeper).sweepFailedProcesses(any());
+        
+        doAnswer(invocation -> {
             if (!txnHostSweep2.isDone()) {
                 txnHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(txnSweeper).handleFailedProcess(anyString());
 
         // Create request sweeper.
         StreamMetadataTasks streamMetadataTasks = new StreamMetadataTasks(streamStore, mock(BucketStore.class), taskStore, segmentHelper, executor,
@@ -245,18 +246,19 @@ public class ControllerClusterListenerTest {
             return false;
         }).when(requestSweeper).isReady();
 
-        when(requestSweeper.sweepFailedProcesses(any())).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!requestSweep.isDone()) {
                 requestSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(requestSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(requestSweeper).sweepFailedProcesses(any());
+        
+        doAnswer(invocation -> {
             if (!requestHostSweep2.isDone()) {
                 requestHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(requestSweeper).handleFailedProcess(anyString());
 
         // Create ControllerClusterListener.
         ControllerClusterListener clusterListener = new ControllerClusterListener(host, clusterZK, executor,

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * ControllerClusterListener tests.


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
ControllerClusterListenerTest does `when(mock.method(qualifiers)).thenAnswer(x -> answer)`. This causes the underlying method to be invoked while mock is being instantiated. 

Changing it to `doAnswer(x -> answer).when(mock).method(qualifiers)` ensures the mocks are set and only they are invoked. Underlying method is not invoked. 

**Purpose of the change**  
Fixes #3882 

**What the code does**  
After verifying the behaviour with `when(mock.method(qualifiers)).thenAnswer(x -> answer)` I observed that the actual method is called during the initialization. 
Sometimes, and this is something i am not sure when, the invocation count for the mock is incremented with actual method invocation. 
Thats when the unexpected method invocation is flagged by the mockito verification. 
Methodology:
1. Added logs to the mock methods to see if the mock was actually invoked.
2. Added logs to actual method to see when they were invoked. 
During both successful and failed runs of the test, the actual methods were being invoked because of the way mocks were declared. But the mock methods were only invoked along expected lines. However, in failed runs, the method invocation count for the mock was incremented. 
It is unclear at this point what the trigger for that is. 

When I changed the mock declaration to `doAnswer(x -> answer).when(mock).method(qualifiers)` the real method is not invoked during mock declaration. And the incorrect counting of mock invocation does not happen. This was run in a loop for four hours without failure. 


**How to verify it**  
Test should pass consistently.