### PR TITLE
Issue 4033: Ensure query parameters are validated for scaling-events api.

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -685,6 +685,14 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                                  final SecurityContext securityContext, final AsyncResponse asyncResponse) {
         long traceId = LoggerHelpers.traceEnter(log, "getScalingEvents");
 
+        if (from == null || to == null) {
+            // Validate the input since there is no mechanism in JAX-RS to validate query params.
+            log.warn("Received an invalid request with missing query parameters for scopeName/streamName: {}/{}", scopeName, streamName);
+            asyncResponse.resume(Response.status(Status.BAD_REQUEST).build());
+            LoggerHelpers.traceLeave(log, "getScalingEvents", traceId);
+            return;
+        }
+
         try {
             restAuthHelper.authenticateAuthorize(
                     getAuthorizationHeader(),

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -779,6 +779,9 @@ public class StreamMetaDataTests {
         response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
         assertEquals("Get Scaling Events response code", 400, response.getStatus());
 
+        response = addAuthHeaders(client.target(resourceURI).queryParam("from", fromDateTime).request()).buildGet().invoke();
+        assertEquals("Get Scaling Events response code", 400, response.getStatus());
+
         // 2. from > to is tested here.
         doAnswer(x -> CompletableFuture.completedFuture(scaleMetadataList))
                 .when(mockControllerService).getScaleRecords(anyString(), anyString(), anyLong(), anyLong());

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -775,7 +775,11 @@ public class StreamMetaDataTests {
         assertEquals("Get Scaling Events response code", 404, response.getStatus());
 
         // Test for getScalingEvents for bad request.
-        // from > to is tested here
+        // 1. Missing query parameters are validated here.
+        response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
+        assertEquals("Get Scaling Events response code", 400, response.getStatus());
+
+        // 2. from > to is tested here.
         doAnswer(x -> CompletableFuture.completedFuture(scaleMetadataList))
                 .when(mockControllerService).getScaleRecords(anyString(), anyString(), anyLong(), anyLong());
 
@@ -789,7 +793,9 @@ public class StreamMetaDataTests {
         doAnswer(x -> completableFuture)
                 .when(mockControllerService).getScaleRecords(anyString(), anyString(), anyLong(), anyLong());
 
-        response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
+        response = addAuthHeaders(client.target(resourceURI)
+                                        .queryParam("from", fromDateTime)
+                                        .queryParam("to", toDateTime).request()).buildGet().invoke();
         assertEquals("Get Scaling Events response code", 500, response.getStatus());
     }
 


### PR DESCRIPTION
**Change log description**  
Ensure query parameter validation is performed for scaling-events api.

**Purpose of the change**  
Fixes #4033 

**What the code does**  
The scaling events REST api `/{scopeName}/streams/{streamName}/scaling-events` expects two mandatory parameters `from` and `to` . If these parameters are not supplied the `JAX-RS` sets these parameters as NULL . Also, `JAX-RS` does not have a way to configure these parameters as mandatory to ensure the 400 response code response.
The PR validates the queryparameters and sends a `BAD_REQUEST` (http error code 400) incase of missing parameters.

**How to verify it**  
The existing and newly added tests should continue to pass.
