### PR TITLE
Issue 3929: (SegmentStore) Cache eviction bug fix

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -224,7 +224,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 // every single byte in the entry has been truncated out.
                 long lastOffset = entry.getLastStreamSegmentOffset();
                 boolean canRemove = entry.isDataEntry()
-                        && lastOffset <= this.metadata.getStorageLength()
+                        && lastOffset < this.metadata.getStorageLength()
                         && (entry.getGeneration() < oldestGeneration || lastOffset < this.metadata.getStartOffset());
                 if (canRemove) {
                     toRemove.add(entry);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -804,7 +804,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     public void testCacheEviction() throws Exception {
         // Create a CachePolicy with a set number of generations and a known max size.
         // Each generation contains exactly one entry, so the number of generations is also the number of entries.
-        final int appendSize = 100;
+        // We append one byte at each time. This allows us to test edge cases as well by having the finest precision when
+        // it comes to selecting which bytes we want evicted and which kept.
+        final int appendSize = 1;
         final int entriesPerSegment = 100; // This also doubles as number of generations (each generation, we add one append for each segment).
         final int cacheMaxSize = SEGMENT_COUNT * entriesPerSegment * appendSize;
         final int postStorageEntryCount = entriesPerSegment / 4; // 25% of the entries are beyond the StorageOffset


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `StreamSegmentReadIndex` where it could erroneously evict a cache entry if it had an EntryLength of 1 and a SegmentOffset equaling to the Segment's StorageLength.

**Purpose of the change**  
Fixes #3929.

**What the code does**  
- Fixed a bug in `StreamSegmentReadIndex` where it could erroneously evict a cache entry if it had an EntryLength of 1 and a SegmentOffset equaling to the Segment's StorageLength.
    - By definition, no Cache Entry which has at least one byte that hasn't been moved to Tier 2 can be evicted.
    - The eviction logic was checking the `Entry.getLastStreamSegmentOffset` which was calculated as `Offset+Length-1`. As such `<` should be used instead of `<=`.

**How to verify it**  
Updated the `ContainerReadIndexTests.testCacheEviction` to use cache entries of size 1. That would have triggered this bug.
