### PR TITLE
Issue 3945: Cherry-pick commits from master to r0.5

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -122,12 +122,24 @@ public class ClientConfig implements Serializable {
         @VisibleForTesting
         ClientConfigBuilder extractCredentials(Properties properties, Map<String, String> env) {
             if (credentials != null) {
+                log.info("Client credentials were extracted using the explicitly supplied credentials object.");
                 return this;
             }
-
-            credentials = extractCredentialsFromProperties(properties);
-            if (credentials == null) {
+            if (properties != null) {
+                credentials = extractCredentialsFromProperties(properties);
+                if (credentials != null) {
+                    log.info("Client credentials were extracted from system properties. {}",
+                            "They weren't explicitly supplied as a Credentials object.");
+                    return this;
+                }
+            }
+            if (env != null) {
                 credentials = extractCredentialsFromEnv(env);
+                if (credentials != null) {
+                    log.info("Client credentials were extracted from environment variables. {}",
+                            "They weren't explicitly supplied as a Credentials object or system properties.");
+                    return this;
+                }
             }
             return this;
         }

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionFactoryImpl.java
@@ -18,6 +18,7 @@ import io.pravega.shared.protocol.netty.ReplyProcessor;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ConnectionFactoryImpl implements ConnectionFactory {
 
+    private static final AtomicInteger POOLCOUNT = new AtomicInteger();
+    
     private final ClientConfig clientConfig;
     private final ScheduledExecutorService executor;
     @VisibleForTesting
@@ -43,7 +46,8 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
     public ConnectionFactoryImpl(ClientConfig clientConfig, ConnectionPool connectionPool, Integer numThreadsInPool) {
         this.clientConfig = Preconditions.checkNotNull(clientConfig, "clientConfig");
         this.connectionPool = Preconditions.checkNotNull(connectionPool);
-        this.executor = ExecutorServiceHelpers.newScheduledThreadPool(getThreadPoolSize(numThreadsInPool), "clientInternal");
+        this.executor = ExecutorServiceHelpers.newScheduledThreadPool(getThreadPoolSize(numThreadsInPool),
+                                                                      "clientInternal-" + POOLCOUNT.incrementAndGet());
     }
 
     @VisibleForTesting

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -499,7 +499,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             } catch (SegmentSealedException | NoSuchSegmentException e) {
                 if (StreamSegmentNameUtils.isTransactionSegment(segmentName)) {
                     log.warn("Exception observed during a flush on a transaction segment, this indicates that the transaction is " +
-                                     "commited/aborted. Details: {}", e.getMessage());
+                                     "committed/aborted. Details: {}", e.getMessage());
                     failConnection(e);
                 } else {
                     log.info("Exception observed while obtaining connection during flush. Details: {} ", e.getMessage());

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -10,83 +10,202 @@
 package io.pravega.client;
 
 import io.pravega.client.stream.impl.Credentials;
+
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class CredentialsExtractorTest {
+
     @Test
-    public void testextractCredentials() {
-        //No creds defined
-        ClientConfig config = ClientConfig.builder().build();
-        assertEquals("Empty list should return null", config.getCredentials(), null);
-
-        //Test custom creds
+    public void testExtractsCredentialsFromProperties() {
         Properties properties = new Properties();
-        properties.setProperty("pravega.client.auth.method", "temp");
-        properties.setProperty("pravega.client.auth.token", "mytoken");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
 
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
 
-        assertEquals("Method is not picked up from properties",
-                "temp", config.getCredentials().getAuthenticationType());
-
-        assertEquals("Token is not same",
-                "mytoken", config.getCredentials().getAuthenticationToken());
-
-        //If a credential is explicitly mentioned, do not override from properties
-        config = ClientConfig.builder().credentials(new Credentials() {
-            @Override
-            public String getAuthenticationType() {
-                return null;
-            }
-
-            @Override
-            public String getAuthenticationToken() {
-                return null;
-            }
-        }).build();
-
-        config = config.toBuilder().extractCredentials(properties, new HashMap<String, String>()).build();
-
-        assertNotEquals("Credentials should not be overridden",
-                config.getCredentials().getAuthenticationType(), "temp");
-
-        //In case dynamic creds system property is false, load the creds from properties
-        properties.setProperty("pravega.client.auth.loadDynamic", "false");
-
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        assertEquals("Method is not picked up from properties",
-                config.getCredentials().getAuthenticationType(), "temp");
-
-        //In case dynamic creds system property is true and class does not exist, the API should return null.
-        properties.setProperty("pravega.client.auth.loadDynamic", "true");
-
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        Assert.assertNull("Creds should not be picked up from properties",
-                config.getCredentials());
-
-        //In case dynamic creds system property is true, the correct class should be loaded.
-        properties.setProperty("pravega.client.auth.method", "DynamicallyLoadedCredsSecond");
-        config = ClientConfig.builder().extractCredentials(properties, new HashMap<String, String>()).build();
-        Assert.assertEquals("Correct creds object should be loaded dynamically",
-                config.getCredentials().getAuthenticationType(), "DynamicallyLoadedCredsSecond");
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
     }
 
+    @Test
+    public void testExtractsCredentialsFromEnvVariables() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(null, authEnvVariables).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void testExplicitlySpecifiedCredentialsAreNotOverridden() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                .credentials(new Credentials() {
+                    @Override
+                    public String getAuthenticationType() {
+                        return "typeSpecifiedViaExplicitObject";
+                    }
+
+                    @Override
+                    public String getAuthenticationToken() {
+                        return "tokenSpecifiedViaExplicitObject";
+                    }
+                }).extractCredentials(properties, authEnvVariables)
+                .build();
+
+        assertEquals("Explicitly set credentials should not be overridden", "typeSpecifiedViaExplicitObject",
+                clientConfig.getCredentials().getAuthenticationType());
+
+        assertEquals("Explicitly set credentials should not be overridden", "tokenSpecifiedViaExplicitObject",
+                clientConfig.getCredentials().getAuthenticationToken());
+    }
+
+    @Test
+    public void testCredentialsSpecifiedViaPropertiesAreNotOverriddenByEnvVariables() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_method", "bmethod");
+        authEnvVariables.put("pravega_client_auth_token", "btoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                .extractCredentials(properties, authEnvVariables)
+              .build();
+
+        assertEquals("amethod", clientConfig.getCredentials().getAuthenticationType());
+        assertEquals("atoken", clientConfig.getCredentials().getAuthenticationToken());
+    }
+
+    @Test
+    public void testLoadsCredentialsObjOfAGenericTypeFromPropertiesIfLoadDynamicIsFalse() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "false");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void testLoadsCredentialsObjOfAGenericTypeFromEnvVariablesIfLoadDynamicIsFalse() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "false");
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig =
+                ClientConfig.builder().extractCredentials(null, authEnvVariables).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull(credentials);
+        assertNotNull("io.pravega.client.ClientConfig$ClientConfigBuilder$1",
+                credentials.getClass());
+        assertEquals("amethod", credentials.getAuthenticationType());
+        assertEquals("atoken", credentials.getAuthenticationToken());
+    }
+
+    @Test
+    public void testDoesNotLoadCredentialsOfNonExistentClassIfLoadDynamicIsTrue() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "true");
+        properties.setProperty("pravega.client.auth.method", "amethod");
+        properties.setProperty("pravega.client.auth.token", "atoken");
+
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
+        authEnvVariables.put("pravega_client_auth_method", "amethod");
+        authEnvVariables.put("pravega_client_auth_token", "atoken");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                    .extractCredentials(properties, authEnvVariables)
+                .build();
+
+        // Expecting a null because there is no Credentials implementation in the classpath that registers an
+        // authentication type "amethod".
+        assertNull(clientConfig.getCredentials());
+    }
+
+    @Test
+    public void testLoadsCredentialsObjOfARegisteredTypeFromPropertiesIfLoadDynamicIsTrue() {
+        Properties properties = new Properties();
+        properties.setProperty("pravega.client.auth.loadDynamic", "true");
+        properties.setProperty("pravega.client.auth.method", "Bearer");
+
+        ClientConfig clientConfig = ClientConfig.builder().extractCredentials(properties, null).build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull("Credentials is null", credentials);
+        assertNotNull(DynamicallyLoadedCreds.class.getName(), credentials.getClass());
+        assertEquals("Expected a different authentication type", "Bearer",
+                credentials.getAuthenticationType());
+    }
+
+    @Test
+    public void testLoadsCredentialsObjOfARegisteredTypeFromEnvVariablesIfLoadDynamicIsTrue() {
+        Map authEnvVariables = new HashMap();
+        authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
+        authEnvVariables.put("pravega_client_auth_method", "Bearer");
+
+        ClientConfig clientConfig = ClientConfig.builder()
+                   .extractCredentials(null, authEnvVariables)
+                .build();
+        Credentials credentials = clientConfig.getCredentials();
+
+        assertNotNull("Credentials is null", credentials);
+        assertNotNull(DynamicallyLoadedCreds.class.getName(), credentials.getClass());
+        assertEquals("Expected a different authentication type", "Bearer",
+                credentials.getAuthenticationType());
+    }
+
+    /**
+     * A class representing Credentials. It is dynamically loaded using a {@link java.util.ServiceLoader} by
+     * the code under test, in the enclosing test class. For ServiceLoader to find it, it is configured in
+     * META-INF/services/io.pravega.client.stream.impl.Credentials.
+     */
     public static class DynamicallyLoadedCreds implements Credentials {
 
         @Override
         public String getAuthenticationType() {
-            return "DynamicallyLoadedCreds";
+            return "Bearer";
         }
 
         @Override
         public String getAuthenticationToken() {
-            return "DynamicallyLoadedCreds";
+            return "SomeToken";
         }
     }
 

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -267,7 +267,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         @SuppressWarnings("resource")
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
-        
+
         output.reconnect();
         cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
         output.write(PendingEvent.withoutHeader(null, getBuffer("test1"), new CompletableFuture<>()));

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
@@ -22,6 +22,9 @@ import io.pravega.common.util.RetriesExhaustedException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -31,7 +34,9 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
 import static io.pravega.test.common.AssertExtensions.assertFutureThrows;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -72,7 +77,7 @@ public class SegmentSelectorTest {
         }
     }
 
-    private void addNewSegment(TreeMap<Double, SegmentWithRange> segments, int number, double low, double high) {
+    private void addNewSegment(TreeMap<Double, SegmentWithRange> segments, long number, double low, double high) {
         segments.put(high, new SegmentWithRange(new Segment(scope, streamName, number), low, high));
     }
 
@@ -215,6 +220,68 @@ public class SegmentSelectorTest {
 
         assertEquals(Collections.emptyList(), selector.refreshSegmentEventWritersUponSealed(segment0, segmentSealedCallback));
         assertFutureThrows("Writer Future", writerFuture, t -> t instanceof ControllerFailureException);
+    }
+
+    @Test
+    public void testSegmentRefreshOnSealed() {
+        final Segment segment0 = new Segment(scope, streamName, 0);
+        final Segment segment1 = new Segment(scope, streamName, computeSegmentId(1, 1));
+        final Segment segment2 = new Segment(scope, streamName, computeSegmentId(2, 1));
+        final CompletableFuture<Void> writerFuture = new CompletableFuture<>();
+        final PendingEvent pendingEvent = PendingEvent.withHeader("0", ByteBuffer.wrap("e".getBytes()), writerFuture);
+
+        TreeMap<Double, SegmentWithRange> segmentBeforeScale = new TreeMap<>();
+        addNewSegment(segmentBeforeScale, 0, 0.0, 1.0);
+        StreamSegments streamSegmentsBeforeScale = new StreamSegments(segmentBeforeScale, "");
+
+        Map<SegmentWithRange, List<Long>> newRange = new HashMap<>();
+        newRange.put(new SegmentWithRange(segment1, 0.0, 0.5), ImmutableList.of(segment0.getSegmentId()));
+        newRange.put(new SegmentWithRange(segment2, 0.5, 1.0), ImmutableList.of(segment0.getSegmentId()));
+        StreamSegmentsWithPredecessors segmentsWithPredecessors = new StreamSegmentsWithPredecessors(newRange, "");
+
+        // Setup Mock.
+        SegmentOutputStream s0Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStream s1Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStream s2Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+
+        when(s0Writer.getUnackedEventsOnSeal()).thenReturn(ImmutableList.of(pendingEvent));
+        when(factory.createOutputStreamForSegment(eq(segment0), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s0Writer);
+        when(factory.createOutputStreamForSegment(eq(segment1), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s1Writer);
+        when(factory.createOutputStreamForSegment(eq(segment2), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), anyString()))
+                .thenReturn(s2Writer);
+        // get current segments returns segment 0
+        when(controller.getCurrentSegments(scope, streamName))
+                .thenReturn(CompletableFuture.completedFuture(streamSegmentsBeforeScale));
+        when(controller.getSuccessors(segment0))
+                .thenAnswer(i -> {
+                    CompletableFuture<StreamSegmentsWithPredecessors> result = new CompletableFuture<>();
+                    result.complete(segmentsWithPredecessors);
+                    return result;
+                });
+
+        SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config);
+        //trigger refresh
+        selector.refreshSegmentEventWriters(segmentSealedCallback);
+        // only segment 0 writer is present.
+        assertEquals(singletonList(s0Writer), selector.getWriters());
+
+        // trigger a referesh of writers due to segment 0 being sealed.
+        List<PendingEvent> pendingEvents = selector.refreshSegmentEventWritersUponSealed(segment0, segmentSealedCallback);
+        // one pending event is returned by segment0
+        assertEquals(singletonList(pendingEvent), pendingEvents);
+        // the current number of writers is 3, it includes the writer to segment 0.
+        List<SegmentOutputStream> writers = selector.getWriters();
+        assertEquals(3, writers.size());
+        assertTrue(writers.contains(s0Writer));
+        assertTrue(writers.contains(s1Writer));
+        assertTrue(writers.contains(s2Writer));
+        // remove segment 0, this is done post resending the pending events.
+        selector.removeSegmentWriter(segment0);
+        assertFalse(selector.getWriters().contains(s0Writer));
     }
 
 }

--- a/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
@@ -13,7 +13,9 @@ import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.function.RunnableWithException;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -28,18 +30,32 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Helper methods for ExecutorService.
  */
+@Slf4j
 public final class ExecutorServiceHelpers {
     
+    @Data
     private static class CallerRuns implements RejectedExecutionHandler {
+        private final String poolName;
+
         @Override
         public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            log.debug("Caller to executor: " + poolName + " rejected and run in the caller.");
             r.run();
+        }
+    }
+
+    private static final class LogUncaughtExceptions implements UncaughtExceptionHandler {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            log.error("Exception thrown out of root of thread: " + t.getName(), e);
         }
     }
     
@@ -56,6 +72,7 @@ public final class ExecutorServiceHelpers {
             @Override
             public Thread newThread(Runnable r) {
                 Thread thread = new Thread(r, groupName + "-" + threadCount.incrementAndGet());
+                thread.setUncaughtExceptionHandler(new LogUncaughtExceptions());
                 thread.setDaemon(true);
                 return thread;
             }
@@ -70,7 +87,7 @@ public final class ExecutorServiceHelpers {
      */
     public static ScheduledExecutorService newScheduledThreadPool(int size, String poolName) {
         // Caller runs only occurs after shutdown, as queue size is unbounded.
-        ScheduledThreadPoolExecutor result = new ScheduledThreadPoolExecutor(size, getThreadFactory(poolName), new CallerRuns());
+        ScheduledThreadPoolExecutor result = new ScheduledThreadPoolExecutor(size, getThreadFactory(poolName), new CallerRuns(poolName));
 
         // Do not execute any periodic tasks after shutdown.
         result.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
@@ -112,7 +129,7 @@ public final class ExecutorServiceHelpers {
      */
     public static ThreadPoolExecutor getShrinkingExecutor(int maxThreadCount, int threadTimeout, String poolName) {
         return new ThreadPoolExecutor(0, maxThreadCount, threadTimeout, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
-                getThreadFactory(poolName), new CallerRuns()); // Caller runs only occurs after shutdown, as queue size is unbounded.
+                getThreadFactory(poolName), new CallerRuns(poolName)); // Caller runs only occurs after shutdown, as queue size is unbounded.
     }
 
     /**
@@ -194,7 +211,12 @@ public final class ExecutorServiceHelpers {
                 if (!pool.awaitTermination(timer.getRemaining().toMillis(), TimeUnit.MILLISECONDS)) {
                     // Cancel currently executing tasks and wait for them to respond to being cancelled.
                     pool.shutdownNow();
-                    pool.awaitTermination(timer.getRemaining().toMillis(), TimeUnit.MILLISECONDS);
+                    if (!pool.awaitTermination(timer.getRemaining().toMillis(), TimeUnit.MILLISECONDS)) {
+                        List<Runnable> remainingTasks = pool.shutdownNow();
+                        log.warn("One or more threads from pool " + pool
+                                + " did not shutdown properly. Waiting tasks: " + remainingTasks);
+
+                    }
                 }
             } catch (InterruptedException ie) {
                 pool.shutdownNow();

--- a/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
+++ b/controller/src/main/java/io/pravega/controller/fault/ControllerClusterListener.java
@@ -136,7 +136,7 @@ public class ControllerClusterListener extends AbstractIdleService {
         return Futures.allOf(sweepers.stream().map(sweeper -> RetryHelper.withIndefiniteRetriesAsync(() -> {
             if (!sweeper.isReady()) {
                 log.trace("sweeper not ready, retrying with exponential backoff");
-                throw new RuntimeException("sweeper not ready");
+                throw new RuntimeException(String.format("sweeper %s not ready", sweeper.getClass()));
             }
             return sweeper.sweepFailedProcesses(processes);
         }, e -> log.warn(e.getMessage()), executor)).collect(Collectors.toList()));

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -713,7 +713,7 @@ class PravegaTablesStream extends PersistentStreamBase {
         String tableName = getCompletedTransactionsBatchTableName(batch);
 
         Map<String, byte[]> map = complete.entrySet().stream().collect(Collectors.toMap(
-                x -> String.format(COMPLETED_TRANSACTIONS_KEY_FORMAT, getScope(), getName(), x.getKey().toString()), Map.Entry::getValue));
+                x -> getCompletedTransactionKey(getScope(), getName(), x.getKey()), Map.Entry::getValue));
 
         return Futures.toVoid(Futures.exceptionallyComposeExpecting(
                 storeHelper.addNewEntriesIfAbsent(tableName, map),
@@ -724,7 +724,13 @@ class PravegaTablesStream extends PersistentStreamBase {
                 });
     }
 
-    private String getCompletedTransactionsBatchTableName(int batch) {
+    @VisibleForTesting
+    static String getCompletedTransactionKey(String scope, String stream, String txnId) {
+        return String.format(COMPLETED_TRANSACTIONS_KEY_FORMAT, scope, stream, txnId);
+    }
+
+    @VisibleForTesting
+    static String getCompletedTransactionsBatchTableName(int batch) {
         return getQualifiedTableName(INTERNAL_SCOPE_NAME, 
                 String.format(COMPLETED_TRANSACTIONS_BATCH_TABLE_FORMAT, batch));
     }
@@ -751,7 +757,7 @@ class PravegaTablesStream extends PersistentStreamBase {
                           .thenCompose(v -> {
                               return Futures.allOfWithResults(batches.stream().map(batch -> {
                                   String table = getCompletedTransactionsBatchTableName(batch);
-                                  String key = String.format(COMPLETED_TRANSACTIONS_KEY_FORMAT, getScope(), getName(), txId.toString());
+                                  String key = getCompletedTransactionKey(getScope(), getName(), txId.toString());
 
                                   return storeHelper.expectingDataNotFound(
                                           storeHelper.getCachedData(table, key, CompletedTxnRecord::fromBytes), null);

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * ControllerClusterListener tests.
@@ -183,14 +182,14 @@ public class ControllerClusterListenerTest {
         TaskSweeper taskSweeper = spy(new TaskSweeper(taskStore, host.getHostId(), executor,
                 new TestTasks(taskStore, executor, host.getHostId())));
 
-        when(taskSweeper.sweepFailedProcesses(any(Supplier.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!taskSweep.isDone()) {
                 // we complete the future when this method is called for the first time.
                 taskSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(taskSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(taskSweeper).sweepFailedProcesses(any(Supplier.class));
+        doAnswer(invocation -> {
             if (!taskHostSweep1.isDone()) {
                 // we complete this future when task sweeper for a failed host is called for the first time.
                 taskHostSweep1.complete(null);
@@ -199,7 +198,7 @@ public class ControllerClusterListenerTest {
                 taskHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(taskSweeper).handleFailedProcess(anyString());
 
         // Create txn sweeper.
         StreamMetadataStore streamStore = StreamStoreFactory.createInMemoryStore(executor);
@@ -216,18 +215,19 @@ public class ControllerClusterListenerTest {
             return false;
         }).when(txnSweeper).isReady();
 
-        when(txnSweeper.sweepFailedProcesses(any())).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!txnSweep.isDone()) {
                 txnSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(txnSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(txnSweeper).sweepFailedProcesses(any());
+        
+        doAnswer(invocation -> {
             if (!txnHostSweep2.isDone()) {
                 txnHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(txnSweeper).handleFailedProcess(anyString());
 
         // Create request sweeper.
         StreamMetadataTasks streamMetadataTasks = new StreamMetadataTasks(streamStore, mock(BucketStore.class), taskStore, segmentHelper, executor,
@@ -245,18 +245,19 @@ public class ControllerClusterListenerTest {
             return false;
         }).when(requestSweeper).isReady();
 
-        when(requestSweeper.sweepFailedProcesses(any())).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             if (!requestSweep.isDone()) {
                 requestSweep.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
-        when(requestSweeper.handleFailedProcess(anyString())).thenAnswer(invocation -> {
+        }).when(requestSweeper).sweepFailedProcesses(any());
+        
+        doAnswer(invocation -> {
             if (!requestHostSweep2.isDone()) {
                 requestHostSweep2.complete(null);
             }
             return CompletableFuture.completedFuture(null);
-        });
+        }).when(requestSweeper).handleFailedProcess(anyString());
 
         // Create ControllerClusterListener.
         ControllerClusterListener clusterListener = new ControllerClusterListener(host, clusterZK, executor,

--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -129,7 +129,7 @@ public class SegmentHelperMock {
             return CompletableFuture.runAsync(() -> {
                 synchronized (lock) {
                     mapOfTables.putIfAbsent(tableName, new HashMap<>());
-                    mapOfTablesPosition.put(tableName, new HashMap<>());
+                    mapOfTablesPosition.putIfAbsent(tableName, new HashMap<>());
                 }
             }, executor);
         }).when(helper).createTableSegment(anyString(), anyString(), anyLong());

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
@@ -14,6 +14,8 @@ import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.controller.mocks.SegmentHelperMock;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.rpc.auth.AuthHelper;
+import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
+import io.pravega.controller.store.stream.records.CompletedTxnRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
@@ -28,10 +30,21 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static io.pravega.controller.store.stream.PravegaTablesStreamMetadataStore.COMPLETED_TRANSACTIONS_BATCHES_TABLE;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 /**
  * Zookeeper based stream metadata store tests.
@@ -40,6 +53,7 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
 
     private TestingServer zkServer;
     private CuratorFramework cli;
+    private SegmentHelper segmentHelperMockForTables;
 
     @Override
     public void setupStore() throws Exception {
@@ -49,8 +63,8 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
         int connectionTimeout = 5000;
         cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), sessionTimeout, connectionTimeout, new RetryOneTime(2000));
         cli.start();
-        SegmentHelper segmentHelperMockForTables = SegmentHelperMock.getSegmentHelperMockForTables(executor);
-        store = new PravegaTablesStreamMetadataStore(segmentHelperMockForTables, cli, executor, Duration.ofSeconds(1), AuthHelper.getDisabledAuthHelper());
+        segmentHelperMockForTables = SegmentHelperMock.getSegmentHelperMockForTables(executor);
+        store = new PravegaTablesStreamMetadataStore(segmentHelperMockForTables, cli, executor, Duration.ofSeconds(100), AuthHelper.getDisabledAuthHelper());
         bucketStore = StreamStoreFactory.createZKBucketStore(1, cli, executor);
     }
 
@@ -196,6 +210,207 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
         assertEquals("Number of merges", new Long(4), simpleEntrySplitsMerges3.getValue());
     }
     
+    @Test
+    public void testGarbageCollection() {
+        try (PravegaTablesStreamMetadataStore testStore = new PravegaTablesStreamMetadataStore(
+                segmentHelperMockForTables, cli, executor, Duration.ofSeconds(100), AuthHelper.getDisabledAuthHelper())) {
+            AtomicInteger currentBatch = new AtomicInteger(0);
+            Supplier<Integer> supplier = currentBatch::get;
+            ZKGarbageCollector gc = mock(ZKGarbageCollector.class);
+            doAnswer(x -> supplier.get()).when(gc).getLatestBatch();
+            testStore.setCompletedTxnGCRef(gc);
+
+            String scope = "scopeGC";
+            String stream = "streamGC";
+            testStore.createScope(scope).join();
+
+            StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+            testStore.createStream(scope, stream, config, System.currentTimeMillis(), null, executor).join();
+
+            // batch 0
+            UUID txnId0 = testStore.generateTransactionId(scope, stream, null, executor).join();
+            createAndCommitTransaction(scope, stream, txnId0, testStore);
+            UUID txnId1 = testStore.generateTransactionId(scope, stream, null, executor).join();
+            createAndCommitTransaction(scope, stream, txnId1, testStore);
+            
+            // verify that the completed txn record is created in batch 0
+            Set<Integer> batches = getAllBatches(testStore);
+            assertEquals(batches.size(), 1);
+            assertTrue(batches.contains(0));
+            Map<String, CompletedTxnRecord> transactions = getAllTransactionsInBatch(testStore, 0);
+            // verify that transaction is present in batch 0
+            assertTrue(transactions.containsKey(PravegaTablesStream.getCompletedTransactionKey(scope, stream, txnId1.toString())));
+            
+            // run gc. There should be no purge. 
+            testStore.gcCompletedTxn().join();
+            batches = getAllBatches(testStore);
+            // verify no purge of batch
+            assertEquals(batches.size(), 1);
+            assertTrue(batches.contains(0));
+
+            TxnStatus status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+
+            // create batch 1
+            currentBatch.incrementAndGet();
+            UUID txnId2 = testStore.generateTransactionId(scope, stream, null, executor).join();
+            createAndCommitTransaction(scope, stream, txnId2, testStore);
+            // verify that the completed txn record is created in batch 1
+            batches = getAllBatches(testStore);
+            assertEquals(batches.size(), 2);
+            transactions = getAllTransactionsInBatch(testStore, 1);
+            // verify that transaction is present in batch 1
+            assertTrue(transactions.containsKey(PravegaTablesStream.getCompletedTransactionKey(scope, stream, txnId2.toString())));
+
+            // run gc. There should be no purge. 
+            testStore.gcCompletedTxn().join();
+            batches = getAllBatches(testStore);
+            // verify no purge of batch
+            assertEquals(batches.size(), 2);
+            assertTrue(batches.contains(0));
+            assertTrue(batches.contains(1));
+
+            status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId2, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+
+            // create batch 2
+            currentBatch.incrementAndGet();
+            UUID txnId3 = testStore.generateTransactionId(scope, stream, null, executor).join();
+            createAndCommitTransaction(scope, stream, txnId3, testStore);
+            // verify that the completed txn record is created in batch 2
+            batches = getAllBatches(testStore);
+            assertEquals(batches.size(), 3);
+            assertTrue(batches.contains(0));
+            assertTrue(batches.contains(1));
+            assertTrue(batches.contains(2));
+            status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId2, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId3, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+
+            // dont run gc. let batches get accumulated.
+            transactions = getAllTransactionsInBatch(testStore, 2);
+            // verify that transaction is present in batch 2
+            assertTrue(transactions.containsKey(PravegaTablesStream.getCompletedTransactionKey(scope, stream, txnId3.toString())));
+             
+            // create batch 3
+            currentBatch.incrementAndGet();
+            UUID txnId4 = testStore.generateTransactionId(scope, stream, null, executor).join();
+            createAndCommitTransaction(scope, stream, txnId4, testStore);
+            // verify that the completed txn record is created in batch 3
+            batches = getAllBatches(testStore);
+            assertEquals(batches.size(), 4);
+            assertTrue(batches.contains(0));
+            assertTrue(batches.contains(1));
+            assertTrue(batches.contains(2));
+            assertTrue(batches.contains(3));
+            status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId2, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId3, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId4, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+
+            transactions = getAllTransactionsInBatch(testStore, 3);
+            // verify that transaction is present in batch 3
+            assertTrue(transactions.containsKey(PravegaTablesStream.getCompletedTransactionKey(scope, stream, txnId4.toString())));
+
+            // check that we are able to get status for all 4 transactions.
+            status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId2, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId3, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId4, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            
+            // run gc. There should be two purges. 
+            testStore.gcCompletedTxn().join();
+            batches = getAllBatches(testStore);
+            assertEquals(batches.size(), 2);
+            assertTrue(batches.contains(2));
+            assertTrue(batches.contains(3));
+
+            // we should be able to get txn status for txn3 and txn4 but should get unknown for txn1 and txn2
+            status = testStore.transactionStatus(scope, stream, txnId1, null, executor).join();
+            assertEquals(status, TxnStatus.UNKNOWN);
+            status = testStore.transactionStatus(scope, stream, txnId2, null, executor).join();
+            assertEquals(status, TxnStatus.UNKNOWN);
+            status = testStore.transactionStatus(scope, stream, txnId3, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+            status = testStore.transactionStatus(scope, stream, txnId4, null, executor).join();
+            assertEquals(status, TxnStatus.COMMITTED);
+        }
+    }
+
+    @Test
+    public void testFindStaleBatches() {
+        PravegaTablesStreamMetadataStore store = (PravegaTablesStreamMetadataStore) this.store;
+
+        List<String> batches = Arrays.asList("5", "1", "6", "2", "7", "3", "8", "4", "0");
+        List<String> stale = store.findStaleBatches(batches);
+        assertEquals(batches.size() - 2, stale.size());
+        assertFalse(stale.contains("8"));
+        assertFalse(stale.contains("7"));
+
+        batches = stale;
+        stale = store.findStaleBatches(batches);
+        assertEquals(batches.size() - 2, stale.size());
+        assertFalse(stale.contains("6"));
+        assertFalse(stale.contains("5"));
+
+        batches = stale;
+        stale = store.findStaleBatches(batches);
+        assertEquals(batches.size() - 2, stale.size());
+        assertFalse(stale.contains("4"));
+        assertFalse(stale.contains("3"));
+
+        batches = stale;
+        stale = store.findStaleBatches(batches);
+        assertEquals(batches.size() - 2, stale.size());
+        assertFalse(stale.contains("2"));
+        assertFalse(stale.contains("1"));
+
+        batches = stale;
+        stale = store.findStaleBatches(batches);
+        assertTrue(stale.isEmpty());
+    }
+
+    private Set<Integer> getAllBatches(PravegaTablesStreamMetadataStore testStore) {
+        Set<Integer> batches = new ConcurrentSkipListSet<>();
+        testStore.getStoreHelper().getAllKeys(COMPLETED_TRANSACTIONS_BATCHES_TABLE)
+                 .collectRemaining(x -> {
+                     batches.add(Integer.parseInt(x));
+                     return true;
+                 }).join();
+        return batches;
+    }
+
+    private Map<String, CompletedTxnRecord> getAllTransactionsInBatch(PravegaTablesStreamMetadataStore testStore, int batch) {
+        Map<String, CompletedTxnRecord> transactions = new ConcurrentHashMap<>();
+        testStore.getStoreHelper().getAllEntries(PravegaTablesStream.getCompletedTransactionsBatchTableName(batch), 
+                CompletedTxnRecord::fromBytes)
+                 .collectRemaining(x -> {
+                     transactions.put(x.getKey(), x.getValue().getObject());
+                     return true;
+                 }).join();
+        return transactions;
+    }
+
+    private void createAndCommitTransaction(String scope, String stream, UUID txnId, PravegaTablesStreamMetadataStore testStore) {
+        testStore.createTransaction(scope, stream, txnId, 10000L, 10000L, null, executor).join();
+        testStore.sealTransaction(scope, stream, txnId, true, Optional.empty(), null, executor).join();
+        VersionedMetadata<CommittingTransactionsRecord> record = testStore.startCommitTransactions(scope, stream, null, executor).join();
+        testStore.completeCommitTransactions(scope, stream, record, null, executor).join();
+    }
+
     private SimpleEntry<Long, Long> findSplitsAndMerges(String scope, String stream) throws InterruptedException, java.util.concurrent.ExecutionException {
         return store.getScaleMetadata(scope, stream, 0, Long.MAX_VALUE, null, executor).get()
                 .stream().reduce(new SimpleEntry<>(0L, 0L),

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -953,10 +953,10 @@ public abstract class StreamMetadataTasksTest {
         streamStorePartialMock.setState(SCOPE, streamWithTxn, State.ACTIVE, null, executor).get();
 
         // create txn
-        VersionedTransactionData openTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 100L, null)
+        VersionedTransactionData openTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 10000L, null)
                 .get().getKey();
 
-        VersionedTransactionData committingTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 100L, null)
+        VersionedTransactionData committingTxn = streamTransactionMetadataTasks.createTxn(SCOPE, streamWithTxn, 10000L, null)
                 .get().getKey();
 
         // set transaction to committing

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -17,7 +17,7 @@ try:
         "docker service inspect pravega_segmentstore --format='{{.Spec.TaskTemplate.ContainerSpec.Env}}'", shell=True)
 
     def get_config(name):
-        return re.findall(name + "=(.+?)( |])", env)[0][0]
+        return re.findall(name + "=(.+//)?(.+?)( |]|\r\n|\n)", env)[0][1]
 
     published_address = get_config("publishedIPAddress")
     hdfs_url = get_config("HDFS_URL")
@@ -59,6 +59,8 @@ for instance in to_create:
           --label com.docker.stack.namespace='pravega' \
           -p '{port}:{port}' \
           -e HDFS_URL={hdfs_url} \
+          -e TIER2_STORAGE=HDFS \
+          -e HDFS_REPLICATION=1 \
           -e ZK_URL={zk_url} \
           -e CONTROLLER_URL=tcp://controller:9090 \
           -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Dbookkeeper.bkEnsembleSize=2 -Dbookkeeper.bkAckQuorumSize=2 -Dbookkeeper.bkWriteQuorumSize=2 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -43,6 +43,7 @@ import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableSegmentNotEmptyException;
 import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
@@ -946,7 +947,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             invokeSafely(connection::send, new OperationUnsupported(requestId, operation, clientReplyStackTrace), failureHandler);
         } else if (u instanceof BadOffsetException) {
             BadOffsetException badOffset = (BadOffsetException) u;
-            log.info(requestId, "Segment '{}' is truncated and cannot perform operation '{}' at offset '{}'", operation, offset);
+            log.info(requestId, "Segment '{}' is truncated and cannot perform operation '{}' at offset '{}'", segment, operation, offset);
             invokeSafely(connection::send, new SegmentIsTruncated(requestId, segment, badOffset.getExpectedOffset(),
                                                                   clientReplyStackTrace, offset), failureHandler);
         } else if (u instanceof TableSegmentNotEmptyException) {
@@ -959,12 +960,20 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             log.warn(requestId, "Conditional update on Table segment '{}' failed due to bad key version.", segment);
             invokeSafely(connection::send, new WireCommands.TableKeyBadVersion(requestId, segment, clientReplyStackTrace), failureHandler);
         } else {
-            log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segment, operation, u);
+            logError(requestId, segment, operation, u);
             connection.close(); // Closing connection should reinitialize things, and hopefully fix the problem
             throw new IllegalStateException("Unknown exception.", u);
         }
 
         return null;
+    }
+
+    private void logError(long requestId, String segment, String operation, Throwable u) {
+        if (u instanceof IllegalContainerStateException) {
+            log.warn(requestId, "Error (Segment = '{}', Operation = '{}'): {}", segment, operation, u.toString());
+        } else {
+            log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segment, operation, u);
+        }
     }
 
     private void recordStatForTransaction(SegmentProperties sourceInfo, String targetSegmentName) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
@@ -112,6 +112,8 @@ abstract class SegmentAggregates {
 
     protected abstract long getUpdateCountDelta(long dataLength, int numOfEvents);
 
+    protected abstract double getRate(double rate);
+
     boolean isScalingEnabled() {
         return true;
     }
@@ -173,19 +175,19 @@ abstract class SegmentAggregates {
     }
 
     synchronized double getTwoMinuteRate() {
-        return twoMinuteRate;
+        return getRate(twoMinuteRate);
     }
 
     synchronized double getFiveMinuteRate() {
-        return fiveMinuteRate;
+        return getRate(fiveMinuteRate);
     }
 
     synchronized double getTenMinuteRate() {
-        return tenMinuteRate;
+        return getRate(tenMinuteRate);
     }
 
     synchronized double getTwentyMinuteRate() {
-        return twentyMinuteRate;
+        return getRate(twentyMinuteRate);
     }
 
     boolean reportIfNeeded(Duration reportingDuration) {
@@ -215,7 +217,12 @@ abstract class SegmentAggregates {
 
         @Override
         protected long getUpdateCountDelta(long dataLength, int numOfEvents) {
-            return dataLength / 1024;
+            return dataLength;
+        }
+
+        @Override
+        protected double getRate(double rate) {
+            return rate / 1024;
         }
     }
 
@@ -232,6 +239,11 @@ abstract class SegmentAggregates {
         @Override
         protected long getUpdateCountDelta(long dataLength, int numOfEvents) {
             return numOfEvents;
+        }
+
+        @Override
+        protected double getRate(double rate) {
+            return rate;
         }
     }
 
@@ -253,6 +265,11 @@ abstract class SegmentAggregates {
         @Override
         protected long getUpdateCountDelta(long dataLength, int numOfEvents) {
             return 0;
+        }
+
+        @Override
+        protected double getRate(double rate) {
+            return rate;
         }
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
@@ -148,16 +148,22 @@ class SegmentStatsRecorderImpl implements SegmentStatsRecorder {
     }
 
     @Override
-    public void deleteSegment(String segmentName) {
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(segmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(segmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_READ_BYTES, segmentTags(segmentName));
+    public void deleteSegment(String streamSegmentName) {
+        // Do not close the counter of parent segment when deleting transaction segment.
+        if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_READ_BYTES, segmentTags(streamSegmentName));
+        }
     }
 
     @Override
     public void sealSegment(String streamSegmentName) {
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
-        getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+        // Do not close the counter of parent segment when sealing transaction segment.
+        if (!StreamSegmentNameUtils.isTransactionSegment(streamSegmentName)) {
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_BYTES, segmentTags(streamSegmentName));
+            getDynamicLogger().freezeCounter(SEGMENT_WRITE_EVENTS, segmentTags(streamSegmentName));
+        }
         if (getSegmentAggregate(streamSegmentName) != null) {
             cache.invalidate(streamSegmentName);
             reporter.notifySealed(streamSegmentName);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -185,6 +186,13 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     }
 
     @Override
+    public synchronized Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+        return getAttributes().entrySet().stream()
+                              .filter(e -> filter.test(e.getKey(), e.getValue()))
+                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "Id = %d, Start = %d, Length = %d, StorageLength = %d, Sealed(M/S) = %s/%s, Deleted = %s, Name = %s",
@@ -275,7 +283,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
     @Override
     public synchronized void setLastModified(ImmutableDate date) {
         this.lastModified = date;
-        log.trace("{}: LastModified = {}.", this.lastModified);
+        log.trace("{}: LastModified = {}.", this.traceObjectId, this.lastModified);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiPredicate;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
 
@@ -131,6 +132,11 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Override
     public SegmentProperties getSnapshot() {
         throw new UnsupportedOperationException("getSnapshot() is not supported on " + getClass().getName());
+    }
+
+    @Override
+    public Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+        throw new UnsupportedOperationException("getAttributes(BiPredicate) is not supported on " + getClass().getName());
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -224,7 +224,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 // every single byte in the entry has been truncated out.
                 long lastOffset = entry.getLastStreamSegmentOffset();
                 boolean canRemove = entry.isDataEntry()
-                        && lastOffset <= this.metadata.getStorageLength()
+                        && lastOffset < this.metadata.getStorageLength()
                         && (entry.getGeneration() < oldestGeneration || lastOffset < this.metadata.getStartOffset());
                 if (canRemove) {
                     toRemove.add(entry);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -804,7 +804,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     public void testCacheEviction() throws Exception {
         // Create a CachePolicy with a set number of generations and a known max size.
         // Each generation contains exactly one entry, so the number of generations is also the number of entries.
-        final int appendSize = 100;
+        // We append one byte at each time. This allows us to test edge cases as well by having the finest precision when
+        // it comes to selecting which bytes we want evicted and which kept.
+        final int appendSize = 1;
         final int entriesPerSegment = 100; // This also doubles as number of generations (each generation, we add one append for each segment).
         final int cacheMaxSize = SEGMENT_COUNT * entriesPerSegment * appendSize;
         final int postStorageEntryCount = entriesPerSegment / 4; // 25% of the entries are beyond the StorageOffset

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/DynamicLoggerImpl.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import io.pravega.common.LoggerHelpers;
 import io.pravega.shared.MetricsNames;
 import lombok.extern.slf4j.Slf4j;
 
@@ -94,15 +95,18 @@ public class DynamicLoggerImpl implements DynamicLogger {
     public void incCounterValue(String name, long delta, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(delta);
+        long traceId = LoggerHelpers.traceEnter(log, "incCounterValue", name, delta, tags);
         try {
             MetricsNames.MetricKey keys = metricKey(name, tags);
             Counter counter = countersCache.get(keys.getCacheKey(), new Callable<Counter>() {
                 @Override
                 public Counter call() throws Exception {
+                    LoggerHelpers.traceLeave(log, "createCounter", traceId, keys.getRegistryKey(), tags);
                     return underlying.createCounter(keys.getRegistryKey(), tags);
                 }
             });
             counter.add(delta);
+            LoggerHelpers.traceLeave(log, "counter.add", traceId, counter.get(), delta);
         } catch (ExecutionException e) {
             log.error("Error while countersCache create counter", e);
         }
@@ -111,40 +115,50 @@ public class DynamicLoggerImpl implements DynamicLogger {
     @Override
     public void updateCounterValue(String name, long value, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
+        long traceId = LoggerHelpers.traceEnter(log, "updateCounterValue", name, value, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             counter.clear();
+            LoggerHelpers.traceLeave(log, "counter.clear", traceId, counter.getId());
         } else {
             counter = underlying.createCounter(keys.getRegistryKey(), tags);
+            LoggerHelpers.traceLeave(log, "createCounter", traceId, keys.getRegistryKey(), tags);
         }
         counter.add(value);
+        LoggerHelpers.traceLeave(log, "counter.add", traceId, counter.getId(), value);
         countersCache.put(keys.getCacheKey(), counter);
     }
 
     @Override
     public void freezeCounter(String name, String... tags) {
+        long traceId = LoggerHelpers.traceEnter(log, "freezeCounter", name, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Counter counter = countersCache.getIfPresent(keys.getCacheKey());
         if (counter != null) {
             metrics.remove(counter.getId());
+            LoggerHelpers.traceLeave(log, "metrics.remove", traceId, counter.getId());
         }
         countersCache.invalidate(keys.getRegistryKey());
+        LoggerHelpers.traceLeave(log, "counterCache.invalidate", traceId, keys.getRegistryKey());
     }
 
     @Override
     public <T extends Number> void reportGaugeValue(String name, T value, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(value);
+        long traceId = LoggerHelpers.traceEnter(log, "reportGaugeValue", name, value, tags);
         try {
             MetricsNames.MetricKey keys = metricKey(name, tags);
             Gauge gauge = gaugesCache.get(keys.getCacheKey(), new Callable<Gauge>() {
                 @Override
                 public Gauge call() throws Exception {
+                    LoggerHelpers.traceLeave(log, "registerGauge", traceId, keys.getRegistryKey(), value.doubleValue(), tags);
                     return underlying.registerGauge(keys.getRegistryKey(), value::doubleValue, tags);
                 }
             });
             gauge.setSupplier(value::doubleValue);
+            LoggerHelpers.traceLeave(log, "gauge.setSupplier", traceId, gauge.getId(), value.doubleValue());
         } catch (ExecutionException e) {
             log.error("Error accessing gauge through gaugesCache", e);
         }
@@ -152,27 +166,33 @@ public class DynamicLoggerImpl implements DynamicLogger {
 
     @Override
     public void freezeGaugeValue(String name, String... tags) {
+        long traceId = LoggerHelpers.traceEnter(log, "freezeGaugeValue", name, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         Gauge gauge = gaugesCache.getIfPresent(keys.getCacheKey());
         if (gauge != null) {
             metrics.remove(gauge.getId());
+            LoggerHelpers.traceLeave(log, "metrics.remove", traceId, gauge.getId());
         }
         gaugesCache.invalidate(keys.getCacheKey());
+        LoggerHelpers.traceLeave(log, "gaugeCache.invalidate", traceId, keys.getCacheKey());
     }
 
     @Override
     public void recordMeterEvents(String name, long number, String... tags) {
         Exceptions.checkNotNullOrEmpty(name, "name");
         Preconditions.checkNotNull(number);
+        long traceId = LoggerHelpers.traceEnter(log, "recordMeterEvents", name, number, tags);
         MetricsNames.MetricKey keys = metricKey(name, tags);
         try {
             Meter meter = metersCache.get(keys.getCacheKey(), new Callable<Meter>() {
                 @Override
                 public Meter call() throws Exception {
+                    LoggerHelpers.traceLeave(log, "createMeter", traceId, keys.getRegistryKey(), tags);
                     return underlying.createMeter(keys.getRegistryKey(), tags);
                 }
             });
             meter.recordEvents(number);
+            LoggerHelpers.traceLeave(log, "meter.recordEvents", traceId, meter.getId(), number);
         } catch (ExecutionException e) {
             log.error("Error while metersCache create meter", e);
         }

--- a/test/system/src/main/java/io/pravega/test/system/SingleJUnitTestRunner.java
+++ b/test/system/src/main/java/io/pravega/test/system/SingleJUnitTestRunner.java
@@ -43,7 +43,19 @@ public class SingleJUnitTestRunner extends BlockJUnit4ClassRunner {
         Method m = null;
         try {
             m = this.testClass.getDeclaredMethod(this.methodName);
-            Statement statement = methodBlock(new FrameworkMethod(m));
+            Statement statement = methodBlock(new FrameworkMethod(m) {
+                @Override
+                public Object invokeExplosively(final Object target, final Object... params) throws Throwable {
+                    try {
+                        Object result = super.invokeExplosively(target, params);
+                        log.info("Test " + methodName + " completed without error.");
+                        return result;
+                    } catch (Throwable t) {
+                        log.error("Test " + methodName + " failed with exception. ", t);
+                        throw t;
+                    }
+                }
+            });
             statement.evaluate();
         } catch (Throwable ex) {
             throw new TestFrameworkException(TestFrameworkException.Type.InternalError, "Exception while running test" +

--- a/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/RemoteSequential.java
@@ -60,6 +60,8 @@ public class RemoteSequential implements TestExecutor {
             if (response.status() != CREATED.code()) {
                 throw new TestFrameworkException(TestFrameworkException.Type.ConnectionFailed, "Error while starting " +
                         "test " + testMethod);
+            } else {
+                log.info("Created job succeeded with: " + response.toString());
             }
         }).thenCompose(v2 -> waitForJobCompletion(jobId, client))
                 .<Void>thenApply(v1 -> {

--- a/test/system/src/main/java/io/pravega/test/system/framework/SystemTestRunner.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/SystemTestRunner.java
@@ -85,6 +85,7 @@ public class SystemTestRunner extends BlockJUnit4ClassRunner {
                 eachNotifier.fireTestStarted();
                 execute(type, method.getMethod()).get();
             } catch (Throwable e) {
+                log.error("Test " + method + " failed with exception ", e);
                 eachNotifier.addFailure(unwrap(e));
             } finally {
                 eachNotifier.fireTestFinished();

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -71,7 +71,7 @@ public class K8SequentialExecutor implements TestExecutor {
                              verifyPravegaPodRestart(podStatusBeforeTest, getPravegaPodStatus(client));
                              if (s.getExitCode() != 0) {
                                  log.error("Test {}#{} failed. Details: {}", className, methodName, s);
-                                 throw new AssertionError(methodName + " test failed.");
+                                 throw new AssertionError(methodName + " test failed due to " + s.getReason() + " with message " + s.getMessage());
                              } else {
                                  return null;
                              }

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -203,6 +203,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
                 } catch (Throwable e) {
                     log.error("Test exception in writing events: ", e);
                     testState.getWriteException.set(e);
+                    break;
                 }
             }
             log.info("Completed writing");
@@ -294,6 +295,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
                 } catch (Throwable e) {
                     log.error("Test exception in reading events: ", e);
                     testState.getReadException.set(e);
+                    break;
                 }
             }
             log.info("Completed reading");

--- a/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BookieFailoverTest.java
@@ -144,55 +144,51 @@ public class BookieFailoverTest extends AbstractFailoverTests  {
 
     @Test
     public void bookieFailoverTest() throws ExecutionException, InterruptedException {
+        createWriters(clientFactory, NUM_WRITERS, SCOPE, STREAM);
+        createReaders(clientFactory, readerGroupName, SCOPE, readerGroupManager, STREAM, NUM_READERS);
 
-        try {
-            createWriters(clientFactory, NUM_WRITERS, SCOPE, STREAM);
-            createReaders(clientFactory, readerGroupName, SCOPE, readerGroupManager, STREAM, NUM_READERS);
+        // Give some time to create readers before forcing a bookie failover.
+        Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
 
-            // Give some time to create readers before forcing a bookie failover.
-            Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
+        // Scale down bookie.
+        Futures.getAndHandleExceptions(bookkeeperService.scaleService(2), ExecutionException::new);
 
-            // Scale down bookie.
-            Futures.getAndHandleExceptions(bookkeeperService.scaleService(2), ExecutionException::new);
+        log.info("Sleeping for {} seconds.", BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
+        Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
 
-            log.info("Sleeping for {} seconds.", BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
-            Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
+        long writeCountBeforeSleep  = testState.getEventWrittenCount();
+        log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountBeforeSleep, BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
 
-            long writeCountBeforeSleep  = testState.getEventWrittenCount();
-            log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountBeforeSleep, BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
+        log.info("Sleeping for {} seconds.", BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
+        Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
 
-            log.info("Sleeping for {} seconds.", BOOKIE_FAILOVER_WAIT_MILLIS / 1000);
-            Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
+        long writeCountAfterSleep  = testState.getEventWrittenCount();
+        log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountAfterSleep, 2 * (BOOKIE_FAILOVER_WAIT_MILLIS / 1000));
 
-            long writeCountAfterSleep  = testState.getEventWrittenCount();
-            log.info("Write count is {} after {} seconds sleep after bookie failover.", writeCountAfterSleep, 2 * (BOOKIE_FAILOVER_WAIT_MILLIS / 1000));
+        Assert.assertEquals("Unexpected writes performed during Bookie failover.", writeCountAfterSleep, writeCountBeforeSleep);
+        log.info("Writes failed when bookie is scaled down.");
 
-            Assert.assertEquals("Unexpected writes performed during Bookie failover.", writeCountAfterSleep, writeCountBeforeSleep);
-            log.info("Writes failed when bookie is scaled down.");
+        // Bring up a new bookie instance.
+        Futures.getAndHandleExceptions(bookkeeperService.scaleService(3), ExecutionException::new);
 
-            // Bring up a new bookie instance.
-            Futures.getAndHandleExceptions(bookkeeperService.scaleService(3), ExecutionException::new);
+        // Give some more time to writers to write more events.
+        Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
+        stopWriters();
 
-            // Give some more time to writers to write more events.
-            Exceptions.handleInterrupted(() -> Thread.sleep(BOOKIE_FAILOVER_WAIT_MILLIS));
-            stopWriters();
+        // Also, verify writes happened after bookie is brought back.
+        long finalWriteCount = testState.getEventWrittenCount();
+        log.info("Final write count {}.", finalWriteCount);
+        Assert.assertTrue(finalWriteCount > writeCountAfterSleep);
 
-            // Also, verify writes happened after bookie is brought back.
-            long finalWriteCount = testState.getEventWrittenCount();
-            log.info("Final write count {}.", finalWriteCount);
-            Assert.assertTrue(finalWriteCount > writeCountAfterSleep);
+        stopReaders();
 
-            stopReaders();
+        // Verify that there is no data loss/duplication.
+        validateResults();
 
-            // Verify that there is no data loss/duplication.
-            validateResults();
+        // Cleanup if validation is successful.
+        cleanUp(SCOPE, STREAM, readerGroupManager, readerGroupName);
 
-            // Cleanup if validation is successful.
-            cleanUp(SCOPE, STREAM, readerGroupManager, readerGroupName);
-
-            log.info("Test BookieFailover succeeds.");
-        } finally {
-            testState.checkForAnomalies();
-        }
+        testState.checkForAnomalies();
+        log.info("Test BookieFailover succeeds.");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderTxnWriterWithFailoverTest.java
@@ -132,23 +132,20 @@ public class MultiReaderTxnWriterWithFailoverTest extends AbstractFailoverTests 
 
     @Test
     public void multiReaderTxnWriterWithFailOverTest() throws Exception {
-        try {
-            createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
+        createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
 
-            //run the failover test
-            performFailoverForTestsInvolvingTxns();
+        //run the failover test
+        performFailoverForTestsInvolvingTxns();
 
-            stopWriters();
-            waitForTxnsToComplete();
-            stopReaders();
-            validateResults();
+        stopWriters();
+        waitForTxnsToComplete();
+        stopReaders();
+        validateResults();
 
-            cleanUp(scope, STREAM_NAME, readerGroupManager, readerGroupName); //cleanup if validation is successful.
+        cleanUp(scope, STREAM_NAME, readerGroupManager, readerGroupName); //cleanup if validation is successful.
 
-            log.info("Test MultiReaderWriterTxnWithFailOver succeeds");
-        } finally {
-            testState.checkForAnomalies();
-        }
+        testState.checkForAnomalies();
+        log.info("Test MultiReaderWriterTxnWithFailOver succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/MultiReaderWriterWithFailOverTest.java
@@ -130,22 +130,17 @@ public class MultiReaderWriterWithFailOverTest extends AbstractFailoverTests {
 
     @Test
     public void multiReaderWriterWithFailOverTest() throws Exception {
-        try {
-            createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
+        createWriters(clientFactory, NUM_WRITERS, scope, STREAM_NAME);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, STREAM_NAME, NUM_READERS);
 
-            //run the failover test
-            performFailoverTest();
+        //run the failover test
+        performFailoverTest();
 
-            stopWriters();
-            stopReaders();
-            validateResults();
-
-            cleanUp(scope, STREAM_NAME, readerGroupManager, readerGroupName); //cleanup if validation is successful.
-
-            log.info("Test MultiReaderWriterWithFailOver succeeds");
-        } finally {
-            testState.checkForAnomalies();
-        }
+        stopWriters();
+        stopReaders();
+        validateResults();
+        cleanUp(scope, STREAM_NAME, readerGroupManager, readerGroupName); //cleanup if validation is successful.
+        testState.checkForAnomalies();
+        log.info("Test MultiReaderWriterWithFailOver succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadTxnWriteAutoScaleWithFailoverTest.java
@@ -131,42 +131,39 @@ public class ReadTxnWriteAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @Test
     public void readTxnWriteAutoScaleWithFailoverTest() throws Exception {
-        try {
-            createWriters(clientFactory, INIT_NUM_WRITERS, scope, stream);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, stream, NUM_READERS);
+        createWriters(clientFactory, INIT_NUM_WRITERS, scope, stream);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, stream, NUM_READERS);
 
-            //run the failover test before scaling
-            performFailoverForTestsInvolvingTxns();
+        //run the failover test before scaling
+        performFailoverForTestsInvolvingTxns();
 
-            //bring the instances back to 3 before performing failover during scaling
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover during scaling
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, stream);
+        addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, stream);
 
-            //run the failover test while scaling
-            performFailoverForTestsInvolvingTxns();
+        //run the failover test while scaling
+        performFailoverForTestsInvolvingTxns();
 
-            waitForScaling(scope, stream, config);
+        waitForScaling(scope, stream, config);
 
-            //bring the instances back to 3 before performing failover
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            //run the failover test after scaling
-            performFailoverForTestsInvolvingTxns();
+        //run the failover test after scaling
+        performFailoverForTestsInvolvingTxns();
 
-            stopWriters();
-            waitForTxnsToComplete();
-            stopReaders();
-            validateResults();
+        stopWriters();
+        waitForTxnsToComplete();
+        stopReaders();
+        validateResults();
 
-            cleanUp(scope, stream, readerGroupManager, readerGroupName); //cleanup if validation is successful.
-            log.info("Test ReadTxnWriteAutoScaleWithFailover succeeds");
-        } finally {
-            testState.checkForAnomalies();
-        }
+        cleanUp(scope, stream, readerGroupManager, readerGroupName); //cleanup if validation is successful.
+        testState.checkForAnomalies();
+        log.info("Test ReadTxnWriteAutoScaleWithFailover succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndAutoScaleWithFailoverTest.java
@@ -133,41 +133,38 @@ public class ReadWriteAndAutoScaleWithFailoverTest extends AbstractFailoverTests
 
     @Test
     public void readWriteAndAutoScaleWithFailoverTest() throws Exception {
-        try {
-            createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
+        createWriters(clientFactory, INIT_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, AUTO_SCALE_STREAM, NUM_READERS);
 
-            //run the failover test before scaling
-            performFailoverTest();
+        //run the failover test before scaling
+        performFailoverTest();
 
-            //bring the instances back to 3 before performing failover during scaling
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover during scaling
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
+        addNewWriters(clientFactory, ADD_NUM_WRITERS, scope, AUTO_SCALE_STREAM);
 
-            //run the failover test while scaling
-            performFailoverTest();
+        //run the failover test while scaling
+        performFailoverTest();
 
-            waitForScaling(scope, AUTO_SCALE_STREAM, config);
+        waitForScaling(scope, AUTO_SCALE_STREAM, config);
 
-            //bring the instances back to 3 before performing failover
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            //run the failover test after scaling
-            performFailoverTest();
+        //run the failover test after scaling
+        performFailoverTest();
 
-            stopWriters();
-            stopReaders();
-            validateResults();
+        stopWriters();
+        stopReaders();
+        validateResults();
 
-            cleanUp(scope, AUTO_SCALE_STREAM, readerGroupManager, readerGroupName); //cleanup if validation is successful.
-            log.info("Test ReadWriteAndAutoScaleWithFailover succeeds");
-        } finally {
-            testState.checkForAnomalies();
-        }
+        cleanUp(scope, AUTO_SCALE_STREAM, readerGroupManager, readerGroupName); //cleanup if validation is successful.
+        testState.checkForAnomalies();
+        log.info("Test ReadWriteAndAutoScaleWithFailover succeeds");
     }
 }

--- a/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ReadWriteAndScaleWithFailoverTest.java
@@ -138,68 +138,65 @@ public class ReadWriteAndScaleWithFailoverTest extends AbstractFailoverTests {
 
     @Test
     public void readWriteAndScaleWithFailoverTest() throws Exception {
-        try {
-            createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
-            createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
+        createWriters(clientFactory, NUM_WRITERS, scope, SCALE_STREAM);
+        createReaders(clientFactory, readerGroupName, scope, readerGroupManager, SCALE_STREAM, NUM_READERS);
 
-            //run the failover test before scaling
-            performFailoverTest();
+        //run the failover test before scaling
+        performFailoverTest();
 
-            //bring the instances back to 3 before performing failover during scaling
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+        //bring the instances back to 3 before performing failover during scaling
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
 
-            //scale manually
-            log.debug("Number of Segments before manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
-                    .get().getSegments().size());
+        //scale manually
+        log.debug("Number of Segments before manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
+                  .get().getSegments().size());
 
-            Map<Double, Double> keyRanges = new HashMap<>();
-            keyRanges.put(0.0, 0.2);
-            keyRanges.put(0.2, 0.4);
-            keyRanges.put(0.4, 0.6);
-            keyRanges.put(0.6, 0.8);
-            keyRanges.put(0.8, 1.0);
+        Map<Double, Double> keyRanges = new HashMap<>();
+        keyRanges.put(0.0, 0.2);
+        keyRanges.put(0.2, 0.4);
+        keyRanges.put(0.4, 0.6);
+        keyRanges.put(0.6, 0.8);
+        keyRanges.put(0.8, 1.0);
 
-            CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
-                    Collections.singletonList(0L),
-                    keyRanges,
-                    executorService).getFuture();
-            Futures.exceptionListener(scaleStatus, t -> log.error("Scale Operation completed with an error", t));
+        CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, SCALE_STREAM),
+                                                                        Collections.singletonList(0L),
+                                                                        keyRanges,
+                                                                        executorService).getFuture();
+        Futures.exceptionListener(scaleStatus, t -> log.error("Scale Operation completed with an error", t));
 
-            //run the failover test while scaling
-            performFailoverTest();
+        //run the failover test while scaling
+        performFailoverTest();
 
-            //do a get on scaleStatus
-            if (Futures.await(scaleStatus)) {
-                log.info("Scale operation has completed: {}", scaleStatus.get());
-                if (!scaleStatus.get()) {
-                    log.error("Scale operation did not complete", scaleStatus.get());
-                    Assert.fail("Scale operation did not complete successfully");
-                }
-            } else {
-                Assert.fail("Scale operation threw an exception");
+        //do a get on scaleStatus
+        if (Futures.await(scaleStatus)) {
+            log.info("Scale operation has completed: {}", scaleStatus.get());
+            if (!scaleStatus.get()) {
+                log.error("Scale operation did not complete", scaleStatus.get());
+                Assert.fail("Scale operation did not complete successfully");
             }
-
-            log.debug("Number of Segments post manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
-                    .get().getSegments().size());
-
-            //bring the instances back to 3 before performing failover after scaling
-            Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
-            Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
-            Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
-
-            //run the failover test after scaling
-            performFailoverTest();
-
-            stopWriters();
-            stopReaders();
-            validateResults();
-
-            cleanUp(scope, SCALE_STREAM, readerGroupManager, readerGroupName); //cleanup if validation is successful.
-            log.info("Test ReadWriteAndScaleWithFailover succeeds");
-        } finally {
-            testState.checkForAnomalies();
+        } else {
+            Assert.fail("Scale operation threw an exception");
         }
+
+        log.debug("Number of Segments post manual scale: {}", controller.getCurrentSegments(scope, SCALE_STREAM)
+                  .get().getSegments().size());
+
+        //bring the instances back to 3 before performing failover after scaling
+        Futures.getAndHandleExceptions(controllerInstance.scaleService(3), ExecutionException::new);
+        Futures.getAndHandleExceptions(segmentStoreInstance.scaleService(3), ExecutionException::new);
+        Exceptions.handleInterrupted(() -> Thread.sleep(WAIT_AFTER_FAILOVER_MILLIS));
+
+        //run the failover test after scaling
+        performFailoverTest();
+
+        stopWriters();
+        stopReaders();
+        validateResults();
+
+        cleanUp(scope, SCALE_STREAM, readerGroupManager, readerGroupName); //cleanup if validation is successful.
+        testState.checkForAnomalies();
+        log.info("Test ReadWriteAndScaleWithFailover succeeds");
     }
 }

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -67,6 +67,28 @@ public class AssertExtensions {
     }
 
     /**
+     * Invokes `eval` in a loop over and over (with a small sleep) and asserts that the value eventually reaches `expected`.
+     *
+     * @param <T>                 The type of the value to compare.
+     * @param message             The message ot include.
+     * @param expected            The expected return value.
+     * @param eval                The function to test
+     * @param checkIntervalMillis The number of milliseconds to wait between two checks.
+     * @param timeoutMillis       The timeout in milliseconds after which an assertion error should be thrown.
+     * @throws Exception If the is an assertion error, and exception from `eval`, or the thread is interrupted.
+     */
+    public static <T> void assertEventuallyEquals(String message, T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
+        long remainingMillis = timeoutMillis;
+        while (remainingMillis > 0) {
+            if ((expected == null && eval.call() == null) || (expected != null && expected.equals(eval.call()))) {
+                return;
+            }
+            Thread.sleep(checkIntervalMillis);
+        }
+        assertEquals(message, expected, eval.call());
+    }
+
+    /**
      * Asserts that an exception of the Type provided is thrown.
      *
      * @param run  The Runnable to execute.


### PR DESCRIPTION
**Change log description**  
* Cherry-picks recent fixes in master.

**Purpose of the change**  
Fixes #3945

**What the code does**  
It brings in the following list of changes:

```
    Issue 3736: Reduce log severity for CancellationException inside AppendProcessor. (#3766)
    Issue 3692: Do not remove counter of parent segment when delete or seal txn segment (#3924)
    Issue 3933: Calculated byte rate for autoscaling is underestimated (#3934)
    Issue 3929: (SegmentStore) Cache eviction bug fix. (#3930)
    Issue 3859: Fix scale_segmentStore script for external access (#3868)
    Issue 3916: (SegmentStore) Reduce logging verbosity of IllegalContainerStateException. (#3917)
    Issue 3904: Fix PravegaTableStreamMetadataStore's garbage collection for old batch gc (#3911)
    Issue 3425: Ensure the Sealed segment writer is removed after all inflight events are resent to the newer segment writers. (#3901)
    Issue 3907: Sporadic build failure in PravegaTablesStreamMetadataTasksTest.sealStreamWithTx (#3908)
    Issue 3893: System test logging (#3894)
    Issue 3853: (SegmentStore) Bugfix for ConcurrentModificationException in SegmentAttributeIterator (#3862)
    Issue 3847: Fix issues causing error in extracting client credentials  (#3849)
    Issue 3882: ControllerClusterListener test mocks invoke the method once with null/empty values (#3885)
    Issue 3867: RequestSweeper has incorrect exit check in doWhile loop  (#3871)
    Issue 3718: Fixed flaky unit tests in OperationProcessorTests. (#3879)
```

**How to verify it**  
(Optional: steps to verify that the changes are effective)
