### PR TITLE
Issue 4025: Cherry-pick changes from master to r0.5

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
@@ -137,7 +137,7 @@ public final class SegmentStoreMetrics {
         /**
          * Number of ContainerMetadataUpdateTransactions committed at once.
          */
-        private final OpStatsLogger metadataCommitTxnCount;
+        private final OpStatsLogger memoryCommitCount;
 
         /**
          * Amount of time elapsed to commit operations to memory, including commit to Metadata, adding to InMemoryLog
@@ -161,7 +161,7 @@ public final class SegmentStoreMetrics {
             this.operationCommitLatency = STATS_LOGGER.createStats(MetricsNames.OPERATION_COMMIT_LATENCY, this.containerTag);
             this.operationLatency = STATS_LOGGER.createStats(MetricsNames.OPERATION_LATENCY, this.containerTag);
             this.memoryCommitLatency = STATS_LOGGER.createStats(MetricsNames.OPERATION_COMMIT_MEMORY_LATENCY, this.containerTag);
-            this.metadataCommitTxnCount = STATS_LOGGER.createStats(MetricsNames.OPERATION_COMMIT_METADATA_TXN_COUNT, this.containerTag);
+            this.memoryCommitCount = STATS_LOGGER.createStats(MetricsNames.OPERATION_COMMIT_MEMORY_COUNT, this.containerTag);
             this.processOperationsLatency = STATS_LOGGER.createStats(MetricsNames.PROCESS_OPERATIONS_LATENCY, this.containerTag);
             this.processOperationsBatchSize = STATS_LOGGER.createStats(MetricsNames.PROCESS_OPERATIONS_BATCH_SIZE, this.containerTag);
         }
@@ -175,7 +175,7 @@ public final class SegmentStoreMetrics {
             this.operationCommitLatency.close();
             this.operationLatency.close();
             this.memoryCommitLatency.close();
-            this.metadataCommitTxnCount.close();
+            this.memoryCommitCount.close();
             this.processOperationsLatency.close();
             this.processOperationsBatchSize.close();
         }
@@ -193,8 +193,8 @@ public final class SegmentStoreMetrics {
             this.operationQueueWaitTime.reportSuccessValue(queueWaitTimeMillis);
         }
 
-        public void memoryCommit(int metadataUpdateTxnCount, Duration elapsed) {
-            this.metadataCommitTxnCount.reportSuccessValue(metadataUpdateTxnCount);
+        public void memoryCommit(int commitCount, Duration elapsed) {
+            this.memoryCommitCount.reportSuccessValue(commitCount);
             this.memoryCommitLatency.reportSuccessEvent(elapsed);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -233,23 +233,23 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         val delay = new AtomicReference<ThrottlerCalculator.DelayResult>(this.throttlerCalculator.getThrottlingDelay());
         if (!delay.get().isMaximum()) {
             // We are not delaying the maximum amount. We only need to do this once.
-            return throttleOnce(delay.get().getDurationMillis(), delay.get().isMaximum());
+            return throttleOnce(delay.get());
         } else {
             // The initial delay calculation indicated that we need to throttle to the maximum, which means there's
             // significant pressure. In order to protect downstream components, we need to run in a loop and delay as much
             // as needed until the pressure is relieved.
             return Futures.loop(
                     () -> !delay.get().isMaximum(),
-                    () -> throttleOnce(delay.get().getDurationMillis(), delay.get().isMaximum())
+                    () -> throttleOnce(delay.get())
                             .thenRun(() -> delay.set(this.throttlerCalculator.getThrottlingDelay())),
                     this.executor);
         }
     }
 
-    private CompletableFuture<Void> throttleOnce(int millis, boolean max) {
-        this.metrics.processingDelay(millis);
-        log.debug("{}: Processing delay = {}ms (max={}).", this.traceObjectId, millis, max);
-        return Futures.delayedFuture(Duration.ofMillis(millis), this.executor);
+    private CompletableFuture<Void> throttleOnce(ThrottlerCalculator.DelayResult delay) {
+        this.metrics.processingDelay(delay.getDurationMillis());
+        log.debug("{}: Processing delay = {}.", this.traceObjectId, delay);
+        return Futures.delayedFuture(Duration.ofMillis(delay.getDurationMillis()), this.executor);
     }
 
     /**
@@ -414,7 +414,9 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
     private void processCommits(Collection<List<CompletableOperation>> items) {
         try {
             do {
+                Timer memoryCommitTimer = new Timer();
                 this.stateUpdater.process(items.stream().flatMap(List::stream).map(CompletableOperation::getOperation).iterator());
+                this.metrics.memoryCommit(items.size(), memoryCommitTimer.getElapsed());
                 items = this.commitQueue.poll(MAX_COMMIT_QUEUE_SIZE);
             } while (!items.isEmpty());
         } catch (Throwable ex) {
@@ -535,17 +537,15 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                     }
 
                     // Collect operations to commit.
-                    Timer memoryCommitTimer = new Timer();
                     toAck = collectCompletionCandidates(commitArgs);
 
                     // Commit metadata updates.
-                    int updateTxnCommitCount = OperationProcessor.this.metadataUpdater.commit(commitArgs.getMetadataTransactionId());
+                    OperationProcessor.this.metadataUpdater.commit(commitArgs.getMetadataTransactionId());
 
-                    // Commit operations to memory. Note that this will block synchronously if the Commit Queue is full (until it clears up).
+                    // Queue operations for memory commit, which will be done asynchronously.
                     toAck.forEach(OperationProcessor.this.commitQueue::add);
 
                     this.highestCommittedDataFrame = addressSequence;
-                    metrics.memoryCommit(updateTxnCommitCount, memoryCommitTimer.getElapsed());
                 }
             } finally {
                 if (toAck != null) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -295,7 +295,7 @@ class ThrottlerCalculator {
 
         @Override
         public String toString() {
-            return String.format("{}ms (Max={}, Reason={})", this.durationMillis, this.maximum, this.reason);
+            return String.format("%dms (Max=%s, Reason=%s)", this.durationMillis, this.maximum, this.reason);
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -39,7 +39,7 @@ class ThrottlerCalculator {
      * Maximum delay (millis) we are willing to introduce in order to throttle the incoming operations.
      */
     @VisibleForTesting
-    static final int MAX_DELAY_MILLIS = 10000;
+    static final int MAX_DELAY_MILLIS = 25000;
     /**
      * Amount of time (millis) to increase throttling by for each percentage point increase in the cache utilization (above 100%).
      */
@@ -50,13 +50,13 @@ class ThrottlerCalculator {
      * Number of items in the Commit Backlog above which throttling will apply.
      */
     @VisibleForTesting
-    static final int COMMIT_BACKLOG_COUNT_THRESHOLD = 300;
+    static final int COMMIT_BACKLOG_COUNT_THRESHOLD = 100;
 
     /**
      * Amount of time (millis) to increase throttling by for each incremental increase of the Commit Queue, over the threshold.
      */
     @VisibleForTesting
-    static final int THROTTLING_MILLIS_PER_COMMIT_OVER_LIMIT = 4;
+    static final int THROTTLING_MILLIS_PER_COMMIT_OVER_LIMIT = 50;
 
     @Singular
     private final List<Throttler> throttlers;
@@ -93,19 +93,24 @@ class ThrottlerCalculator {
         // a throttling delay will have increased batching as a side effect.
         int maxDelay = 0;
         boolean maximum = false;
+        String throttlerName = null;
         for (Throttler t : this.throttlers) {
             int delay = t.getDelayMillis();
             if (delay >= MAX_DELAY_MILLIS) {
                 // This throttler introduced the maximum delay. No need to search more.
                 maxDelay = MAX_DELAY_MILLIS;
                 maximum = true;
+                throttlerName = t.getName();
                 break;
             }
 
-            maxDelay = Math.max(maxDelay, delay);
+            if (delay > maxDelay) {
+                maxDelay = delay;
+                throttlerName = t.getName();
+            }
         }
 
-        return new DelayResult(maxDelay, maximum);
+        return new DelayResult(throttlerName, maxDelay, maximum);
     }
 
     //endregion
@@ -125,6 +130,13 @@ class ThrottlerCalculator {
          * Calculates a throttling delay based on information available at the moment.
          */
         abstract int getDelayMillis();
+
+        /**
+         * Gets a log-friendly name for this Throttle instance.
+         *
+         * @return
+         */
+        abstract String getName();
     }
 
     /**
@@ -145,6 +157,11 @@ class ThrottlerCalculator {
             // We only throttle if we exceed the cache capacity. We increase the throttling amount in a linear fashion.
             double cacheUtilization = this.getCacheUtilization.get();
             return (int) Math.max((cacheUtilization - 1.0) * 100 * THROTTLING_MILLIS_PER_PERCENT_OVER_LIMIT, 0);
+        }
+
+        @Override
+        String getName() {
+            return "Cache";
         }
     }
 
@@ -167,6 +184,11 @@ class ThrottlerCalculator {
             // We only throttle if we exceed the threshold. We increase the throttling amount in a linear fashion.
             long count = this.getCommitBacklogCount.get();
             return (int) MathHelpers.minMax((count - COMMIT_BACKLOG_COUNT_THRESHOLD) * THROTTLING_MILLIS_PER_COMMIT_OVER_LIMIT, 0, Integer.MAX_VALUE);
+        }
+
+        @Override
+        String getName() {
+            return "Commit Backlog";
         }
     }
 
@@ -195,6 +217,11 @@ class ThrottlerCalculator {
             // Finally, we use the the ExpectedProcessingTime to give us a baseline as to how long items usually take to process.
             int delayMillis = (int) Math.round(stats.getExpectedProcessingTimeMillis() * fillRatioAdj);
             return Math.min(delayMillis, MAX_BATCHING_DELAY_MILLIS);
+        }
+
+        @Override
+        String getName() {
+            return "Batching";
         }
     }
 
@@ -251,6 +278,10 @@ class ThrottlerCalculator {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     static class DelayResult {
         /**
+         * The name of the throttler inducing this delay.
+         */
+        private final String reason;
+        /**
          * The suggested delay, in millis.
          */
         @Getter
@@ -261,6 +292,11 @@ class ThrottlerCalculator {
          */
         @Getter
         private final boolean maximum;
+
+        @Override
+        public String toString() {
+            return String.format("{}ms (Max={}, Reason={})", this.durationMillis, this.maximum, this.reason);
+        }
     }
 
     //endregion

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -136,7 +136,7 @@ public final class MetricsNames {
     public static final String OPERATION_PROCESSOR_DELAY_MILLIS = PREFIX + "segmentstore.container.operation_processor.delay_ms";            // Per-container Histogram
     public static final String OPERATION_COMMIT_LATENCY = PREFIX + "segmentstore.container.operation_commit.latency_ms";                     // Per-container Histogram
     public static final String OPERATION_LATENCY = PREFIX + "segmentstore.container.operation.latency_ms";                                   // Per-container Histogram
-    public static final String OPERATION_COMMIT_METADATA_TXN_COUNT = PREFIX + "segmentstore.container.operation_commit.metadata_txn_count";  // Per-container Histogram
+    public static final String OPERATION_COMMIT_MEMORY_COUNT = PREFIX + "segmentstore.container.operation_commit.memory_count";              // Per-container Histogram
     public static final String OPERATION_COMMIT_MEMORY_LATENCY = PREFIX + "segmentstore.container.operation_commit.memory_latency_ms";       // Per-container Histogram
     public static final String OPERATION_LOG_SIZE = PREFIX + "segmentstore.container.operation.log_size";                                    // Per-container Counter
 


### PR DESCRIPTION
**Change log description**  
* Cherry-picks changes from master to r0.5

**Purpose of the change**  
Fixes #4025 

**What the code does**  
Cherry-picks:

```
Issue 4011: (SegmentStore) Making Commit Backlog Throttler more aggressive (#4016)
Issue 4011: Fixed ThrottlerCalculator.Delay.ToString() (#4023)
```

**How to verify it**  
Build must pass.
