### PR TITLE
Issue 3921: SegmentHelper should not throw a ConnectionFailedException incase of TableSegmentIsEmpty response for deleteTableSegment

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -341,7 +341,8 @@ public class SegmentHelperTest {
         requestId = ((MockConnection) (factory.connection)).getRequestId();
         factory.rp.process(new WireCommands.TableSegmentNotEmpty(requestId, getQualifiedStreamSegmentName("", "", 0L), ""));
         AssertExtensions.assertThrows("", result::join,
-                                      ex -> ex instanceof ConnectionFailedException);
+                                      ex -> ex instanceof WireCommandFailedException &&
+                                              (((WireCommandFailedException) ex).getReason() == WireCommandFailedException.Reason.TableSegmentNotEmpty));
 
         Supplier<CompletableFuture<?>> futureSupplier = () -> helper.deleteTableSegment("", true, "", 0L);
         validateAuthTokenCheckFailed(factory, futureSupplier);


### PR DESCRIPTION
Signed-off-by: huide9 <huide9@gmail.com>

**Change log description**  
Modify to throw correct exception instead using an unmatching exception info.

**Purpose of the change**  
fixes #3921

**What the code does**  
* change to use matching exception for TableSegmentIsEmpty reply
* add WireCommandType info into exception so can get find out the operation type

**How to verify it**  
UT case modified to verify the changes. The matching excpetion reason: *WireCommandFailedException.Reason.TableSegmentNotEmpty*  should be caught correctly.
