### PR TITLE
Issue 3425: Ensure the Sealed segment writer is removed after all inflight events are resent to the newer segment writers.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -509,13 +509,13 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
             state.waitForInflight();
             Exceptions.checkNotClosed(state.isClosed(), this);
-        }
-        /* SegmentSealedException is thrown if either of the below conditions are true
+            /* SegmentSealedException is thrown if either of the below conditions are true
                  - resendToSuccessorsCallback has been invoked.
                  - the segment corresponds to an aborted Transaction.
-         */
-        if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
-            throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
+             */
+            if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
+                throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
+            }
         }
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -499,7 +499,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             } catch (SegmentSealedException | NoSuchSegmentException e) {
                 if (StreamSegmentNameUtils.isTransactionSegment(segmentName)) {
                     log.warn("Exception observed during a flush on a transaction segment, this indicates that the transaction is " +
-                                     "commited/aborted. Details: {}", e.getMessage());
+                                     "committed/aborted. Details: {}", e.getMessage());
                     failConnection(e);
                 } else {
                     log.info("Exception observed while obtaining connection during flush. Details: {} ", e.getMessage());
@@ -509,13 +509,13 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             }
             state.waitForInflight();
             Exceptions.checkNotClosed(state.isClosed(), this);
-            /* SegmentSealedException is thrown if either of the below conditions are true
+        }
+        /* SegmentSealedException is thrown if either of the below conditions are true
                  - resendToSuccessorsCallback has been invoked.
                  - the segment corresponds to an aborted Transaction.
-             */
-            if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
-                throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
-            }
+         */
+        if (state.needSuccessors.get() || (StreamSegmentNameUtils.isTransactionSegment(segmentName) && state.isAlreadySealed())) {
+            throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -157,6 +157,8 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
                          log.info("Sealing segment {} ", toSeal);
                          while (toSeal != null) {
                              resend(selector.refreshSegmentEventWritersUponSealed(toSeal, segmentSealedCallBack));
+                             // remove segment writer after resending inflight events of the sealed segment.
+                             selector.removeSegmentWriter(toSeal);
                              /* In the case of segments merging Flush ensures there can't be anything left
                               * inflight that will need to be resent to the new segment when the write lock
                               * is released. (To preserve order)

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -142,7 +142,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         retransmitPool.execute(() -> {
             Retry.indefinitelyWithExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
                                              config.getMaxBackoffMillis(),
-                                             t -> log.error("Encountered excemption when handeling a sealed segment: ", t))
+                                             t -> log.error("Encountered exception when handling a sealed segment: ", t))
                  .run(() -> {
                      /*
                       * Using writeSealLock prevents concurrent segmentSealedCallback for different segments
@@ -152,27 +152,33 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
                       * entries that will succeed in being written to a new segment are written and any
                       * segmentSealedCallbacks that will be called happen before the next write is invoked.
                       */
-                     synchronized (writeSealLock) {
-                         Segment toSeal = sealedSegmentQueue.poll();
-                         log.info("Sealing segment {} ", toSeal);
-                         while (toSeal != null) {
-                             resend(selector.refreshSegmentEventWritersUponSealed(toSeal, segmentSealedCallBack));
-                             /* In the case of segments merging Flush ensures there can't be anything left
-                              * inflight that will need to be resent to the new segment when the write lock
-                              * is released. (To preserve order)
-                              */
-                             for (SegmentOutputStream writer : selector.getWriters()) {
-                                 try {
-                                     writer.write(PendingEvent.withoutHeader(null, ByteBufferUtils.EMPTY, null));
-                                     writer.flush();
-                                 } catch (SegmentSealedException e) {
-                                     // Segment sealed exception observed during a flush. Re-run flush on all the
-                                     // available writers.
-                                     log.info("Flush on segment {} failed due to {}, it will be retried.", writer.getSegmentName(), e.getMessage());
+                     try {
+                         synchronized (writeSealLock) {
+                             Segment toSeal = sealedSegmentQueue.poll();
+                             log.info("Sealing segment {} ", toSeal);
+                             while (toSeal != null) {
+                                 resend(selector.refreshSegmentEventWritersUponSealed(toSeal, segmentSealedCallBack));
+                                 /* In the case of segments merging Flush ensures there can't be anything left
+                                  * inflight that will need to be resent to the new segment when the write lock
+                                  * is released. (To preserve order)
+                                  */
+                                 for (SegmentOutputStream writer : selector.getWriters()) {
+                                     try {
+                                         writer.write(PendingEvent.withoutHeader(null, ByteBufferUtils.EMPTY, null));
+                                         writer.flush();
+                                     } catch (SegmentSealedException e) {
+                                         // Segment sealed exception observed during a flush. Re-run flush on all the
+                                         // available writers.
+                                         log.info("Flush on segment {} failed due to {}, it will be retried.", writer.getSegmentName(), e.getMessage());
+                                     }
                                  }
+                                 toSeal = sealedSegmentQueue.poll();
+                                 log.info("Sealing another segment {} ", toSeal);
                              }
-                             toSeal = sealedSegmentQueue.poll();
-                             log.info("Sealing another segment {} ", toSeal);
+                         }
+                     } finally {
+                         if (sealedSegmentQueue.isEmpty()) {
+                             sealedSegmentQueue.notifyAll();
                          }
                      }
                      return null;
@@ -358,6 +364,8 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         synchronized (writeFlushLock) {
             boolean success = false;
             while (!success) {
+                // no new writes can happen on acquiring this lock.
+                waitForResendToComplete();
                 success = true;
                 for (SegmentOutputStream writer : selector.getWriters()) {
                     try {
@@ -374,15 +382,23 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         }
     }
 
+    private void waitForResendToComplete() {
+        if (!sealedSegmentQueue.isEmpty()) {
+            Exceptions.handleInterrupted(() -> sealedSegmentQueue.wait()); // TODO: add timeout
+        }
+    }
+
     @Override
     public void close() {
         if (closed.getAndSet(true)) {
             return;
         }
         pinger.close();
-        synchronized (writeFlushLock) { 
+        synchronized (writeFlushLock) {
             boolean success = false;
             while (!success) {
+                // no new writes can happen on acquiring this lock.
+                waitForResendToComplete();
                 success = true;
                 for (SegmentOutputStream writer : selector.getWriters()) {
                     try {

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -152,33 +152,27 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
                       * entries that will succeed in being written to a new segment are written and any
                       * segmentSealedCallbacks that will be called happen before the next write is invoked.
                       */
-                     try {
-                         synchronized (writeSealLock) {
-                             Segment toSeal = sealedSegmentQueue.poll();
-                             log.info("Sealing segment {} ", toSeal);
-                             while (toSeal != null) {
-                                 resend(selector.refreshSegmentEventWritersUponSealed(toSeal, segmentSealedCallBack));
-                                 /* In the case of segments merging Flush ensures there can't be anything left
-                                  * inflight that will need to be resent to the new segment when the write lock
-                                  * is released. (To preserve order)
-                                  */
-                                 for (SegmentOutputStream writer : selector.getWriters()) {
-                                     try {
-                                         writer.write(PendingEvent.withoutHeader(null, ByteBufferUtils.EMPTY, null));
-                                         writer.flush();
-                                     } catch (SegmentSealedException e) {
-                                         // Segment sealed exception observed during a flush. Re-run flush on all the
-                                         // available writers.
-                                         log.info("Flush on segment {} failed due to {}, it will be retried.", writer.getSegmentName(), e.getMessage());
-                                     }
+                     synchronized (writeSealLock) {
+                         Segment toSeal = sealedSegmentQueue.poll();
+                         log.info("Sealing segment {} ", toSeal);
+                         while (toSeal != null) {
+                             resend(selector.refreshSegmentEventWritersUponSealed(toSeal, segmentSealedCallBack));
+                             /* In the case of segments merging Flush ensures there can't be anything left
+                              * inflight that will need to be resent to the new segment when the write lock
+                              * is released. (To preserve order)
+                              */
+                             for (SegmentOutputStream writer : selector.getWriters()) {
+                                 try {
+                                     writer.write(PendingEvent.withoutHeader(null, ByteBufferUtils.EMPTY, null));
+                                     writer.flush();
+                                 } catch (SegmentSealedException e) {
+                                     // Segment sealed exception observed during a flush. Re-run flush on all the
+                                     // available writers.
+                                     log.info("Flush on segment {} failed due to {}, it will be retried.", writer.getSegmentName(), e.getMessage());
                                  }
-                                 toSeal = sealedSegmentQueue.poll();
-                                 log.info("Sealing another segment {} ", toSeal);
                              }
-                         }
-                     } finally {
-                         if (sealedSegmentQueue.isEmpty()) {
-                             sealedSegmentQueue.notifyAll();
+                             toSeal = sealedSegmentQueue.poll();
+                             log.info("Sealing another segment {} ", toSeal);
                          }
                      }
                      return null;
@@ -364,8 +358,6 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         synchronized (writeFlushLock) {
             boolean success = false;
             while (!success) {
-                // no new writes can happen on acquiring this lock.
-                waitForResendToComplete();
                 success = true;
                 for (SegmentOutputStream writer : selector.getWriters()) {
                     try {
@@ -382,12 +374,6 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         }
     }
 
-    private void waitForResendToComplete() {
-        if (!sealedSegmentQueue.isEmpty()) {
-            Exceptions.handleInterrupted(() -> sealedSegmentQueue.wait()); // TODO: add timeout
-        }
-    }
-
     @Override
     public void close() {
         if (closed.getAndSet(true)) {
@@ -397,8 +383,6 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type>, Tra
         synchronized (writeFlushLock) {
             boolean success = false;
             while (!success) {
-                // no new writes can happen on acquiring this lock.
-                waitForResendToComplete();
                 success = true;
                 for (SegmentOutputStream writer : selector.getWriters()) {
                     try {

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -81,6 +81,13 @@ public class SegmentSelector {
         return currentSegments.getSegmentForKey(routingKey);
     }
 
+    /**
+     * Refresh segment writers corresponding to the successors of the sealed segment and return inflight event list of the sealed segment.
+     * The segment writer for sealed segment is not removed.
+     * @param sealedSegment The sealed segment.
+     * @param segmentSealedCallback Sealed segment callback.
+     * @return List of pending events.
+     */
     public List<PendingEvent> refreshSegmentEventWritersUponSealed(Segment sealedSegment, Consumer<Segment> segmentSealedCallback) {
         StreamSegmentsWithPredecessors successors = Futures.getAndHandleExceptions(
                 controller.getSuccessors(sealedSegment), t -> {

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -112,6 +112,15 @@ public class SegmentSelector {
                 segmentSealedCallBack);
     }
 
+    /**
+     * Remove a segment writer.
+     * @param segment The segment whose writer should be removed.
+     */
+    @Synchronized
+    void removeSegmentWriter(Segment segment) {
+        writers.remove(segment);
+    }
+
     @Synchronized
     private List<PendingEvent> updateSegments(StreamSegments newSteamSegments, Consumer<Segment>
             segmentSealedCallBack) {
@@ -142,7 +151,7 @@ public class SegmentSelector {
         currentSegments = currentSegments.withReplacementRange(sealedSegment, successors);
         createMissingWriters(segmentSealedCallback, currentSegments.getDelegationToken());
         log.debug("Fetch unacked events for segment: {}, and adding new segments {}", sealedSegment, currentSegments);
-        return writers.remove(sealedSegment).getUnackedEventsOnSeal();
+        return writers.get(sealedSegment).getUnackedEventsOnSeal();
     }
 
     @Synchronized

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -173,15 +173,14 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        @Cleanup
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, resendToSuccessorsCallback, RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).noSuchSegment(new WireCommands.NoSuchSegment(output.getRequestId(), SEGMENT, "SomeException", -1L));
         assertThrows(SegmentSealedException.class, () -> Futures.getThrowingException(output.getConnection()));
         assertTrue(callbackInvoked.get());
+        assertThrows(SegmentSealedException.class, output::close);
     }
-
 
     @Test(timeout = 10000)
     public void testConnectWithMultipleFailures() throws Exception {
@@ -629,6 +628,25 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.getProcessor(uri).segmentIsSealed(new WireCommands.SegmentIsSealed(output.getRequestId(), SEGMENT, "SomeException", 1));
         output.getUnackedEventsOnSeal(); // this is invoked by the segmentSealedCallback.
         AssertExtensions.assertThrows(SegmentSealedException.class, () -> output.flush());
+    }
+
+    @Test(timeout = 10000)
+    public void testFlushForEmptyInflightSealedSegment() throws Exception {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        cf.setExecutor(executorService());
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        InOrder order = Mockito.inOrder(connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        output.reconnect();
+        order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
+        cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
+        cf.getProcessor(uri).segmentIsSealed(new WireCommands.SegmentIsSealed(output.getRequestId(), SEGMENT, "SomeException", 0));
+        output.getUnackedEventsOnSeal(); // this is invoked by the segmentSealedCallback.
+        AssertExtensions.assertThrows(SegmentSealedException.class, output::flush);
     }
 
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
@@ -22,6 +22,9 @@ import io.pravega.common.util.RetriesExhaustedException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -31,7 +34,9 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.test.common.AssertExtensions.assertFutureThrows;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -72,7 +77,7 @@ public class SegmentSelectorTest {
         }
     }
 
-    private void addNewSegment(TreeMap<Double, SegmentWithRange> segments, int number, double low, double high) {
+    private void addNewSegment(TreeMap<Double, SegmentWithRange> segments, long number, double low, double high) {
         segments.put(high, new SegmentWithRange(new Segment(scope, streamName, number), low, high));
     }
 
@@ -215,6 +220,68 @@ public class SegmentSelectorTest {
 
         assertEquals(Collections.emptyList(), selector.refreshSegmentEventWritersUponSealed(segment0, segmentSealedCallback));
         assertFutureThrows("Writer Future", writerFuture, t -> t instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testSegmentRefreshOnSealed() {
+        final Segment segment0 = new Segment(scope, streamName, 0);
+        final Segment segment1 = new Segment(scope, streamName, computeSegmentId(1, 1));
+        final Segment segment2 = new Segment(scope, streamName, computeSegmentId(2, 1));
+        final CompletableFuture<Void> writerFuture = new CompletableFuture<>();
+        final PendingEvent pendingEvent = PendingEvent.withHeader("0", ByteBuffer.wrap("e".getBytes()), writerFuture);
+
+        TreeMap<Double, SegmentWithRange> segmentBeforeScale = new TreeMap<>();
+        addNewSegment(segmentBeforeScale, 0, 0.0, 1.0);
+        StreamSegments streamSegmentsBeforeScale = new StreamSegments(segmentBeforeScale, "");
+
+        Map<SegmentWithRange, List<Long>> newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(segment1, 0.0, 0.5), ImmutableList.of(segment0.getSegmentId()));
+        newRange.put(new SegmentWithRange(segment2, 0.5, 1.0), ImmutableList.of(segment0.getSegmentId()));
+        StreamSegmentsWithPredecessors segmentsWithPredecessors = new StreamSegmentsWithPredecessors(newRange, "");
+
+        // Setup Mock.
+        SegmentOutputStream s0Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStream s1Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStream s2Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+
+        when(s0Writer.getUnackedEventsOnSeal()).thenReturn(ImmutableList.of(pendingEvent));
+        when(factory.createOutputStreamForSegment(eq(segment0), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s0Writer);
+        when(factory.createOutputStreamForSegment(eq(segment1), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s1Writer);
+        when(factory.createOutputStreamForSegment(eq(segment2), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s2Writer);
+        // get current segments returns segment 0
+        when(controller.getCurrentSegments(scope, streamName))
+                .thenReturn(CompletableFuture.completedFuture(streamSegmentsBeforeScale));
+        when(controller.getSuccessors(segment0))
+                .thenAnswer(i -> {
+                    CompletableFuture<StreamSegmentsWithPredecessors> result = new CompletableFuture<>();
+                    result.complete(segmentsWithPredecessors);
+                    return result;
+                });
+
+        SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
+        //trigger refresh
+        selector.refreshSegmentEventWriters(segmentSealedCallback);
+        // only segment 0 writer is present.
+        assertEquals(singletonList(s0Writer), selector.getWriters());
+
+        // trigger a referesh of writers due to segment 0 being sealed.
+        List<PendingEvent> pendingEvents = selector.refreshSegmentEventWritersUponSealed(segment0, segmentSealedCallback);
+        // one pending event is returned by segment0
+        assertEquals(singletonList(pendingEvent), pendingEvents);
+        // the current number of writers is 3, it includes the writer to segment 0.
+        List<SegmentOutputStream> writers = selector.getWriters();
+        assertEquals(3, writers.size());
+        assertTrue(writers.contains(s0Writer));
+        assertTrue(writers.contains(s1Writer));
+        assertTrue(writers.contains(s2Writer));
+        // remove segment 0, this is done post resending the pending events.
+        selector.removeSegmentWriter(segment0);
+        assertFalse(selector.getWriters().contains(s0Writer));
     }
 
 }


### PR DESCRIPTION
**Change log description**  
Ensure `SegmentOutputStream#flush` of a sealed segment throws a `SegmentSealedException` in the case of a zero inflight events.

**Purpose of the change**  
Fixes #3425

**What the code does**  
`EventStreamWriter.flush()` invokes a `flush()` on all the Segment writers. Now if any of the segment writers threw a `SegmentSealedException` during a `SegmentOutputStream.flush()` the event stream writer will fetch the latest segment writers again and perform a flush over each of them, thereby ensuring all the inflight events are written/durably persisted.

For this logic to work we need to remove the older writer only after we have resent the inflight events to the successor segments. This was not the case earlier and could cause a flush to prematurely stop blocking before the events were durably persisted by the newer segment writers.

**How to verify it**  
All the existing and newly added tests should continue to pass.
