### PR TITLE
Issue 3686: Reduce stacktrace upon exceptional RawClient connection close

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -220,7 +220,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         if (closed.get()) {
             log.info("Closing connection to segment: {}", segmentId);
         } else {            
-            log.info("Closing connection to segment {} with exception: {}", segmentId, exceptionToInflightRequests);
+            log.info("Closing connection to segment {} with exception: {}", segmentId, exceptionToInflightRequests.toString());
         }
         CompletableFuture<ClientConnection> c;
         synchronized (lock) {


### PR DESCRIPTION
**Change log description**  
Reduce stacktrace upon exceptional RawClient connection close.

**Purpose of the change**  
Fixes #3686.

**What the code does**  
Outputs a summarized form of an unexpected exception when closing a connection in RawClient.

**How to verify it**  
All test should be passing as usual.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
