### PR TITLE
Issue 3948: Log KeepAlives at Trace level

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -40,7 +40,12 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         Request cmd = (Request) msg;
-        log.debug("Processing request: {}", cmd);
+        if (cmd.mustLog()) {
+            log.debug("Received request: {}", cmd);
+        } else {
+            log.trace("Received request: {}", cmd);
+        }
+
         RequestProcessor requestProcessor = processor.get();
         if (requestProcessor == null) {
             throw new IllegalStateException("No command processor set for connection");

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -141,7 +141,7 @@ public class FailingRequestProcessor implements RequestProcessor {
 
     @Override
     public void keepAlive(KeepAlive keepAlive) {
-        log.debug("Received KeepAlive");
+        // This method intentionally left blank.
     }
 
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
@@ -17,4 +17,8 @@ public interface Request {
     long getRequestId();
     
     void process(RequestProcessor cp);
+
+    default boolean mustLog() {
+        return true;
+    }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1505,6 +1505,11 @@ public final class WireCommands {
         public long getRequestId() {
             return -1;
         }
+
+        @Override
+        public boolean mustLog() {
+            return false;
+        }
     }
 
     @Data


### PR DESCRIPTION
**Change log description**  
- Logging `WireCommand.KeepAlive` as `TRACE`

**Purpose of the change**  
Fixes #3948.

**What the code does**  
See description.

**How to verify it**  
Build must pass.
