### PR TITLE
Issue 4011: Fixed ThrottlerCalculator.Delay.ToString()

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -295,7 +295,7 @@ class ThrottlerCalculator {
 
         @Override
         public String toString() {
-            return String.format("{}ms (Max={}, Reason={})", this.durationMillis, this.maximum, this.reason);
+            return String.format("%dms (Max=%s, Reason=%s)", this.durationMillis, this.maximum, this.reason);
         }
     }
 


### PR DESCRIPTION
**Change log description**  
- Fixed ThrottlerCalculator.Delay.toString()

**Purpose of the change**  
Fixes #4011.

**What the code does**  
- Wrong formatting used in `toString`. Without this, any throttling delay recording is useless.

**How to verify it**  
Run a test where DEBUG logging is enabled and verify `Processing delay` outputs something readable.
