### PR TITLE
Issue 4038: Add connection pooling switch for event writers in r0.5

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -62,7 +62,7 @@ public class ClientConfig implements Serializable {
     private final boolean validateHostName;
 
     /**
-     * Maximum number of connections per Segment store.
+     * Maximum number of connections per Segment store to be used by connection pooling.
      */
     private final int maxConnectionsPerSegmentStore;
 

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -98,6 +98,10 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
         log.info("Closing Flow {} for endpoint {}", flow, clientConnectionImpl.getConnectionName());
         flowIdReplyProcessorMap.remove(flow);
         flowIDBatchSizeTrackerMap.remove(flow);
+        if (flow == FLOW_DISABLED) {
+            // close the channel immediately since this netty channel will not be reused by other flows.
+            close();
+        }
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -35,14 +35,16 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     @Override
     public SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, EventWriterConfig config,
                                                                 String delegationToken) {
-        return new SegmentOutputStreamImpl(StreamSegmentNameUtils.getTransactionNameFromId(segment.getScopedName(), txId), controller, cf,
-                UUID.randomUUID(), nopSegmentSealedCallback, getRetryFromConfig(config), delegationToken);
+        return new SegmentOutputStreamImpl(StreamSegmentNameUtils.getTransactionNameFromId(segment.getScopedName(), txId),
+                                           config.isEnableConnectionPooling(), controller, cf, UUID.randomUUID(), nopSegmentSealedCallback,
+                                           getRetryFromConfig(config), delegationToken);
     }
 
     @Override
     public SegmentOutputStream createOutputStreamForSegment(Segment segment, Consumer<Segment> segmentSealedCallback, EventWriterConfig config, String delegationToken) {
-        SegmentOutputStreamImpl result = new SegmentOutputStreamImpl(segment.getScopedName(), controller, cf,
-                UUID.randomUUID(), segmentSealedCallback, getRetryFromConfig(config), delegationToken);
+        SegmentOutputStreamImpl result =
+                new SegmentOutputStreamImpl(segment.getScopedName(), config.isEnableConnectionPooling(), controller, cf, UUID.randomUUID(), segmentSealedCallback,
+                                            getRetryFromConfig(config), delegationToken);
         try {
             result.getConnection();
         } catch (RetriesExhaustedException | SegmentSealedException | NoSuchSegmentException e) {
@@ -53,7 +55,7 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     
     @Override
     public SegmentOutputStream createOutputStreamForSegment(Segment segment, EventWriterConfig config, String delegationToken) {
-        return new SegmentOutputStreamImpl(segment.getScopedName(), controller, cf, UUID.randomUUID(),
+        return new SegmentOutputStreamImpl(segment.getScopedName(), config.isEnableConnectionPooling(), controller, cf, UUID.randomUUID(),
                                            Callbacks::doNothing, getRetryFromConfig(config), delegationToken);
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -69,6 +69,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
 
     @Getter
     private final String segmentName;
+    @VisibleForTesting
+    @Getter
+    private final boolean useConnectionPooling;
     private final Controller controller;
     private final ConnectionFactory connectionFactory;
     private final UUID writerId;
@@ -545,7 +548,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                      log.info("Fetching endpoint for segment {}, writer {}", segmentName, writerId);
                      return controller.getEndpointForSegment(segmentName).thenComposeAsync((PravegaNodeUri uri) -> {
                          log.info("Establishing connection to {} for {}, writerID: {}", uri, segmentName, writerId);
-                         return connectionFactory.establishConnection(Flow.from(requestId), uri, responseProcessor);
+                         return establishConnection(uri);
                      }, connectionFactory.getInternalExecutor()).thenComposeAsync(connection -> {
                          CompletableFuture<Void> connectionSetupFuture = state.newConnection(connection);
                          SetupAppend cmd = new SetupAppend(requestId, writerId, segmentName, delegationToken);
@@ -573,7 +576,13 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
         }, new CompletableFuture<ClientConnection>());
     }
 
-
+    private CompletableFuture<ClientConnection> establishConnection(PravegaNodeUri uri) {
+        if (useConnectionPooling) {
+            return connectionFactory.establishConnection(Flow.from(requestId), uri, responseProcessor);
+        } else {
+            return connectionFactory.establishConnection(uri, responseProcessor);
+        }
+    }
 
     /**
      * This function is invoked by SegmentSealedCallback, i.e., when SegmentSealedCallback or getUnackedEventsOnSeal()

--- a/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
+++ b/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
@@ -25,6 +25,6 @@ public class SynchronizerConfig implements Serializable {
     EventWriterConfig eventWriterConfig;
     
     public static class SynchronizerConfigBuilder {
-        private EventWriterConfig eventWriterConfig = EventWriterConfig.builder().build();
+        private EventWriterConfig eventWriterConfig = EventWriterConfig.builder().enableConnectionPooling(true).build();
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -23,6 +23,7 @@ public class EventWriterConfig implements Serializable {
     private final int maxBackoffMillis;
     private final int retryAttempts;
     private final int backoffMultiple;
+    private final boolean enableConnectionPooling;
     /*
      * The transaction timeout parameter corresponds to the lease renewal period.
      * In every period, the client must send at least one ping to keep the txn alive.
@@ -52,5 +53,7 @@ public class EventWriterConfig implements Serializable {
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
         private long transactionTimeoutTime = 30 * 1000 - 1;
+        // connection pooling for event writers is enabled by default.
+        private boolean enableConnectionPooling = true;
     }
 }

--- a/client/src/test/java/io/pravega/client/netty/impl/ConnectionFactoryImplTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/ConnectionFactoryImplTest.java
@@ -137,14 +137,16 @@ public class ConnectionFactoryImplTest {
     }
 
     @Test
-    public void getActiveChannelTest() throws InterruptedException, ConnectionFailedException {
+    public void getActiveChannelTestWithConnectionPooling() throws InterruptedException, ConnectionFailedException {
         @Cleanup
         ConnectionFactoryImpl factory = new ConnectionFactoryImpl(ClientConfig.builder()
                                                                               .controllerURI(URI.create( "tcp://" + "localhost"))
                                                                               .build());
-        // establish a connection.
+        Flow flow = Flow.create();
+        // establish a connection with Flow.
         @Cleanup
-        ClientConnectionImpl connection = (ClientConnectionImpl) factory.establishConnection(new PravegaNodeUri("localhost", port), new FailingReplyProcessor() {
+        ClientConnectionImpl connection = (ClientConnectionImpl) factory.establishConnection(flow, new PravegaNodeUri("localhost", port),
+                                                                                             new FailingReplyProcessor() {
 
             @Override
             public void connectionDropped() {
@@ -170,6 +172,7 @@ public class ConnectionFactoryImplTest {
 
         // close the connection, this does not close the underlying network connection due to connection pooling.
         connection.close();
+        // the underlying connection is closed only on closing the connection pool
         factory.getConnectionPool().close();
 
         // wait until the channel is closed.
@@ -177,5 +180,48 @@ public class ConnectionFactoryImplTest {
         assertEquals("Expected active channel count is 0", 0, factory.getActiveChannelCount());
         // verify that the channel is removed from channelGroup too.
         assertEquals(0,  ((ConnectionPoolImpl) factory.getConnectionPool()).getChannelGroup().size());
+    }
+
+    @Test
+    public void getActiveChannelTestWithoutConnectionPooling() throws InterruptedException, ConnectionFailedException {
+        @Cleanup
+        ConnectionFactoryImpl factory = new ConnectionFactoryImpl(ClientConfig.builder()
+                                                                              .controllerURI(URI.create("tcp://" + "localhost"))
+                                                                              .build());
+        final FailingReplyProcessor rp = new FailingReplyProcessor() {
+
+            @Override
+            public void connectionDropped() {
+
+            }
+
+            @Override
+            public void processingFailure(Exception error) {
+
+            }
+
+            @Override
+            public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
+
+            }
+        };
+        // establish a connection with Flow.
+        @Cleanup
+        ClientConnectionImpl connection = (ClientConnectionImpl) factory.establishConnection(new PravegaNodeUri("localhost", port), rp).join();
+
+        assertEquals("Expected active channel count is 1", 1, factory.getActiveChannelCount());
+
+        // add a listener to track the channel close.
+        final CountDownLatch latch = new CountDownLatch(1);
+        connection.getNettyHandler().getChannel().closeFuture().addListener(future -> latch.countDown());
+
+        // close the connection, this closes the underlying network connection since connection pooling is disabled.
+        connection.close();
+
+        // wait until the channel is closed.
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertEquals("Expected active channel count is 0", 0, factory.getActiveChannelCount());
+        // verify that the channel is removed from channelGroup too.
+        assertEquals(0, ((ConnectionPoolImpl) factory.getConnectionPool()).getChannelGroup().size());
     }
 }

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.segment.impl;
+
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.impl.Controller;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static io.pravega.shared.segment.StreamSegmentNameUtils.isTransactionSegment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SegmentOutputStreamFactoryTest {
+
+    @Mock
+    private Controller controller;
+    @Mock
+    private ConnectionFactory cf;
+    @Mock
+    private ScheduledExecutorService executor;
+
+    private SegmentOutputStreamFactory factory;
+    private final Segment segment = new Segment("scope", "stream", 0);
+    private final UUID txId = UUID.randomUUID();
+
+    @Before
+    public void setup() {
+        when(cf.getInternalExecutor()).thenReturn(executor);
+        factory = new SegmentOutputStreamFactoryImpl(controller, cf);
+    }
+
+    @Test
+    public void createOutputStreamForTransaction() {
+        EventWriterConfig writerConfig = EventWriterConfig.builder().build();
+
+        SegmentOutputStreamImpl segWriter = (SegmentOutputStreamImpl) factory.createOutputStreamForTransaction(segment, txId, writerConfig, "");
+        assertTrue(isTransactionSegment(segWriter.getSegmentName()));
+        assertEquals(writerConfig.isEnableConnectionPooling(), segWriter.isUseConnectionPooling());
+    }
+
+    @Test
+    public void createOutputStreamForSegment() {
+        EventWriterConfig writerConfig = EventWriterConfig.builder().enableConnectionPooling(false).build();
+        SegmentOutputStreamImpl segWriter = (SegmentOutputStreamImpl) factory.createOutputStreamForSegment(segment, writerConfig, "");
+        assertEquals(segment.getScopedName(), segWriter.getSegmentName());
+        assertEquals(writerConfig.isEnableConnectionPooling(), segWriter.isUseConnectionPooling());
+    }
+
+    @Test
+    public void createOutputStreamForSegmentAndconnect() {
+        EventWriterConfig writerConfig = EventWriterConfig.builder().enableConnectionPooling(false).build();
+        SegmentOutputStreamImpl segWriter = (SegmentOutputStreamImpl) factory.createOutputStreamForSegment(segment, s -> {
+        }, writerConfig, "");
+        assertEquals(segment.getScopedName(), segWriter.getSegmentName());
+        assertEquals(writerConfig.isEnableConnectionPooling(), segWriter.isUseConnectionPooling());
+    }
+}

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -104,7 +104,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -127,7 +128,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         reset(connection);
@@ -151,7 +153,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         doThrow(ConnectionFailedException.class).doNothing().when(connection).send(any(SetupAppend.class));
         cf.provideConnection(uri, connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection, times(2)).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
     }
@@ -174,7 +177,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, resendToSuccessorsCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, resendToSuccessorsCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).noSuchSegment(new WireCommands.NoSuchSegment(output.getRequestId(), SEGMENT, "SomeException", -1L));
@@ -197,7 +201,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         reset(connection);
@@ -246,7 +251,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -266,7 +272,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         InOrder inOrder = inOrder(connection);
         cf.provideConnection(uri, connection);
         @SuppressWarnings("resource")
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
 
         output.reconnect();
         cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
@@ -323,7 +330,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
 
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -355,7 +363,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
@@ -395,7 +404,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
@@ -436,7 +446,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(1, SEGMENT, cid, 0));
@@ -474,7 +485,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         InOrder inOrder = Mockito.inOrder(connection);
         inOrder.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
@@ -530,7 +542,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         InOrder inOrder = Mockito.inOrder(connection);
         inOrder.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
@@ -589,7 +602,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -616,7 +630,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -641,7 +656,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -679,7 +695,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -715,7 +732,7 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
         @Cleanup
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid,
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid,
                 segmentSealedCallback, RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
@@ -763,7 +780,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         InOrder inOrder = inOrder(connection);
         cf.provideConnection(uri, connection);
         @SuppressWarnings("resource")
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         
         output.reconnect();
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -838,7 +856,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
                 throw new IllegalStateException();
             }
         };
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, exceptionCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, exceptionCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -876,7 +895,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
 
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
@@ -909,7 +929,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
 
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(TXN_SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(TXN_SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, TXN_SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), TXN_SEGMENT, cid, 0));
@@ -944,7 +965,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         cf.provideConnection(uri, connection);
         InOrder order = Mockito.inOrder(connection);
 
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(TXN_SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(TXN_SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
         output.reconnect();
         order.verify(connection).send(new SetupAppend(output.getRequestId(), cid, TXN_SEGMENT, ""));
         cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), TXN_SEGMENT, cid, 0));
@@ -993,7 +1015,8 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
         InOrder order = Mockito.inOrder(connection);
 
         // Create a Segment writer.
-        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, controller, cf, cid, segmentSealedCallback, RETRY_SCHEDULE, "");
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
 
         // trigger establishment of connection.
         output.reconnect();
@@ -1037,5 +1060,24 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
         // Verify no further reconnection attempts which involves sending of SetupAppend wire command.
         order.verifyNoMoreInteractions();
+    }
+
+    @Test(timeout = 10000)
+    public void testConnectAndSendWithoutConnectionPooling() throws SegmentSealedException, ConnectionFailedException {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        cf.setExecutor(executorService());
+        MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, false, controller, cf, cid, segmentSealedCallback,
+                                                                     RETRY_SCHEDULE, "");
+        output.reconnect();
+        verify(connection).send(new SetupAppend(output.getRequestId(), cid, SEGMENT, ""));
+        cf.getProcessor(uri).appendSetup(new AppendSetup(output.getRequestId(), SEGMENT, cid, 0));
+
+        sendAndVerifyEvent(cid, connection, output, getBuffer("test"), 1);
+        verifyNoMoreInteractions(connection);
     }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndChannelLeakTest.java
@@ -70,6 +70,7 @@ public class EndToEndChannelLeakTest {
     private final int servicePort = TestUtils.getAvailableListenPort();
     private final int containerCount = 4;
     private final JavaSerializer<String> serializer = new JavaSerializer<>();
+    private final EventWriterConfig writerConfig = EventWriterConfig.builder().enableConnectionPooling(true).build();
     private TestingServer zkTestServer;
     private PravegaConnectionListener server;
     private ControllerWrapper controllerWrapper;
@@ -124,8 +125,7 @@ public class EndToEndChannelLeakTest {
 
         //Create a writer.
         @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(SCOPE, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(SCOPE, serializer, writerConfig);
 
         @Cleanup
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl(SCOPE, controller, clientFactory,
@@ -134,7 +134,7 @@ public class EndToEndChannelLeakTest {
                                        .stream(Stream.of(SCOPE, STREAM_NAME)).build());
 
         @Cleanup
-        EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, new JavaSerializer<>(),
+        EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, serializer,
                 ReaderConfig.builder().build());
         //Write an event.
         writer.writeEvent("0", "zero").get();
@@ -202,8 +202,7 @@ public class EndToEndChannelLeakTest {
         
         //Create a writer and write an event.
         @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(STREAM_NAME, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(STREAM_NAME, serializer, writerConfig);
         writer.writeEvent("0", "zero").get();
 
         expectedChannelCount += 1; // connection to segment 0.
@@ -305,8 +304,7 @@ public class EndToEndChannelLeakTest {
         
         //Create a writer.
         @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(SCOPE, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(SCOPE, serializer, writerConfig);
 
         //Write an event.
         writer.writeEvent("0", "zero").get();
@@ -314,7 +312,7 @@ public class EndToEndChannelLeakTest {
         assertChannelCount(channelCount, connectionPool);
 
         @Cleanup
-        EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, new JavaSerializer<>(),
+        EventStreamReader<String> reader1 = clientFactory.createReader("readerId1", READER_GROUP, serializer,
                 ReaderConfig.builder().build());
         
         channelCount += 4; //One for segment 3 for state synchronizer
@@ -409,8 +407,7 @@ public class EndToEndChannelLeakTest {
         
         //Create a writer and write an event.
         @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(STREAM_NAME, new JavaSerializer<>(),
-                EventWriterConfig.builder().build());
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(STREAM_NAME, serializer, writerConfig);
         writer.writeEvent("0", "zero").get();
 
         expectedChannelCount += 1; // connection to segment 0.


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Backports issue #3951 to `r0.5`

**Purpose of the change**  
Fixes #4038 

**What the code does**  
See #3952 

**How to verify it**  
Build must succeed.
