### PR TITLE
Issue 3940: Fix auth resource representation used for stream in list streams operation

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -77,7 +77,9 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -355,6 +357,64 @@ public class ControllerGrpcAuthFocusedTest {
                 .build());
     }
 
+
+    @Test
+    public void listStreamsReturnsAllWhenUserHasWildCardAccess() {
+        // Arrange
+        String scopeName = "scope1";
+        createScopeAndStreams(scopeName, Arrays.asList("stream1", "stream2"),
+                prepareFromFixedScaleTypePolicy(2));
+
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope(scopeName).build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(2, response.getStreamsList().size());
+    }
+
+    @Test
+    public void listStreamReturnsEmptyResultWhenUserHasNoAccessToStreams() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_READ, DEFAULT_PASSWORD);
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(0, response.getStreamsList().size());
+    }
+
+    @Test
+    public void listStreamFiltersResultWhenUserHasAccessToSubsetOfStreams() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM1_LIST_READ, DEFAULT_PASSWORD);
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(1, response.getStreamsList().size());
+    }
+
     //region Private methods
 
     private static TxnId decode(UUID txnId) {
@@ -417,29 +477,44 @@ public class ControllerGrpcAuthFocusedTest {
                 .build();
     }
 
-    private void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {
-        Exceptions.checkNotNullOrEmpty(scope, "scope");
-        Exceptions.checkNotNullOrEmpty(scope, "stream");
-        Preconditions.checkNotNull(scalingPolicy, "scalingPolicy");
-
-        StreamConfig streamConfig = StreamConfig.newBuilder()
-                .setStreamInfo(Controller.StreamInfo.newBuilder()
-                        .setScope(scope)
-                        .setStream(stream)
-                        .build())
-                .setScalingPolicy(scalingPolicy)
-                .build();
-        createScopeAndStream(scope, streamConfig);
+    private void createScopeAndStream(String scopeName, String streamName, ScalingPolicy scalingPolicy) {
+        createScopeAndStreams(scopeName, Arrays.asList(streamName), scalingPolicy);
     }
 
-    private void createScopeAndStream(String scope, StreamConfig streamConfig) {
-        Exceptions.checkNotNullOrEmpty(scope, "scope");
-        Preconditions.checkNotNull(streamConfig, "streamConfig");
+    private void createScopeAndStreams(String scopeName, List<String> streamNames, ScalingPolicy scalingPolicy) {
+        Exceptions.checkNotNullOrEmpty(scopeName, "scope");
+        Preconditions.checkNotNull(streamNames, "stream");
+        Preconditions.checkArgument(streamNames.size() > 0);
+        Preconditions.checkNotNull(scalingPolicy, "scalingPolicy");
 
         ControllerServiceBlockingStub stub =
                 prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
-        stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scope).build());
-        stub.createStream(streamConfig);
+        createScope(stub, scopeName);
+
+        streamNames.stream().forEach(n -> createStream(stub, scopeName, n, scalingPolicy));
+    }
+
+    private void createScope(ControllerServiceBlockingStub stub, String scopeName) {
+        CreateScopeStatus status = stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scopeName).build());
+        if (!status.getStatus().equals(CreateScopeStatus.Status.SUCCESS)) {
+            throw new RuntimeException("Failed to create scope");
+        }
+    }
+
+    private void createStream(ControllerServiceBlockingStub stub, String scopeName,
+                              String streamName, ScalingPolicy scalingPolicy) {
+        StreamConfig streamConfig = StreamConfig.newBuilder()
+                .setStreamInfo(Controller.StreamInfo.newBuilder()
+                        .setScope(scopeName)
+                        .setStream(streamName)
+                        .build())
+                .setScalingPolicy(scalingPolicy)
+                .build();
+        Controller.CreateStreamStatus status = stub.createStream(streamConfig);
+
+        if (!status.getStatus().equals(Controller.CreateStreamStatus.Status.SUCCESS)) {
+            throw new RuntimeException("Failed to create stream");
+        }
     }
 
     private static File createAuthFile() {
@@ -451,9 +526,11 @@ public class ControllerGrpcAuthFocusedTest {
                 String defaultPassword = passwordEncryptor.encryptPassword("1111_aaaa");
                 writer.write(credentialsAndAclAsString(UserNames.ADMIN,  defaultPassword, "*,READ_UPDATE;"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE_READER, defaultPassword, "/,READ"));
+                writer.write(credentialsAndAclAsString(UserNames.SCOPE1_READ, defaultPassword, "scope1,READ"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READUPDATE, defaultPassword, "scope1/stream1,READ_UPDATE"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READ, defaultPassword, "scope1/stream1,READ"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM2_READ, defaultPassword, "scope1/stream2,READ"));
+                writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_LIST_READ, defaultPassword, "scope1,READ;scope1/stream1,READ"));
             }
             return result;
         } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
@@ -469,8 +546,10 @@ public class ControllerGrpcAuthFocusedTest {
     private static class UserNames {
         private final static String ADMIN = "admin";
         private final static String SCOPE_READER = "scopereader";
+        private final static String SCOPE1_READ = "scope1read";
         private final static String SCOPE1_STREAM1_READUPDATE = "authSc1Str1";
         private final static String SCOPE1_STREAM1_READ = "authSc1Str1readonly";
         private final static String SCOPE1_STREAM2_READ = "authSc1Str2readonly";
+        private final static String SCOPE1_STREAM1_LIST_READ = "scope1stream1lr";
     }
 }


### PR DESCRIPTION
**Change log description**  

Fix auth resource representation in Controller gRPC list streams operation to ensure that streams that the user has access to are returned in the filtered list of streams. 

**Purpose of the change**  
Fixes #3940. 

**What the code does**  

1. Fixes the auth resource representation for stream by using `AuthResourceRepresentation.ofStreamInScope(scopeName, streamName)` to create it. 

  By doing that, it changes auth resource representation used for stream in list streams operation to a fully qualified stream name of the form "scope1/stream1`. Earlier the resource string for the stream used in this operation was of the form "stream1".

2. Adds some tests to ControllerGrpcAuthFocusedTest for verifying the operation.

**How to verify it**  
All test should pass. 
