### PR TITLE
Issue 4040: Enable test pod image configuration for system tests 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -815,6 +815,9 @@ project('test:system') {
         // tier2 Configuration, specified as comma seperated key values k1=v1,k2=v2
         systemProperty "tier2Config", System.getProperty("tier2Config")
 
+        //testPodImage , default is openjdk:8u181-jre-alpine
+        systemProperty "testPodImage", System.getProperty("testPodImage", "openjdk:8u181-jre-alpine")
+
         if (System.getProperty("imageVersion") == null) {
             systemProperty "imageVersion", "INVALID_IMAGE_VERSION"
         }

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -44,7 +44,7 @@ public class K8SequentialExecutor implements TestExecutor {
 
     private static final String NAMESPACE = "default"; // KUBERNETES namespace where the tests run.
     private static final String SERVICE_ACCOUNT = "test-framework"; //Service Account used by the test pod.
-    private static final String TEST_POD_IMAGE = System.getProperty("testPodImage", "openjdk:8u181-jre-alpine")
+    private static final String TEST_POD_IMAGE = System.getProperty("testPodImage", "openjdk:8u181-jre-alpine");
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -44,6 +44,7 @@ public class K8SequentialExecutor implements TestExecutor {
 
     private static final String NAMESPACE = "default"; // KUBERNETES namespace where the tests run.
     private static final String SERVICE_ACCOUNT = "test-framework"; //Service Account used by the test pod.
+    private static final String TEST_POD_IMAGE = System.getProperty("testPodImage", "openjdk:8u181-jre-alpine")
 
     @Override
     public CompletableFuture<Void> startTestExecution(Method testMethod) {
@@ -114,7 +115,7 @@ public class K8SequentialExecutor implements TestExecutor {
                                                   .build())
                 .addNewContainer()
                 .withName(podName) // container name is same as that of the pod.
-                .withImage("openjdk:8u181-jre-alpine")
+                .withImage(TEST_POD_IMAGE)
                 .withImagePullPolicy("IfNotPresent")
                 .withCommand("/bin/sh")
                 .withArgs("-c", "java -DexecType=KUBERNETES -cp /data/test-collection.jar io.pravega.test.system.SingleJUnitTestRunner "


### PR DESCRIPTION
**Change log description**  
It will accept the test pod image as Input parameter rather than hard cording

**Purpose of the change**  
Fixes #4040

**What the code does**  
Test pod image for system tests is passed as a parameter.

**How to verify it**  
Verified system tests, with different test pod images.
