### PR TITLE
Issue 4006: Cherry-pick merges from master to r0.5

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -220,7 +220,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
         if (closed.get()) {
             log.info("Closing connection to segment: {}", segmentId);
         } else {            
-            log.info("Closing connection to segment {} with exception: {}", segmentId, exceptionToInflightRequests);
+            log.warn("Closing connection to segment {} with exception: {}", segmentId, exceptionToInflightRequests.toString());
         }
         CompletableFuture<ClientConnection> c;
         synchronized (lock) {

--- a/common/src/main/java/io/pravega/common/util/ContinuationTokenAsyncIterator.java
+++ b/common/src/main/java/io/pravega/common/util/ContinuationTokenAsyncIterator.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -96,10 +95,7 @@ public class ContinuationTokenAsyncIterator<Token, T> implements AsyncIterator<T
                                               isOutstanding = false;
                                           }
                                       }
-                                  }).exceptionally(e -> {
-                        log.warn("Async iteration failed: ", e);
-                        throw new CompletionException(e);
-                    });
+                                  });
         }
 
         return outstanding.thenCompose(v -> {

--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -59,8 +59,6 @@ public final class StreamMetrics extends AbstractControllerMetrics implements Au
         DYNAMIC_LOGGER.incCounterValue(CREATE_STREAM, 1);
         DYNAMIC_LOGGER.reportGaugeValue(OPEN_TRANSACTIONS, 0, streamTags(scope, streamName));
         DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_COUNT, minNumSegments, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.incCounterValue(SEGMENTS_SPLITS, 0, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.incCounterValue(SEGMENTS_MERGES, 0, streamTags(scope, streamName));
 
         createStreamLatency.reportSuccessValue(latency.toMillis());
     }
@@ -211,10 +209,10 @@ public final class StreamMetrics extends AbstractControllerMetrics implements Au
      * @param merges        Number of segment merges in the scale operation.
      */
     public static void reportSegmentSplitsAndMerges(String scope, String streamName, long splits, long merges) {
-        DYNAMIC_LOGGER.updateCounterValue(globalMetricName(SEGMENTS_SPLITS), splits);
-        DYNAMIC_LOGGER.updateCounterValue(SEGMENTS_SPLITS, splits, streamTags(scope, streamName));
-        DYNAMIC_LOGGER.updateCounterValue(globalMetricName(SEGMENTS_MERGES), merges);
-        DYNAMIC_LOGGER.updateCounterValue(SEGMENTS_MERGES, merges, streamTags(scope, streamName));
+        DYNAMIC_LOGGER.reportGaugeValue(globalMetricName(SEGMENTS_SPLITS), splits);
+        DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_SPLITS, splits, streamTags(scope, streamName));
+        DYNAMIC_LOGGER.reportGaugeValue(globalMetricName(SEGMENTS_MERGES), merges);
+        DYNAMIC_LOGGER.reportGaugeValue(SEGMENTS_MERGES, merges, streamTags(scope, streamName));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -16,6 +16,7 @@ import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.Retry;
@@ -241,14 +242,14 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
 
     private CompletableFuture<Void> createScope(final String scopeName) {
         return Futures.toVoid(Retry.indefinitelyWithExpBackoff(DELAY, MULTIPLIER, MAX_DELAY,
-                e -> log.warn("Error creating event processor scope " + scopeName, e))
+                e -> log.warn("Error creating event processor scope {} with exception {}", scopeName, Exceptions.unwrap(e).toString()))
                                    .runAsync(() -> controller.createScope(scopeName)
                         .thenAccept(x -> log.info("Created controller scope {}", scopeName)), executor));
     }
 
     private CompletableFuture<Void> createStream(String scope, String streamName, final StreamConfiguration streamConfig) {
         return Futures.toVoid(Retry.indefinitelyWithExpBackoff(DELAY, MULTIPLIER, MAX_DELAY,
-                e -> log.warn("Error creating event processor stream " + streamName, e))
+                e -> log.warn("Error creating event processor stream {} with exception {}", streamName, Exceptions.unwrap(e).toString()))
                                    .runAsync(() -> controller.createStream(scope, streamName, streamConfig)
                                 .thenAccept(x ->
                                         log.info("Created stream {}/{}", scope, streamName)),

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -166,7 +166,7 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
 
     private <R> CompletableFuture<R> suppressException(CompletableFuture<R> future, R returnOnException, String message) {
         return Futures.exceptionallyExpecting(future, e -> {
-            log.warn(message, e);
+            log.warn("{}. Exception {}", message, Exceptions.unwrap(e).toString());
             return true;
         }, returnOnException);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -106,9 +106,9 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                         future.completeExceptionally(cause);
                     } else {
                         if (r >= 0) {
-                            log.debug("Successfully committed transactions on epoch {} on stream {}/{}", r, scope, stream);
+                            log.info("Successfully committed transactions on epoch {} on stream {}/{}", r, scope, stream);
                         } else {
-                            log.debug("No transactions found in committing state on stream {}/{}", r, scope, stream);
+                            log.info("No transactions found in committing state on stream {}/{}", r, scope, stream);
                         }
                         if (processedEvents != null) {
                             try {
@@ -149,6 +149,8 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                                 } else {
                                     int txnEpoch = versionedMetadata.getObject().getEpoch();
                                     List<UUID> txnList = versionedMetadata.getObject().getTransactionsToCommit();
+
+                                    log.info("Committing {} transactions on epoch {} on stream {}/{}", txnList, txnEpoch, scope, stream);
                                     // Once state is set to committing, we are guaranteed that this will be the only processing that can happen on the stream
                                     // and we can proceed with committing outstanding transactions collected in the txnList step.
                                     CompletableFuture<Void> future;
@@ -230,7 +232,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                 .thenCompose(v -> streamMetadataTasks.notifyNewSegments(scope, stream, activeEpochDuplicate, context, delegationToken))
                 .thenCompose(v -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, txnEpochDuplicate, delegationToken))
                 .thenCompose(sealedSegmentsMap -> {
-                    log.debug("Rolling transaction, created duplicate of active epoch {} for stream {}/{}", activeEpoch, scope, stream);
+                    log.info("Rolling transaction, created duplicate of active epoch {} for stream {}/{}", activeEpoch, scope, stream);
                     return streamMetadataStore.rollingTxnCreateDuplicateEpochs(scope, stream, sealedSegmentsMap,
                             timestamp, existing, context, executor);
                 })
@@ -239,7 +241,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                         .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, activeEpochSegmentIds,
                                 delegationToken))
                         .thenCompose(sealedSegmentsMap -> {
-                            log.debug("Rolling transaction, sealed active epoch {} for stream {}/{}", activeEpoch, scope, stream);
+                            log.info("Rolling transaction, sealed active epoch {} for stream {}/{}", activeEpoch, scope, stream);
                             return streamMetadataStore.completeRollingTxn(scope, stream, sealedSegmentsMap, existing,
                                     context, executor);
                         }));
@@ -264,7 +266,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
 
         return createSegmentsFuture
                 .thenCompose(v -> {
-                    log.debug("Rolling transaction, successfully created duplicate txn epoch {} for stream {}/{}", segmentIds, scope, stream);
+                    log.info("Rolling transaction, successfully created duplicate txn epoch {} for stream {}/{}", segmentIds, scope, stream);
                     // now commit transactions into these newly created segments
                     return commitTransactions(scope, stream, segmentIds, transactionsToCommit);
                 })
@@ -281,7 +283,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
         // if honoured and is based on the order in the list.
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         for (UUID txnId : transactionsToCommit) {
-            log.debug("Committing transaction {} on stream {}/{}", txnId, scope, stream);
+            log.info("Committing transaction {} on stream {}/{}", txnId, scope, stream);
             // commit transaction in segment store
             future = future
                     // Note, we can use the same segments and transaction id as only

--- a/controller/src/main/java/io/pravega/controller/store/index/HostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/HostIndex.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.pravega.controller.store.index;
 

--- a/controller/src/main/java/io/pravega/controller/store/index/InMemoryHostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/InMemoryHostIndex.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.pravega.controller.store.index;
 

--- a/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.controller.store.index;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.controller.store.stream.StoreException;
 import lombok.extern.slf4j.Slf4j;
@@ -93,12 +94,13 @@ public class ZKHostIndex implements HostIndex {
     @Override
     public CompletableFuture<List<String>> getEntities(final String hostId) {
         Preconditions.checkNotNull(hostId);
-        return getChildren(getHostPath(hostId));
+        String hostPath = getHostPath(hostId);
+        return sync(hostPath).thenCompose(v -> getChildren(hostPath));
     }
 
     @Override
     public CompletableFuture<Set<String>> getHosts() {
-        return getChildren(hostRoot).thenApply(list -> list.stream().collect(Collectors.toSet()));
+        return sync(hostRoot).thenCompose(v -> getChildren(hostRoot)).thenApply(list -> list.stream().collect(Collectors.toSet()));
     }
 
     private CompletableFuture<Void> createNode(CreateMode createMode, boolean createParents, String path, byte[] data) {
@@ -157,6 +159,25 @@ public class ZKHostIndex implements HostIndex {
         } catch (Exception e) {
             result.completeExceptionally(StoreException.create(StoreException.Type.UNKNOWN, e));
         }
+        return result;
+    }
+
+    @VisibleForTesting
+    CompletableFuture<Void> sync(final String path) {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+
+        try {
+            client.sync().inBackground((cli, event) -> {
+                if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+                    result.complete(null);
+                } else {
+                    result.completeExceptionally(translateErrorCode(path, event));
+                }
+                }, executor).forPath(path);
+        } catch (Exception e) {
+            result.completeExceptionally(StoreException.create(StoreException.Type.UNKNOWN, e, path));
+        }
+
         return result;
     }
 

--- a/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
+++ b/controller/src/main/java/io/pravega/controller/store/index/ZKHostIndex.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.pravega.controller.store.index;
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
@@ -146,11 +146,16 @@ class ZKGarbageCollector extends AbstractService implements AutoCloseable {
                 }, gcExecutor)
                 // fetch the version and update it.
                 .exceptionally(e -> {
-                    if (Exceptions.unwrap(e) instanceof StoreException.WriteConflictException) {
+                    Throwable unwrap = Exceptions.unwrap(e);
+                    if (unwrap instanceof StoreException.WriteConflictException) {
                         log.debug("Unable to acquire guard. Will try in next cycle.");
                     } else {
                         // if GC failed, it will be tried again in the next cycle. So log and ignore.
-                        log.error("Exception thrown during Garbage Collection iteration for {}. Log and ignore.", gcName, e);
+                        if (unwrap instanceof StoreException.StoreConnectionException) {
+                            log.info("StoreConnectionException thrown during Garbage Collection iteration for {}.", gcName);
+                        } else {
+                            log.warn("Exception thrown during Garbage Collection iteration for {}. Log and ignore.", gcName, unwrap);
+                        }
                     }
                     return null;
                 }).thenCompose(v -> fetchVersion());

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKScope.java
@@ -39,9 +39,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class ZKScope implements Scope {
-
+    static final String STREAMS_IN_SCOPE = "_streamsinscope";
     private static final String SCOPE_PATH = "/store/%s";
-    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/streamsinscope/%s";
+    private static final String STREAMS_IN_SCOPE_ROOT_PATH = "/store/" + STREAMS_IN_SCOPE + "/%s";
     private static final String STREAMS_IN_SCOPE_ROOT_PATH_FORMAT = STREAMS_IN_SCOPE_ROOT_PATH + "/streams";
     private static final String COUNTER_PATH = STREAMS_IN_SCOPE_ROOT_PATH + "/counter";
     private static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStoreHelper.java
@@ -339,6 +339,20 @@ public class ZKStoreHelper {
         return result;
     }
     
+    CompletableFuture<Void> sync(final String path) {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+
+        try {
+            BackgroundCallback callback = callback(x -> result.complete(null),
+                    result::completeExceptionally, path);
+            client.sync().inBackground(callback, executor).forPath(path);
+        } catch (Exception e) {
+            result.completeExceptionally(StoreException.create(StoreException.Type.UNKNOWN, e, path));
+        }
+
+        return result;
+    }
+    
     public CompletableFuture<Boolean> checkExists(final String path) {
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -150,7 +150,8 @@ class ZKStreamMetadataStore extends AbstractStreamMetadataStore implements AutoC
 
     @Override
     public CompletableFuture<List<String>> listScopes() {
-        return storeHelper.getChildren(SCOPE_ROOT_PATH);
+        return storeHelper.getChildren(SCOPE_ROOT_PATH)
+                .thenApply(children -> children.stream().filter(x -> !x.equals(ZKScope.STREAMS_IN_SCOPE)).collect(Collectors.toList()));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/task/TxnResource.java
+++ b/controller/src/main/java/io/pravega/controller/store/task/TxnResource.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) Dell Inc., or its subsidiaries.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.pravega.controller.store.task;
 

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server.eventProcessor;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Service;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.eventProcessor.EventProcessorGroup;
 import io.pravega.controller.eventProcessor.EventProcessorSystem;
@@ -28,12 +29,18 @@ import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.impl.Controller;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -41,12 +48,22 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 public class ControllerEventProcessorsTest {
     ScheduledExecutorService executor;
 
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdown();
+    }
+    
     @Test(timeout = 10000)
     public void testEventKey() {
         UUID txid = UUID.randomUUID();
@@ -68,7 +85,6 @@ public class ControllerEventProcessorsTest {
         ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
         StreamMetadataTasks streamMetadataTasks = mock(StreamMetadataTasks.class);
         StreamTransactionMetadataTasks streamTransactionMetadataTasks = mock(StreamTransactionMetadataTasks.class);
-        executor = Executors.newSingleThreadScheduledExecutor();
         ControllerEventProcessorConfig config = ControllerEventProcessorConfigImpl.withDefault();
         EventProcessorSystem system = mock(EventProcessorSystem.class);
         EventProcessorGroup<ControllerEvent> processor = new EventProcessorGroup<ControllerEvent>() {
@@ -159,4 +175,112 @@ public class ControllerEventProcessorsTest {
         assertTrue(Futures.await(processors.handleFailedProcess("host1")));
         processors.shutDown();
     }
+    
+    @Test(timeout = 30000L)
+    public void testBootstrap() {
+        Controller controller = mock(Controller.class);
+        CheckpointStore checkpointStore = mock(CheckpointStore.class);
+        StreamMetadataStore streamStore = mock(StreamMetadataStore.class);
+        BucketStore bucketStore = mock(BucketStore.class);
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        StreamMetadataTasks streamMetadataTasks = mock(StreamMetadataTasks.class);
+        StreamTransactionMetadataTasks streamTransactionMetadataTasks = mock(StreamTransactionMetadataTasks.class);
+        ControllerEventProcessorConfig config = ControllerEventProcessorConfigImpl.withDefault();
+        EventProcessorSystem system = mock(EventProcessorSystem.class);
+
+        doAnswer(x -> null).when(streamMetadataTasks).initializeStreamWriters(any(), any());
+        doAnswer(x -> null).when(streamTransactionMetadataTasks).initializeStreamWriters(any(EventStreamClientFactory.class), 
+                any(ControllerEventProcessorConfig.class));
+
+        LinkedBlockingQueue<CompletableFuture<Boolean>> createScopeResponses = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<CompletableFuture<Void>> createScopeSignals = new LinkedBlockingQueue<>();
+        List<CompletableFuture<Boolean>> createScopeResponsesList = new LinkedList<>();
+        List<CompletableFuture<Void>> createScopeSignalsList = new LinkedList<>();
+        for (int i = 0; i < 2; i++) {
+            CompletableFuture<Boolean> responseFuture = new CompletableFuture<>();
+            CompletableFuture<Void> signalFuture = new CompletableFuture<>();
+            createScopeResponsesList.add(responseFuture);
+            createScopeResponses.add(responseFuture);
+            createScopeSignalsList.add(signalFuture);
+            createScopeSignals.add(signalFuture);
+        }
+
+        // return a future from latches queue
+        doAnswer(x -> {
+            createScopeSignals.take().complete(null);
+            return createScopeResponses.take();
+        }).when(controller).createScope(anyString());
+
+        LinkedBlockingQueue<CompletableFuture<Boolean>> createStreamResponses = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<CompletableFuture<Void>> createStreamSignals = new LinkedBlockingQueue<>();
+        List<CompletableFuture<Boolean>> createStreamResponsesList = new LinkedList<>();
+        List<CompletableFuture<Void>> createStreamSignalsList = new LinkedList<>();
+        for (int i = 0; i < 6; i++) {
+            CompletableFuture<Boolean> responseFuture = new CompletableFuture<>();
+            CompletableFuture<Void> signalFuture = new CompletableFuture<>();
+            createStreamResponsesList.add(responseFuture);
+            createStreamResponses.add(responseFuture);
+            createStreamSignalsList.add(signalFuture);
+            createStreamSignals.add(signalFuture);
+        }
+
+        // return a future from latches queue
+        doAnswer(x -> {
+            createStreamSignals.take().complete(null);
+            return createStreamResponses.take();
+        }).when(controller).createStream(anyString(), anyString(), any());
+
+        ControllerEventProcessors processors = new ControllerEventProcessors("host1",
+                config, controller, checkpointStore, streamStore, bucketStore,
+                connectionFactory, streamMetadataTasks, streamTransactionMetadataTasks,
+                system, executor);
+
+        // call bootstrap on ControllerEventProcessors
+        processors.bootstrap(streamTransactionMetadataTasks, streamMetadataTasks);
+        
+        // wait on create scope being called.
+        createScopeSignalsList.get(0).join();
+        
+        verify(controller, times(1)).createScope(any());
+        
+        // complete scopeFuture1 exceptionally. this should result in a retry. 
+        createScopeResponsesList.get(0).completeExceptionally(new RuntimeException());
+
+        // wait on second scope signal being called
+        createScopeSignalsList.get(1).join();
+
+        verify(controller, times(2)).createScope(any());
+        
+        // so far no create stream should have been invoked
+        verify(controller, times(0)).createStream(anyString(), anyString(), any());
+
+        // complete scopeFuture2 successfully
+        createScopeResponsesList.get(1).complete(true);
+
+        // create streams should be called now
+        // since we call three create streams. We will wait on first three signal futures
+        createStreamSignalsList.get(0).join();
+        createStreamSignalsList.get(1).join();
+        createStreamSignalsList.get(2).join();
+
+        verify(controller, times(3)).createStream(anyString(), anyString(), any());
+
+        // fail first three requests
+        createStreamResponsesList.get(0).completeExceptionally(new RuntimeException());
+        createStreamResponsesList.get(1).completeExceptionally(new RuntimeException());
+        createStreamResponsesList.get(2).completeExceptionally(new RuntimeException());
+        
+        // this should result in a retry for three create streams. wait on next three signals
+        createStreamSignalsList.get(3).join();
+        createStreamSignalsList.get(4).join();
+        createStreamSignalsList.get(5).join();
+
+        verify(controller, times(6)).createStream(anyString(), anyString(), any());
+        
+        // complete successfully
+        createStreamResponsesList.get(3).complete(true);
+        createStreamResponsesList.get(4).complete(true);
+        createStreamResponsesList.get(5).complete(true);
+    }
+    
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -31,7 +31,6 @@ import io.pravega.controller.server.eventProcessor.requesthandlers.StreamRequest
 import io.pravega.controller.server.eventProcessor.requesthandlers.TaskExceptions;
 import io.pravega.controller.server.rpc.auth.AuthHelper;
 import io.pravega.controller.store.stream.BucketStore;
-import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
 import io.pravega.controller.store.stream.State;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
@@ -258,8 +257,8 @@ public abstract class ScaleRequestHandlerTest {
         // This will bring down the test duration drastically because a retryable failure can keep retrying for few seconds.
         // And if someone changes retry durations and number of attempts in retry helper, it will impact this test's running time.
         // hence sending incorrect segmentsToSeal list which will result in a non retryable failure and this will fail immediately
-        assertFalse(Futures.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(6L),
-                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()))));
+        assertFalse(Futures.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(five),
+                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()))));
         activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
         assertTrue(activeSegments.stream().noneMatch(z -> z.segmentId() == three));
         assertTrue(activeSegments.stream().noneMatch(z -> z.segmentId() == four));
@@ -798,8 +797,7 @@ public abstract class ScaleRequestHandlerTest {
         this.streamStore.setState(scope, stream, State.SCALING, null, executor).join();
 
         // rerun same auto scaling job. 
-        AssertExtensions.assertSuppliedFutureThrows("", () -> scaleRequestHandler.execute(event2),
-                e -> Exceptions.unwrap(e) instanceof EpochTransitionOperationExceptions.PreConditionFailureException);
+        scaleRequestHandler.execute(event2).join();
         assertEquals(State.ACTIVE, streamStore.getState(scope, stream, true, null, executor).join());
         assertEquals(2, streamStore.getActiveEpoch(scope, stream, null, true, executor).join().getEpoch());
 

--- a/controller/src/test/java/io/pravega/controller/store/index/ZkHostIndexTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/index/ZkHostIndexTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.controller.store.index;
+
+import io.pravega.test.common.TestingServerStarter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ZkHostIndexTest {
+    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+    protected CuratorFramework cli;
+    private TestingServer zkServer;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServerStarter().start();
+        zkServer.start();
+
+        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), new RetryOneTime(2000));
+        cli.start();
+    }
+    
+    @After
+    public void tearDown() throws IOException {
+        cli.close();
+        zkServer.stop();
+        zkServer.close();
+        executor.shutdown();
+    }
+    
+    @Test
+    public void testSync() {
+        ZKHostIndex index = spy(new ZKHostIndex(cli, "/hostRequestIndex", executor));
+        String hostId = "hostId";
+        index.addEntity(hostId, "entity").join();
+        List<String> entities = index.getEntities(hostId).join();
+        verify(index, times(1)).sync(any());
+        assertEquals(entities.size(), 1);
+
+        Set<String> hosts = index.getHosts().join();
+        verify(index, times(2)).sync(any());
+        assertTrue(hosts.contains(hostId));
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -325,6 +325,10 @@ public abstract class StreamMetadataStoreTest {
         store.deleteScope("Scope2").get();
         list = store.listScopes().get();
         assertEquals("List Scopes size", 2, list.size());
+
+        store.createStream("Scope3", "stream1", configuration1, System.currentTimeMillis(), null, executor).join();
+        list = store.listScopes().get();
+        assertEquals("List Scopes size", 2, list.size());
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStoreHelperTest.java
@@ -30,6 +30,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Unit tests for ZKStoreHelper.
  */
@@ -92,7 +95,7 @@ public class ZKStoreHelperTest {
         cli2.start();
         ZKStoreHelper zkStoreHelper2 = new ZKStoreHelper(cli2, executor);
 
-        Assert.assertTrue(zkStoreHelper2.createEphemeralZNode("/testEphemeral", new byte[0]).join());
+        assertTrue(zkStoreHelper2.createEphemeralZNode("/testEphemeral", new byte[0]).join());
         Assert.assertNotNull(zkStoreHelper2.getData("/testEphemeral", x -> x).join());
         zkStoreHelper2.getClient().getZookeeperClient().close();
         zkStoreHelper2.getClient().close();
@@ -100,5 +103,15 @@ public class ZKStoreHelperTest {
         // now read the data again. Verify that node no longer exists
         AssertExtensions.assertFutureThrows("", Futures.delayedFuture(() -> zkStoreHelper.getData("/testEphemeral", x -> x), 1000, executor),
                 e -> e instanceof StoreException.DataNotFoundException);
+    }
+    
+    @Test
+    public void testSync() {
+        String path = "/path";
+        byte[] entry = new byte[1];
+        zkStoreHelper.createZNode(path, entry).join();
+        zkStoreHelper.sync(path).join();
+        byte[] data = zkStoreHelper.getData(path, x -> x).join().getObject();
+        assertEquals(1, data.length);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -213,8 +213,6 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
         AssertExtensions.assertFutureThrows("Remove txn fails", store.removeTxnFromIndex(host, txn, true), checker);
         AssertExtensions.assertFutureThrows("Remove host fails", store.removeHostFromIndex(host), checker);
         AssertExtensions.assertFutureThrows("Get txn version fails", store.getTxnVersionFromIndex(host, txn), checker);
-        AssertExtensions.assertFutureThrows("Get random txn fails", store.getRandomTxnFromIndex(host), checker);
-        AssertExtensions.assertFutureThrows("List hosts fails", store.listHostsOwningTxn(), checker);
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
@@ -95,7 +95,14 @@ public class ZkGarbageCollectorTest {
         // add some delay
         assertEquals(2, gc1.getLatestBatch());
         assertEquals(2, gc2.getLatestBatch());
+    
+        // fail processing with store connection exception
+        queue.add(Futures.failedFuture(StoreException.create(StoreException.Type.CONNECTION_ERROR, "store connection")));
 
+        // the processing should not fail and gc should happen in the next period. 
+        Futures.delayedFuture(gcPeriod.plus(delta), executor).join();
+        assertEquals(3, gc1.getLatestBatch());
+        assertEquals(3, gc2.getLatestBatch());
         queue.add(CompletableFuture.completedFuture(null));
 
         // now stop GC1 so that gc2 become leader for GC workflow.
@@ -104,13 +111,13 @@ public class ZkGarbageCollectorTest {
 
         Futures.delayedFuture(gcPeriod.plus(delta), executor).join();
         gc2.fetchVersion().join();
-        assertEquals(3, gc2.getLatestBatch());
+        assertEquals(4, gc2.getLatestBatch());
         
         // now deliberately set the gc version for gc2 to an older value and call process. 
         gc2.setVersion(0);
         gc2.process().join();
         
-        assertEquals(3, gc2.getVersion());
+        assertEquals(4, gc2.getVersion());
         
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
@@ -32,6 +32,10 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ZkOrderedStoreTest {
     //Ensure each test completes within 30 seconds.
@@ -130,5 +134,19 @@ public class ZkOrderedStoreTest {
         store.removeEntities(scope, stream, Collections.singletonList(position5)).join();
         // verify that collection 2 is not deleted as it is not sealed
         assertFalse(store.isDeleted(scope, stream, 2).join());
+    }
+
+    @Test
+    public void testSync() {
+        String test = "test";
+        String scope = "test";
+        String stream = "test";
+        ZKStoreHelper zkStoreHelper = spy(this.zkStoreHelper);
+        ZkOrderedStore store = new ZkOrderedStore(test, zkStoreHelper, executor, 1);
+        
+        store.addEntity(scope, stream, test + 1).join();
+        store.getEntitiesWithPosition(scope, stream).join();
+        
+        verify(zkStoreHelper, times(1)).sync(any());
     }
 }

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -55,6 +55,9 @@ init_kubernetes() {
                 echo "Trying to obtain LoadBalancer external endpoint..."
                 sleep 10
                 export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].ip" )
+                if [ -z "${PUBLISHED_ADDRESS}" ]; then
+                    export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].hostname" )
+                fi
                 export PUBLISHED_PORT=$( k8 "${ns}" "services" "${podname}" ".spec.ports[].port" )
             done
         elif [ "${service_type}" == "NodePort" ]; then

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -188,8 +188,8 @@ public final class MetricsNames {
 
     // Stream segment counts
     public static final String SEGMENTS_COUNT = PREFIX + "controller.segments.count";    // Per-stream Gauge
-    public static final String SEGMENTS_SPLITS = PREFIX + "controller.segment.splits";   // Per-stream Counter
-    public static final String SEGMENTS_MERGES = PREFIX + "controller.segment.merges";   // Per-stream Counter
+    public static final String SEGMENTS_SPLITS = PREFIX + "controller.segment.splits";   // Per-stream Gauge
+    public static final String SEGMENTS_MERGES = PREFIX + "controller.segment.merges";   // Per-stream Gauge
 
     // Stream retention operations
     public static final String RETENTION_FREQUENCY = PREFIX + "controller.retention.frequency";   // Per-stream Counter

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration;
+
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.host.stat.AutoScaleMonitor;
+import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.metrics.MetricRegistryUtils;
+import io.pravega.shared.metrics.MetricsConfig;
+import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.StatsProvider;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.pravega.shared.MetricsTags.streamTags;
+import static org.junit.Assert.assertEquals;
+
+@Slf4j
+public class StreamMetricsTest {
+
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(1);
+    private final StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(scalingPolicy).build();
+    private TestingServer zkTestServer = null;
+    private PravegaConnectionListener server = null;
+    private ControllerWrapper controllerWrapper = null;
+    private Controller controller = null;
+    private StatsProvider statsProvider = null;
+    private ServiceBuilder serviceBuilder = null;
+    private AutoScaleMonitor monitor = null;
+
+    @Before
+    public void setup() throws Exception {
+        final int controllerPort = TestUtils.getAvailableListenPort();
+        final String serviceHost = "localhost";
+        final int servicePort = TestUtils.getAvailableListenPort();
+        final int containerCount = 4;
+
+        // 1. Start Metrics service
+        log.info("Initializing metrics provider ...");
+
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
+                .build();
+        metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(60));
+
+        MetricsProvider.initialize(metricsConfig);
+        statsProvider = MetricsProvider.getMetricsProvider();
+        statsProvider.startWithoutExporting();
+        log.info("Metrics Stats provider is started");
+
+        // 2. Start ZK
+        this.zkTestServer = new TestingServerStarter().start();
+
+        // 3. Start Pravega SegmentStore service.
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+        monitor = new AutoScaleMonitor(store, AutoScalerConfig.builder().build());
+        TableStore tableStore = serviceBuilder.createTableStoreService();
+
+        this.server = new PravegaConnectionListener(false, "localhost", servicePort, store, tableStore,
+                monitor.getStatsRecorder(), monitor.getTableSegmentStatsRecorder(), new PassingTokenVerifier(),
+                null, null, true);
+        this.server.startListening();
+
+        // 4. Start Pravega Controller service
+        this.controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
+                controllerPort, serviceHost, servicePort, containerCount);
+        this.controllerWrapper.awaitRunning();
+        this.controller = controllerWrapper.getController();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.statsProvider != null) {
+            statsProvider.close();
+            statsProvider = null;
+            log.info("Metrics statsProvider is now closed.");
+        }
+
+        if (this.controllerWrapper != null) {
+            this.controllerWrapper.close();
+            this.controllerWrapper = null;
+        }
+
+        if (this.server != null) {
+            this.server.close();
+            this.server = null;
+        }
+
+        if (this.monitor != null) {
+            this.monitor.close();
+            this.monitor = null;
+        }
+
+        if (this.serviceBuilder != null) {
+            this.serviceBuilder.close();
+            this.serviceBuilder = null;
+        }
+
+        if (this.zkTestServer != null) {
+            this.zkTestServer.close();
+            this.zkTestServer = null;
+        }
+    }
+
+    @Test
+    public void testSegmentSplitMerge() throws Exception {
+
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        String scaleScopeName = "scaleScope";
+        String scaleStreamName = "scaleStream";
+
+        controllerWrapper.getControllerService().createScope(scaleScopeName).get();
+        if (!controller.createStream(scaleScopeName, scaleStreamName, config).get()) {
+            log.error("Stream {} for scale testing already existed, exiting", scaleScopeName + "/" + scaleStreamName);
+            return;
+        }
+        Stream scaleStream = new StreamImpl(scaleScopeName, scaleStreamName);
+
+        //split to 3 segments
+        Map<Double, Double> keyRanges = new HashMap<>();
+        keyRanges.put(0.0, 0.33);
+        keyRanges.put(0.33, 0.66);
+        keyRanges.put(0.66, 1.0);
+
+        if (!controller.scaleStream(scaleStream, Collections.singletonList(0L), keyRanges, executor).getFuture().get()) {
+            log.error("Scale stream: splitting segment into three failed, exiting");
+            return;
+        }
+
+        assertEquals(3, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_COUNT, streamTags(scaleScopeName, scaleStreamName)).value());
+        assertEquals(1, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_SPLITS, streamTags(scaleScopeName, scaleStreamName)).value());
+        assertEquals(0, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_MERGES, streamTags(scaleScopeName, scaleStreamName)).value());
+
+        //merge back to 2 segments
+        keyRanges = new HashMap<>();
+        keyRanges.put(0.0, 0.5);
+        keyRanges.put(0.5, 1.0);
+
+        if (!controller.scaleStream(scaleStream, Arrays.asList(1L, 2L, 3L), keyRanges, executor).getFuture().get()) {
+            log.error("Scale stream: merging segments into two failed, exiting");
+            return;
+        }
+
+        assertEquals(2, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_COUNT, streamTags(scaleScopeName, scaleStreamName)).value());
+        assertEquals(1, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_SPLITS, streamTags(scaleScopeName, scaleStreamName)).value());
+        assertEquals(1, (long) MetricRegistryUtils.getGauge(MetricsNames.SEGMENTS_MERGES, streamTags(scaleScopeName, scaleStreamName)).value());
+    }
+}

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndStatsTest.java
@@ -1,17 +1,11 @@
 /**
- * Copyright (c) Dell Inc., or its subsidiaries.
- * <p>
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration.endtoendtest;
 


### PR DESCRIPTION
**Change log description**  
* Cherry-picks commits from master to r0.5

**Purpose of the change**  
Fixes #4006

**What the code does**  
All code changes are from cherry-picking the following merges to `master`:

```
Issue 3442: Ensure znode store/streamsInScope is ignored when listing scopes for Zk based stream store (#3988)
Issues 3958, 3755: Adding sync before zookeeper reads for ZK orderer and ZK Host Index (#3985)
Issue 3978: (BookKeeperLog) Fetching appropriate ZNode version. (#3990)
Issue 3989: Fix license headers (#3991)
Issue 3686: Reduce stacktrace upon exceptional AsyncSegmentInputStreamImpl connection close (#3996)
Issue 3999: Soft handle expected exception logs (#3997)
Issue 4002: Use load balancer external endpoint hostname if IP isn't available (#4004)
Issue 3556: Changed segment splits/merges metrics from counter to gauge (#3995)
```

**How to verify it**  
Build must succeed.
