### PR TITLE
Issue 3692: Do not remove counter of parent segment when delete or seal txn segment

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
@@ -149,7 +149,7 @@ class SegmentStatsRecorderImpl implements SegmentStatsRecorder {
 
     @Override
     public void deleteSegment(String streamSegmentName) {
-        // Do not close the counter of parent segment when delete transaction segment.
+        // Do not close the counter of parent segment when deleting transaction segment.
         if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
             getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
             getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
@@ -159,7 +159,7 @@ class SegmentStatsRecorderImpl implements SegmentStatsRecorder {
 
     @Override
     public void sealSegment(String streamSegmentName) {
-        // Do not close the counter of parent segment when seal transaction segment.
+        // Do not close the counter of parent segment when sealing transaction segment.
         if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
             getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
             getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
@@ -148,16 +148,22 @@ class SegmentStatsRecorderImpl implements SegmentStatsRecorder {
     }
 
     @Override
-    public void deleteSegment(String segmentName) {
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(segmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(segmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_READ_BYTES, segmentTags(segmentName));
+    public void deleteSegment(String streamSegmentName) {
+        // Do not close the counter of parent segment when delete transaction segment.
+        if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_READ_BYTES, segmentTags(streamSegmentName));
+        }
     }
 
     @Override
     public void sealSegment(String streamSegmentName) {
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+        // Do not close the counter of parent segment when seal transaction segment.
+        if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+        }
         if (getSegmentAggregate(streamSegmentName) != null) {
             cache.invalidate(streamSegmentName);
             reporter.notifySealed(streamSegmentName);

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -95,18 +95,18 @@ public class DynamicLoggerImpl implements DynamicLogger {
     public void incCounterValue(String name, long delta, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(delta);
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: incCounterValue", name, delta, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "incCounterValue", name, delta, tags);
         try {
             MetricsNames.MetricKey keys = metricKey(name, tags);
             Counter counter = countersCache.get(keys.getCacheKey(), new Callable<Counter>() {
                 @Override
                 public Counter call() throws Exception {
-                    LoggerHelpers.traceLeave(log, "Metrics: createCounter", traceId, keys.getRegistryKey(), tags);
+                    LoggerHelpers.traceLeave(log, "createCounter", traceId, keys.getRegistryKey(), tags);
                     return underlying.createCounter(keys.getRegistryKey(), tags);
                 }
             });
             counter.add(delta);
-            LoggerHelpers.traceLeave(log, "Metrics: counter.add", traceId, counter.get(), delta);
+            LoggerHelpers.traceLeave(log, "counter.add", traceId, counter.get(), delta);
         } catch (ExecutionException e) {
             log.error("Error while countersCache create counter", e);
         }
@@ -115,50 +115,50 @@ public class DynamicLoggerImpl implements DynamicLogger {
     @Override
     public void updateCounterValue(String name, long value, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: updateCounterValue", name, value, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "updateCounterValue", name, value, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             counter.clear();
-            LoggerHelpers.traceLeave(log, "Metrics: counter.clear", traceId, counter.getId());
+            LoggerHelpers.traceLeave(log, "counter.clear", traceId, counter.getId());
         } else {
             counter = underlying.createCounter(keys.getRegistryKey(), tags);
-            LoggerHelpers.traceLeave(log, "Metrics: createCounter", traceId, keys.getRegistryKey(), tags);
+            LoggerHelpers.traceLeave(log, "createCounter", traceId, keys.getRegistryKey(), tags);
         }
         counter.add(value);
-        LoggerHelpers.traceLeave(log, "Metrics: counter.add", traceId, counter.getId(), value);
+        LoggerHelpers.traceLeave(log, "counter.add", traceId, counter.getId(), value);
         countersCache.put(keys.getCacheKey(), counter);
     }
 
     @Override
     public void freezeCounter(String name, String... tags) {
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: freezeCounter", name, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "freezeCounter", name, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             metrics.remove(counter.getId());
-            LoggerHelpers.traceLeave(log, "Metrics: metrics.remove", traceId, counter.getId());
+            LoggerHelpers.traceLeave(log, "metrics.remove", traceId, counter.getId());
         }
         countersCache.invalidate(keys.getRegistryKey());
-        LoggerHelpers.traceLeave(log, "Metrics: counterCache.invalidate", traceId, keys.getRegistryKey());
+        LoggerHelpers.traceLeave(log, "counterCache.invalidate", traceId, keys.getRegistryKey());
     }
 
     @Override
     public <T extends Number> void reportGaugeValue(String name, T value, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(value);
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: reportGaugeValue", name, value, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "reportGaugeValue", name, value, tags);
         try {
             MetricsNames.MetricKey keys = metricKey(name, tags);
             Gauge gauge = gaugesCache.get(keys.getCacheKey(), new Callable<Gauge>() {
                 @Override
                 public Gauge call() throws Exception {
-                    LoggerHelpers.traceLeave(log, "Metrics: registerGauge", traceId, keys.getRegistryKey(), value.doubleValue(), tags);
+                    LoggerHelpers.traceLeave(log, "registerGauge", traceId, keys.getRegistryKey(), value.doubleValue(), tags);
                     return underlying.registerGauge(keys.getRegistryKey(), value::doubleValue, tags);
                 }
             });
             gauge.setSupplier(value::doubleValue);
-            LoggerHelpers.traceLeave(log, "Metrics: gauge.setSupplier", traceId, gauge.getId(), value.doubleValue());
+            LoggerHelpers.traceLeave(log, "gauge.setSupplier", traceId, gauge.getId(), value.doubleValue());
         } catch (ExecutionException e) {
             log.error("Error accessing gauge through gaugesCache", e);
         }
@@ -166,33 +166,33 @@ public class DynamicLoggerImpl implements DynamicLogger {
 
     @Override
     public void freezeGaugeValue(String name, String... tags) {
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: freezeGaugeValue", name, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "freezeGaugeValue", name, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Gauge gauge = gaugesCache.getIfPresent(keys.getCacheKey());
         if (gauge != null) {
             metrics.remove(gauge.getId());
-            LoggerHelpers.traceLeave(log, "Metrics: metrics.remove", traceId, gauge.getId());
+            LoggerHelpers.traceLeave(log, "metrics.remove", traceId, gauge.getId());
         }
         gaugesCache.invalidate(keys.getCacheKey());
-        LoggerHelpers.traceLeave(log, "Metrics: gaugeCache.invalidate", traceId, keys.getCacheKey());
+        LoggerHelpers.traceLeave(log, "gaugeCache.invalidate", traceId, keys.getCacheKey());
     }
 
     @Override
     public void recordMeterEvents(String name, long number, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(number);
-        long traceId = LoggerHelpers.traceEnter(log, "Metrics: recordMeterEvents", name, number, tags);
+        long traceId = LoggerHelpers.traceEnter(log, "recordMeterEvents", name, number, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         try {
             Meter meter = metersCache.get(keys.getCacheKey(), new Callable<Meter>() {
                 @Override
                 public Meter call() throws Exception {
-                    LoggerHelpers.traceLeave(log, "Metrics: createMeter", traceId, keys.getRegistryKey(), tags);
+                    LoggerHelpers.traceLeave(log, "createMeter", traceId, keys.getRegistryKey(), tags);
                     return underlying.createMeter(keys.getRegistryKey(), tags);
                 }
             });
             meter.recordEvents(number);
-            LoggerHelpers.traceLeave(log, "Metrics: meter.recordEvents", traceId, meter.getId(), number);
+            LoggerHelpers.traceLeave(log, "meter.recordEvents", traceId, meter.getId(), number);
         } catch (ExecutionException e) {
             log.error("Error while metersCache create meter", e);
         }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -103,7 +103,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             counter.add(delta);
-            log.debug("Metrics: increased counter {} by {} ", keys.getCacheKey(), delta);
+            log.trace("Metrics: increased counter {} by {} ", keys.getCacheKey(), delta);
         } catch (ExecutionException e) {
             log.error("Error while countersCache create counter", e);
         }
@@ -116,12 +116,12 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             counter.clear();
-            log.debug("Metrics: cleared counter {}", keys.getCacheKey());
+            log.trace("Metrics: cleared counter {}", keys.getCacheKey());
         } else {
             counter = underlying.createCounter(keys.getRegistryKey(), tags);
         }
         counter.add(value);
-        log.debug("Metrics: increased counter {} by {} ", keys.getCacheKey(), value);
+        log.trace("Metrics: increased counter {} by {} ", keys.getCacheKey(), value);
         countersCache.put(keys.getCacheKey(), counter);
     }
 
@@ -131,7 +131,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             metrics.remove(counter.getId());
-            log.debug("Metrics: removed counter {} from registry.", keys.getCacheKey());
+            log.trace("Metrics: removed counter {} from registry.", keys.getCacheKey());
         }
         countersCache.invalidate(keys.getRegistryKey());
     }
@@ -149,7 +149,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             gauge.setSupplier(value::doubleValue);
-            log.debug("Metrics: set supplier for gauge {}; and current value is {}", keys.getCacheKey(), value.doubleValue());
+            log.trace("Metrics: set supplier for gauge {}; and current value is {}", keys.getCacheKey(), value.doubleValue());
         } catch (ExecutionException e) {
             log.error("Error accessing gauge through gaugesCache", e);
         }
@@ -161,7 +161,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Gauge gauge = gaugesCache.getIfPresent(keys.getCacheKey());
         if (gauge != null) {
             metrics.remove(gauge.getId());
-            log.debug("Metrics: removed gauge {} from registry", keys.getCacheKey());
+            log.trace("Metrics: removed gauge {} from registry", keys.getCacheKey());
         }
         gaugesCache.invalidate(keys.getCacheKey());
     }
@@ -179,7 +179,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             meter.recordEvents(number);
-            log.debug("Metrics: record meter {} for event {}", keys.getCacheKey(), number);
+            log.trace("Metrics: record meter {} for event {}", keys.getCacheKey(), number);
         } catch (ExecutionException e) {
             log.error("Error while metersCache create meter", e);
         }

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -103,6 +103,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             counter.add(delta);
+            log.debug("Metrics: increased counter {} by {} ", keys.getCacheKey(), delta);
         } catch (ExecutionException e) {
             log.error("Error while countersCache create counter", e);
         }
@@ -115,10 +116,12 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             counter.clear();
+            log.debug("Metrics: cleared counter {}", keys.getCacheKey());
         } else {
             counter = underlying.createCounter(keys.getRegistryKey(), tags);
         }
         counter.add(value);
+        log.debug("Metrics: increased counter {} by {} ", keys.getCacheKey(), value);
         countersCache.put(keys.getCacheKey(), counter);
     }
 
@@ -128,6 +131,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             metrics.remove(counter.getId());
+            log.debug("Metrics: removed counter {} from registry.", keys.getCacheKey());
         }
         countersCache.invalidate(keys.getRegistryKey());
     }
@@ -145,6 +149,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             gauge.setSupplier(value::doubleValue);
+            log.debug("Metrics: set supplier for gauge {}; and current value is {}", keys.getCacheKey(), value.doubleValue());
         } catch (ExecutionException e) {
             log.error("Error accessing gauge through gaugesCache", e);
         }
@@ -156,6 +161,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
         Gauge gauge = gaugesCache.getIfPresent(keys.getCacheKey());
         if (gauge != null) {
             metrics.remove(gauge.getId());
+            log.debug("Metrics: removed gauge {} from registry", keys.getCacheKey());
         }
         gaugesCache.invalidate(keys.getCacheKey());
     }
@@ -173,6 +179,7 @@ public class DynamicLoggerImpl implements DynamicLogger {
                 }
             });
             meter.recordEvents(number);
+            log.debug("Metrics: record meter {} for event {}", keys.getCacheKey(), number);
         } catch (ExecutionException e) {
             log.error("Error while metersCache create meter", e);
         }


### PR DESCRIPTION
**Change log description**  
- Stopped deleting counter of parent segment when delete or seal transaction segment.
- Added metrics registry level activity logs.

**Purpose of the change**  
Fixes #3692 

**What the code does**  
Inside SegmentStatsRecorderImpl, when delete or seal segment, first check if it is transaction segment.
If it is txn segment, then do not close the counter, because there is no associated counter for txn segment.

**How to verify it**  
Unit tests should pass.
In particular, longevity small-tx and other txn related tests should now see the metrics of committed txn.
