### PR TITLE
Issue 4046: (SegmentStore) Segment Container Recovery bug with partial operations

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
@@ -49,7 +49,7 @@ public class DataFrameInputStream extends InputStream {
      *
      * However, in certain exceptional cases (such as when an Operation has been split but only one part was successfully
      * written to the {@link DurableDataLog}), we may have had to request more {@link DataFrame.DataFrameEntry} instances
-     * in order to figure our the situation (which means we may have also read part of the next (valid) operation). When
+     * in order to figure out the situation (which means we may have also read part of the next (valid) operation). When
      * this happens, we need to notify the upstream code (via a {@link RecordResetException}) and set ourselves in a state
      * where we can only proceed once that upstream code has recovered from this situation and is ready to begin reading
      * the next item ({@link #beginRecord}.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
@@ -93,8 +93,7 @@ public class DataFrameInputStream extends InputStream {
     @Override
     @SneakyThrows(DurableDataLogException.class)
     public int read() throws IOException {
-        Preconditions.checkState(!this.prefetchedEntry,
-                "Cannot read or skip from a prefetched entry without prior calling beginRecord().");
+        Preconditions.checkState(!this.prefetchedEntry, "Must call beginRecord() before reading or skipping from a prefetched entry.");
         while (!this.closed) {
             int r = this.currentEntry.getData().read();
             if (r >= 0) {
@@ -114,8 +113,7 @@ public class DataFrameInputStream extends InputStream {
     @Override
     @SneakyThrows(DurableDataLogException.class)
     public int read(byte[] buffer, int index, int length) throws IOException {
-        Preconditions.checkState(!this.prefetchedEntry,
-                "Cannot read or skip from a prefetched entry without prior calling beginRecord().");
+        Preconditions.checkState(!this.prefetchedEntry, "Must call beginRecord() before reading or skipping from a prefetched entry.");
         Preconditions.checkNotNull(buffer, "buffer");
         if (index < 0 || length < 0 | index + length > buffer.length) {
             throw new IndexOutOfBoundsException();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
@@ -160,6 +160,20 @@ public class DataFrameInputStreamTests {
                         ex -> ex instanceof DataFrameInputStream.RecordResetException);
                 missingLastItem = false;
                 multiSpan = false;
+
+                // Verify that we cannot read or skip anymore (until we call beginRecord() again).
+                AssertExtensions.assertThrows(
+                        "Able to read(byte) after processing partial record.",
+                        inputStream::read,
+                        ex -> ex instanceof IllegalStateException);
+                AssertExtensions.assertThrows(
+                        "Able to read(byte[]) after processing partial record.",
+                        () -> inputStream.read(new byte[1], 0, 1),
+                        ex -> ex instanceof IllegalStateException);
+                AssertExtensions.assertThrows(
+                        "Able to skip after processing partial record.",
+                        () -> inputStream.skip(1),
+                        ex -> ex instanceof IllegalStateException);
             }
 
             val br = inputStream.beginRecord();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
@@ -168,11 +168,15 @@ public class DataFrameInputStreamTests {
                         ex -> ex instanceof IllegalStateException);
                 AssertExtensions.assertThrows(
                         "Able to read(byte[]) after processing partial record.",
-                        () -> inputStream.read(new byte[1], 0, 1),
+                        () -> {
+                            int ignored = inputStream.read(new byte[1], 0, 1);
+                        },
                         ex -> ex instanceof IllegalStateException);
                 AssertExtensions.assertThrows(
                         "Able to skip after processing partial record.",
-                        () -> inputStream.skip(1),
+                        () -> {
+                            long ignored = inputStream.skip(1);
+                        },
                         ex -> ex instanceof IllegalStateException);
             }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -32,6 +32,7 @@ import io.pravega.segmentstore.server.TestDurableDataLogFactory;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
+import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -1031,6 +1032,68 @@ public class DurableLogTests extends OperationLogTestBase {
                             && ex.getCause() instanceof DataCorruptionException
                             && ex.getCause().getCause() instanceof MetadataUpdateException);
         }
+    }
+
+    /**
+     * Tests the ability of the DurableLog properly recover from situations where operations were split across multiple
+     * DataFrames, but were not persisted in their entirety. These operations should be ignored as they are incomplete
+     * and were never acknowledged to the upstream callers.
+     */
+    @Test
+    public void testRecoveryPartialOperations() throws Exception {
+        // Setup the first Durable Log and create the segment.
+        @Cleanup
+        ContainerSetup setup = new ContainerSetup(executorService());
+        @Cleanup
+        DurableLog dl1 = setup.createDurableLog();
+        dl1.startAsync().awaitRunning();
+        Assert.assertNotNull("Internal error: could not grab a pointer to the created TestDurableDataLog.", setup.dataLog.get());
+        val segmentId = createStreamSegmentsWithOperations(1, dl1).stream().findFirst().orElse(-1L);
+
+        // Part of this operation should fail.
+        ErrorInjector<Exception> aSyncErrorInjector = new ErrorInjector<>(
+                count -> count == 1,
+                () -> new DurableDataLogException("intentional"));
+        setup.dataLog.get().setAppendErrorInjectors(null, aSyncErrorInjector);
+        val append1 = new StreamSegmentAppendOperation(segmentId, new byte[MAX_DATA_LOG_APPEND_SIZE], null);
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expected the operation to have failed.",
+                () -> dl1.add(append1, TIMEOUT),
+                ex -> ex instanceof DurableDataLogException);
+
+        AssertExtensions.assertThrows(
+                "Expected the DurableLog to have failed after failed operation.",
+                dl1::awaitTerminated,
+                ex -> ex instanceof IllegalStateException);
+        dl1.close();
+        setup.dataLog.get().setAppendErrorInjectors(null, null);
+
+        // Setup the second Durable Log. Ensure the recovery succeeds and that we don't see that failed operation.
+        @Cleanup
+        val dl2 = setup.createDurableLog();
+        dl2.startAsync().awaitRunning();
+        val ops2 = dl2.read(0, 10, TIMEOUT).join();
+        Assert.assertTrue("Expected first operation to be a checkpoint.", ops2.hasNext() && ops2.next() instanceof MetadataCheckpointOperation);
+        Assert.assertTrue("Expected second operation to be a segment map.", ops2.hasNext() && ops2.next() instanceof StreamSegmentMapOperation);
+        Assert.assertFalse("Not expecting any other operations.", ops2.hasNext());
+
+        // Add a new operation. This one should succeed.
+        val append2 = new StreamSegmentAppendOperation(segmentId, new byte[10], null);
+        dl2.add(append2, TIMEOUT).join();
+        dl2.stopAsync().awaitTerminated();
+        dl2.close();
+
+        // Setup the third Durable Log. Ensure the recovery succeeds that we only see the operations we care about.
+        @Cleanup
+        val dl3 = setup.createDurableLog();
+        dl3.startAsync().awaitRunning();
+        val ops3 = dl3.read(0, 10, TIMEOUT).join();
+        Assert.assertTrue("Expected first operation to be a checkpoint.", ops3.hasNext() && ops3.next() instanceof MetadataCheckpointOperation);
+        Assert.assertTrue("Expected second operation to be a segment map.", ops3.hasNext() && ops3.next() instanceof StreamSegmentMapOperation);
+        Assert.assertTrue("Expected third operation to be an append.", ops3.hasNext() && ops3.next() instanceof CachedStreamSegmentAppendOperation);
+        Assert.assertFalse("Not expecting any other operations.", ops3.hasNext());
+        dl2.stopAsync().awaitTerminated();
+        dl3.close();
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -1040,7 +1040,7 @@ public class DurableLogTests extends OperationLogTestBase {
      * and were never acknowledged to the upstream callers.
      */
     @Test
-    public void testRecoveryPartialOperations() throws Exception {
+    public void testRecoveryPartialOperations() {
         // Setup the first Durable Log and create the segment.
         @Cleanup
         ContainerSetup setup = new ContainerSetup(executorService());
@@ -1051,10 +1051,10 @@ public class DurableLogTests extends OperationLogTestBase {
         val segmentId = createStreamSegmentsWithOperations(1, dl1).stream().findFirst().orElse(-1L);
 
         // Part of this operation should fail.
-        ErrorInjector<Exception> aSyncErrorInjector = new ErrorInjector<>(
+        ErrorInjector<Exception> asyncErrorInjector = new ErrorInjector<>(
                 count -> count == 1,
                 () -> new DurableDataLogException("intentional"));
-        setup.dataLog.get().setAppendErrorInjectors(null, aSyncErrorInjector);
+        setup.dataLog.get().setAppendErrorInjectors(null, asyncErrorInjector);
         val append1 = new StreamSegmentAppendOperation(segmentId, new byte[MAX_DATA_LOG_APPEND_SIZE], null);
         AssertExtensions.assertSuppliedFutureThrows(
                 "Expected the operation to have failed.",


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `DataFrameInputStream` where it was possible to skip over (parts of) a valid operation if the previous operation was only partially committed to Tier 1.

**Purpose of the change**  
Fixes #4046.

**What the code does**  
- The `DataFrameInputStream` provides an InputStream-like interface on top of `DataFrame Entries`  that make up the Tier 1 `DurableDataLog`. Every call to `DataFrameInputStream.read` may either read from the currently loaded `DataFrameEntry` or fetch another one (via `fetchNextEntry`).
- However, in certain exceptional cases (such as when an Operation has been split but only one part was successfully written to Tier 1 (BK or Segment Store crashed), we may have had to request more DataFrameEntries in order to figure out the situation (which means we may have also read part of the next (valid) operation). When this happens, we notify the upstream code (via a `RecordResetException`) and set ourselves in a state where we can only proceed once that upstream code has recovered from this situation and is ready to begin reading the item (via  `beginRecord`).
 - The upstream code is `VersionedSerializer`, which wraps this in a `BoundedInputStream` (bounded for each `DataFrameRecord` (i.e., Operation)) with a bound set to its initial serialization length. It further wraps it in `RevisionDataInputStream` (one such per revision of the code).
    - In normal conditions, it is ok for the `RevisionDataInputStream` to request a `skip` of a number of bytes - this happens in case of forward compatibility (older code reads data serialized in newer format), so `skip` must be a valid operation.
    - However, in an exceptional case, such as when `RecordResetException` is thrown, the `BoundedInputStream` skips over to its "perceived" end of the record. However, for a partially commited operation, that "end of the record" is way past the last written byte of that operation (since we haven't committed the second part); it may be in the middle of the next operation or even beyond.
    - This would cause the `DataFrameInputStream` to erroneously jump to the middle of another record or even past it, which is a sure cause for a `DataCorruptionException`.
- As such, we need a way to "freeze" the `DataFrameInputStream` until the upstream code can tell us it is ready to proceed. Such a state is already codified in the `prefetchedEntry`, so all we need to do is block reads and skips (skips by default invoke `read`) if this flag is set to true.

**How to verify it**  
Unit tests updated to verify behavior.
New unit test for `DurableLog` that verifies the scenario used to reproduce the issue initially.
