### PR TITLE
Issue 4020: Expose additional stream metadata records for internal records on StreamMetadataStore interface 

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
  * Implementation of create and update queries are delegated to the specific implementations of this abstract class.
  */
 @Slf4j
-public abstract class AbstractStreamMetadataStore implements StreamMetadataStore {
+public abstract class AbstractStreamMetadataStore implements ExtendedStreamMetadataStore {
     public static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;
     public static final Predicate<Throwable> DATA_NOT_EMPTY_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotEmptyException;
 
@@ -405,7 +405,6 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
         Stream stream = getStream(scope, streamName, context);
         return withCompletion(stream.isStreamCutValid(streamCut), executor);
     }
-
 
     @Override
     public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> submitScale(final String scope,

--- a/controller/src/main/java/io/pravega/controller/store/stream/ExtendedStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ExtendedStreamMetadataStore.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
+import io.pravega.controller.store.stream.records.HistoryTimeSeriesRecord;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public interface ExtendedStreamMetadataStore extends StreamMetadataStore {
+    CompletableFuture<HistoryTimeSeriesRecord> getHistoryTimeSeriesRecord(final String scope, final String streamName,
+                                                                          final int epoch, final OperationContext context,
+                                                                          final Executor executor);
+
+    CompletableFuture<Boolean> checkSegmentSealed(final String scope, final String streamName, final long segmentId,
+                                                  final OperationContext context, final Executor executor);
+
+    CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunkRecent(final String scope, final String streamName,
+                                                                         final OperationContext context, final Executor executor);
+}

--- a/controller/src/main/java/io/pravega/controller/store/stream/ExtendedStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ExtendedStreamMetadataStore.java
@@ -15,14 +15,54 @@ import io.pravega.controller.store.stream.records.HistoryTimeSeriesRecord;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+/**
+ * Extended Stream Metadata.
+ */
 public interface ExtendedStreamMetadataStore extends StreamMetadataStore {
-    CompletableFuture<HistoryTimeSeriesRecord> getHistoryTimeSeriesRecord(final String scope, final String streamName,
-                                                                          final int epoch, final OperationContext context,
+
+    /**
+     * Method to get the HistoryTimeSeriesRecord, given the epoch to which it corresponds to.
+     *
+     * @param scope       stream scope.
+     * @param streamName  stream name.
+     * @param epoch       epoch.
+     * @param context     operation context.
+     * @param executor    callers executor.
+     * @return Completable future that, upon completion, holds the history record corresponding to request epoch.
+     */
+    CompletableFuture<HistoryTimeSeriesRecord> getHistoryTimeSeriesRecord(final String scope,
+                                                                          final String streamName,
+                                                                          final int epoch,
+                                                                          final OperationContext context,
                                                                           final Executor executor);
 
-    CompletableFuture<Boolean> checkSegmentSealed(final String scope, final String streamName, final long segmentId,
-                                                  final OperationContext context, final Executor executor);
+    /**
+     * Method to check if the given segment, whose ID is given, is sealed or not.
+     *
+     * @param scope       stream scope.
+     * @param streamName  stream name.
+     * @param segmentId   segment ID.
+     * @param context     operation context.
+     * @param executor    callers executor.
+     * @return Completable future that, upon completion, holds the boolean representing whether the segment is sealed or not.
+     */
+    CompletableFuture<Boolean> checkSegmentSealed(final String scope,
+                                                  final String streamName,
+                                                  final long segmentId,
+                                                  final OperationContext context,
+                                                  final Executor executor);
 
-    CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunkRecent(final String scope, final String streamName,
-                                                                         final OperationContext context, final Executor executor);
+    /**
+     * Method to get the most recent chunk of the HistoryTimeSeries.
+     *
+     * @param scope       stream scope.
+     * @param streamName  stream name.
+     * @param context     operation context.
+     * @param executor    callers executor.
+     * @return Completable future that, upon completion, holds the most recent HistoryTimeSeries chunk.
+     */
+    CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunkRecent(final String scope,
+                                                                         final String streamName,
+                                                                         final OperationContext context,
+                                                                         final Executor executor);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactoryExtended.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactoryExtended.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import io.pravega.controller.server.SegmentHelper;
+import io.pravega.controller.server.rpc.auth.AuthHelper;
+import io.pravega.controller.store.client.StoreClient;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.curator.framework.CuratorFramework;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class StreamStoreFactoryExtended extends StreamStoreFactory {
+    public static ExtendedStreamMetadataStore createStore(final StoreClient storeClient, final SegmentHelper segmentHelper,
+                                                                  final AuthHelper authHelper, final ScheduledExecutorService executor) {
+        switch (storeClient.getType()) {
+            case InMemory:
+                return new InMemoryStreamMetadataStore(executor);
+            case Zookeeper:
+                return new ZKStreamMetadataStore((CuratorFramework) storeClient.getClient(), executor);
+            case PravegaTable:
+                return new PravegaTablesStreamMetadataStore(segmentHelper, (CuratorFramework) storeClient.getClient(), executor, authHelper);
+            default:
+                throw new NotImplementedException(storeClient.getType().toString());
+        }
+    }
+
+    public static ExtendedStreamMetadataStore createPravegaTablesStore(final SegmentHelper segmentHelper, final AuthHelper authHelper,
+                                                               final CuratorFramework client, final ScheduledExecutorService executor) {
+        return new PravegaTablesStreamMetadataStore(segmentHelper, client, executor, authHelper);
+    }
+
+    public static ExtendedStreamMetadataStore createZKStore(final CuratorFramework client, final ScheduledExecutorService executor) {
+        return new ZKStreamMetadataStore(client, executor);
+    }
+
+    public static ExtendedStreamMetadataStore createInMemoryStore(final Executor executor) {
+        return new InMemoryStreamMetadataStore(executor);
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactoryExtended.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamStoreFactoryExtended.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.controller.store.stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.rpc.auth.AuthHelper;
 import io.pravega.controller.store.client.StoreClient;
@@ -20,7 +21,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class StreamStoreFactoryExtended extends StreamStoreFactory {
     public static ExtendedStreamMetadataStore createStore(final StoreClient storeClient, final SegmentHelper segmentHelper,
-                                                                  final AuthHelper authHelper, final ScheduledExecutorService executor) {
+                                                          final AuthHelper authHelper, final ScheduledExecutorService executor) {
         switch (storeClient.getType()) {
             case InMemory:
                 return new InMemoryStreamMetadataStore(executor);
@@ -33,15 +34,18 @@ public class StreamStoreFactoryExtended extends StreamStoreFactory {
         }
     }
 
+    @VisibleForTesting
     public static ExtendedStreamMetadataStore createPravegaTablesStore(final SegmentHelper segmentHelper, final AuthHelper authHelper,
-                                                               final CuratorFramework client, final ScheduledExecutorService executor) {
+                                                                       final CuratorFramework client, final ScheduledExecutorService executor) {
         return new PravegaTablesStreamMetadataStore(segmentHelper, client, executor, authHelper);
     }
 
+    @VisibleForTesting
     public static ExtendedStreamMetadataStore createZKStore(final CuratorFramework client, final ScheduledExecutorService executor) {
         return new ZKStreamMetadataStore(client, executor);
     }
 
+    @VisibleForTesting
     public static ExtendedStreamMetadataStore createInMemoryStore(final Executor executor) {
         return new InMemoryStreamMetadataStore(executor);
     }


### PR DESCRIPTION
**Change log description**  

- There are metadata records per stream that are not exposed via StreamMetadataStore interface as they are relevant to the metadata schema only. However, for purposes of troubleshooter tool for metadata, we need to expose all such records so that the tool can check for consistency. So this PR makes records such as the `HistoryTimeSeries`, `HistoryTimeSeriesRecord` and `SealedSegmentRecord` accessible on an extended interface.

**Purpose of the change**  
Fixes #4020 

**What the code does**  
- A new store interface called `ExtendedStreamMetadataStore` which extends the `StreamMetadataStore` interface has been created in the `controller.store.stream` package.
- The `AbstractStreamMetadataStore` class now implements the `ExtendedStreamMetadataStore` instead of the `StreamMetadataStore`.
- The three types of metadata stores; `InMemoryStreamMetadataStore`, `PravegaTablesStreamMetadataStore` and the `ZKStreamMetadataStore`; have implementations for the methods described in the `ExtendedStreamMetadataStore` interface.
- A new class `StreamStoreFactoryExtended` which extends the `StreamStoreFactory` has also been created.
- Allows for access to the most recent chunk of the `HistoryTimeSeries` and `HistoryTimeSeriesRecord` given the epoch number.
- Can do a check on whether a given segment is sealed or not.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
