### PR TITLE
Issue 3983: Cherry-pick commits from master to r0.5

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Builder(toBuilder = true)
 public class ClientConfig implements Serializable {
 
-    static final int DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE = 5;
+    static final int DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE = 10;
     private static final long serialVersionUID = 1L;
 
 

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -37,7 +37,6 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.pravega.client.ClientConfig;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
-import io.pravega.shared.protocol.netty.AppendBatchSizeTracker;
 import io.pravega.shared.protocol.netty.CommandDecoder;
 import io.pravega.shared.protocol.netty.CommandEncoder;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
@@ -119,8 +118,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
         } else {
             // create a new connection.
             log.info("Creating a new connection to {}", location);
-            final AppendBatchSizeTracker batchSizeTracker = new AppendBatchSizeTrackerImpl();
-            final FlowHandler handler = new FlowHandler(location.getEndpoint(), batchSizeTracker);
+            final FlowHandler handler = new FlowHandler(location.getEndpoint());
             CompletableFuture<Void> establishedFuture = establishConnection(location, handler);
             connection = new Connection(location, handler, establishedFuture);
             prunedConnectionList.add(connection);
@@ -131,14 +129,14 @@ public class ConnectionPoolImpl implements ConnectionPool {
     }
 
     @Override
+    @Synchronized
     public CompletableFuture<ClientConnection> getClientConnection(PravegaNodeUri location, ReplyProcessor rp) {
         Preconditions.checkNotNull(location, "Location");
         Preconditions.checkNotNull(rp, "ReplyProcessor");
         Exceptions.checkNotClosed(closed.get(), this);
 
         // create a new connection.
-        final AppendBatchSizeTracker batchSizeTracker = new AppendBatchSizeTrackerImpl();
-        final FlowHandler handler = new FlowHandler(location.getEndpoint(), batchSizeTracker);
+        final FlowHandler handler = new FlowHandler(location.getEndpoint());
         CompletableFuture<Void> connectedFuture = establishConnection(location, handler);
         Connection connection = new Connection(location, handler, connectedFuture);
         ClientConnection result = connection.getFlowHandler().createConnectionWithFlowDisabled(rp);
@@ -248,7 +246,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
                 }
                 p.addLast(
                         new ExceptionLoggingHandler(location.getEndpoint()),
-                        new CommandEncoder(handler.getBatchSizeTracker()),
+                        new CommandEncoder(handler::getAppendBatchSizeTracker),
                         new LengthFieldBasedFrameDecoder(WireCommands.MAX_WIRECOMMAND_SIZE, 4, 4),
                         new CommandDecoder(),
                         handler);

--- a/client/src/main/java/io/pravega/client/netty/impl/Flow.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/Flow.java
@@ -46,7 +46,7 @@ public class Flow {
      * @return Flow.
      */
     public static Flow create() {
-        return new Flow(ID_GENERATOR.updateAndGet(i -> i == Integer.MAX_VALUE ? 0 : i + 1), 0);
+        return new Flow(ID_GENERATOR.updateAndGet(i -> i == Integer.MAX_VALUE ? 1 : i + 1), 0);
     }
 
     /**
@@ -57,6 +57,16 @@ public class Flow {
      */
     public static Flow from(long flowAsLong) {
         return new Flow((int) (flowAsLong >> 32), (int) flowAsLong);
+    }
+
+    /**
+     * Obtain a FlowID from a {@code long} representation.
+     *
+     * @param requestID request identifier.
+     * @return Flow ID.
+     */
+    public static int toFlowID(long requestID) {
+        return (int) (requestID >> 32);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -36,23 +36,23 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoCloseable {
 
-    private static final int FLOW_DISABLED = -1;
+    private static final int FLOW_DISABLED = 0;
     private final String connectionName;
     private final AtomicReference<Channel> channel = new AtomicReference<>();
     private final AtomicReference<ScheduledFuture<?>> keepAliveFuture = new AtomicReference<>();
     private final AtomicBoolean recentMessage = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
     @Getter
-    private final AppendBatchSizeTracker batchSizeTracker;
     private final ReusableFutureLatch<Void> registeredFutureLatch = new ReusableFutureLatch<>();
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)
     private final ConcurrentHashMap<Integer, ReplyProcessor> flowIdReplyProcessorMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, AppendBatchSizeTracker> flowIDBatchSizeTrackerMap = new ConcurrentHashMap<>();
+
     private final AtomicBoolean disableFlow = new AtomicBoolean(false);
 
-    public FlowHandler(String connectionName, AppendBatchSizeTracker batchSizeTracker) {
+    public FlowHandler(String connectionName) {
         this.connectionName = connectionName;
-        this.batchSizeTracker = batchSizeTracker;
     }
 
     /**
@@ -64,11 +64,13 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
     public ClientConnection createFlow(final Flow flow, final ReplyProcessor rp) {
         Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkState(!disableFlow.get(), "Ensure flows are enabled.");
+        final int flowID = flow.getFlowId();
         log.info("Creating Flow {} for endpoint {}. The current Channel is {}.", flow.getFlowId(), connectionName, channel.get());
-        if (flowIdReplyProcessorMap.put(flow.getFlowId(), rp) != null) {
-            throw new IllegalArgumentException("Multiple flows cannot be created with the same Flow id " + flow.getFlowId());
+        if (flowIdReplyProcessorMap.put(flowID, rp) != null) {
+            throw new IllegalArgumentException("Multiple flows cannot be created with the same Flow id " + flowID);
         }
-        return new ClientConnectionImpl(connectionName, flow.getFlowId(), batchSizeTracker, this);
+        createAppendBatchSizeTrackerIfNeeded(flowID);
+        return new ClientConnectionImpl(connectionName, flowID, this);
     }
 
     /**
@@ -82,7 +84,8 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         Preconditions.checkState(!disableFlow.getAndSet(true), "Flows are disabled, incorrect usage pattern.");
         log.info("Creating a new connection with flow disabled for endpoint {}. The current Channel is {}.", connectionName, channel.get());
         flowIdReplyProcessorMap.put(FLOW_DISABLED, rp);
-        return new ClientConnectionImpl(connectionName, FLOW_DISABLED, batchSizeTracker, this);
+        createAppendBatchSizeTrackerIfNeeded(FLOW_DISABLED);
+        return new ClientConnectionImpl(connectionName, FLOW_DISABLED, this);
     }
 
     /**
@@ -94,6 +97,31 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         int flow = clientConnectionImpl.getFlowId();
         log.info("Closing Flow {} for endpoint {}", flow, clientConnectionImpl.getConnectionName());
         flowIdReplyProcessorMap.remove(flow);
+        flowIDBatchSizeTrackerMap.remove(flow);
+    }
+
+    /**
+     * Create a Batch size tracker, ignore if already existing
+     *
+     * @param flowID flow ID.
+     */
+    private void createAppendBatchSizeTrackerIfNeeded(final int  flowID) {
+        if (flowIDBatchSizeTrackerMap.containsKey(flowID)) {
+            log.debug("Reusing Batch size tracker for Flow ID {}.", flowID);
+        } else {
+            log.debug("Creating Batch size tracker for flow ID {}.", flowID);
+            flowIDBatchSizeTrackerMap.put(flowID, new AppendBatchSizeTrackerImpl());
+        }
+    }
+
+    /**
+     * Get a Batch size tracker for requestID.
+     *
+     * @param requestID flow ID.
+     * @return Batch size Tracker object.
+     */
+    public AppendBatchSizeTracker getAppendBatchSizeTracker(final long requestID) {
+        return flowIDBatchSizeTrackerMap.get(Flow.toFlowID(requestID));
     }
 
     /**
@@ -201,7 +229,11 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         }
 
         if (cmd instanceof WireCommands.DataAppended) {
-            batchSizeTracker.recordAck(((WireCommands.DataAppended) cmd).getEventNumber());
+            final WireCommands.DataAppended dataAppended = (WireCommands.DataAppended) cmd;
+            final AppendBatchSizeTracker batchSizeTracker = getAppendBatchSizeTracker(dataAppended.getRequestId());
+            if (batchSizeTracker != null) {
+                batchSizeTracker.recordAck(dataAppended.getEventNumber());
+            }
         }
         // Obtain ReplyProcessor and process the reply.
         getReplyProcessor(cmd).ifPresent(processor -> {
@@ -237,6 +269,10 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
                 if (openFlowCount != 0) {
                     log.warn("{} flows are not closed", openFlowCount);
                 }
+                final int appendTrackerCount = flowIDBatchSizeTrackerMap.size();
+                if (appendTrackerCount != 0) {
+                    log.warn("{} AppendBatchSizeTrackers are not closed", appendTrackerCount);
+                }
                 ch.close();
             }
         }
@@ -257,7 +293,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
     }
 
     private Optional<ReplyProcessor> getReplyProcessor(Reply cmd) {
-        int flowId = disableFlow.get() ? FLOW_DISABLED : Flow.from(cmd.getRequestId()).getFlowId();
+        int flowId = disableFlow.get() ? FLOW_DISABLED : Flow.toFlowID(cmd.getRequestId());
         final ReplyProcessor processor = flowIdReplyProcessorMap.get(flowId);
         if (processor == null) {
             log.warn("No ReplyProcessor found for the provided flowId {}. Ignoring response", flowId);

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -396,18 +396,20 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
 
     @Override
     public void listStreamsInScope(Controller.StreamsInScopeRequest request, StreamObserver<Controller.StreamsInScopeResponse> responseObserver) {
-        String scope = request.getScope().getScope();
-        RequestTag requestTag = requestTracker.initializeAndTrackRequestTag(requestIdGenerator.get(), "listStream", scope);
-        log.info(requestTag.getRequestId(), "listStream called for scope {}.", scope);
+        String scopeName = request.getScope().getScope();
+        RequestTag requestTag = requestTracker.initializeAndTrackRequestTag(requestIdGenerator.get(), "listStream", scopeName);
+        log.info(requestTag.getRequestId(), "listStream called for scope {}.", scopeName);
         authenticateExecuteAndProcessResults(
-                () -> this.authHelper.checkAuthorization(AuthResourceRepresentation.ofScope(scope),
+                () -> this.authHelper.checkAuthorization(AuthResourceRepresentation.ofScope(scopeName),
                         AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.listStreams(
-                        scope, request.getContinuationToken().getToken(), listStreamsInScopeLimit)
+                        scopeName, request.getContinuationToken().getToken(), listStreamsInScopeLimit)
                         .thenApply(response -> {
                              List<StreamInfo> streams = response.getKey().stream()
-                                     .filter(m -> authHelper.isAuthorized(m, AuthHandler.Permissions.READ))
-                                     .map(m -> StreamInfo.newBuilder().setScope(scope).setStream(m).build())
+                                     .filter(streamName -> authHelper.isAuthorized(
+                                             AuthResourceRepresentation.ofStreamInScope(scopeName, streamName),
+                                             AuthHandler.Permissions.READ))
+                                     .map(m -> StreamInfo.newBuilder().setScope(scopeName).setStream(m).build())
                                      .collect(Collectors.toList());
                              return Controller.StreamsInScopeResponse.newBuilder().addAllStreams(streams)
                                      .setContinuationToken(Controller.ContinuationToken.newBuilder().setToken(

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -62,6 +62,7 @@ import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc;
 import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc.ControllerServiceBlockingStub;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+import io.pravega.test.common.AssertExtensions;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -77,7 +78,9 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -355,6 +358,82 @@ public class ControllerGrpcAuthFocusedTest {
                 .build());
     }
 
+
+    @Test
+    public void listStreamsReturnsAllWhenUserHasWildCardAccess() {
+        // Arrange
+        String scopeName = "scope1";
+        createScopeAndStreams(scopeName, Arrays.asList("stream1", "stream2"),
+                prepareFromFixedScaleTypePolicy(2));
+
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope(scopeName).build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(2, response.getStreamsList().size());
+    }
+
+    @Test
+    public void listStreamReturnsEmptyResultWhenUserHasNoAccessToStreams() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_READ, DEFAULT_PASSWORD);
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(0, response.getStreamsList().size());
+    }
+
+    @Test
+    public void listStreamFiltersResultWhenUserHasAccessToSubsetOfStreams() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE1_STREAM1_LIST_READ, DEFAULT_PASSWORD);
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act
+        Controller.StreamsInScopeResponse response = stub.listStreamsInScope(request);
+
+        // Assert
+        assertEquals(1, response.getStreamsList().size());
+    }
+
+    @Test
+    public void listStreamThrowsExceptionWhenUserHasNoAccessToScope() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+
+        ControllerServiceBlockingStub stub = prepareCallStub(UserNames.SCOPE2_READ, DEFAULT_PASSWORD);
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act and assert
+        AssertExtensions.assertThrows("Expected auth failure.",
+                () -> stub.listStreamsInScope(request),
+                e -> e.getMessage().contains("UNAUTHENTICATED"));
+    }
+
     //region Private methods
 
     private static TxnId decode(UUID txnId) {
@@ -417,29 +496,44 @@ public class ControllerGrpcAuthFocusedTest {
                 .build();
     }
 
-    private void createScopeAndStream(String scope, String stream, ScalingPolicy scalingPolicy) {
-        Exceptions.checkNotNullOrEmpty(scope, "scope");
-        Exceptions.checkNotNullOrEmpty(scope, "stream");
-        Preconditions.checkNotNull(scalingPolicy, "scalingPolicy");
-
-        StreamConfig streamConfig = StreamConfig.newBuilder()
-                .setStreamInfo(Controller.StreamInfo.newBuilder()
-                        .setScope(scope)
-                        .setStream(stream)
-                        .build())
-                .setScalingPolicy(scalingPolicy)
-                .build();
-        createScopeAndStream(scope, streamConfig);
+    private void createScopeAndStream(String scopeName, String streamName, ScalingPolicy scalingPolicy) {
+        createScopeAndStreams(scopeName, Arrays.asList(streamName), scalingPolicy);
     }
 
-    private void createScopeAndStream(String scope, StreamConfig streamConfig) {
-        Exceptions.checkNotNullOrEmpty(scope, "scope");
-        Preconditions.checkNotNull(streamConfig, "streamConfig");
+    private void createScopeAndStreams(String scopeName, List<String> streamNames, ScalingPolicy scalingPolicy) {
+        Exceptions.checkNotNullOrEmpty(scopeName, "scope");
+        Preconditions.checkNotNull(streamNames, "stream");
+        Preconditions.checkArgument(streamNames.size() > 0);
+        Preconditions.checkNotNull(scalingPolicy, "scalingPolicy");
 
         ControllerServiceBlockingStub stub =
                 prepareCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
-        stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scope).build());
-        stub.createStream(streamConfig);
+        createScope(stub, scopeName);
+
+        streamNames.stream().forEach(n -> createStream(stub, scopeName, n, scalingPolicy));
+    }
+
+    private void createScope(ControllerServiceBlockingStub stub, String scopeName) {
+        CreateScopeStatus status = stub.createScope(Controller.ScopeInfo.newBuilder().setScope(scopeName).build());
+        if (!status.getStatus().equals(CreateScopeStatus.Status.SUCCESS)) {
+            throw new RuntimeException("Failed to create scope");
+        }
+    }
+
+    private void createStream(ControllerServiceBlockingStub stub, String scopeName,
+                              String streamName, ScalingPolicy scalingPolicy) {
+        StreamConfig streamConfig = StreamConfig.newBuilder()
+                .setStreamInfo(Controller.StreamInfo.newBuilder()
+                        .setScope(scopeName)
+                        .setStream(streamName)
+                        .build())
+                .setScalingPolicy(scalingPolicy)
+                .build();
+        Controller.CreateStreamStatus status = stub.createStream(streamConfig);
+
+        if (!status.getStatus().equals(Controller.CreateStreamStatus.Status.SUCCESS)) {
+            throw new RuntimeException("Failed to create stream");
+        }
     }
 
     private static File createAuthFile() {
@@ -451,9 +545,12 @@ public class ControllerGrpcAuthFocusedTest {
                 String defaultPassword = passwordEncryptor.encryptPassword("1111_aaaa");
                 writer.write(credentialsAndAclAsString(UserNames.ADMIN,  defaultPassword, "*,READ_UPDATE;"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE_READER, defaultPassword, "/,READ"));
+                writer.write(credentialsAndAclAsString(UserNames.SCOPE1_READ, defaultPassword, "scope1,READ"));
+                writer.write(credentialsAndAclAsString(UserNames.SCOPE2_READ, defaultPassword, "scope2,READ"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READUPDATE, defaultPassword, "scope1/stream1,READ_UPDATE"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_READ, defaultPassword, "scope1/stream1,READ"));
                 writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM2_READ, defaultPassword, "scope1/stream2,READ"));
+                writer.write(credentialsAndAclAsString(UserNames.SCOPE1_STREAM1_LIST_READ, defaultPassword, "scope1,READ;scope1/stream1,READ"));
             }
             return result;
         } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
@@ -469,8 +566,11 @@ public class ControllerGrpcAuthFocusedTest {
     private static class UserNames {
         private final static String ADMIN = "admin";
         private final static String SCOPE_READER = "scopereader";
+        private final static String SCOPE1_READ = "scope1read";
+        private final static String SCOPE2_READ = "scope2read";
         private final static String SCOPE1_STREAM1_READUPDATE = "authSc1Str1";
         private final static String SCOPE1_STREAM1_READ = "authSc1Str1readonly";
         private final static String SCOPE1_STREAM2_READ = "authSc1Str2readonly";
+        private final static String SCOPE1_STREAM1_LIST_READ = "scope1stream1lr";
     }
 }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -72,8 +72,8 @@ public class AppendProcessor extends DelegatingRequestProcessor {
     //region Members
 
     static final Duration TIMEOUT = Duration.ofMinutes(1);
-    private static final int HIGH_WATER_MARK = 128 * 1024;
-    private static final int LOW_WATER_MARK = 64 * 1024;
+    private static final int HIGH_WATER_MARK = 1024 * 1024; // 1MB
+    private static final int LOW_WATER_MARK = 640 * 1024;  // 640KB
     private static final String EMPTY_STACK_TRACE = "";
     private final StreamSegmentStore store;
     private final ServerConnection connection;

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -356,7 +356,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             connection.send(new OperationUnsupported(requestId, doingWhat, clientReplyStackTrace));
         } else if (u instanceof CancellationException) {
             // Cancellation exception is thrown when the Operation processor is shutting down.
-            log.info("Closing connection '{}' while performing append on Segment '{}' due to {}.", connection, segment, u.getMessage());
+            log.info("Closing connection '{}' while performing append on Segment '{}' due to {}.", connection, segment, u.toString());
             connection.close();
         } else {
             logError(segment, u);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -936,7 +936,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             invokeSafely(connection::send, new SegmentRead(segment, offset, true, false, EMPTY_BYTE_BUFFER, requestId), failureHandler);
         } else if (u instanceof CancellationException) {
             log.info(requestId, "Closing connection {} while performing {} due to {}.",
-                     connection, operation, u.getMessage());
+                     connection, operation, u.toString());
             connection.close();
         } else if (u instanceof AuthenticationException) {
             log.warn(requestId, "Authentication error during '{}'.", operation);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -40,7 +40,12 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         Request cmd = (Request) msg;
-        log.debug("Processing request: {}", cmd);
+        if (cmd.mustLog()) {
+            log.debug("Received request: {}", cmd);
+        } else {
+            log.trace("Received request: {}", cmd);
+        }
+
         RequestProcessor requestProcessor = processor.get();
         if (requestProcessor == null) {
             throw new IllegalStateException("No command processor set for connection");

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -138,6 +138,25 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
     }
 
     /**
+     * Updates the tail cache for the given Table Segment with the given data, which represents a pre-index result of the
+     * tail section of the Segment.
+     *
+     * @param segmentId  Segment Id.
+     * @param keyOffsets A Map of KeyHashes to {@link CacheBucketOffset} instances that represents the latest values (including
+     *                   deletions) for all the pre-indexed keys).
+     */
+    void includeTailCache(long segmentId, Map<UUID, CacheBucketOffset> keyOffsets) {
+        SegmentKeyCache cache;
+        int generation;
+        synchronized (this.segmentCaches) {
+            generation = this.currentCacheGeneration;
+            cache = this.segmentCaches.computeIfAbsent(segmentId, s -> new SegmentKeyCache(s, this.cache));
+        }
+
+        cache.includeTailCache(keyOffsets, generation);
+    }
+
+    /**
      * Updates the contents of a Cache Entry associated with the given Segment Id and KeyHash. This method cannot be
      * used to remove values.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -9,12 +9,14 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.MultiKeySequentialProcessor;
+import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
 import io.pravega.segmentstore.contracts.tables.ConditionalTableUpdateException;
@@ -24,7 +26,10 @@ import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableSegmentNotEmptyException;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
+import io.pravega.segmentstore.server.reading.AsyncReadResultProcessor;
 import io.pravega.segmentstore.storage.CacheFactory;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,7 +42,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
@@ -46,6 +55,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 /**
@@ -53,9 +63,21 @@ import lombok.val;
  * of recently used Keys for faster access.
  */
 @ThreadSafe
+@Slf4j
 class ContainerKeyIndex implements AutoCloseable {
     //region Members
 
+    /**
+     * The maximum amount of time to wait for a Table Segment Recovery. If any recovery takes more than this amount of time,
+     * all registered calls will be failed with a {@link TimeoutException}.
+     */
+    @VisibleForTesting
+    static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(60);
+    /**
+     * The maximum unindexed length ({@link SegmentProperties#getLength() - {@link TableAttributes#INDEX_OFFSET}}) of a
+     * Segment for which {@link #triggerCacheTailIndex} can be invoked.
+     */
+    private static final int MAX_TAIL_CACHE_PRE_INDEX_LENGTH = 64 * 1024 * 1024;
     @Getter
     private final IndexReader indexReader;
     private final ScheduledExecutorService executor;
@@ -64,6 +86,8 @@ class ContainerKeyIndex implements AutoCloseable {
     private final MultiKeySequentialProcessor<Map.Entry<Long, UUID>> conditionalUpdateProcessor;
     private final RecoveryTracker recoveryTracker;
     private final AtomicBoolean closed;
+    private final KeyHasher keyHasher;
+    private final String traceObjectId;
 
     //endregion
 
@@ -75,9 +99,11 @@ class ContainerKeyIndex implements AutoCloseable {
      * @param containerId  Id of the SegmentContainer this instance is associated with.
      * @param cacheFactory A {@link CacheFactory} that can be used to create Cache instances.
      * @param cacheManager A {@link CacheManager} that can be used to manage Cache instances.
+     * @param keyHasher    A {@link KeyHasher} that can be used to hash keys.
      * @param executor     Executor for async operations.
      */
-    ContainerKeyIndex(int containerId, @NonNull CacheFactory cacheFactory, @NonNull CacheManager cacheManager, @NonNull ScheduledExecutorService executor) {
+    ContainerKeyIndex(int containerId, @NonNull CacheFactory cacheFactory, @NonNull CacheManager cacheManager,
+                      @NonNull KeyHasher keyHasher, @NonNull ScheduledExecutorService executor) {
         this.cache = new ContainerKeyCache(containerId, cacheFactory);
         this.cacheManager = cacheManager;
         this.cacheManager.register(this.cache);
@@ -85,7 +111,9 @@ class ContainerKeyIndex implements AutoCloseable {
         this.indexReader = new IndexReader(executor);
         this.conditionalUpdateProcessor = new MultiKeySequentialProcessor<>(this.executor);
         this.recoveryTracker = new RecoveryTracker();
+        this.keyHasher = keyHasher;
         this.closed = new AtomicBoolean();
+        this.traceObjectId = String.format("KeyIndex[%d]", containerId);
     }
 
     //endregion
@@ -99,6 +127,7 @@ class ContainerKeyIndex implements AutoCloseable {
             this.cacheManager.unregister(this.cache);
             this.cache.close();
             this.recoveryTracker.close();
+            log.info("{}: Closed.", this.traceObjectId);
         }
     }
 
@@ -133,7 +162,7 @@ class ContainerKeyIndex implements AutoCloseable {
      * </ul>
      */
     <T> CompletableFuture<T> executeIfEmpty(DirectSegmentAccess segment, Supplier<CompletableFuture<T>> action, TimeoutTimer timer) {
-        return this.recoveryTracker.waitIfNeeded(segment, () -> this.conditionalUpdateProcessor.addWithFilter(
+        return this.recoveryTracker.waitIfNeeded(segment, ignored -> this.conditionalUpdateProcessor.addWithFilter(
                 conditionKey -> conditionKey.getKey() == segment.getSegmentId(),
                 () -> isTableSegmentEmpty(segment, timer)
                         .thenCompose(isEmpty -> {
@@ -243,7 +272,7 @@ class ContainerKeyIndex implements AutoCloseable {
             return CompletableFuture.completedFuture(result);
         } else {
             // Fetch information for missing hashes.
-            return this.recoveryTracker.waitIfNeeded(segment, () -> getBucketOffsetFromSegment(segment, result, toLookup, timer));
+            return this.recoveryTracker.waitIfNeeded(segment, cacheUpdated -> getBucketOffsetFromSegment(segment, result, toLookup, cacheUpdated, timer));
         }
     }
 
@@ -262,12 +291,12 @@ class ContainerKeyIndex implements AutoCloseable {
     CompletableFuture<Long> getBucketOffsetDirect(DirectSegmentAccess segment, UUID keyHash, TimeoutTimer timer) {
         // Get the bucket offset from the segment, which will update the cache if actually newer.
         return this.recoveryTracker.waitIfNeeded(segment,
-                () -> getBucketOffsetFromSegment(segment, Collections.synchronizedMap(new HashMap<>()), Collections.singleton(keyHash), timer)
+                cacheUpdated -> getBucketOffsetFromSegment(segment, Collections.synchronizedMap(new HashMap<>()), Collections.singleton(keyHash), cacheUpdated, timer)
                         .thenApply(result -> result.get(keyHash)));
     }
 
     private CompletableFuture<Map<UUID, Long>> getBucketOffsetFromSegment(DirectSegmentAccess segment, Map<UUID, Long> result,
-                                                                          Collection<UUID> toLookup, TimeoutTimer timer) {
+                                                                          Collection<UUID> toLookup, boolean tryCache, TimeoutTimer timer) {
         return this.indexReader
                 .locateBuckets(segment, toLookup, timer)
                 .thenApplyAsync(bucketsByHash -> {
@@ -275,12 +304,16 @@ class ContainerKeyIndex implements AutoCloseable {
                         UUID keyHash = e.getKey();
                         TableBucket bucket = e.getValue();
 
-                        // Cache the bucket's location, but only if its path is complete.
+                        // Cache the bucket's location, but only if it exists.
                         if (bucket.exists()) {
                             // Update the cache information.
                             long highestOffset = this.cache.includeExistingKey(
                                     segment.getSegmentId(), keyHash, bucket.getSegmentOffset());
                             result.put(keyHash, highestOffset);
+                        } else if (tryCache) {
+                            // We were instructed to retry the cache.
+                            val existingValue = this.cache.get(segment.getSegmentId(), keyHash);
+                            result.put(keyHash, existingValue == null || existingValue.isRemoval() ? TableKey.NOT_EXISTS : existingValue.getSegmentOffset());
                         } else {
                             // Inexistent bucket. What we are looking for does not exist. Do not update the information
                             // in the cache as this would have the potential to fill up the cache with useless keys
@@ -315,7 +348,7 @@ class ContainerKeyIndex implements AutoCloseable {
             return this.indexReader.getBackpointerOffset(segment, offset, timeout);
         } else {
             // Nothing in the tail cache; look it up in the index.
-            return this.recoveryTracker.waitIfNeeded(segment, () -> this.indexReader.getBackpointerOffset(segment, offset, timeout));
+            return this.recoveryTracker.waitIfNeeded(segment, ignored -> this.indexReader.getBackpointerOffset(segment, offset, timeout));
         }
     }
 
@@ -502,7 +535,87 @@ class ContainerKeyIndex implements AutoCloseable {
     CompletableFuture<Map<UUID, CacheBucketOffset>> getUnindexedKeyHashes(DirectSegmentAccess segment) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         return this.recoveryTracker.waitIfNeeded(segment,
-                () -> CompletableFuture.completedFuture(this.cache.getTailHashes(segment.getSegmentId())));
+                ignored -> CompletableFuture.completedFuture(this.cache.getTailHashes(segment.getSegmentId())));
+    }
+
+    /**
+     * Reads the tail section (beyond {@link TableAttributes#INDEX_OFFSET}) of the given segment and caches the latest
+     * values recorded there in the tail index.
+     *
+     * The operation will not execute if any of the following is true:
+     * - The tail section has a length of 0.
+     * - The tail section has a length exceeding {@link #getMaxTailCachePreIndexLength()}.
+     *
+     * This method triggers this operation asynchronously and does not wait for it to complete. Its completion status and
+     * any errors will be logged.
+     *
+     * NOTE: this does not peform a proper recovery nor does it update the durable index - it simply caches the values.
+     * The {@link WriterTableProcessor} must be used to update the index.
+     *
+     * @param segment       A {@link DirectSegmentAccess} representing the Segment for which to cache the tail index.
+     */
+    private void triggerCacheTailIndex(DirectSegmentAccess segment, long lastIndexedOffset, long segmentLength) {
+        long tailIndexLength = segmentLength - lastIndexedOffset;
+        if (lastIndexedOffset >= segmentLength) {
+            // Fully caught up. Nothing else to do.
+            log.debug("{}: Table Segment {} fully indexed.", this.traceObjectId, segment.getSegmentId());
+            return;
+        } else if (tailIndexLength > getMaxTailCachePreIndexLength()) {
+            log.debug("{}: Table Segment {} cannot perform tail-caching because tail index too long ({}).", this.traceObjectId,
+                    segment.getSegmentId(), tailIndexLength);
+            return;
+        }
+
+        // Read the tail section of the segment and process its updates. All of this should already be in the cache so
+        // we are not going to do any Storage reads.
+        log.debug("{}: Tail-caching started for Table Segment {}. LastIndexedOffset={}, SegmentLength={}.",
+                this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, segmentLength);
+        ReadResult rr = segment.read(lastIndexedOffset, (int) tailIndexLength, getRecoveryTimeout());
+        AsyncReadResultProcessor
+                .processAll(rr, this.executor, getRecoveryTimeout())
+                .thenAcceptAsync(inputStream -> {
+                    // Parse out all Table Keys and collect their latest offsets, as well as whether they were deleted.
+                    val updates = collectLatestOffsets(inputStream, lastIndexedOffset, (int) tailIndexLength);
+
+                    // Incorporate that into the cache.
+                    this.cache.includeTailCache(segment.getSegmentId(), updates);
+                    log.debug("{}: Tail-caching complete for Table Segment {}. Update Count={}.",
+                            this.traceObjectId, segment.getSegmentId(), updates.size());
+
+                    // Notify the Recovery Tracker that this segment has been recovered, so it can unblock any calls it
+                    // may have collected.
+                    this.recoveryTracker.updateSegmentIndexOffset(segment.getSegmentId(), segmentLength, updates.size() > 0);
+                }, this.executor)
+                .exceptionally(ex -> {
+                    log.warn("{}: Tail-caching failed for Table Segment {}.", this.traceObjectId, segment.getSegmentId(), Exceptions.unwrap(ex));
+                    return null;
+                });
+    }
+
+    @SneakyThrows(IOException.class)
+    private Map<UUID, CacheBucketOffset> collectLatestOffsets(InputStream input, long startOffset, int maxLength) {
+        EntrySerializer serializer = new EntrySerializer();
+        val entries = new HashMap<UUID, CacheBucketOffset>();
+        long nextOffset = startOffset;
+        final long maxOffset = startOffset + maxLength;
+        while (nextOffset < maxOffset) {
+            val e = AsyncTableEntryReader.readEntryComponents(input, nextOffset, serializer);
+            val hash = this.keyHasher.hash(e.getKey());
+            entries.put(hash, new CacheBucketOffset(nextOffset, e.getHeader().isDeletion()));
+            nextOffset += e.getHeader().getTotalLength();
+        }
+
+        return entries;
+    }
+
+    @VisibleForTesting
+    protected long getMaxTailCachePreIndexLength() {
+        return MAX_TAIL_CACHE_PRE_INDEX_LENGTH;
+    }
+
+    @VisibleForTesting
+    protected Duration getRecoveryTimeout() {
+        return RECOVERY_TIMEOUT;
     }
 
     //endregion
@@ -528,7 +641,10 @@ class ContainerKeyIndex implements AutoCloseable {
             }
 
             ObjectClosedException ex = new ObjectClosedException(ContainerKeyIndex.this);
-            toCancel.forEach(t -> t.task.completeExceptionally(ex));
+            toCancel.forEach(task -> {
+                task.task.completeExceptionally(ex);
+                log.info("{}: Cancelled one or more tasks that were waiting on Table Segment {} recovery.", traceObjectId, task.segmentId);
+            });
         }
 
         /**
@@ -538,24 +654,33 @@ class ContainerKeyIndex implements AutoCloseable {
          * @param indexOffset The current Index Offset. -1 means it has been evicted and tasks should be cancelled.
          */
         void updateSegmentIndexOffset(long segmentId, long indexOffset) {
+            updateSegmentIndexOffset(segmentId, indexOffset, false);
+        }
+
+        /**
+         * Updates the SegmentIndexOffset for the given Segment and releases any blocked tasks, if appropriate.
+         *
+         * @param segmentId    The Segment id.
+         * @param indexOffset  The current Index Offset. -1 means it has been evicted and tasks should be cancelled.
+         * @param cacheUpdated True if the cache was updated during the recovery process.
+         */
+        void updateSegmentIndexOffset(long segmentId, long indexOffset, boolean cacheUpdated) {
             boolean removed = indexOffset < 0;
             RecoveryTask task;
             synchronized (this) {
+                task = this.recoveryTasks.get(segmentId);
                 if (removed) {
                     // Segment evicted. Free resources.
-                    task = this.recoveryTasks.remove(segmentId);
                     this.recoveredSegments.remove(segmentId);
-                } else {
-                    task = this.recoveryTasks.get(segmentId);
                 }
 
                 if (task != null && !removed) {
                     if (indexOffset < task.triggerIndexOffset) {
                         // There is a task, but the trigger condition is not met.
+                        log.debug("{}: For TableSegment {}, IndexOffset={}, TriggerOffset={}.", traceObjectId, segmentId, indexOffset, task.triggerIndexOffset);
                         task = null;
                     } else {
                         // Segment is fully recovered.
-                        this.recoveryTasks.remove(segmentId);
                         this.recoveredSegments.add(segmentId);
                     }
                 }
@@ -564,10 +689,12 @@ class ContainerKeyIndex implements AutoCloseable {
             if (task != null) {
                 if (removed) {
                     // Normally nobody should be waiting on this, but in case they did, there's nothing we can do about it now.
+                    log.debug("{}: TableSegment {} evicted; cancelling dependent tasks.", traceObjectId, segmentId);
                     task.task.cancel(true);
                 } else {
                     // Notify whoever is waiting that it's all clear to execute.
-                    task.task.complete(null);
+                    log.debug("{}: TableSegment {} fully recovered; triggering dependent tasks.", traceObjectId, segmentId);
+                    task.task.complete(cacheUpdated);
                 }
             }
         }
@@ -577,13 +704,17 @@ class ContainerKeyIndex implements AutoCloseable {
          * If the Segment's Index is up-to-date, the given task is executed right away.
          *
          * @param segment   The Segment to execute the task on.
-         * @param toExecute A Supplier that, when invoked, will execute a task and return a CompletableFuture which will
-         *                  complete when the task is done.
+         * @param toExecute A Function that, when invoked, will execute a task and return a CompletableFuture which will
+         *                  complete when the task is done. The argument to this Function is a boolean indicating whether
+         *                  the Cache has been updated during the recovery.
          * @param <T>       Return type.
          * @return A CompletableFuture that will be completed when the task is done.
          */
-        <T> CompletableFuture<T> waitIfNeeded(DirectSegmentAccess segment, Supplier<CompletableFuture<T>> toExecute) {
+        <T> CompletableFuture<T> waitIfNeeded(DirectSegmentAccess segment, Function<Boolean, CompletableFuture<T>> toExecute) {
             RecoveryTask task = null;
+            long segmentLength = -1;
+            long lastIndexedOffset = -1;
+            boolean firstTask = false;
             synchronized (this) {
                 if (!this.recoveredSegments.contains(segment.getSegmentId())) {
                     // This segment wasn't marked as having completed recovery. Check its status.
@@ -591,16 +722,17 @@ class ContainerKeyIndex implements AutoCloseable {
                     if (task == null) {
                         // Nobody waiting on it either.
                         SegmentProperties sp = segment.getInfo();
-                        long segmentLength = sp.getLength();
-                        long lastIndexedOffset = ContainerKeyIndex.this.indexReader.getLastIndexedOffset(sp);
+                        segmentLength = sp.getLength();
+                        lastIndexedOffset = ContainerKeyIndex.this.indexReader.getLastIndexedOffset(sp);
                         if (lastIndexedOffset >= segmentLength) {
                             // Already caught up.
                             this.recoveredSegments.add(segment.getSegmentId());
                         } else {
                             // Need to catch up. Setup a RecoveryTask that will be completed once we are notified that
                             // the Segment's LastIndexedOffset is at least the current length.
-                            task = new RecoveryTask(segmentLength);
+                            task = new RecoveryTask(segment.getSegmentId(), segmentLength);
                             this.recoveryTasks.put(segment.getSegmentId(), task);
+                            firstTask = true;
                         }
                     }
                 }
@@ -608,17 +740,49 @@ class ContainerKeyIndex implements AutoCloseable {
 
             if (task == null) {
                 // No recovery task. Execute right away.
-                return toExecute.get();
+                return toExecute.apply(false);
             } else {
+                log.debug("{}: TableSegment {} is not fully recovered. Queuing 1 task.", traceObjectId, segment.getSegmentId());
+                if (firstTask) {
+                    setupRecoveryTask(task);
+                    assert lastIndexedOffset >= 0;
+                    triggerCacheTailIndex(segment, lastIndexedOffset, segmentLength);
+                }
+
                 // A recovery task is registered. Queue behind it.
-                return task.task.thenComposeAsync(ignored -> toExecute.get(), executor);
+                return task.task.thenComposeAsync(toExecute, executor);
             }
+        }
+
+        private void setupRecoveryTask(RecoveryTask task) {
+            // Cancel the recovery task (and future that's waiting on it) if it took too long. This will prevent anyone
+            // waiting on this from getting stuck forever. In case of an external retry, the state of the Table Segment
+            // will be reinspected and the associated request may go through (if the recovery completed) or be blocked
+            // again (and trigger another pre-cache).
+            ScheduledFuture<Boolean> sf = executor.schedule(
+                    () -> task.task.completeExceptionally(new TimeoutException(String.format("Table Segment %d recovery timed out.", task.segmentId))),
+                    getRecoveryTimeout().toMillis(),
+                    TimeUnit.MILLISECONDS);
+
+            // Cleanup whenever the task is done.
+            task.task.whenComplete((r, ex) -> {
+                sf.cancel(true);
+                synchronized (this) {
+                    // Cleanup.
+                    RecoveryTask removed = this.recoveryTasks.remove(task.segmentId);
+                    if (removed != task) {
+                        // Some weird thing happened and we removed a differen task. Add it back.
+                        this.recoveryTasks.put(task.segmentId, removed);
+                    }
+                }
+            });
         }
 
         @RequiredArgsConstructor
         private class RecoveryTask {
+            final long segmentId;
             final long triggerIndexOffset;
-            final CompletableFuture<Void> task = new CompletableFuture<>();
+            final CompletableFuture<Boolean> task = new CompletableFuture<>();
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -49,11 +49,13 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 /**
  * A {@link ContainerTableExtension} that implements Table Segments on top of a {@link SegmentContainer}.
  */
+@Slf4j
 public class ContainerTableExtensionImpl implements ContainerTableExtension {
     //region Members
 
@@ -70,6 +72,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     private final ContainerKeyIndex keyIndex;
     private final EntrySerializer serializer;
     private final AtomicBoolean closed;
+    private final String traceObjectId;
 
     //endregion
 
@@ -103,9 +106,10 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         this.segmentContainer = segmentContainer;
         this.executor = executor;
         this.hasher = hasher;
-        this.keyIndex = new ContainerKeyIndex(segmentContainer.getId(), cacheFactory, cacheManager, this.executor);
+        this.keyIndex = new ContainerKeyIndex(segmentContainer.getId(), cacheFactory, cacheManager, this.hasher, this.executor);
         this.serializer = new EntrySerializer();
         this.closed = new AtomicBoolean();
+        this.traceObjectId = String.format("TableExtension[%d]", this.segmentContainer.getId());
     }
 
     //endregion
@@ -116,6 +120,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     public void close() {
         if (!this.closed.getAndSet(true)) {
             this.keyIndex.close();
+            log.info("{}: Closed.", this.traceObjectId);
         }
     }
 
@@ -145,11 +150,13 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
                 .entrySet().stream()
                 .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, e.getValue()))
                 .collect(Collectors.toList());
+        logRequest("createSegment", segmentName);
         return this.segmentContainer.createStreamSegment(segmentName, attributes, timeout);
     }
 
     @Override
     public CompletableFuture<Void> deleteSegment(@NonNull String segmentName, boolean mustBeEmpty, Duration timeout) {
+        logRequest("deleteSegment", segmentName, mustBeEmpty);
         if (mustBeEmpty) {
             TimeoutTimer timer = new TimeoutTimer(timeout);
             return this.segmentContainer
@@ -183,6 +190,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         // Generate an Update Batch for all the entries (since we need to know their Key Hashes and relative offsets in
         // the batch itself).
         val updateBatch = batch(entries, TableEntry::getKey, this.serializer::getUpdateLength, TableKeyBatch.update());
+        logRequest("put", segmentName, updateBatch.isConditional(), updateBatch.isRemoval(), entries.size(), updateBatch.getLength());
         return this.segmentContainer
                 .forSegment(segmentName, timer.getRemaining())
                 .thenComposeAsync(segment -> this.keyIndex.update(segment, updateBatch,
@@ -198,6 +206,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         // Generate an Update Batch for all the keys (since we need to know their Key Hashes and relative offsets in
         // the batch itself).
         val removeBatch = batch(keys, key -> key, this.serializer::getRemovalLength, TableKeyBatch.removal());
+        logRequest("remove", segmentName, removeBatch.isConditional(), removeBatch.isRemoval(), keys.size(), removeBatch.getLength());
         return this.segmentContainer
                 .forSegment(segmentName, timer.getRemaining())
                 .thenComposeAsync(segment -> this.keyIndex.update(segment, removeBatch,
@@ -209,6 +218,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     @Override
     public CompletableFuture<List<TableEntry>> get(@NonNull String segmentName, @NonNull List<ArrayView> keys, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
+        logRequest("get", segmentName, keys.size());
         if (keys.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         } else {
@@ -263,11 +273,13 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
 
     @Override
     public CompletableFuture<AsyncIterator<IteratorItem<TableKey>>> keyIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        logRequest("keyIterator", segmentName);
         return newIterator(segmentName, serializedState, fetchTimeout, TableBucketReader::key);
     }
 
     @Override
     public CompletableFuture<AsyncIterator<IteratorItem<TableEntry>>> entryIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        logRequest("entryIterator", segmentName);
         return newIterator(segmentName, serializedState, fetchTimeout, TableBucketReader::entry);
     }
 
@@ -350,6 +362,10 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
 
     private TableEntry maybeDeleted(TableEntry e) {
         return e == null || e.getValue() == null ? null : e;
+    }
+
+    private void logRequest(String requestName, Object... args) {
+        log.debug("{}: {} {}", this.traceObjectId, requestName, args);
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -106,6 +106,57 @@ public class ContainerKeyCacheTests {
     }
 
     /**
+     * Tests the {@link ContainerKeyCache#includeTailCache} method.
+     */
+    @Test
+    public void testIncludeTailCache() {
+        final long segmentId = 0L;
+        final long baseOffset = 1000;
+        @Cleanup
+        val cacheFactory = new InMemoryCacheFactory();
+        @Cleanup
+        val keyCache = new ContainerKeyCache(CONTAINER_ID, cacheFactory);
+        val expectedResult = new HashMap<TestKey, CacheBucketOffset>();
+
+        // Insert some pre-existing values.
+        for (int i = 0; i < KEYS_PER_SEGMENT; i++) {
+            long offset = baseOffset + i;
+            val keyHash = newSimpleHash();
+            keyCache.updateSegmentIndexOffset(segmentId, offset);
+            long updateResult = keyCache.includeExistingKey(segmentId, keyHash, offset);
+            Assert.assertEquals("Unexpected result from includeExistingKey() for new insertion.", offset, updateResult);
+            expectedResult.put(new TestKey(segmentId, keyHash), new CacheBucketOffset(offset, false));
+        }
+        // Perform updates.
+        val rnd = new Random(0);
+        boolean successfulUpdate = false;
+        val updateBatch = new HashMap<UUID, CacheBucketOffset>();
+        for (val e : expectedResult.entrySet()) {
+            // Every other update will try to set an obsolete offset. We need to verify that such a case will not be accepted.
+            successfulUpdate = !successfulUpdate;
+            val existingOffset = e.getValue().getSegmentOffset();
+            val segmentIndexOffset = keyCache.getSegmentIndexOffset(e.getKey().segmentId);
+
+            long newOffset;
+            boolean isRemoved;
+            if (successfulUpdate) {
+                newOffset = existingOffset + 1;
+                isRemoved = existingOffset % 3 == 0; // Need to pick odd number since only odd offsets are successful.
+                e.setValue(new CacheBucketOffset(newOffset, isRemoved));
+            } else {
+                newOffset = existingOffset - 1;
+                isRemoved = existingOffset % 4 == 0; // Need to pick even number since only even offsets are unsuccessful.
+            }
+
+            updateBatch.put(e.getKey().keyHash, new CacheBucketOffset(newOffset, isRemoved));
+        }
+
+        // Update the cache, then check it.
+        keyCache.includeTailCache(segmentId, updateBatch);
+        checkCache(expectedResult, keyCache);
+    }
+
+    /**
      * Tests the {@link ContainerKeyCache#includeUpdateBatch} method for inserts.
      */
     @Test

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -23,6 +23,7 @@ import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableSegmentNotEmptyException;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.CachePolicy;
+import io.pravega.segmentstore.storage.CacheFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryCacheFactory;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -39,12 +40,15 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.junit.Assert;
@@ -61,6 +65,8 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
     private static final long SHORT_TIMEOUT_MILLIS = TIMEOUT.toMillis() / 3;
     private static final KeyHasher HASHER = KeyHashers.DEFAULT_HASHER;
+    private static final int TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH = 128 * 1024;
+    private static final Duration SHORT_RECOVERY_TIMEOUT = Duration.ofSeconds(1);
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
@@ -401,7 +407,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testRecovery() throws Exception {
-        final int segmentLength = 123456;
+        val s = new EntrySerializer();
         @Cleanup
         val context = new TestContext();
 
@@ -409,37 +415,47 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val iw = new IndexWriter(HASHER, executorService());
         context.segment.updateAttributes(TableAttributes.DEFAULT_VALUES);
 
-        // Generate keys and index them by Hashes and assign offsets. Only half the keys exist; the others do not.
+        // 1. Generate initial set of keys and serialize them to the segment.
         val keys = generateUnversionedKeys(BATCH_SIZE, context);
+        val entries1 = new ArrayList<TableEntry>(keys.size());
         val offset = new AtomicLong();
         val hashes = new ArrayList<UUID>();
         val keysWithOffsets = new HashMap<UUID, KeyWithOffset>();
         for (val k : keys) {
             val hash = HASHER.hash(k.getKey());
             hashes.add(hash);
-            keysWithOffsets.put(hash, new KeyWithOffset(new HashedArray(k.getKey()), offset.getAndAdd(k.getKey().getLength())));
+            byte[] valueData = new byte[Math.max(1, context.random.nextInt(100))];
+            context.random.nextBytes(valueData);
+            val entry = TableEntry.unversioned(k.getKey(), new ByteArraySegment(valueData));
+            keysWithOffsets.put(hash, new KeyWithOffset(new HashedArray(k.getKey()), offset.getAndAdd(s.getUpdateLength(entry))));
+            entries1.add(entry);
         }
+        val update1 = new byte[(int) offset.get()];
+        s.serializeUpdate(entries1, update1);
+        context.segment.append(update1, null, TIMEOUT).join();
 
-        // Update the keys in the segment (via their buckets).
+        // 2. Initiate a recovery and verify pre-caching is triggered and requests are auto-unblocked.
+        val get1 = context.index.getBucketOffsets(context.segment, hashes, context.timer);
+        val result1 = get1.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        val expected1 = new HashMap<UUID, Long>();
+        keysWithOffsets.forEach((k, o) -> expected1.put(k, o.offset));
+        AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after auto pre-caching.", expected1, result1);
+
+        // 3. Set LastIdx to Length, and increase by TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH + 1 (so we don't do pre-caching).
         val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
         Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
-                                   .map(e -> {
-                                       val builder = BucketUpdate.forBucket(e.getValue());
-                                       val ko = keysWithOffsets.get(e.getKey());
-                                       builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
-                                       return builder.build();
-                                   })
-                                   .collect(Collectors.toList());
+                                                        .map(e -> {
+                                                            val builder = BucketUpdate.forBucket(e.getValue());
+                                                            val ko = keysWithOffsets.get(e.getKey());
+                                                            builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                                                            return builder.build();
+                                                        })
+                                                        .collect(Collectors.toList());
+        iw.updateBuckets(context.segment, bucketUpdates, 0L, offset.get(), keysWithOffsets.size(), TIMEOUT).join();
+        context.segment.append(new byte[TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH + 1], null, TIMEOUT).join();
 
-        // We leave the IndexOffset unchanged for now.
-        iw.updateBuckets(context.segment, bucketUpdates, 0L, 0L, 0, TIMEOUT).join();
-
-        // Simulate writing the data to the segment by increasing its length.
-        context.segment.append(new byte[segmentLength], null, TIMEOUT).join();
-
-        // So far we haven't touched the container index, so it has no knowledge of all the keys that were just indexed.
-
-        // 1. Verify getBucketOffsets(), getBackpointers() and conditional updates block on IndexOffset being up-to-date.
+        // 4. Verify pre-caching is disabled and that the requests are blocked.
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), -1); // Force-evict it so we start clean.
         val getBucketOffsets = context.index.getBucketOffsets(context.segment, hashes, context.timer);
         val backpointerKey = keysWithOffsets.values().stream().findFirst().get();
         val getBackpointers = context.index.getBackpointerOffset(context.segment, backpointerKey.offset, context.timer.getRemaining());
@@ -448,27 +464,27 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val conditionalUpdate = context.index.update(
                 context.segment,
                 toUpdateBatch(conditionalUpdateKey),
-                () -> CompletableFuture.completedFuture(segmentLength + 1L),
+                () -> CompletableFuture.completedFuture(context.segment.getInfo().getLength() + 1L),
                 context.timer);
         Assert.assertFalse("Expected getBucketOffsets() to block.", getBucketOffsets.isDone());
         Assert.assertFalse("Expected getBackpointerOffset() to block.", getBackpointers.isDone());
         Assert.assertFalse("Expecting conditional update to block.", conditionalUpdate.isDone());
 
-        // 2. Verify unconditional updates go through.
+        // 4.1. Verify unconditional updates go through.
         val unconditionalUpdateKey = generateUnversionedKeys(1, context).get(0);
         val unconditionalUpdateResult = context.index.update(
                 context.segment,
                 toUpdateBatch(unconditionalUpdateKey),
-                () -> CompletableFuture.completedFuture(segmentLength + 2L),
+                () -> CompletableFuture.completedFuture(context.segment.getInfo().getLength() + 2L),
                 context.timer).get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         Assert.assertEquals("Unexpected result from the non-blocked unconditional update.",
-                segmentLength + 2L, (long) unconditionalUpdateResult.get(0));
+                context.segment.getInfo().getLength() + 2L, (long) unconditionalUpdateResult.get(0));
 
         // 3. Verify that all operations are unblocked when we reached the expected IndexOffset.
-        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), segmentLength - 1);
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), context.segment.getInfo().getLength() - 1);
         Assert.assertFalse("Not expecting anything to be unblocked at this point",
                 getBucketOffsets.isDone() || getBackpointers.isDone() || conditionalUpdate.isDone() || getUnindexedKeys.isDone());
-        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), segmentLength);
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), context.segment.getInfo().getLength());
         val getBucketOffsetsResult = getBucketOffsets.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         val getBackpointersResult = getBackpointers.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         val conditionalUpdateResult = conditionalUpdate.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
@@ -476,7 +492,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         checkKeyOffsets(hashes, keysWithOffsets, getBucketOffsetsResult);
         Assert.assertEquals("Unexpected result from unblocked getBackpointerOffset().", -1L, (long) getBackpointersResult);
         Assert.assertEquals("Unexpected result from unblocked conditional update.",
-                segmentLength + 1L, (long) conditionalUpdateResult.get(0));
+                context.segment.getInfo().getLength() + 1L, (long) conditionalUpdateResult.get(0));
 
         // Depending on the order in which the internal recovery tracker (implemented by CompletableFuture.thenCompose)
         // executes its callbacks, the result of this call may be either 1 or 2 (it may unblock prior to the conditional
@@ -488,16 +504,16 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val finalGetUnindexedKeysResult = context.index.getUnindexedKeyHashes(context.segment).get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         Assert.assertEquals("Unexpected result size from final getUnindexedKeyHashes().", 2, finalGetUnindexedKeysResult.size());
 
-        // 4. Verify no new requests are blocked now.
+        // 5. Verify no new requests are blocked now.
         getBucketOffsets.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS); // A timeout check will suffice
 
-        // 5. Verify requests are cancelled if we notify the segment has been removed.
+        // 6. Verify requests are cancelled if we notify the segment has been removed.
         context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), -1L);
         val cancelledKey = TableKey.notExists(generateUnversionedKeys(1, context).get(0).getKey());
         val cancelledRequest = context.index.update(
                 context.segment,
                 toUpdateBatch(cancelledKey),
-                () -> CompletableFuture.completedFuture(segmentLength + 3L),
+                () -> CompletableFuture.completedFuture(context.segment.getInfo().getLength() + 3L),
                 context.timer);
         context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), -1L);
         AssertExtensions.assertFutureThrows(
@@ -511,13 +527,70 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val cancelledRequest2 = context.index.update(
                 context.segment,
                 toUpdateBatch(cancelledKey2),
-                () -> CompletableFuture.completedFuture(segmentLength + 4L),
+                () -> CompletableFuture.completedFuture(context.segment.getInfo().getLength() + 4L),
                 context.timer);
         context.index.close();
         AssertExtensions.assertFutureThrows(
                 "Blocked request was not cancelled when a the index was closed.",
                 cancelledRequest2,
                 ex -> ex instanceof ObjectClosedException);
+    }
+
+    /**
+     * Checks the ability for the {@link ContainerKeyIndex} class to cancel recovery-bound tasks if recovery took too long.
+     */
+    @Test
+    public void testRecoveryTimeout() throws Exception {
+        val s = new EntrySerializer();
+        @Cleanup
+        val context = new TestContext(SHORT_RECOVERY_TIMEOUT);
+
+        // Setup the segment with initial attributes.
+        val iw = new IndexWriter(HASHER, executorService());
+        context.segment.updateAttributes(TableAttributes.DEFAULT_VALUES);
+
+        // Generate initial set of keys.
+        val keys = generateUnversionedKeys(BATCH_SIZE, context);
+        val entries1 = new ArrayList<TableEntry>(keys.size());
+        long offset = 0;
+        val hashes = new ArrayList<UUID>();
+        val keysWithOffsets = new HashMap<UUID, KeyWithOffset>();
+        for (val k : keys) {
+            val hash = HASHER.hash(k.getKey());
+            hashes.add(hash);
+            keysWithOffsets.put(hash, new KeyWithOffset(new HashedArray(k.getKey()), offset));
+            offset += k.getKey().getLength();
+        }
+
+        // Write some garbage data to the segment, but make it longer than the threshold to trigger pre-caching; we don't
+        // want to deal with that now since we can't control its runtime.
+        context.segment.append(new byte[TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH + 1], null, TIMEOUT).join();
+
+        // Update the index, but keep the LastIndexedOffset at 0.
+        val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
+                                                        .map(e -> {
+                                                            val builder = BucketUpdate.forBucket(e.getValue());
+                                                            val ko = keysWithOffsets.get(e.getKey());
+                                                            builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                                                            return builder.build();
+                                                        })
+                                                        .collect(Collectors.toList());
+        iw.updateBuckets(context.segment, bucketUpdates, 0L, 0, keysWithOffsets.size(), TIMEOUT).join();
+
+        // Issue a request and verify it times out.
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Request did not fail when recovery timed out.",
+                () -> context.index.getBucketOffsets(context.segment, hashes, context.timer),
+                ex -> ex instanceof TimeoutException);
+
+        // Verify that a new operation will be unblocked if we notify that the recovery completed successfully.
+        val get1 = context.index.getBucketOffsets(context.segment, hashes, context.timer);
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), context.segment.getInfo().getLength());
+        val result1 = get1.get(SHORT_RECOVERY_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        val expected1 = new HashMap<UUID, Long>();
+        keysWithOffsets.forEach((k, o) -> expected1.put(k, o.offset));
+        AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after a retry.", expected1, result1);
     }
 
     /**
@@ -736,10 +809,16 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         final Random random;
 
         TestContext() {
+            // This is for most tests. Due to variability in test environments, we do not want to set a very small value
+            // for most tests; we will customize this only for those tests that we want to test this feature on.
+            this(ContainerKeyIndex.RECOVERY_TIMEOUT);
+        }
+
+        TestContext(Duration recoveryTimeout) {
             this.cacheFactory = new InMemoryCacheFactory();
             this.cacheManager = new CacheManager(CachePolicy.INFINITE, executorService());
             this.segment = new SegmentMock(executorService());
-            this.index = new ContainerKeyIndex(CONTAINER_ID, this.cacheFactory, this.cacheManager, executorService());
+            this.index = new TestContainerKeyIndex(CONTAINER_ID, this.cacheFactory, this.cacheManager, KeyHashers.DEFAULT_HASHER, executorService());
             this.timer = new TimeoutTimer(TIMEOUT);
             this.random = new Random(0);
         }
@@ -749,6 +828,22 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             this.index.close();
             this.cacheManager.close();
             this.cacheFactory.close();
+        }
+
+        private class TestContainerKeyIndex extends ContainerKeyIndex {
+            TestContainerKeyIndex(int containerId, @NonNull CacheFactory cacheFactory, @NonNull CacheManager cacheManager, @NonNull KeyHasher keyHasher, @NonNull ScheduledExecutorService executor) {
+                super(containerId, cacheFactory, cacheManager, keyHasher, executor);
+            }
+
+            @Override
+            protected long getMaxTailCachePreIndexLength() {
+                return TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH;
+            }
+
+            @Override
+            protected Duration getRecoveryTimeout() {
+                return SHORT_RECOVERY_TIMEOUT;
+            }
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -56,7 +56,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -412,7 +411,9 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
         val data = generateTestData(context);
 
         // Process each such batch in turn.
-        for (val current : data) {
+        for (int i = 0; i < data.size(); i++) {
+            val current = data.get(i);
+
             // First, add the updates from this iteration to the index, but do not flush them. The only long-term effect
             // of this is writing the data to the Segment.
             try (val ext = context.createExtension()) {
@@ -431,24 +432,23 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
                 long segmentLength = context.segment().getInfo().getLength();
                 AssertExtensions.assertGreaterThan("Expected some unindexed data.", lastIndexedOffset, segmentLength);
 
+                boolean useProcessor = i % 2 == 0; // This ensures that last iteration uses the processor.
+
                 // Verify get requests are blocked.
-                val blockedKey = current.expectedEntries.keySet().stream().findFirst().orElse(null);
-                val blockedGet = ext.get(SEGMENT_NAME, Collections.singletonList(blockedKey), TIMEOUT);
-                AssertExtensions.assertThrows(
-                        "get() is not blocked on lack of indexing.",
-                        () -> blockedGet.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
-                        ex -> ex instanceof TimeoutException);
+                val key1 = current.expectedEntries.keySet().stream().findFirst().orElse(null);
+                val get1 = ext.get(SEGMENT_NAME, Collections.singletonList(key1), TIMEOUT);
+                val getResult1 = get1.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                Assert.assertEquals("Unexpected completion result for recovered get.",
+                        current.expectedEntries.get(key1), new HashedArray(getResult1.get(0).getValue()));
 
-                // Create, populate, and flush the processor.
-                @Cleanup
-                val processor = (WriterTableProcessor) ext.createWriterSegmentProcessors(context.segment().getMetadata()).stream().findFirst().orElse(null);
-                addToProcessor(lastIndexedOffset, (int) (segmentLength - lastIndexedOffset), processor);
-                processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-                Assert.assertFalse("Unexpected result from WriterTableProcessor.mustFlush() after flushing.", processor.mustFlush());
-
-                val blockedGetResult = blockedGet.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-                Assert.assertEquals("Unexpected completion result for previously blocked get.",
-                        current.expectedEntries.get(blockedKey), new HashedArray(blockedGetResult.get(0).getValue()));
+                if (useProcessor) {
+                    // Create, populate, and flush the processor.
+                    @Cleanup
+                    val processor = (WriterTableProcessor) ext.createWriterSegmentProcessors(context.segment().getMetadata()).stream().findFirst().orElse(null);
+                    addToProcessor(lastIndexedOffset, (int) (segmentLength - lastIndexedOffset), processor);
+                    processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                    Assert.assertFalse("Unexpected result from WriterTableProcessor.mustFlush() after flushing.", processor.mustFlush());
+                }
             }
         }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -26,8 +26,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -64,15 +65,15 @@ import static io.pravega.shared.protocol.netty.WireCommands.TYPE_SIZE;
 @Slf4j
 public class CommandEncoder extends MessageToByteEncoder<Object> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
-
-    private final AppendBatchSizeTracker blockSizeSupplier;
+    private final Function<Long, AppendBatchSizeTracker> appendTracker;
     private final Map<Map.Entry<String, UUID>, Session> setupSegments = new HashMap<>();
+    private final AtomicLong tokenCounter = new AtomicLong(0);
     private String segmentBeingAppendedTo;
     private UUID writerIdPerformingAppends;
     private int currentBlockSize;
     private int bytesLeftInBlock;
 
-    @Data
+    @RequiredArgsConstructor
     private static final class Session {
         private final UUID id;
         private long lastEventNumber = -1L;
@@ -88,56 +89,54 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
             Session session = setupSegments.get(new SimpleImmutableEntry<>(append.segment, append.getWriterId()));
             validateAppend(append, session);
             if (!append.segment.equals(segmentBeingAppendedTo) || !append.getWriterId().equals(writerIdPerformingAppends)) {
-                breakFromAppend(out);
+                breakFromAppend(null, null, out);
+            }
+            final ByteBuf data = append.getData().slice();
+            final int msgSize = data.readableBytes();
+            final AppendBatchSizeTracker blockSizeSupplier = (appendTracker == null) ? null :
+                    appendTracker.apply(append.getFlowId());
+
+            session.lastEventNumber = append.getEventNumber();
+            session.eventCount++;
+            if (blockSizeSupplier != null) {
+                blockSizeSupplier.recordAppend(append.getEventNumber(), msgSize);
             }
             if (bytesLeftInBlock == 0) {
-                currentBlockSize = Math.max(TYPE_PLUS_LENGTH_SIZE, blockSizeSupplier.getAppendBlockSize());
+                currentBlockSize = msgSize + TYPE_PLUS_LENGTH_SIZE;
+                if (blockSizeSupplier != null) {
+                    currentBlockSize = Math.max(currentBlockSize, blockSizeSupplier.getAppendBlockSize());
+                }
                 bytesLeftInBlock = currentBlockSize;
                 segmentBeingAppendedTo = append.segment;
                 writerIdPerformingAppends = append.writerId;
                 writeMessage(new AppendBlock(session.id), out);
-                if (ctx != null) {
-                    ctx.executor().schedule(new BlockTimeouter(ctx.channel(), currentBlockSize),
+                if (ctx != null && currentBlockSize > (msgSize + TYPE_PLUS_LENGTH_SIZE)) {
+                    ctx.executor().schedule(new BlockTimeouter(ctx.channel(), tokenCounter.incrementAndGet()),
                                             blockSizeSupplier.getBatchTimeout(),
                                             TimeUnit.MILLISECONDS);
                 }
             }
-
-            session.lastEventNumber = append.getEventNumber();
-            session.eventCount++;
-            ByteBuf data = append.getData().slice();
-            int msgSize = data.readableBytes();
             // Is there enough space for a subsequent message after this one?
             if (bytesLeftInBlock - msgSize > TYPE_PLUS_LENGTH_SIZE) {
                 out.writeBytes(data);
                 bytesLeftInBlock -= msgSize;
             } else {
-                int bytesInBlock = bytesLeftInBlock - TYPE_PLUS_LENGTH_SIZE; 
-                ByteBuf dataInsideBlock = data.readSlice(bytesInBlock);
-                ByteBuf dataRemainging = data;
-                writeMessage(new PartialEvent(dataInsideBlock), out);
-                writeMessage(new AppendBlockEnd(append.writerId,
-                                                currentBlockSize - bytesLeftInBlock,
-                                                dataRemainging,
-                                                session.eventCount,
-                                                session.lastEventNumber,
-                                                append.getRequestId()), out);
-                bytesLeftInBlock = 0;
-                session.eventCount = 0;
+                ByteBuf dataInsideBlock = data.readSlice(bytesLeftInBlock - TYPE_PLUS_LENGTH_SIZE);
+                breakFromAppend(dataInsideBlock, data, out);
             }
         } else if (msg instanceof SetupAppend) {
-            breakFromAppend(out);
+            breakFromAppend(null, null, out);
             writeMessage((SetupAppend) msg, out);
             SetupAppend setup = (SetupAppend) msg;
             setupSegments.put(new SimpleImmutableEntry<>(setup.getSegment(), setup.getWriterId()),
                               new Session(setup.getWriterId(), setup.getRequestId()));
         } else if (msg instanceof BlockTimeout) {
             BlockTimeout timeoutMsg = (BlockTimeout) msg;
-            if (currentBlockSize == timeoutMsg.ifStillBlockSize) {
-                breakFromAppend(out);
+            if (tokenCounter.get() == timeoutMsg.token) {
+                breakFromAppend(null, null, out);
             }
         } else if (msg instanceof WireCommand) {
-            breakFromAppend(out);
+            breakFromAppend(null, null, out);
             writeMessage((WireCommand) msg, out);
         } else {
             throw new IllegalArgumentException("Expected a wire command and found: " + msg);
@@ -159,19 +158,23 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
                 "Bug in CommandEncoder.encode, block is too small.");
     }
 
-    private void breakFromAppend(ByteBuf out) {
+    private void breakFromAppend(ByteBuf data, ByteBuf pendingData, ByteBuf out) {
         if (bytesLeftInBlock != 0) {
-            writeMessage(new Padding(bytesLeftInBlock - TYPE_PLUS_LENGTH_SIZE), out);
+            if (data != null) {
+                writeMessage(new PartialEvent(data), out);
+            } else {
+                writeMessage(new Padding(bytesLeftInBlock - TYPE_PLUS_LENGTH_SIZE), out);
+            }
             Session session = setupSegments.get(new SimpleImmutableEntry<>(segmentBeingAppendedTo, writerIdPerformingAppends));
-
             writeMessage(new AppendBlockEnd(session.id,
                     currentBlockSize - bytesLeftInBlock,
-                    null,
+                    pendingData,
                     session.eventCount,
                     session.lastEventNumber, session.requestId), out);
             bytesLeftInBlock = 0;
             currentBlockSize = 0;
             session.eventCount = 0;
+            tokenCounter.incrementAndGet();
         }
         segmentBeingAppendedTo = null;
         writerIdPerformingAppends = null;
@@ -208,18 +211,19 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
 
     @RequiredArgsConstructor
     private static final class BlockTimeout {
-        private final int ifStillBlockSize;
+        private final long token;
     }
-    
+
     @RequiredArgsConstructor
-    private static final class BlockTimeouter implements Runnable {
+    private final class BlockTimeouter implements Runnable {
         private final Channel channel;
-        private final int blockSize;
+        private final long token;
 
         @Override
         public void run() {
-            channel.writeAndFlush(new BlockTimeout(blockSize));
+            if (tokenCounter.get() == token) {
+                channel.writeAndFlush(new BlockTimeout(token));
+            }
         }
     }
-
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -141,7 +141,7 @@ public class FailingRequestProcessor implements RequestProcessor {
 
     @Override
     public void keepAlive(KeepAlive keepAlive) {
-        log.debug("Received KeepAlive");
+        // This method intentionally left blank.
     }
 
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Request.java
@@ -17,4 +17,8 @@ public interface Request {
     long getRequestId();
     
     void process(RequestProcessor cp);
+
+    default boolean mustLog() {
+        return true;
+    }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1505,6 +1505,11 @@ public final class WireCommands {
         public long getRequestId() {
             return -1;
         }
+
+        @Override
+        public boolean mustLog() {
+            return false;
+        }
     }
 
     @Data

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -13,10 +13,17 @@ import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetector.Level;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.ScheduledFuture;
 import io.pravega.shared.protocol.netty.WireCommands.Event;
 import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
@@ -24,29 +31,207 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.Iterator;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import static io.pravega.shared.protocol.netty.WireCommandType.EVENT;
 import static io.pravega.shared.protocol.netty.WireCommands.TYPE_PLUS_LENGTH_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AppendEncodeDecodeTest {
 
     private final int appendBlockSize = 1024;  
     private final UUID writerId = new UUID(1, 2);
     private final String streamName = "Test Stream Name";
-    private final CommandEncoder encoder = new CommandEncoder(new FixedBatchSizeTracker(appendBlockSize));
+    private final ConcurrentHashMap<Long, AppendBatchSizeTracker> idBatchSizeTrackerMap = new ConcurrentHashMap<>();
+    private final CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
     private final FakeLengthDecoder lengthDecoder = new FakeLengthDecoder();
     private final AppendDecoder appendDecoder = new AppendDecoder();
     private Level origionalLogLevel;
-    
+
+    private EventExecutor executor =  new EventExecutor() {
+        private final ScheduledExecutorService scheduler  = Executors.newSingleThreadScheduledExecutor();
+        @Override
+        public EventExecutor next() {
+            return null;
+        }
+
+        @Override
+        public EventExecutorGroup parent() {
+            return null;
+        }
+
+        @Override
+        public boolean inEventLoop() {
+            return false;
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return false;
+        }
+
+        @Override
+        public <V> Promise<V> newPromise() {
+            return null;
+        }
+
+        @Override
+        public <V> ProgressivePromise<V> newProgressivePromise() {
+            return null;
+        }
+
+        @Override
+        public <V> Future<V> newSucceededFuture(V result) {
+            return null;
+        }
+
+        @Override
+        public <V> Future<V> newFailedFuture(Throwable cause) {
+            return null;
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return false;
+        }
+
+        @Override
+        public Future<?> shutdownGracefully() {
+            return null;
+        }
+
+        @Override
+        public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public Future<?> terminationFuture() {
+            return null;
+        }
+
+        @Override
+        public void shutdown() {
+
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return null;
+        }
+
+        @Override
+        public Iterator<EventExecutor> iterator() {
+            return null;
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            return null;
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            return null;
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            return null;
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            scheduler.schedule(command, delay, unit);
+            return null;
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+            return false;
+        }
+
+        @Override
+        public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> collection) throws InterruptedException {
+            return null;
+        }
+
+        @Override
+        public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) throws InterruptedException {
+            return null;
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> collection) throws InterruptedException, ExecutionException {
+            return null;
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+            return null;
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+
+        }
+    };
+
+    @Mock
+    private ChannelHandlerContext ctx;
+    @Mock
+    private Channel ch;
+
     @Before
     public void setup() {
+        Mockito.when(ctx.channel()).thenReturn(ch);
+        Mockito.when(ctx.executor()).thenReturn(executor);
+        idBatchSizeTrackerMap.put(0L, new FixedBatchSizeTracker(appendBlockSize));
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
         origionalLogLevel = ResourceLeakDetector.getLevel();
         ResourceLeakDetector.setLevel(Level.PARANOID);
     }
@@ -129,7 +314,15 @@ public class AppendEncodeDecodeTest {
         // Simulate an error by directly sending AppendBlockEnd.
         appendDecoder.processCommand((WireCommand) appendBlock);
     }
-    
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIlligalWireCommand() throws Exception {
+        @Cleanup("release")
+        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        CommandEncoder commandEncoder = new CommandEncoder(null);
+        commandEncoder.encode(ctx, null, fakeNetwork);
+    }
+
     @Test
     public void testVerySmallBlockSize() throws Exception {
         @Cleanup("release")
@@ -137,8 +330,10 @@ public class AppendEncodeDecodeTest {
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(3));
         Append msg = new Append("segment", writerId, 1, event, 1);
-        CommandEncoder commandEncoder = new CommandEncoder(new FixedBatchSizeTracker(3));
+        CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(null, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
@@ -158,6 +353,8 @@ public class AppendEncodeDecodeTest {
         int numEvents = 2;
         UUID c1 = new UUID(1, 1);
         UUID c2 = new UUID(2, 2);
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
         String s1 = "Stream 1";
         String s2 = "Stream 2";
         sendAndVerifyEvents(s1, c1, numEvents, size, numEvents);
@@ -165,7 +362,7 @@ public class AppendEncodeDecodeTest {
     }
 
     private void sendAndVerifyEvents(String segment, UUID writerId, int numEvents, int eventSize,
-            int expectedMessages) throws Exception {
+                                     int expectedMessages) throws Exception {
         @Cleanup("release")
         ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         ArrayList<Object> received = setupAppend(segment, writerId, fakeNetwork);
@@ -182,6 +379,7 @@ public class AppendEncodeDecodeTest {
         received.remove(received.size() - 1);
         verify(received, numEvents, eventSize);
     }
+
 
     @Test
     public void testFlushBeforeEndOfBlock() throws Exception {
@@ -210,6 +408,92 @@ public class AppendEncodeDecodeTest {
         assertEquals(size + TYPE_PLUS_LENGTH_SIZE, one.getData().readableBytes());
         KeepAlive two = (KeepAlive) received.get(1);
         assertEquals(keepAlive, two);
+    }
+
+
+    @Test
+    public void testAppendWithoutBatchTracker() throws Exception {
+        @Cleanup("release")
+        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+        Event event = new Event(Unpooled.wrappedBuffer(content));
+        Append msg = new Append("segment", writerId, 1, event, 1);
+        CommandEncoder commandEncoder = new CommandEncoder(null);
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        commandEncoder.encode(ctx, setupAppend, fakeNetwork);
+        appendDecoder.processCommand(setupAppend);
+        ArrayList<Object> received = new ArrayList<>();
+        commandEncoder.encode(ctx, msg, fakeNetwork);
+        read(fakeNetwork, received);
+        assertEquals(2, received.size());
+        Append readAppend = (Append) received.get(1);
+        assertEquals(msg.data.readableBytes(), readAppend.data.readableBytes());
+        assertEquals(content.length + TYPE_PLUS_LENGTH_SIZE, readAppend.data.readableBytes());
+    }
+
+    @Test
+    public void testblockTimeout() throws Exception {
+        @Cleanup("release")
+        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+        Event event = new Event(Unpooled.wrappedBuffer(content));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
+        Append msg = new Append("segment", writerId, 1, event, 1);
+        CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        commandEncoder.encode(ctx, setupAppend, fakeNetwork);
+        appendDecoder.processCommand(setupAppend);
+        ArrayList<Object> received = new ArrayList<>();
+        Mockito.when(ch.writeAndFlush(Mockito.any())).thenAnswer(i -> {
+           commandEncoder.encode(ctx, i.getArgument(0), fakeNetwork);
+           return null;
+        });
+        commandEncoder.encode(ctx, msg, fakeNetwork);
+        Thread.sleep(idBatchSizeTrackerMap.get(1L).getBatchTimeout() + 100);
+        read(fakeNetwork, received);
+        assertEquals(2, received.size());
+        Append readAppend = (Append) received.get(1);
+        assertEquals(msg.data.readableBytes(), readAppend.data.readableBytes());
+        assertEquals(content.length + TYPE_PLUS_LENGTH_SIZE, readAppend.data.readableBytes());
+    }
+
+    @Test(expected = InvalidMessageException.class)
+    public void testInvalidAppendEventNumber() throws Exception {
+        @Cleanup("release")
+        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+        Event event = new Event(Unpooled.wrappedBuffer(content));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(3));
+        Append msg = new Append("segment", writerId, 1, event, 1);
+        CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        commandEncoder.encode(ctx, setupAppend, fakeNetwork);
+        commandEncoder.encode(ctx, msg, fakeNetwork);
+        Append invalidMsg = new Append("segment", writerId, 0, event, 1);
+        commandEncoder.encode(ctx, invalidMsg, fakeNetwork);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAppendConditional() throws Exception {
+        @Cleanup("release")
+        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        byte[] content = new byte[100];
+        Arrays.fill(content, (byte) 1);
+        Event event = new Event(Unpooled.wrappedBuffer(content));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(3));
+        Append msg = new Append("segment", writerId, 1, event, 1);
+        CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
+        SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
+        commandEncoder.encode(ctx, setupAppend, fakeNetwork);
+        commandEncoder.encode(ctx, msg, fakeNetwork);
+        Append invalidMsg = new Append("segment", writerId, 2, event, 0, 1);
+        commandEncoder.encode(ctx, invalidMsg, fakeNetwork);
     }
 
     @Test
@@ -261,9 +545,12 @@ public class AppendEncodeDecodeTest {
     @Test 
     public void testSwitchingWriters() throws Exception {
         int size = 20; //Used to force a minimum size
-        CommandEncoder encoder = new CommandEncoder(new FixedBatchSizeTracker(size));
         UUID writer1 = new UUID(1, 1);
         UUID writer2 = new UUID(2, 2);
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
+
+        CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
         @Cleanup("release")
         ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writer1, streamName, "");
@@ -279,7 +566,9 @@ public class AppendEncodeDecodeTest {
     @Test
     public void testZeroSizeAppend() throws Exception {
         int size = 0; //Used to force a minimum size
-        CommandEncoder encoder = new CommandEncoder(new FixedBatchSizeTracker(size));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
+        CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
         @Cleanup("release")
         ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writerId, streamName, "");
@@ -303,7 +592,9 @@ public class AppendEncodeDecodeTest {
     @Test
     public void testZeroSizeAppendInBlock() throws Exception {
         int size = 100;
-        CommandEncoder encoder = new CommandEncoder(new FixedBatchSizeTracker(size));
+        idBatchSizeTrackerMap.remove(1L);
+        idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
+        CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
         @Cleanup("release")
         ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writerId, streamName, "");

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -63,6 +63,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
     static final int RK_RENEWAL_RATE_WRITER = 500;
     static final int SCALE_WAIT_ITERATIONS = 12;
     private static final int READ_TIMEOUT = 1000;
+    private static final int WRITE_THROTTLING_TIME = 100;
 
     final String readerName = "reader";
     ScheduledExecutorService executorService;
@@ -179,7 +180,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
             long seqNumber = 0;
             while (!stopFlag.get()) {
                 try {
-                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
+                    Exceptions.handleInterrupted(() -> Thread.sleep(WRITE_THROTTLING_TIME));
 
                     // The content of events is generated following the pattern routingKey:seq_number, where
                     // seq_number is monotonically increasing for every routing key, being the expected delta between
@@ -225,6 +226,7 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
                     String uniqueRoutingKey = transaction.getTxnId().toString();
                     long seqNumber = 0;
                     for (int j = 1; j <= NUM_EVENTS_PER_TRANSACTION; j++) {
+                        Exceptions.handleInterrupted(() -> Thread.sleep(WRITE_THROTTLING_TIME));
                         // The content of events is generated following the pattern routingKey:seq_number. In this case,
                         // the context of the routing key is the transaction.
                         transaction.writeEvent(uniqueRoutingKey, uniqueRoutingKey + RK_VALUE_SEPARATOR + seqNumber);


### PR DESCRIPTION
**Change log description**  
* Cherry-picks commits from `master` to `r0.5`

**Purpose of the change**  
Fixes #3983

**What the code does**  
The following is the list of commits that we are cherry-picking in this PR:

```
Issue 3948: Log KeepAlives at Trace level. (#3949) 
Issues 3918, 3919, 3920: Throttle Transactional Writers in System Tests (#3950)
Issue 3774: Update the default max connection and Netty channel watermarking for performance Improvement (#3959)
Issue 3940: Fix auth resource representation used for stream in listStreams operation
Issue 3909: AppendBatchSizeTracker bug fix (#3863)
Issue 3918: (SegmentStore) Table Segment Pre-Caching (#3928)
```

**How to verify it**  
Build must pass.
