### PR TITLE
Issue 3442: Ensure znode store/streamsInScope is ignored when listing scopes for Zk based stream store

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class ZKScope implements Scope {
 
     private static final String SCOPE_PATH = "/store/%s";
-    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/streamsinscope/%s";
+    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/_streamsinscope/%s";
     private static final String STREAMS_IN_SCOPE_ROOT_PATH_FORMAT = STREAMS_IN_SCOPE_ROOT_PATH + "/streams";
     private static final String COUNTER_PATH = STREAMS_IN_SCOPE_ROOT_PATH + "/counter";
     private static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
@@ -39,9 +39,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class ZKScope implements Scope {
-
+    static final String STREAMS_IN_SCOPE = "_streamsinscope";
     private static final String SCOPE_PATH = "/store/%s";
-    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/_streamsinscope/%s";
+    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/" + STREAMS_IN_SCOPE + "/%s";
     private static final String STREAMS_IN_SCOPE_ROOT_PATH_FORMAT = STREAMS_IN_SCOPE_ROOT_PATH + "/streams";
     private static final String COUNTER_PATH = STREAMS_IN_SCOPE_ROOT_PATH + "/counter";
     private static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -150,7 +150,8 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore implements AutoC
 
     @Override
     public CompletableFuture<List<String>> listScopes() {
-        return storeHelper.getChildren(SCOPE_ROOT_PATH);
+        return storeHelper.getChildren(SCOPE_ROOT_PATH)
+                .thenApply(children -> children.stream().filter(x -> !x.equals(ZKScope.STREAMS_IN_SCOPE)).collect(Collectors.toList()));
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -325,6 +325,10 @@ public abstract class StreamMetadataStoreTest {
         store.deleteScope("Scope2").get();
         list = store.listScopes().get();
         assertEquals("List Scopes size", 2, list.size());
+
+        store.createStream("Scope3", "stream1", configuration1, System.currentTimeMillis(), null, executor).join();
+        list = store.listScopes().get();
+        assertEquals("List Scopes size", 2, list.size());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
1. Changes znode store/streamsInScope to store/_streamsInScope
2. Filters streamsInScope when listing scopes 

**Purpose of the change**  
Fixes #3442 

**What the code does**  
Changes znode store/streamsInScope to store/_streamsInScope so that it can be ignored from list scopes call. 

**How to verify it**  
Unit test updated