### PR TITLE
Issue 3645: Make direct reads configurable in RocksDB

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -413,9 +413,9 @@ extendeds3.url=localhost:9020
 
 # According to RocksDB documentation, enabling direct reads may be beneficial for performance due to: i) it avoids extra
 # copies of data on OS page cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g.,
-# replacement). However, as not all OS/environments support direct IO, we keep it disabled by default for safety. For
-# more information, please check: https://github.com/facebook/rocksdb/wiki/Direct-IO.
-#rocksdb.directReads=false
+# replacement). However, as not all OS/environments support direct IO, we allow disabling this option. For more
+# information, please check: https://github.com/facebook/rocksdb/wiki/Direct-IO.
+#rocksdb.directReads=true
 
 ##endregion
 

--- a/config/config.properties
+++ b/config/config.properties
@@ -411,6 +411,12 @@ extendeds3.url=localhost:9020
 # will decrease, so the index size will also reduce linearly (but increasing read amplification).
 #rocksdb.cacheBlockSizeKB=32
 
+# According to RocksDB documentation, enabling direct reads may be beneficial for performance due to: i) it avoids extra
+# copies of data on OS page cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g.,
+# replacement). However, as not all OS/environments support direct IO, we keep it disabled by default for safety. For
+# more information, please check: https://github.com/facebook/rocksdb/wiki/Direct-IO.
+#rocksdb.directReads=false
+
 ##endregion
 
 ##region DurableLog Settings

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -69,6 +69,7 @@ class RocksDBCache implements Cache {
     private final int writeBufferSizeMB;
     private final int readCacheSizeMB;
     private final int cacheBlockSizeKB;
+    private final boolean directReads;
 
     //endregion
 
@@ -95,6 +96,7 @@ class RocksDBCache implements Cache {
         this.writeBufferSizeMB = config.getWriteBufferSizeMB() / MAX_WRITE_BUFFER_NUMBER;
         this.readCacheSizeMB = config.getReadCacheSizeMB();
         this.cacheBlockSizeKB = config.getCacheBlockSizeKB();
+        this.directReads = config.isDirectReads();
         try {
             this.databaseOptions = createDatabaseOptions();
             this.writeOptions = createWriteOptions();
@@ -254,7 +256,7 @@ class RocksDBCache implements Cache {
                 .setMinWriteBufferNumberToMerge(MIN_WRITE_BUFFER_NUMBER_TO_MERGE)
                 .setTableFormatConfig(tableFormatConfig)
                 .setOptimizeFiltersForHits(true)
-                .setUseDirectReads(true);
+                .setUseDirectReads(this.directReads);
     }
 
     private void clear(boolean recreateDirectory) {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -25,7 +25,7 @@ public class RocksDBConfig {
     public static final Property<Integer> WRITE_BUFFER_SIZE_MB = Property.named("writeBufferSizeMB", 64);
     public static final Property<Integer> READ_CACHE_SIZE_MB = Property.named("readCacheSizeMB", 8);
     public static final Property<Integer> CACHE_BLOCK_SIZE_KB = Property.named("cacheBlockSizeKB", 32);
-    public static final Property<Boolean> DIRECT_READS = Property.named("directReads", false);
+    public static final Property<Boolean> DIRECT_READS = Property.named("directReads", true);
     private static final String COMPONENT_CODE = "rocksdb";
 
     //endregion
@@ -64,7 +64,7 @@ public class RocksDBConfig {
     /**
      * Enabling direct reads may be beneficial for performance due to: i) it avoids extra copies of data on OS page
      * cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g., replacement). However,
-     * as not all OS/environments support direct IO, we keep it disabled by default for safety.
+     * as not all OS/environments support direct IO, so we allow to disable it.
      */
     @Getter
     private final boolean directReads;

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBConfig.java
@@ -25,6 +25,7 @@ public class RocksDBConfig {
     public static final Property<Integer> WRITE_BUFFER_SIZE_MB = Property.named("writeBufferSizeMB", 64);
     public static final Property<Integer> READ_CACHE_SIZE_MB = Property.named("readCacheSizeMB", 8);
     public static final Property<Integer> CACHE_BLOCK_SIZE_KB = Property.named("cacheBlockSizeKB", 32);
+    public static final Property<Boolean> DIRECT_READS = Property.named("directReads", false);
     private static final String COMPONENT_CODE = "rocksdb";
 
     //endregion
@@ -60,6 +61,14 @@ public class RocksDBConfig {
     @Getter
     private final int cacheBlockSizeKB;
 
+    /**
+     * Enabling direct reads may be beneficial for performance due to: i) it avoids extra copies of data on OS page
+     * cache, ii) it exploits better knowledge of the behavior of data to apply policies (e.g., replacement). However,
+     * as not all OS/environments support direct IO, we keep it disabled by default for safety.
+     */
+    @Getter
+    private final boolean directReads;
+
     //endregion
 
     //region Constructor
@@ -74,6 +83,7 @@ public class RocksDBConfig {
         this.writeBufferSizeMB = properties.getInt(WRITE_BUFFER_SIZE_MB);
         this.readCacheSizeMB = properties.getInt(READ_CACHE_SIZE_MB);
         this.cacheBlockSizeKB = properties.getInt(CACHE_BLOCK_SIZE_KB);
+        this.directReads = properties.getBoolean(DIRECT_READS);
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
* Enables RocksDB direct reads to be configurable via rocksdb.directReads
* Sets the default value rocksdb.directReads=true

**Purpose of the change**  
Fixes #3645 

**What the code does**  
Makes RocksDB direct reads configurable, as not all OS/environments support this option. See also PR #3647 .

**How to verify it**  
No code changes, all tests should be passing as before.
