### PR TITLE
Issue 3508: Remove year from copyright in r05

### DIFF
--- a/client/src/main/java/io/pravega/client/byteStream/ByteStreamClient.java
+++ b/client/src/main/java/io/pravega/client/byteStream/ByteStreamClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/client/src/main/java/io/pravega/client/byteStream/ByteStreamReader.java
+++ b/client/src/main/java/io/pravega/client/byteStream/ByteStreamReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/byteStream/ByteStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/byteStream/ByteStreamWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/byteStream/impl/BufferedByteStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/BufferedByteStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamReaderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/pravega/client/stream/TransactionalEventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/TransactionalEventStreamWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/byteStream/ByteStreamReaderTest.java
+++ b/client/src/test/java/io/pravega/client/byteStream/ByteStreamReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/byteStream/ByteStreamWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/client/src/test/java/io/pravega/client/state/impl/SerializationTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SerializationTest.java
@@ -1,5 +1,5 @@
 /**
-  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ByteSerializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/pravega/client/stream/impl/SerializationTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SerializationTest.java
@@ -1,5 +1,5 @@
 /**
-  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/io/pravega/common/util/ByteBufferUtilsTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteBufferUtilsTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) Dell Inc., or its subsidiaries.
+  Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/ByteStreamTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ByteStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/IdleSegmentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <fpj@apache.org>

**Change log description**  
* Removes year from copyright from remaining files.

**Purpose of the change**  
It is part of #3508 , but does not close it.

**What the code does**  
There is no code change, it only updates the license header across some files.

**How to verify it**  
There is no change of behavior, it should build correctly.