### PR TITLE
Issue 4059: Change Pravega version to 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ gradleGitPluginVersion=2.2.0
 k8ClientVersion=3.0.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.5.0-SNAPSHOT
+pravegaVersion=0.5.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
* Removes `-SNAPSHOT` suffix from Pravega version in gradle.properties in preparation to release 0.5.0.

**Purpose of the change**  
Fixes #4059 

**What the code does**  
There is no code change, only a change to the Pravega version in `gradle.properties`.

**How to verify it**  
Build should succeed regularly and artifacts should not contain the commit id suffix.
