### PR TITLE
Issue 4046: (SegmentStore) Segment Container Recovery bug with partial operations

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameInputStream.java
@@ -42,6 +42,22 @@ public class DataFrameInputStream extends InputStream {
     @Getter
     private boolean closed;
     private boolean hasReadAnyData;
+    /**
+     * The {@link DataFrameInputStream} provides an {@link InputStream}-like interface on top of
+     * {@link DataFrame.DataFrameEntry} instances that make up the {@link DurableDataLog}. Every call to {@link #read} may
+     * either read from the currently loaded {@link DataFrame.DataFrameEntry} or fetch another one ({@link #fetchNextEntry()}.
+     *
+     * However, in certain exceptional cases (such as when an Operation has been split but only one part was successfully
+     * written to the {@link DurableDataLog}), we may have had to request more {@link DataFrame.DataFrameEntry} instances
+     * in order to figure out the situation (which means we may have also read part of the next (valid) operation). When
+     * this happens, we need to notify the upstream code (via a {@link RecordResetException}) and set ourselves in a state
+     * where we can only proceed once that upstream code has recovered from this situation and is ready to begin reading
+     * the next item ({@link #beginRecord}.
+     *
+     * Upstream code may wrap this instance in other types of {@link InputStream}s which may invoke {@link #skip} when
+     * closed (for exceptional cases). We need to make sure we don't skip over bytes that may actually be needed, while
+     * at the same time do support {@link #skip} for other, valid cases.
+     */
     private boolean prefetchedEntry;
 
     //endregion
@@ -77,6 +93,7 @@ public class DataFrameInputStream extends InputStream {
     @Override
     @SneakyThrows(DurableDataLogException.class)
     public int read() throws IOException {
+        Preconditions.checkState(!this.prefetchedEntry, "Must call beginRecord() before reading or skipping from a prefetched entry.");
         while (!this.closed) {
             int r = this.currentEntry.getData().read();
             if (r >= 0) {
@@ -96,6 +113,7 @@ public class DataFrameInputStream extends InputStream {
     @Override
     @SneakyThrows(DurableDataLogException.class)
     public int read(byte[] buffer, int index, int length) throws IOException {
+        Preconditions.checkState(!this.prefetchedEntry, "Must call beginRecord() before reading or skipping from a prefetched entry.");
         Preconditions.checkNotNull(buffer, "buffer");
         if (index < 0 || length < 0 | index + length > buffer.length) {
             throw new IndexOutOfBoundsException();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameInputStreamTests.java
@@ -160,6 +160,24 @@ public class DataFrameInputStreamTests {
                         ex -> ex instanceof DataFrameInputStream.RecordResetException);
                 missingLastItem = false;
                 multiSpan = false;
+
+                // Verify that we cannot read or skip anymore (until we call beginRecord() again).
+                AssertExtensions.assertThrows(
+                        "Able to read(byte) after processing partial record.",
+                        inputStream::read,
+                        ex -> ex instanceof IllegalStateException);
+                AssertExtensions.assertThrows(
+                        "Able to read(byte[]) after processing partial record.",
+                        () -> {
+                            int ignored = inputStream.read(new byte[1], 0, 1);
+                        },
+                        ex -> ex instanceof IllegalStateException);
+                AssertExtensions.assertThrows(
+                        "Able to skip after processing partial record.",
+                        () -> {
+                            long ignored = inputStream.skip(1);
+                        },
+                        ex -> ex instanceof IllegalStateException);
             }
 
             val br = inputStream.beginRecord();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -32,6 +32,7 @@ import io.pravega.segmentstore.server.TestDurableDataLogFactory;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
+import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -1031,6 +1032,68 @@ public class DurableLogTests extends OperationLogTestBase {
                             && ex.getCause() instanceof DataCorruptionException
                             && ex.getCause().getCause() instanceof MetadataUpdateException);
         }
+    }
+
+    /**
+     * Tests the ability of the DurableLog properly recover from situations where operations were split across multiple
+     * DataFrames, but were not persisted in their entirety. These operations should be ignored as they are incomplete
+     * and were never acknowledged to the upstream callers.
+     */
+    @Test
+    public void testRecoveryPartialOperations() {
+        // Setup the first Durable Log and create the segment.
+        @Cleanup
+        ContainerSetup setup = new ContainerSetup(executorService());
+        @Cleanup
+        DurableLog dl1 = setup.createDurableLog();
+        dl1.startAsync().awaitRunning();
+        Assert.assertNotNull("Internal error: could not grab a pointer to the created TestDurableDataLog.", setup.dataLog.get());
+        val segmentId = createStreamSegmentsWithOperations(1, dl1).stream().findFirst().orElse(-1L);
+
+        // Part of this operation should fail.
+        ErrorInjector<Exception> asyncErrorInjector = new ErrorInjector<>(
+                count -> count == 1,
+                () -> new DurableDataLogException("intentional"));
+        setup.dataLog.get().setAppendErrorInjectors(null, asyncErrorInjector);
+        val append1 = new StreamSegmentAppendOperation(segmentId, new byte[MAX_DATA_LOG_APPEND_SIZE], null);
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expected the operation to have failed.",
+                () -> dl1.add(append1, TIMEOUT),
+                ex -> ex instanceof DurableDataLogException);
+
+        AssertExtensions.assertThrows(
+                "Expected the DurableLog to have failed after failed operation.",
+                dl1::awaitTerminated,
+                ex -> ex instanceof IllegalStateException);
+        dl1.close();
+        setup.dataLog.get().setAppendErrorInjectors(null, null);
+
+        // Setup the second Durable Log. Ensure the recovery succeeds and that we don't see that failed operation.
+        @Cleanup
+        val dl2 = setup.createDurableLog();
+        dl2.startAsync().awaitRunning();
+        val ops2 = dl2.read(0, 10, TIMEOUT).join();
+        Assert.assertTrue("Expected first operation to be a checkpoint.", ops2.hasNext() && ops2.next() instanceof MetadataCheckpointOperation);
+        Assert.assertTrue("Expected second operation to be a segment map.", ops2.hasNext() && ops2.next() instanceof StreamSegmentMapOperation);
+        Assert.assertFalse("Not expecting any other operations.", ops2.hasNext());
+
+        // Add a new operation. This one should succeed.
+        val append2 = new StreamSegmentAppendOperation(segmentId, new byte[10], null);
+        dl2.add(append2, TIMEOUT).join();
+        dl2.stopAsync().awaitTerminated();
+        dl2.close();
+
+        // Setup the third Durable Log. Ensure the recovery succeeds that we only see the operations we care about.
+        @Cleanup
+        val dl3 = setup.createDurableLog();
+        dl3.startAsync().awaitRunning();
+        val ops3 = dl3.read(0, 10, TIMEOUT).join();
+        Assert.assertTrue("Expected first operation to be a checkpoint.", ops3.hasNext() && ops3.next() instanceof MetadataCheckpointOperation);
+        Assert.assertTrue("Expected second operation to be a segment map.", ops3.hasNext() && ops3.next() instanceof StreamSegmentMapOperation);
+        Assert.assertTrue("Expected third operation to be an append.", ops3.hasNext() && ops3.next() instanceof CachedStreamSegmentAppendOperation);
+        Assert.assertFalse("Not expecting any other operations.", ops3.hasNext());
+        dl2.stopAsync().awaitTerminated();
+        dl3.close();
     }
 
     //endregion


### PR DESCRIPTION
Signed-off-by: Andrei Paduroiu <andrei.paduroiu@emc.com>
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Fixes a bug in DurableLog/DataFrameInputStream where it would erroneously skip over some operations in some cases.

**Purpose of the change**  
Fixes #4046 

**What the code does**  
This is a cherry-pick of PR #4047, see PR #4047 for detail. 

**How to verify it**  
Unit tests updated to verify behavior.
New unit test for DurableLog that verifies the scenario used to reproduce the issue initially.
