### PR TITLE
Issue 3937: Resolve JsonWebToken test failures in Java 11 builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,12 @@ project('shared:security') {
         compile project(':common')
         compile project(':shared:authplugin')
         compile group: 'io.jsonwebtoken', name: 'jjwt', version: jjwtVersion
-        
-        // since Java 9, JAXB is not bundled with Java SE, so we need them explicitly here.
+
+        // Adding JAXB API and the reference implementation as a dependency here, since they are not available
+        // in newer Java SE versions (9 and newer).
         compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
         compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+
         testCompile project(':test:testcommon')
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,10 @@ project('shared:security') {
         compile project(':common')
         compile project(':shared:authplugin')
         compile group: 'io.jsonwebtoken', name: 'jjwt', version: jjwtVersion
+        
+        // since Java 9, JAXB is not bundled with Java SE, so we need them explicitly here.
+        compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
+        compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
         testCompile project(':test:testcommon')
     }
 


### PR DESCRIPTION
**Change log description**  

Add JAXB API and reference implementation dependencies to the `shared/security` subproject.

**Purpose of the change**  
Resolves #3937. 

**What the code does**  
The code changes add JAXB API and reference implementation dependencies to shared security subproject. 

See Jesper de Jong's excellent [article](https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/) for detailed information about the context.

**How to verify it**  
Run the failed tests mentioned in the issue (#3937) description on a host running Java SE 11. 
