### PR TITLE
Issue 3889: Improve test code for ControllerServiceImplTest to enable debugging and avoid false positives

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -307,18 +307,20 @@ public abstract class ControllerServiceImplTest {
     @Test
     public void testCreateStreamThrowsLockFailed() {
         // Check that concurrent calls to create a stream throw FailedLockingException
+        final String lockingScope = "locking-scope";
+        final String lockingStream = "locking";
         final ScalingPolicy policy = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
 
         ResultObserver<CreateScopeStatus> result = new ResultObserver<>();
-        this.controllerService.createScope(ScopeInfo.newBuilder().setScope("locking-scope").build(), result);
+        this.controllerService.createScope(ScopeInfo.newBuilder().setScope(lockingScope).build(), result);
         Assert.assertEquals(result.get().getStatus(), CreateScopeStatus.Status.SUCCESS);
 
         ResultObserver<CreateStreamStatus> result1 = new ResultObserver<>();
         ResultObserver<CreateStreamStatus> result2 = new ResultObserver<>();
         this.blockCriticalSection();
-        this.controllerService.createStream(ModelHelper.decode("locking-scope", "locking", configuration), result1);
-        this.controllerService.createStream(ModelHelper.decode("locking-scope", "locking", configuration), result2);
+        this.controllerService.createStream(ModelHelper.decode(lockingScope, lockingStream, configuration), result1);
+        this.controllerService.createStream(ModelHelper.decode(lockingScope, lockingStream, configuration), result2);
         AssertExtensions.assertThrows(
                 "Concurrent call to create stream did not fail to lock or has thrown something else.",
                 () -> {

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceImplTest.java
@@ -309,11 +309,16 @@ public abstract class ControllerServiceImplTest {
         // Check that concurrent calls to create a stream throw FailedLockingException
         final ScalingPolicy policy = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
+
+        ResultObserver<CreateScopeStatus> result = new ResultObserver<>();
+        this.controllerService.createScope(ScopeInfo.newBuilder().setScope("locking-scope").build(), result);
+        Assert.assertEquals(result.get().getStatus(), CreateScopeStatus.Status.SUCCESS);
+
         ResultObserver<CreateStreamStatus> result1 = new ResultObserver<>();
         ResultObserver<CreateStreamStatus> result2 = new ResultObserver<>();
         this.blockCriticalSection();
-        this.controllerService.createStream(ModelHelper.decode(SCOPE1, "locking", configuration), result1);
-        this.controllerService.createStream(ModelHelper.decode(SCOPE1, "locking", configuration), result2);
+        this.controllerService.createStream(ModelHelper.decode("locking-scope", "locking", configuration), result1);
+        this.controllerService.createStream(ModelHelper.decode("locking-scope", "locking", configuration), result2);
         AssertExtensions.assertThrows(
                 "Concurrent call to create stream did not fail to lock or has thrown something else.",
                 () -> {

--- a/controller/src/test/java/io/pravega/controller/store/task/TaskStoreFactoryForTests.java
+++ b/controller/src/test/java/io/pravega/controller/store/task/TaskStoreFactoryForTests.java
@@ -81,9 +81,14 @@ public class TaskStoreFactoryForTests {
 
             CompletableFuture<Void> lf = latch.get();
             if (lf != null && first.getAndSet(false)) {
+                log.debug("Waiting on the second thread to request the lock and complete the future");
                 lf.join();
             } else if (lf != null) {
+                log.debug("I'm the second thread, completing the future");
                 lf.complete(null);
+                latch.set(null);
+            } else {
+                log.debug("Latch is null");
             }
 
             return future;
@@ -125,6 +130,9 @@ public class TaskStoreFactoryForTests {
             } else if (lf != null) {
                 log.debug("I'm the second thread, completing the future");
                 lf.complete(null);
+                latch.set(null);
+            } else {
+                log.debug("Latch is null");
             }
 
             return future;

--- a/controller/src/test/java/io/pravega/controller/store/task/TaskStoreFactoryForTests.java
+++ b/controller/src/test/java/io/pravega/controller/store/task/TaskStoreFactoryForTests.java
@@ -120,8 +120,10 @@ public class TaskStoreFactoryForTests {
 
             CompletableFuture<Void> lf = latch.get();
             if (lf != null && first.getAndSet(false)) {
+                log.debug("Waiting on the second thread to request the lock and complete the future");
                 lf.join();
             } else if (lf != null) {
+                log.debug("I'm the second thread, completing the future");
                 lf.complete(null);
             }
 


### PR DESCRIPTION
**Change log description**  
* Adds more log messages to test code to enable debugging in the case the issue hits again.

* Resets the latch variable once both threads have requested lock concurrently in TaskMetadataStoreForTests  implementations.

**Purpose of the change**  
Fixes #3889 

**What the code does**  
Even though the test failures have happened on Jenkins, I have not been able to reproduce the issue locally or on Jenkins even with branch builds. This PR is proposing two defensive changes:

- It adds more log messages so that we get a better sense of the flow in the case the problem hits again.
- It resets the latch variable once we have that both threads have requested the lock concurrently.

The changes are in both `ZKTaskMetadataStoreForTests` and  `InMemoryTaskMetadataStoreForTests`. 

It also adds the creation of scopes to the test case. The absence of calls to create the scope were introducing errors in the logs because the test case was trying to create streams on a non-existing scope. That is harmless in the context of the test case, but better to fix to avoid misleading errors in the logs.

**How to verify it**  
Build must succeed.
