### PR TITLE
Issue 4029: Enable RocksDB logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,6 +283,8 @@ project('segmentstore:storage:impl') {
         compile group: 'org.rocksdb', name: 'rocksdbjni', version: rocksdbjniVersion
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
+        testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
+        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
     }
     javadoc {
         dependencies {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -259,6 +259,7 @@ class RocksDBCache implements Cache {
                 .setTableFormatConfig(tableFormatConfig)
                 .setOptimizeFiltersForHits(true)
                 .setUseDirectReads(true);
+
         InfoLogLevel logLevel = translateRocksDBLogLevel(rocksDBLogLevel);
         Options logOptions = new Options().
                 setInfoLogLevel(logLevel).
@@ -316,22 +317,31 @@ class RocksDBCache implements Cache {
     }
 
     private InfoLogLevel translateRocksDBLogLevel(String logLevel) {
+        InfoLogLevel rocksDBlogLevel;
         switch (logLevel) {
             case "DEBUG":
-                return InfoLogLevel.DEBUG_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.DEBUG_LEVEL;
+                break;
             case "INFO":
-                return InfoLogLevel.INFO_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.INFO_LEVEL;
+                break;
             case "WARN":
-                return InfoLogLevel.WARN_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.WARN_LEVEL;
+                break;
             case "ERROR":
-                return InfoLogLevel.ERROR_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.ERROR_LEVEL;
+                break;
             case "FATAL":
-                return InfoLogLevel.FATAL_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.FATAL_LEVEL;
+                break;
             case "HEADER":
-                return InfoLogLevel.HEADER_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.HEADER_LEVEL;
+                break;
             default:
-                return InfoLogLevel.ERROR_LEVEL;
+                rocksDBlogLevel = InfoLogLevel.ERROR_LEVEL;
+                break;
         }
+        return rocksDBlogLevel;
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -24,7 +24,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.rocksdb.*;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.InfoLogLevel;
+import org.rocksdb.Logger;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
 
 /**
  * RocksDB-backed Cache.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -25,6 +25,7 @@ public class RocksDBConfig {
     public static final Property<Integer> WRITE_BUFFER_SIZE_MB = Property.named("writeBufferSizeMB", 64);
     public static final Property<Integer> READ_CACHE_SIZE_MB = Property.named("readCacheSizeMB", 8);
     public static final Property<Integer> CACHE_BLOCK_SIZE_KB = Property.named("cacheBlockSizeKB", 32);
+    public static final Property<String> ROCKSDB_LOG_LEVEL = Property.named("rocksDBLogLevel", "ERROR");
     private static final String COMPONENT_CODE = "rocksdb";
 
     //endregion
@@ -60,6 +61,13 @@ public class RocksDBConfig {
     @Getter
     private final int cacheBlockSizeKB;
 
+    /**
+     * Setting rocksDBLogLevel to DEBUG is useful when debugging RocksDB. However, there are certain performance penalties for that,
+     * so it is necessary to explicitly set level when in need, otherwise the default setting is ERROR.
+     */
+    @Getter
+    private final String rocksDBLogLevel;
+
     //endregion
 
     //region Constructor
@@ -74,6 +82,7 @@ public class RocksDBConfig {
         this.writeBufferSizeMB = properties.getInt(WRITE_BUFFER_SIZE_MB);
         this.readCacheSizeMB = properties.getInt(READ_CACHE_SIZE_MB);
         this.cacheBlockSizeKB = properties.getInt(CACHE_BLOCK_SIZE_KB);
+        this.rocksDBLogLevel = properties.get(ROCKSDB_LOG_LEVEL);
     }
 
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -25,7 +25,8 @@ public class RocksDBConfig {
     public static final Property<Integer> WRITE_BUFFER_SIZE_MB = Property.named("writeBufferSizeMB", 64);
     public static final Property<Integer> READ_CACHE_SIZE_MB = Property.named("readCacheSizeMB", 8);
     public static final Property<Integer> CACHE_BLOCK_SIZE_KB = Property.named("cacheBlockSizeKB", 32);
-    public static final Property<String> ROCKSDB_LOG_LEVEL = Property.named("rocksDBLogLevel", "ERROR");
+    public static final Property<String> ROCKSDB_LOG_LEVEL = Property.named("rocksDBLogLevel", "DEBUG");
+    public static final Property<Boolean> DIRECT_READS = Property.named("directReads", false);
     private static final String COMPONENT_CODE = "rocksdb";
 
     //endregion
@@ -68,6 +69,14 @@ public class RocksDBConfig {
     @Getter
     private final String rocksDBLogLevel;
 
+    /**
+     * Enabling direct reads may be beneficial for performance due to: i) it avoids extra copies of data on OS page
+     * cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g., replacement). However,
+     * as not all OS/environments support direct IO, we keep it disabled by default for safety.
+     */
+    @Getter
+    private final boolean directReads;
+
     //endregion
 
     //region Constructor
@@ -83,6 +92,7 @@ public class RocksDBConfig {
         this.readCacheSizeMB = properties.getInt(READ_CACHE_SIZE_MB);
         this.cacheBlockSizeKB = properties.getInt(CACHE_BLOCK_SIZE_KB);
         this.rocksDBLogLevel = properties.get(ROCKSDB_LOG_LEVEL);
+        this.directReads = properties.getBoolean(DIRECT_READS);
     }
 
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -25,7 +25,8 @@ public class RocksDBConfig {
     public static final Property<Integer> WRITE_BUFFER_SIZE_MB = Property.named("writeBufferSizeMB", 64);
     public static final Property<Integer> READ_CACHE_SIZE_MB = Property.named("readCacheSizeMB", 8);
     public static final Property<Integer> CACHE_BLOCK_SIZE_KB = Property.named("cacheBlockSizeKB", 32);
-    public static final Property<String> ROCKSDB_LOG_LEVEL = Property.named("rocksDBLogLevel", "DEBUG");
+    public static final Property<String> ROCKSDB_LOG_LEVEL = Property.named("rocksDBLogLevel", "WARN");
+    public static final Property<Boolean> ROCKSDB_STATISTICS = Property.named("rocksDBStatistics", true);
     public static final Property<Boolean> DIRECT_READS = Property.named("directReads", false);
     private static final String COMPONENT_CODE = "rocksdb";
 
@@ -70,6 +71,13 @@ public class RocksDBConfig {
     private final String rocksDBLogLevel;
 
     /**
+     * Setting rocksDBStatistics to True will enable the statistics in RockDB, it will dump the statistics to the log
+     * every 5 minutes.
+     */
+    @Getter
+    private final Boolean rocksDBStatistics;
+
+    /**
      * Enabling direct reads may be beneficial for performance due to: i) it avoids extra copies of data on OS page
      * cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g., replacement). However,
      * as not all OS/environments support direct IO, we keep it disabled by default for safety.
@@ -92,6 +100,7 @@ public class RocksDBConfig {
         this.readCacheSizeMB = properties.getInt(READ_CACHE_SIZE_MB);
         this.cacheBlockSizeKB = properties.getInt(CACHE_BLOCK_SIZE_KB);
         this.rocksDBLogLevel = properties.get(ROCKSDB_LOG_LEVEL);
+        this.rocksDBStatistics = properties.getBoolean(ROCKSDB_STATISTICS);
         this.directReads = properties.getBoolean(DIRECT_READS);
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/StatsCallback.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/StatsCallback.java
@@ -1,0 +1,24 @@
+package io.pravega.segmentstore.storage.impl.rocksdb;
+
+import lombok.extern.slf4j.Slf4j;
+import org.rocksdb.HistogramData;
+import org.rocksdb.HistogramType;
+import org.rocksdb.StatisticsCollectorCallback;
+import org.rocksdb.TickerType;
+
+@Slf4j
+public class StatsCallback implements StatisticsCollectorCallback {
+
+    public void tickerCallback(TickerType tickerType, long tickerCount) {
+        log.info("Ticker type is %s and count %d", tickerType.toString(), tickerCount);
+    }
+
+    public void histogramCallback(HistogramType histType,
+                                  HistogramData histData) {
+        log.info("HistogramType %s and average %f", histType.toString(), histData.getAverage());
+        log.info("HistogramType %s and median %f", histType.toString(), histData.getMedian());
+        log.info("HistogramType %s and p95 %f", histType.toString(), histData.getPercentile95());
+        log.info("HistogramType %s and p99 %f", histType.toString(), histData.getPercentile99());
+        log.info("HistogramType %s and std %f", histType.toString(), histData.getStandardDeviation());
+    }
+}


### PR DESCRIPTION
**Change log description**  
This PR enables RocksDB logging. User can specify different logging level for RocksDB, e.g. DEBUG, INFO, WARN, ERROR, etc. The default level is ERROR, which is suggested in production. 

**Purpose of the change**  
Fix #4029 

**What the code does**  
The code adds an additional field in `RocksDBConfig.java` for the RocksDB log level. In `RocksDBCache.java`, the code gets the log level from RocksDBConfig and pass that to the RocksDB configuration when initializing.  

**How to verify it**  
Specify `rocksdb.rocksDBLogLevel: "DEBUG"` in the `pravega: option` of the pravega manifest and deploy it. We should be able to see RocksDB log when `kubectl logs pravega-segmentstore`.
