### PR TITLE
Issue 3774: Update the default max connection and Netty channel water marking for performance Improvement

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Builder(toBuilder = true)
 public class ClientConfig implements Serializable {
 
-    static final int DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE = 5;
+    static final int DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE = 10;
     private static final long serialVersionUID = 1L;
 
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -72,8 +72,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     //region Members
 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
-    private static final int HIGH_WATER_MARK = 640 * 1024; // 640KB
-    private static final int LOW_WATER_MARK = 320 * 1024;  // 320KB
+    private static final int HIGH_WATER_MARK = 1024 * 1024; // 1MB
+    private static final int LOW_WATER_MARK = 640 * 1024;  // 640KB
     private static final String EMPTY_STACK_TRACE = "";
     private final StreamSegmentStore store;
     private final ServerConnection connection;


### PR DESCRIPTION
**Change log description**  
The default max connections per segment store is set to 10 and in the append processor netty channel water marking low and high values are set to 640KB And 1MB respectively.

**Purpose of the change**  
Fixes #3774

**What the code does**  
Since the current value of DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE is 5 and its not adequate to keep at least 10 writers ;  so, its set as 10 to improve the throughput.
Similarly, due to connection pooling a single netty channel is expected to more data due to multiple writers/reader, hence the netty channel water marking low and high values are set to 640KB And 1MB respectively.


**How to verify it**  
Pravega is tested with unit tests and integration tests.
Pravega is tested with bare-metal deployment with 1 controller and 3 segment nodes on Lagaunitas (white cluster).
Benchmark mark tool : https://github.com/pravega/pravega-benchmark is used for performance bench-marking.

Here are the performance bench marking numbers fro 10 writers with 1K event size on lagunitas cluster with isilon as tier2

without fix:
Worst performance : 9-10 MB/s ,  Average performance : 18 - 20 MB/s  , Best performance :  40- 50MB/s

With this fix:
Worst performance : 18-36 MB/s ,  Average performance : 50 - 60 MB/s  , Best performance :  75 - 100MB/s

Signed-off-by: Keshava Munegowda keshava.munegowda@dell.com