### PR TITLE
Issue 3918: (SegmentStore) Metadata Table Segment pre-caching

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -30,6 +30,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
 import io.pravega.shared.protocol.netty.Append;
@@ -358,8 +359,16 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             log.info("Closing connection '{}' while performing append on Segment '{}' due to {}.", connection, segment, u.getMessage());
             connection.close();
         } else {
-            log.error("Error (Segment = '{}', Operation = 'append')", segment, u);
+            logError(segment, u);
             connection.close(); // Closing connection should reinitialize things, and hopefully fix the problem
+        }
+    }
+
+    private void logError(String segment, Throwable u) {
+        if (u instanceof IllegalContainerStateException) {
+            log.warn("Error (Segment = '{}', Operation = 'append'): {}.", segment, u.toString());
+        } else {
+            log.error("Error (Segment = '{}', Operation = 'append')", segment, u);
         }
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -356,7 +356,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             connection.send(new OperationUnsupported(requestId, doingWhat, clientReplyStackTrace));
         } else if (u instanceof CancellationException) {
             // Cancellation exception is thrown when the Operation processor is shutting down.
-            log.info("Closing connection '{}' while performing append on Segment '{}' due to {}.", connection, segment, u.getMessage());
+            log.info("Closing connection '{}' while performing append on Segment '{}' due to {}.", connection, segment, u.toString());
             connection.close();
         } else {
             logError(segment, u);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -936,7 +936,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             invokeSafely(connection::send, new SegmentRead(segment, offset, true, false, EMPTY_BYTE_BUFFER, requestId), failureHandler);
         } else if (u instanceof CancellationException) {
             log.info(requestId, "Closing connection {} while performing {} due to {}.",
-                     connection, operation, u.getMessage());
+                     connection, operation, u.toString());
             connection.close();
         } else if (u instanceof AuthenticationException) {
             log.warn(requestId, "Authentication error during '{}'.", operation);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -43,6 +43,7 @@ import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableSegmentNotEmptyException;
 import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
@@ -946,7 +947,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             invokeSafely(connection::send, new OperationUnsupported(requestId, operation, clientReplyStackTrace), failureHandler);
         } else if (u instanceof BadOffsetException) {
             BadOffsetException badOffset = (BadOffsetException) u;
-            log.info(requestId, "Segment '{}' is truncated and cannot perform operation '{}' at offset '{}'", operation, offset);
+            log.info(requestId, "Segment '{}' is truncated and cannot perform operation '{}' at offset '{}'", segment, operation, offset);
             invokeSafely(connection::send, new SegmentIsTruncated(requestId, segment, badOffset.getExpectedOffset(),
                                                                   clientReplyStackTrace, offset), failureHandler);
         } else if (u instanceof TableSegmentNotEmptyException) {
@@ -959,12 +960,20 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             log.warn(requestId, "Conditional update on Table segment '{}' failed due to bad key version.", segment);
             invokeSafely(connection::send, new WireCommands.TableKeyBadVersion(requestId, segment, clientReplyStackTrace), failureHandler);
         } else {
-            log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segment, operation, u);
+            logError(requestId, segment, operation, u);
             connection.close(); // Closing connection should reinitialize things, and hopefully fix the problem
             throw new IllegalStateException("Unknown exception.", u);
         }
 
         return null;
+    }
+
+    private void logError(long requestId, String segment, String operation, Throwable u) {
+        if (u instanceof IllegalContainerStateException) {
+            log.warn(requestId, "Error (Segment = '{}', Operation = '{}'): {}", segment, operation, u.toString());
+        } else {
+            log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segment, operation, u);
+        }
     }
 
     private void recordStatForTransaction(SegmentProperties sourceInfo, String targetSegmentName) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -104,12 +104,22 @@ public abstract class MetadataStore implements AutoCloseable {
     }
 
     /**
-     * Initializes the MetadataStore, if necessary.
+     * Initializes the MetadataStore, if necessary. These are tasks that can be executed without the owning Segment
+     * Container running, but which are required for its proper functioning.
      *
      * @param timeout Timeout for the operation.
      * @return A CompletableFuture that, when completed, will indicate the initialization is done.
      */
     abstract CompletableFuture<Void> initialize(Duration timeout);
+
+    /**
+     * Attempts to load the Metadata Index (if any) in memory. This is an optional task that can be run in parallel with
+     * other methods, whose purpose is to optimize subsequent calls.
+     *
+     * @param timeout Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate the index has been cached.
+     */
+    abstract CompletableFuture<Void> cacheIndex(Duration timeout);
 
     //endregion
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -208,6 +208,11 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                         // We are started and ready to accept requests when DurableLog starts. All other (secondary) services
                         // are not required for accepting new operations and can still start in the background.
                         notifyStarted();
+
+                        // Request that the Metadata Store pre-cache the index. We do not care if or when this task finishes
+                        // successfully or whether it failed. It is not meant to provide any critical services to the Segment
+                        // Container, rather it is meant to perform certain optimizations that can help later on.
+                        this.metadataStore.cacheIndex(this.config.getMetadataStoreInitTimeout());
                     } else {
                         doStop(ex);
                     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
@@ -26,6 +26,7 @@ import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
 import java.time.Duration;
 import java.util.Collection;
@@ -48,7 +49,7 @@ import lombok.val;
 @Slf4j
 class TableMetadataStore extends MetadataStore {
     //region Members
-    private final TableStore tableStore;
+    private final ContainerTableExtension tableStore;
     private final String metadataSegmentName;
     private final AtomicBoolean initialized;
 
@@ -62,7 +63,7 @@ class TableMetadataStore extends MetadataStore {
      * @param tableStore A {@link TableStore} to use.
      * @param executor   The executor to use for async operations.
      */
-    TableMetadataStore(Connector connector, @NonNull TableStore tableStore, Executor executor) {
+    TableMetadataStore(Connector connector, @NonNull ContainerTableExtension tableStore, Executor executor) {
         super(connector, executor);
         this.tableStore = tableStore;
         this.metadataSegmentName = StreamSegmentNameUtils.getMetadataSegmentName(connector.getContainerMetadata().getContainerId());
@@ -87,6 +88,11 @@ class TableMetadataStore extends MetadataStore {
                     this.initialized.set(true);
                     log.info("{}: Metadata Segment pinned. Name = '{}', Id = '{}'", this.traceObjectId, this.metadataSegmentName, segmentId);
                 });
+    }
+
+    @Override
+    public CompletableFuture<Void> cacheIndex(Duration timeout) {
+        return this.tableStore.cacheTailIndex(this.metadataSegmentName, timeout);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -138,6 +138,25 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
     }
 
     /**
+     * Updates the tail cache for the given Table Segment with the given data, which represents a pre-index result of the
+     * tail section of the Segment.
+     *
+     * @param segmentId  Segment Id.
+     * @param keyOffsets A Map of KeyHashes to {@link CacheBucketOffset} instances that represents the latest values (including
+     *                   deletions) for all the pre-indexed keys).
+     */
+    void includeTailCache(long segmentId, Map<UUID, CacheBucketOffset> keyOffsets) {
+        SegmentKeyCache cache;
+        int generation;
+        synchronized (this.segmentCaches) {
+            generation = this.currentCacheGeneration;
+            cache = this.segmentCaches.computeIfAbsent(segmentId, s -> new SegmentKeyCache(s, this.cache));
+        }
+
+        cache.includeTailCache(keyOffsets, generation);
+    }
+
+    /**
      * Updates the contents of a Cache Entry associated with the given Segment Id and KeyHash. This method cannot be
      * used to remove values.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -659,7 +659,7 @@ class ContainerKeyIndex implements AutoCloseable {
          */
         synchronized RecoveryTask beginRecovery(long segmentId, long segmentLength) {
             RecoveryTask task = new RecoveryTask(segmentLength);
-            this.recoveryTasks.put(segmentId, task);
+            this.recoveryTasks.putIfAbsent(segmentId, task);
             return task;
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtension.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtension.java
@@ -9,12 +9,25 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Defines a {@link SegmentContainerExtension} that implements Tables on top of Segment Containers.
  */
 public interface ContainerTableExtension extends TableStore, SegmentContainerExtension {
-
+    /**
+     * Caches the unindexed Tail Section of the given Table Segment. This scans the tail portion of the segment (beyond
+     * {@link TableAttributes#INDEX_OFFSET}) and updates any internal memory data structures to reflect the updates
+     * recorded in it. This method can be used to speed up recovery of certain Table Segments and should be used sparingly
+     * as it may consume significant CPU resources while processing.
+     *
+     * @param segmentName The name of the Segment to process..
+     * @param timeout     Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate whether the operation succeeded or not.
+     */
+    CompletableFuture<Void> cacheTailIndex(String segmentName, Duration timeout);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -49,11 +49,13 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 /**
  * A {@link ContainerTableExtension} that implements Table Segments on top of a {@link SegmentContainer}.
  */
+@Slf4j
 public class ContainerTableExtensionImpl implements ContainerTableExtension {
     //region Members
 
@@ -70,6 +72,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     private final ContainerKeyIndex keyIndex;
     private final EntrySerializer serializer;
     private final AtomicBoolean closed;
+    private final String traceObjectId;
 
     //endregion
 
@@ -106,6 +109,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         this.keyIndex = new ContainerKeyIndex(segmentContainer.getId(), cacheFactory, cacheManager, this.executor);
         this.serializer = new EntrySerializer();
         this.closed = new AtomicBoolean();
+        this.traceObjectId = String.format("TableExtension[%d]", this.segmentContainer.getId());
     }
 
     //endregion
@@ -116,6 +120,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     public void close() {
         if (!this.closed.getAndSet(true)) {
             this.keyIndex.close();
+            log.info("{}: Closed.", this.traceObjectId);
         }
     }
 
@@ -145,11 +150,13 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
                 .entrySet().stream()
                 .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, e.getValue()))
                 .collect(Collectors.toList());
+        logRequest("createSegment", segmentName);
         return this.segmentContainer.createStreamSegment(segmentName, attributes, timeout);
     }
 
     @Override
     public CompletableFuture<Void> deleteSegment(@NonNull String segmentName, boolean mustBeEmpty, Duration timeout) {
+        logRequest("deleteSegment", segmentName, mustBeEmpty);
         if (mustBeEmpty) {
             TimeoutTimer timer = new TimeoutTimer(timeout);
             return this.segmentContainer
@@ -183,6 +190,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         // Generate an Update Batch for all the entries (since we need to know their Key Hashes and relative offsets in
         // the batch itself).
         val updateBatch = batch(entries, TableEntry::getKey, this.serializer::getUpdateLength, TableKeyBatch.update());
+        logRequest("put", segmentName, updateBatch.isConditional(), updateBatch.isRemoval(), entries.size(), updateBatch.getLength());
         return this.segmentContainer
                 .forSegment(segmentName, timer.getRemaining())
                 .thenComposeAsync(segment -> this.keyIndex.update(segment, updateBatch,
@@ -198,6 +206,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         // Generate an Update Batch for all the keys (since we need to know their Key Hashes and relative offsets in
         // the batch itself).
         val removeBatch = batch(keys, key -> key, this.serializer::getRemovalLength, TableKeyBatch.removal());
+        logRequest("remove", segmentName, removeBatch.isConditional(), removeBatch.isRemoval(), keys.size(), removeBatch.getLength());
         return this.segmentContainer
                 .forSegment(segmentName, timer.getRemaining())
                 .thenComposeAsync(segment -> this.keyIndex.update(segment, removeBatch,
@@ -209,6 +218,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     @Override
     public CompletableFuture<List<TableEntry>> get(@NonNull String segmentName, @NonNull List<ArrayView> keys, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
+        logRequest("get", segmentName, keys.size());
         if (keys.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         } else {
@@ -263,11 +273,13 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
 
     @Override
     public CompletableFuture<AsyncIterator<IteratorItem<TableKey>>> keyIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        logRequest("keyIterator", segmentName);
         return newIterator(segmentName, serializedState, fetchTimeout, TableBucketReader::key);
     }
 
     @Override
     public CompletableFuture<AsyncIterator<IteratorItem<TableEntry>>> entryIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        logRequest("entryIterator", segmentName);
         return newIterator(segmentName, serializedState, fetchTimeout, TableBucketReader::entry);
     }
 
@@ -350,6 +362,10 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
 
     private TableEntry maybeDeleted(TableEntry e) {
         return e == null || e.getValue() == null ? null : e;
+    }
+
+    private void logRequest(String requestName, Object... args) {
+        log.debug("{}: {} {}", this.traceObjectId, requestName, args);
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
@@ -12,11 +12,16 @@ package io.pravega.segmentstore.server.containers;
 import io.pravega.common.util.ArrayView;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.server.TableStoreMock;
+import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
+import io.pravega.segmentstore.server.WriterSegmentProcessor;
+import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ErrorInjector;
 import io.pravega.test.common.IntentionalException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -77,6 +82,9 @@ public class TableMetadataStoreTests extends MetadataStoreTestBase {
             this.metadataStore
                     .initialize(TIMEOUT)
                     .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            this.metadataStore
+                    .cacheIndex(TIMEOUT)
+                    .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         }
 
         @Override
@@ -100,7 +108,7 @@ public class TableMetadataStoreTests extends MetadataStoreTestBase {
             super.close();
         }
 
-        private class TestTableStore extends TableStoreMock {
+        private class TestTableStore extends TableStoreMock implements ContainerTableExtension {
             private final AtomicInteger getCount = new AtomicInteger();
             private final AtomicReference<ErrorInjector<Exception>> putErrorInjector = new AtomicReference<>();
             private final AtomicReference<ErrorInjector<Exception>> getErrorInjectorSync = new AtomicReference<>();
@@ -143,6 +151,21 @@ public class TableMetadataStoreTests extends MetadataStoreTestBase {
                                        this.getCount.incrementAndGet();
                                        return result;
                                    }));
+            }
+
+            @Override
+            public CompletableFuture<Void> cacheTailIndex(String segmentName, Duration timeout) {
+                // TODO: anything?
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public Collection<WriterSegmentProcessor> createWriterSegmentProcessors(UpdateableSegmentMetadata metadata) {
+                return Collections.emptyList();
             }
         }
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -106,6 +106,57 @@ public class ContainerKeyCacheTests {
     }
 
     /**
+     * Tests the {@link ContainerKeyCache#includeTailCache} method.
+     */
+    @Test
+    public void testIncludeTailCache() {
+        final long segmentId = 0L;
+        final long baseOffset = 1000;
+        @Cleanup
+        val cacheFactory = new InMemoryCacheFactory();
+        @Cleanup
+        val keyCache = new ContainerKeyCache(CONTAINER_ID, cacheFactory);
+        val expectedResult = new HashMap<TestKey, CacheBucketOffset>();
+
+        // Insert some pre-existing values.
+        for (int i = 0; i < KEYS_PER_SEGMENT; i++) {
+            long offset = baseOffset + i;
+            val keyHash = newSimpleHash();
+            keyCache.updateSegmentIndexOffset(segmentId, offset);
+            long updateResult = keyCache.includeExistingKey(segmentId, keyHash, offset);
+            Assert.assertEquals("Unexpected result from includeExistingKey() for new insertion.", offset, updateResult);
+            expectedResult.put(new TestKey(segmentId, keyHash), new CacheBucketOffset(offset, false));
+        }
+        // Perform updates.
+        val rnd = new Random(0);
+        boolean successfulUpdate = false;
+        val updateBatch = new HashMap<UUID, CacheBucketOffset>();
+        for (val e : expectedResult.entrySet()) {
+            // Every other update will try to set an obsolete offset. We need to verify that such a case will not be accepted.
+            successfulUpdate = !successfulUpdate;
+            val existingOffset = e.getValue().getSegmentOffset();
+            val segmentIndexOffset = keyCache.getSegmentIndexOffset(e.getKey().segmentId);
+
+            long newOffset;
+            boolean isRemoved;
+            if (successfulUpdate) {
+                newOffset = existingOffset + 1;
+                isRemoved = existingOffset % 3 == 0; // Need to pick odd number since only odd offsets are successful.
+                e.setValue(new CacheBucketOffset(newOffset, isRemoved));
+            } else {
+                newOffset = existingOffset - 1;
+                isRemoved = existingOffset % 4 == 0; // Need to pick even number since only even offsets are unsuccessful.
+            }
+
+            updateBatch.put(e.getKey().keyHash, new CacheBucketOffset(newOffset, isRemoved));
+        }
+
+        // Update the cache, then check it.
+        keyCache.includeTailCache(segmentId, updateBatch);
+        checkCache(expectedResult, keyCache);
+    }
+
+    /**
      * Tests the {@link ContainerKeyCache#includeUpdateBatch} method for inserts.
      */
     @Test


### PR DESCRIPTION
**Change log description**  
- Added the ability to quickly re-cache the tail section of a Table Segment after a container recovery, thus reducing the amount of time required before that segment can be used.
- Enabled this feature only on Container Metadata Table Segments (`_system/containers/metadata_XYZ`, where XYZ is container id), known internally as Segment Id 1 (in each container).

**Purpose of the change**  
Fixes #3918.

**What the code does**  
TBD.

**How to verify it**  
Unit tests added to verify new functionality.
System tests running with NFS should pass.
System tests running with slow HDFS should not fail as described in #3918.
