### PR TITLE
Issue 4002: Use load balancer's external endpoint hostname if IP isn't available

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -55,6 +55,9 @@ init_kubernetes() {
                 echo "Trying to obtain LoadBalancer external endpoint..."
                 sleep 10
                 export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].ip" )
+                if [ -z "${PUBLISHED_ADDRESS}" ]; then
+                    export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].hostname" )
+                fi
                 export PUBLISHED_PORT=$( k8 "${ns}" "services" "${podname}" ".spec.ports[].port" )
             done
         elif [ "${service_type}" == "NodePort" ]; then


### PR DESCRIPTION
**Change log description**  
Retrieve load balancer's external endpoint by host-name if IP is not available. 

**Purpose of the change**  
Fixes #4002 . 

**What the code does**  
If the load balancer's external endpoint's IP isn't available, retrieves the endpoint's hostname. IP address of the load balancer is available in PKS. For AWS, the endpoint address is accessed via hostname. See issue #4002 for additional details. 

**How to verify it**  
Verify that a Kubernetes cluster with external access enabled works for both PKS and AWS. 