### PR TITLE
Issue 3907: Sporadic build failure in PravegaTablesStreamMetadataTasksTest.sealStreamWithTx

### DIFF
--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -953,10 +953,10 @@ public abstract class StreamMetadataTasksTest {
         streamStorePartialMock.setState(SCOPE, streamWithTxn, State.ACTIVE, null, executor).get();
 
         // create txn
-        VersionedTransactionData openTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 100L, null)
+        VersionedTransactionData openTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 10000L, null)
                 .get().getKey();
 
-        VersionedTransactionData committingTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 100L, null)
+        VersionedTransactionData committingTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 10000L, null)
                 .get().getKey();
 
         // set transaction to committing


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes sporadic build failure in PravegaTablesStreamMetadataTasksTest.sealStreamWithTx because the transaction lease is set to only 100 ms and the timeout is executed before we could commit.
This test starts timerwheel service by default, which is racing with the test to abort the transaction as we attempt to commit it. 

**Purpose of the change**  
Fixes #3907

**What the code does**  
Increases transaction lease during transaction creation in the test. 

**How to verify it**  
(Optional: steps to verify that the changes are effective)
