### PR TITLE
Issue 4034: (SegmentStore) Throttling and Cache Management Tweaks

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -110,15 +110,22 @@ pravegaservice.dataLogImplementation=BOOKKEEPER
 # and fetch it back when needed.
 #pravegaservice.cacheMaxSize=17179869184
 
-# Percentage (of pravegaservice.cacheMaxSize) that defines the maximum usable size of the Local Shared Size. The Segment
-# Store will try to keep the cache utilization below this value, and will apply maximum ingestion throttling if exceeded.
+# Percentage (of pravegaservice.cacheMaxSize) that defines target Local Shared Cache. The Segment Store will try to keep
+# the cache utilization at or below this value, and may apply throttling on new operations if it exceeds it.
 # Valid values: 1 to 100 (inclusive).
-# Recommended values: Between 85 and 99. 85 is the same as the min Throttling threshold above which ingestion throttling
-# will apply. Choosing 85 (minimum) will apply maximum throttling once the cache reaches 85% utilization; choosing a higher
-# value will cause it to apply gradual throttling, beginning at 85 up until the limit. It is recommended that this never
-# be set to 100 because that will give the Cache Manager and Throttler no room to maneuver and keep the cache under control
-# (reaching full cache capacity will force the Segment Store to shut down Segment Containers if they want to load more
-# data into the cache).
+# Recommended values: Between 80 and 90. It is not recommended to choose a very high value as that may leave very little
+# buffer for the Segment Store to attempt any cleaning, apply back-pressure or serve other random requests. Consequently,
+# a very low value may have negative impact on the ingestion performance.
+#pravegaservice.cacheTargetUtilizationPercent=85
+
+# Percentage (of pravegaservice.cacheMaxSize) that defines the maximum usable size of the Local Shared Cache. The Segment
+# Store will apply full throttling if reaching or exceeding this value.
+# Valid values: 1 to 100 (inclusive).
+# Recommended values: Between pravegaservice.cacheTargetUtilizationPercent + 10 and 99. Setting a value too close to
+# pravegaservice.cacheTargetUtilizationPercent will cause the Segment Store to apply maximum throttling as soon as that
+# limit is reached, which may cause it to have sudden, multi-second stalls in the ingestion pipeline. It is not recommended
+# to set this value ever to 100, since that would mean the cache is already full when max throttling kicks in, and the
+# Segment Store will likely shut down Segment Containers in order to alleviate cache pressure.
 #pravegaservice.cacheMaxUtilizationPercent=98
 
 # Maximum amount of time (in seconds) to keep a block of data in the Cache.

--- a/config/config.properties
+++ b/config/config.properties
@@ -125,7 +125,7 @@ pravegaservice.dataLogImplementation=BOOKKEEPER
 # pravegaservice.cacheTargetUtilizationPercent will cause the Segment Store to apply maximum throttling as soon as that
 # limit is reached, which may cause it to have sudden, multi-second stalls in the ingestion pipeline. It is not recommended
 # to set this value ever to 100, since that would mean the cache is already full when max throttling kicks in, and the
-# Segment Store will likely shut down Segment Containers in order to alleviate cache pressure.
+# Segment Store will begin shuting down Segment Containers in order to alleviate cache pressure.
 #pravegaservice.cacheMaxUtilizationPercent=98
 
 # Maximum amount of time (in seconds) to keep a block of data in the Cache.

--- a/config/config.properties
+++ b/config/config.properties
@@ -110,6 +110,17 @@ pravegaservice.dataLogImplementation=BOOKKEEPER
 # and fetch it back when needed.
 #pravegaservice.cacheMaxSize=17179869184
 
+# Percentage (of pravegaservice.cacheMaxSize) that defines the maximum usable size of the Local Shared Size. The Segment
+# Store will try to keep the cache utilization below this value, and will apply maximum ingestion throttling if exceeded.
+# Valid values: 1 to 100 (inclusive).
+# Recommended values: Between 85 and 99. 85 is the same as the min Throttling threshold above which ingestion throttling
+# will apply. Choosing 85 (minimum) will apply maximum throttling once the cache reaches 85% utilization; choosing a higher
+# value will cause it to apply gradual throttling, beginning at 85 up until the limit. It is recommended that this never
+# be set to 100 because that will give the Cache Manager and Throttler no room to maneuver and keep the cache under control
+# (reaching full cache capacity will force the Segment Store to shut down Segment Containers if they want to load more
+# data into the cache).
+#pravegaservice.cacheMaxUtilizationPercent=98
+
 # Maximum amount of time (in seconds) to keep a block of data in the Cache.
 # Valid values: Positive integer.
 # Recommended values: Between 300 and 3600 seconds. Choosing lower values will keep the cache size low, ensuring that an

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -144,6 +144,11 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         return (double) this.cacheSize.get() / this.policy.getMaxSize();
     }
 
+    @Override
+    public double getCacheMaxUtilization() {
+        return this.policy.getMaxUtilization();
+    }
+
     //endregion
 
     //region Client Registration
@@ -322,9 +327,9 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
 
     private boolean exceedsPolicy(CacheStatus currentStatus) {
         // We need to increment the OldestGeneration only if any of the following conditions occurred:
-        // 1. We currently exceed the maximum size as defined by the cache policy.
+        // 1. We currently exceed the maximum usable size as defined by the cache policy.
         // 2. The oldest generation reported by the clients is older than the oldest permissible generation.
-        return currentStatus.getSize() > this.policy.getMaxSize()
+        return currentStatus.getSize() > this.policy.getMaxUsableSize()
                 || currentStatus.getOldestGeneration() < getOldestPermissibleGeneration();
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -145,6 +145,11 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     }
 
     @Override
+    public double getCacheTargetUtilization() {
+        return this.policy.getTargetUtilization();
+    }
+
+    @Override
     public double getCacheMaxUtilization() {
         return this.policy.getMaxUtilization();
     }
@@ -329,7 +334,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         // We need to increment the OldestGeneration only if any of the following conditions occurred:
         // 1. We currently exceed the maximum usable size as defined by the cache policy.
         // 2. The oldest generation reported by the clients is older than the oldest permissible generation.
-        return currentStatus.getSize() > this.policy.getMaxUsableSize()
+        return currentStatus.getSize() > this.policy.getEvictionThreshold()
                 || currentStatus.getOldestGeneration() < getOldestPermissibleGeneration();
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
@@ -18,38 +18,39 @@ import lombok.Getter;
  */
 public class CachePolicy {
     //region Members
-    public static final CachePolicy INFINITE = new CachePolicy(Long.MAX_VALUE, 1.0, Duration.ofSeconds(Integer.MAX_VALUE), Duration.ofSeconds(Integer.MAX_VALUE));
+    public static final CachePolicy INFINITE = new CachePolicy(Long.MAX_VALUE, 1.0, 1.0, Duration.ofSeconds(Integer.MAX_VALUE), Duration.ofSeconds(Integer.MAX_VALUE));
     /**
      * Unless specified via the constructor, defines the default value for {@link #getMaxUtilization()}.
      */
-    public static final double DEFAULT_MAX_CACHE_UTILIZATION = 0.98;
+    public static final double DEFAULT_TARGET_UTILIZATION = 0.85;
     /**
-     * Adjusts the {@link #getMaxUtilization()} in order to calculate the maximum usable size. Since both the Cache Manager
-     * and the Operation Processor's Throttler are pegged to this value, we want to instruct the Cache Manager to attempt
-     * evicting the cache before the Throttler reaches its maximum limit.
-     *
-     * For example, if MaxUtilization = 0.98 and the adjustment is -0.01, the Cache Manager will attempt to keep the Cache
-     * at or below 0.97 of its maximum allowed size ({@link #getMaxSize()}). However the Throttler will only apply maximum
-     * throttling when the cache reaches 0.98 (so if the Cache Manager is successful, it should not never reach that spot).
+     * Unless specified via the constructor, defines the default value for {@link #getMaxUtilization()}.
      */
-    private static final double USABLE_RATIO_ADJUSTMENT = -0.01;
+    public static final double DEFAULT_MAX_UTILIZATION = 0.98;
     /**
      * The maximum size of the cache.
      */
     @Getter
     private final long maxSize;
     /**
+     * The target utilization of the cache, expressed as a number between 0.0 and 1.0, representing the ratio of the
+     * used cache to {@link #getMaxSize()}. The CacheManager will attempt to keep the cache at or below this target,
+     * and incoming requests should be expected to be throttled after reaching this limit.
+     */
+    @Getter
+    private final double targetUtilization;
+    /**
      * The maximum utilization of the cache, expressed as a number between 0.0 and 1.0, representing the ratio of the
-     * used cache to {@Link #getMaxSize()}.
+     * used cache to {@link #getMaxSize()}. It is expected that full throttling will apply after reaching this limit.
      */
     @Getter
     private final double maxUtilization;
     /**
      * The maximum usable size of the cache. When the cache reaches or exceeds this threshold, cache eviction will kick in.
-     * This is a pre-calculated value of {@link #getMaxSize()} * ({@link #getMaxUtilization()} - {@link #USABLE_RATIO_ADJUSTMENT}).
+     * This is a pre-calculated value of {@link #getMaxSize()} * {@link #getTargetUtilization()} ()}.
      */
     @Getter
-    private final long maxUsableSize;
+    private final long evictionThreshold;
     /**
      * The maximum number of generations a cache entry can be inactive in the cache for, before being eligible for eviction.
      */
@@ -66,30 +67,36 @@ public class CachePolicy {
     //region Constructor
 
     /**
-     * Creates a new instance of the CachePolicy class with MaxUtilization set to {@link #DEFAULT_MAX_CACHE_UTILIZATION}.
+     * Creates a new instance of the CachePolicy class with TargetUtilization set to {@link #DEFAULT_TARGET_UTILIZATION}
+     * and MaxUtilization set to {@link #DEFAULT_MAX_UTILIZATION}.
      *
      * @param maxSize            The maximum size of the cache.
      * @param maxTime            The maximum amount of time a cache entry can live in the cache.
      * @param generationDuration The amount of time one Cache generation spans.
      */
     public CachePolicy(long maxSize, Duration maxTime, Duration generationDuration) {
-        this(maxSize, DEFAULT_MAX_CACHE_UTILIZATION, maxTime, generationDuration);
+        this(maxSize, DEFAULT_TARGET_UTILIZATION, DEFAULT_MAX_UTILIZATION, maxTime, generationDuration);
     }
 
     /**
      * Creates a new instance of the CachePolicy class.
      *
      * @param maxSize            The maximum size of the cache.
+     * @param targetUtilization  The target cache utilization to set. See {@link #getTargetUtilization()} ()}.
      * @param maxUtilization     The maximum cache utilization to set. See {@link #getMaxUtilization()}.
      * @param maxTime            The maximum amount of time a cache entry can live in the cache.
      * @param generationDuration The amount of time one Cache generation spans.
      */
-    public CachePolicy(long maxSize, double maxUtilization, Duration maxTime, Duration generationDuration) {
+    public CachePolicy(long maxSize, double targetUtilization, double maxUtilization, Duration maxTime, Duration generationDuration) {
         Preconditions.checkArgument(maxSize > 0, "maxSize must be a positive integer");
-        Preconditions.checkArgument(maxUtilization > 0 && maxUtilization <= 1.0, "maxUtilization must be a number in the range (0.0, 1.0].");
+        Preconditions.checkArgument(targetUtilization > 0 && targetUtilization <= 1.0,
+                "maxUtilization must be a number in the range (0.0, 1.0].");
+        Preconditions.checkArgument(maxUtilization >= targetUtilization && maxUtilization <= 1.0,
+                "maxUtilization must be a number in the range (0.0, 1.0], at least equal to targetUtilization(%s).", targetUtilization);
         this.maxSize = maxSize;
+        this.targetUtilization = targetUtilization;
         this.maxUtilization = maxUtilization;
-        this.maxUsableSize = (long) Math.floor(this.maxSize * this.maxUtilization);
+        this.evictionThreshold = (long) Math.floor(this.maxSize * this.targetUtilization);
         this.generationDuration = generationDuration;
         this.maxGenerations = Math.max(1, (int) ((double) maxTime.toMillis() / generationDuration.toMillis()));
     }
@@ -99,6 +106,6 @@ public class CachePolicy {
     @Override
     public String toString() {
         return String.format("MaxSize = %d, UsableSize = %d, MaxGen = %d, Generation = %s",
-                this.maxSize, this.maxUsableSize, this.maxGenerations, this.generationDuration);
+                this.maxSize, this.evictionThreshold, this.maxGenerations, this.generationDuration);
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
@@ -11,15 +11,54 @@ package io.pravega.segmentstore.server;
 
 import com.google.common.base.Preconditions;
 import java.time.Duration;
+import lombok.Getter;
 
 /**
  * Represents a Policy for a CacheManager.
  */
 public class CachePolicy {
     //region Members
-    public static final CachePolicy INFINITE = new CachePolicy(Long.MAX_VALUE, Duration.ofSeconds(Integer.MAX_VALUE), Duration.ofSeconds(Integer.MAX_VALUE));
+    public static final CachePolicy INFINITE = new CachePolicy(Long.MAX_VALUE, 1.0, Duration.ofSeconds(Integer.MAX_VALUE), Duration.ofSeconds(Integer.MAX_VALUE));
+    /**
+     * Unless specified via the constructor, defines the default value for {@link #getMaxUtilization()}.
+     */
+    public static final double DEFAULT_MAX_CACHE_UTILIZATION = 0.98;
+    /**
+     * Adjusts the {@link #getMaxUtilization()} in order to calculate the maximum usable size. Since both the Cache Manager
+     * and the Operation Processor's Throttler are pegged to this value, we want to instruct the Cache Manager to attempt
+     * evicting the cache before the Throttler reaches its maximum limit.
+     *
+     * For example, if MaxUtilization = 0.98 and the adjustment is -0.01, the Cache Manager will attempt to keep the Cache
+     * at or below 0.97 of its maximum allowed size ({@link #getMaxSize()}). However the Throttler will only apply maximum
+     * throttling when the cache reaches 0.98 (so if the Cache Manager is successful, it should not never reach that spot).
+     */
+    private static final double USABLE_RATIO_ADJUSTMENT = -0.01;
+    /**
+     * The maximum size of the cache.
+     */
+    @Getter
     private final long maxSize;
+    /**
+     * The maximum utilization of the cache, expressed as a number between 0.0 and 1.0, representing the ratio of the
+     * used cache to {@Link #getMaxSize()}.
+     */
+    @Getter
+    private final double maxUtilization;
+    /**
+     * The maximum usable size of the cache. When the cache reaches or exceeds this threshold, cache eviction will kick in.
+     * This is a pre-calculated value of {@link #getMaxSize()} * ({@link #getMaxUtilization()} - {@link #USABLE_RATIO_ADJUSTMENT}).
+     */
+    @Getter
+    private final long maxUsableSize;
+    /**
+     * The maximum number of generations a cache entry can be inactive in the cache for, before being eligible for eviction.
+     */
+    @Getter
     private final int maxGenerations;
+    /**
+     * The amount of time a particular Cache generation lasts.
+     */
+    @Getter
     private final Duration generationDuration;
 
     //endregion
@@ -27,55 +66,39 @@ public class CachePolicy {
     //region Constructor
 
     /**
-     * Creates a new instance of the CachePolicy class.
+     * Creates a new instance of the CachePolicy class with MaxUtilization set to {@link #DEFAULT_MAX_CACHE_UTILIZATION}.
      *
      * @param maxSize            The maximum size of the cache.
      * @param maxTime            The maximum amount of time a cache entry can live in the cache.
      * @param generationDuration The amount of time one Cache generation spans.
      */
     public CachePolicy(long maxSize, Duration maxTime, Duration generationDuration) {
+        this(maxSize, DEFAULT_MAX_CACHE_UTILIZATION, maxTime, generationDuration);
+    }
+
+    /**
+     * Creates a new instance of the CachePolicy class.
+     *
+     * @param maxSize            The maximum size of the cache.
+     * @param maxUtilization     The maximum cache utilization to set. See {@link #getMaxUtilization()}.
+     * @param maxTime            The maximum amount of time a cache entry can live in the cache.
+     * @param generationDuration The amount of time one Cache generation spans.
+     */
+    public CachePolicy(long maxSize, double maxUtilization, Duration maxTime, Duration generationDuration) {
         Preconditions.checkArgument(maxSize > 0, "maxSize must be a positive integer");
+        Preconditions.checkArgument(maxUtilization > 0 && maxUtilization <= 1.0, "maxUtilization must be a number in the range (0.0, 1.0].");
         this.maxSize = maxSize;
+        this.maxUtilization = maxUtilization;
+        this.maxUsableSize = (long) Math.floor(this.maxSize * this.maxUtilization);
         this.generationDuration = generationDuration;
         this.maxGenerations = Math.max(1, (int) ((double) maxTime.toMillis() / generationDuration.toMillis()));
     }
 
     //endregion
 
-    //region Properties
-
-    /**
-     * Gets a value indicating the maximum size of the cache.
-     *
-     * @return The value.
-     */
-    public long getMaxSize() {
-        return this.maxSize;
-    }
-
-    /**
-     * Gets a value indicating the maximum number of generations a cache entry can be inactive in the cache for, before
-     * being eligible for eviction.
-     *
-     * @return The value.
-     */
-    public int getMaxGenerations() {
-        return this.maxGenerations;
-    }
-
-    /**
-     * Gets the amount of time a particular Cache generation lasts.
-     *
-     * @return The value.
-     */
-    public Duration getGenerationDuration() {
-        return this.generationDuration;
-    }
-
     @Override
     public String toString() {
-        return String.format("MaxSize = %d, MaxGen = %d, Generation = %s", this.maxSize, this.maxGenerations, this.generationDuration);
+        return String.format("MaxSize = %d, UsableSize = %d, MaxGen = %d, Generation = %s",
+                this.maxSize, this.maxUsableSize, this.maxGenerations, this.generationDuration);
     }
-
-    //endregion
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -25,8 +25,20 @@ public interface CacheUtilizationProvider {
     double getCacheUtilization();
 
     /**
+     * Gets a value representing the target utilization of the cache, as a ratio of cache used to cache max size.
+     * The cache should be kept at or below this level. Any utilization above this limit should cause throttling and/or
+     * cache eviction to occur.
+     *
+     * See {@link #getCacheUtilization()} for more details.
+     *
+     * @return The maximum cache utilization.
+     */
+    double getCacheTargetUtilization();
+
+    /**
      * Gets a value representing the maximum allowed utilization of the cache, as a ratio of cache used to cache max size.
-     * Any utilization above this limit should cause throttling and/or cache eviction to occur.
+     * Any utilization above this limit should cause both full throttling and cache eviction to occur.
+     *
      * See {@link #getCacheUtilization()} for more details.
      *
      * @return The maximum cache utilization.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -23,4 +23,13 @@ public interface CacheUtilizationProvider {
      * @return The cache utilization.
      */
     double getCacheUtilization();
+
+    /**
+     * Gets a value representing the maximum allowed utilization of the cache, as a ratio of cache used to cache max size.
+     * Any utilization above this limit should cause throttling and/or cache eviction to occur.
+     * See {@link #getCacheUtilization()} for more details.
+     *
+     * @return The maximum cache utilization.
+     */
+    double getCacheMaxUtilization();
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -72,6 +72,11 @@ class MemoryStateUpdater implements CacheUtilizationProvider {
     }
 
     @Override
+    public double getCacheTargetUtilization() {
+        return this.readIndex.getCacheTargetUtilization();
+    }
+
+    @Override
     public double getCacheMaxUtilization() {
         return this.readIndex.getCacheMaxUtilization();
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -71,6 +71,11 @@ class MemoryStateUpdater implements CacheUtilizationProvider {
         return this.readIndex.getCacheUtilization();
     }
 
+    @Override
+    public double getCacheMaxUtilization() {
+        return this.readIndex.getCacheMaxUtilization();
+    }
+
     /**
      * Puts the Log Updater in Recovery Mode, using the given Metadata Source as interim.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -98,10 +98,10 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         this.dataFrameBuilder = new DataFrameBuilder<>(durableDataLog, OperationSerializer.DEFAULT, args);
         this.metrics = new SegmentStoreMetrics.OperationProcessor(this.metadata.getContainerId());
         this.throttlerCalculator = ThrottlerCalculator.builder()
-                                                      .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheMaxUtilization())
-                                                      .commitBacklogThrottler(this.commitQueue::size)
-                                                      .batchingThrottler(durableDataLog::getQueueStatistics)
-                                                      .build();
+                .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheTargetUtilization(), stateUpdater.getCacheMaxUtilization())
+                .commitBacklogThrottler(this.commitQueue::size)
+                .batchingThrottler(durableDataLog::getQueueStatistics)
+                .build();
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -98,7 +98,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         this.dataFrameBuilder = new DataFrameBuilder<>(durableDataLog, OperationSerializer.DEFAULT, args);
         this.metrics = new SegmentStoreMetrics.OperationProcessor(this.metadata.getContainerId());
         this.throttlerCalculator = ThrottlerCalculator.builder()
-                                                      .cacheThrottler(stateUpdater::getCacheUtilization)
+                                                      .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheMaxUtilization())
                                                       .commitBacklogThrottler(this.commitQueue::size)
                                                       .batchingThrottler(durableDataLog::getQueueStatistics)
                                                       .build();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -47,6 +47,11 @@ class ThrottlerCalculator {
      * the CacheManager (keep the Cache Utilization at or below target, so that we may not need to slow operations if
      * we don't need to).
      *
+     * The goal of this adjustment is to give the CacheManager enough breathing room so that it can do its job. It's an
+     * async task so it is possible that the cache utilization may slightly exceed the target until it can be reduced to
+     * an acceptable level. To avoid unnecessary wobbling in throttling, there is a need for a buffer (adjustment) between
+     * this target and when we begin throttling.
+     *
      * Example: If CachePolicy.getTargetUtilization()==0.85 and Adjustment==0.05, then throttling will begin to apply
      * at 0.85+0.05=0.90 (90%) of maximum cache capacity.
      */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -193,8 +193,7 @@ class ThrottlerCalculator {
         }
 
         static int getDelayMultiplier(int backlogCount) {
-            int base = backlogCount - COMMIT_BACKLOG_COUNT_THRESHOLD;
-            return base < 0 ? 0 : base * base;
+            return backlogCount - COMMIT_BACKLOG_COUNT_THRESHOLD;
         }
 
         @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -329,6 +329,11 @@ public class ContainerReadIndex implements ReadIndex {
     }
 
     @Override
+    public double getCacheTargetUtilization() {
+        return this.cacheManager.getCacheTargetUtilization();
+    }
+
+    @Override
     public double getCacheMaxUtilization() {
         return this.cacheManager.getCacheMaxUtilization();
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -328,6 +328,11 @@ public class ContainerReadIndex implements ReadIndex {
         return this.cacheManager.getCacheUtilization();
     }
 
+    @Override
+    public double getCacheMaxUtilization() {
+        return this.cacheManager.getCacheUtilization();
+    }
+
     //endregion
 
     //region Helpers

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -330,7 +330,7 @@ public class ContainerReadIndex implements ReadIndex {
 
     @Override
     public double getCacheMaxUtilization() {
-        return this.cacheManager.getCacheUtilization();
+        return this.cacheManager.getCacheMaxUtilization();
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -49,7 +49,8 @@ public class ServiceConfig {
     public static final Property<String> CERT_FILE = Property.named("certFile", "");
     public static final Property<String> KEY_FILE = Property.named("keyFile", "");
     public static final Property<Long> CACHE_POLICY_MAX_SIZE = Property.named("cacheMaxSize", 16L * 1024 * 1024 * 1024);
-    public static final Property<Integer> CACHE_POLICY_MAX_UTILIZATION = Property.named("cacheMaxUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_MAX_CACHE_UTILIZATION));
+    public static final Property<Integer> CACHE_POLICY_TARGET_UTILIZATION = Property.named("cacheTargetUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_TARGET_UTILIZATION));
+    public static final Property<Integer> CACHE_POLICY_MAX_UTILIZATION = Property.named("cacheMaxUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_MAX_UTILIZATION));
     public static final Property<Integer> CACHE_POLICY_MAX_TIME = Property.named("cacheMaxTimeSeconds", 30 * 60);
     public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cacheGenerationTimeSeconds", 5);
     public static final Property<Boolean> REPLY_WITH_STACK_TRACE_ON_ERROR = Property.named("replyWithStackTraceOnError", false);
@@ -306,10 +307,11 @@ public class ServiceConfig {
         this.keyFile = properties.get(KEY_FILE);
         this.certFile = properties.get(CERT_FILE);
         long cachePolicyMaxSize = properties.getLong(CACHE_POLICY_MAX_SIZE);
-        double cachepolicyMaxUtilization = properties.getInt(CACHE_POLICY_MAX_UTILIZATION) / 100.0;
+        double cachePolicyTargetUtilization = properties.getInt(CACHE_POLICY_TARGET_UTILIZATION) / 100.0;
+        double cachePolicyMaxUtilization = properties.getInt(CACHE_POLICY_MAX_UTILIZATION) / 100.0;
         int cachePolicyMaxTime = properties.getInt(CACHE_POLICY_MAX_TIME);
         int cachePolicyGenerationTime = properties.getInt(CACHE_POLICY_GENERATION_TIME);
-        this.cachePolicy = new CachePolicy(cachePolicyMaxSize, cachepolicyMaxUtilization,
+        this.cachePolicy = new CachePolicy(cachePolicyMaxSize, cachePolicyTargetUtilization, cachePolicyMaxUtilization,
                 Duration.ofSeconds(cachePolicyMaxTime), Duration.ofSeconds(cachePolicyGenerationTime));
         this.replyWithStackTraceOnError = properties.getBoolean(REPLY_WITH_STACK_TRACE_ON_ERROR);
         this.instanceId = properties.get(INSTANCE_ID);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -49,6 +49,7 @@ public class ServiceConfig {
     public static final Property<String> CERT_FILE = Property.named("certFile", "");
     public static final Property<String> KEY_FILE = Property.named("keyFile", "");
     public static final Property<Long> CACHE_POLICY_MAX_SIZE = Property.named("cacheMaxSize", 16L * 1024 * 1024 * 1024);
+    public static final Property<Integer> CACHE_POLICY_MAX_UTILIZATION = Property.named("cacheMaxUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_MAX_CACHE_UTILIZATION));
     public static final Property<Integer> CACHE_POLICY_MAX_TIME = Property.named("cacheMaxTimeSeconds", 30 * 60);
     public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cacheGenerationTimeSeconds", 5);
     public static final Property<Boolean> REPLY_WITH_STACK_TRACE_ON_ERROR = Property.named("replyWithStackTraceOnError", false);
@@ -305,9 +306,11 @@ public class ServiceConfig {
         this.keyFile = properties.get(KEY_FILE);
         this.certFile = properties.get(CERT_FILE);
         long cachePolicyMaxSize = properties.getLong(CACHE_POLICY_MAX_SIZE);
+        double cachepolicyMaxUtilization = properties.getInt(CACHE_POLICY_MAX_UTILIZATION) / 100.0;
         int cachePolicyMaxTime = properties.getInt(CACHE_POLICY_MAX_TIME);
         int cachePolicyGenerationTime = properties.getInt(CACHE_POLICY_GENERATION_TIME);
-        this.cachePolicy = new CachePolicy(cachePolicyMaxSize, Duration.ofSeconds(cachePolicyMaxTime), Duration.ofSeconds(cachePolicyGenerationTime));
+        this.cachePolicy = new CachePolicy(cachePolicyMaxSize, cachepolicyMaxUtilization,
+                Duration.ofSeconds(cachePolicyMaxTime), Duration.ofSeconds(cachePolicyGenerationTime));
         this.replyWithStackTraceOnError = properties.getBoolean(REPLY_WITH_STACK_TRACE_ON_ERROR);
         this.instanceId = properties.get(INSTANCE_ID);
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -109,8 +109,9 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         final int cycleCount = 12345;
         final int defaultOldestGeneration = 0;
         final int maxSize = 2048;
-        final double maxUtilization = 0.5;
-        final CachePolicy policy = new CachePolicy(maxSize, maxUtilization, Duration.ofHours(10 * cycleCount), Duration.ofHours(1));
+        final double targetUtilization = 0.5;
+        final double maxUtilization = 0.95;
+        final CachePolicy policy = new CachePolicy(maxSize, targetUtilization, maxUtilization, Duration.ofHours(10 * cycleCount), Duration.ofHours(1));
         final long excess = policy.getMaxSize(); // This is the excess size when we want to test Oldest Generation increases.
         @Cleanup
         TestCacheManager cm = new TestCacheManager(policy, executorService());
@@ -137,7 +138,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             AtomicInteger callCount = new AtomicInteger();
             if (exceeds) {
                 // If the total size does exceed the policy limit, repeated calls to 'update' should be made until either the cache is within limits or no change can be made.
-                client.setCacheStatus(policy.getMaxUsableSize() + excess, currentOldestGeneration.get(), currentGeneration.get());
+                client.setCacheStatus(policy.getEvictionThreshold() + excess, currentOldestGeneration.get(), currentGeneration.get());
                 client.setUpdateGenerationsImpl((current, oldest) -> {
                     AssertExtensions.assertGreaterThan("Expected an increase in oldestGeneration.", currentOldestGeneration.get(), oldest);
                     currentOldestGeneration.set(oldest);
@@ -150,7 +151,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                 });
             } else {
                 // If the total size does not exceed the policy limit, nothing should change
-                client.setCacheStatus(policy.getMaxUsableSize() - 1, defaultOldestGeneration, currentGeneration.get());
+                client.setCacheStatus(policy.getEvictionThreshold() - 1, defaultOldestGeneration, currentGeneration.get());
                 client.setUpdateGenerationsImpl((current, oldest) -> {
                     Assert.assertEquals("Not expecting a change for oldestGeneration", currentOldestGeneration.get(), (int) oldest);
                     return 0L;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -108,7 +108,9 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
     public void testIncrementOldestGeneration() {
         final int cycleCount = 12345;
         final int defaultOldestGeneration = 0;
-        final CachePolicy policy = new CachePolicy(1024, Duration.ofHours(10 * cycleCount), Duration.ofHours(1));
+        final int maxSize = 2048;
+        final double maxUtilization = 0.5;
+        final CachePolicy policy = new CachePolicy(maxSize, maxUtilization, Duration.ofHours(10 * cycleCount), Duration.ofHours(1));
         final long excess = policy.getMaxSize(); // This is the excess size when we want to test Oldest Generation increases.
         @Cleanup
         TestCacheManager cm = new TestCacheManager(policy, executorService());
@@ -135,7 +137,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             AtomicInteger callCount = new AtomicInteger();
             if (exceeds) {
                 // If the total size does exceed the policy limit, repeated calls to 'update' should be made until either the cache is within limits or no change can be made.
-                client.setCacheStatus(policy.getMaxSize() + excess, currentOldestGeneration.get(), currentGeneration.get());
+                client.setCacheStatus(policy.getMaxUsableSize() + excess, currentOldestGeneration.get(), currentGeneration.get());
                 client.setUpdateGenerationsImpl((current, oldest) -> {
                     AssertExtensions.assertGreaterThan("Expected an increase in oldestGeneration.", currentOldestGeneration.get(), oldest);
                     currentOldestGeneration.set(oldest);
@@ -148,7 +150,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                 });
             } else {
                 // If the total size does not exceed the policy limit, nothing should change
-                client.setCacheStatus(policy.getMaxSize() - 1, defaultOldestGeneration, currentGeneration.get());
+                client.setCacheStatus(policy.getMaxUsableSize() - 1, defaultOldestGeneration, currentGeneration.get());
                 client.setUpdateGenerationsImpl((current, oldest) -> {
                     Assert.assertEquals("Not expecting a change for oldestGeneration", currentOldestGeneration.get(), (int) oldest);
                     return 0L;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -270,6 +270,11 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
         }
 
         @Override
+        public double getCacheTargetUtilization() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public double getCacheMaxUtilization() {
             throw new UnsupportedOperationException();
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -18,11 +18,11 @@ import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.SegmentOperation;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
-import io.pravega.segmentstore.server.SegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
@@ -266,7 +266,12 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
 
         @Override
         public double getCacheUtilization() {
-            throw new IllegalStateException("Not Implemented");
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public double getCacheMaxUtilization() {
+            throw new UnsupportedOperationException();
         }
 
         private void invoke(MethodInvocation methodInvocation) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
@@ -29,21 +29,22 @@ public class ThrottlerCalculatorTests {
      */
     @Test
     public void testCacheThrottling() {
-        val t = ThrottlerCalculator.CACHE_UTILIZATION_THRESHOLD;
+        val t = 0.85;
+        val tAdj = t + ThrottlerCalculator.CACHE_TARGET_UTILIZATION_THRESHOLD_ADJUSTMENT;
         val maxU = 0.98;
         val cacheUtilization = new AtomicReference<Double>(0.0);
-        val tc = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, maxU).build();
+        val tc = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, t, maxU).build();
         testThrottling(tc, cacheUtilization,
-                new Double[]{-1.0, 0.0, 0.5, t},
-                new Double[]{t + 0.01, t + 0.05, t + 0.1, maxU},
+                new Double[]{-1.0, 0.0, 0.5, tAdj},
+                new Double[]{tAdj + 0.01, tAdj + 0.05, tAdj + 0.06, maxU},
                 new Double[]{maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
 
         // Now verify behavior when the max threshold is less than the min threshold.
-        val tc2 = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, t - 0.01).build();
+        val tc2 = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, t, t - 0.01).build();
         testThrottling(tc2, cacheUtilization,
-                new Double[]{-1.0, 0.0, 0.5, t},
+                new Double[]{-1.0, 0.0, 0.5, tAdj},
                 new Double[0],
-                new Double[]{t + 0.01, t + 0.05, t + 0.1, maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
+                new Double[]{tAdj + 0.01, tAdj + 0.05, tAdj + 0.06, maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
@@ -29,28 +29,28 @@ public class ThrottlerCalculatorTests {
      */
     @Test
     public void testCacheThrottling() {
-        val maxU = 1.0 + ThrottlerCalculator.MAX_DELAY_MILLIS / ThrottlerCalculator.THROTTLING_MILLIS_PER_PERCENT_OVER_LIMIT / 100.0;
+        val t = ThrottlerCalculator.CACHE_UTILIZATION_THRESHOLD;
+        val maxU = ThrottlerCalculator.CACHE_UTILIZATION_FULL_THROTTLE_THRESHOLD;
         val cacheUtilization = new AtomicReference<Double>(0.0);
         val tc = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get).build();
         testThrottling(tc, cacheUtilization,
-                new Double[]{-1.0, 0.0, 0.5, 1.0},
-                new Double[]{1.01, 1.05, 1.1, maxU},
+                new Double[]{-1.0, 0.0, 0.5, t},
+                new Double[]{t + 0.01, t + 0.05, t + 0.1, maxU},
                 new Double[]{maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
     }
-
 
     /**
      * Tests the ability to properly calculate throttling delays caused by commit log queue overflows.
      */
     @Test
     public void testCommitBacklogThrottling() {
-        val maxU = ThrottlerCalculator.COMMIT_BACKLOG_COUNT_THRESHOLD + ThrottlerCalculator.MAX_DELAY_MILLIS / ThrottlerCalculator.THROTTLING_MILLIS_PER_COMMIT_OVER_LIMIT;
+        val maxU = ThrottlerCalculator.COMMIT_BACKLOG_COUNT_FULL_THROTTLE_THRESHOLD;
         val commitLogCount = new AtomicReference<Integer>(0);
         val tc = ThrottlerCalculator.builder().commitBacklogThrottler(commitLogCount::get).build();
         testThrottling(tc, commitLogCount,
                 new Integer[]{-1, 0, ThrottlerCalculator.COMMIT_BACKLOG_COUNT_THRESHOLD / 2, ThrottlerCalculator.COMMIT_BACKLOG_COUNT_THRESHOLD},
                 new Integer[]{ThrottlerCalculator.COMMIT_BACKLOG_COUNT_THRESHOLD + 1, ThrottlerCalculator.COMMIT_BACKLOG_COUNT_THRESHOLD + 10, maxU},
-                new Integer[]{maxU, maxU + 1, maxU * 2, Integer.MAX_VALUE});
+                new Integer[]{maxU, maxU + 1, maxU * 2, 10000});
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerCalculatorTests.java
@@ -30,13 +30,20 @@ public class ThrottlerCalculatorTests {
     @Test
     public void testCacheThrottling() {
         val t = ThrottlerCalculator.CACHE_UTILIZATION_THRESHOLD;
-        val maxU = ThrottlerCalculator.CACHE_UTILIZATION_FULL_THROTTLE_THRESHOLD;
+        val maxU = 0.98;
         val cacheUtilization = new AtomicReference<Double>(0.0);
-        val tc = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get).build();
+        val tc = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, maxU).build();
         testThrottling(tc, cacheUtilization,
                 new Double[]{-1.0, 0.0, 0.5, t},
                 new Double[]{t + 0.01, t + 0.05, t + 0.1, maxU},
                 new Double[]{maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
+
+        // Now verify behavior when the max threshold is less than the min threshold.
+        val tc2 = ThrottlerCalculator.builder().cacheThrottler(cacheUtilization::get, t - 0.01).build();
+        testThrottling(tc2, cacheUtilization,
+                new Double[]{-1.0, 0.0, 0.5, t},
+                new Double[0],
+                new Double[]{t + 0.01, t + 0.05, t + 0.1, maxU, maxU + 0.01, maxU * 2, Double.MAX_VALUE});
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -811,7 +811,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         final int cacheMaxSize = SEGMENT_COUNT * entriesPerSegment * appendSize;
         final int postStorageEntryCount = entriesPerSegment / 4; // 25% of the entries are beyond the StorageOffset
         final int preStorageEntryCount = entriesPerSegment - postStorageEntryCount; // 75% of the entries are before the StorageOffset.
-        CachePolicy cachePolicy = new CachePolicy(cacheMaxSize, Duration.ofMillis(1000 * 2 * entriesPerSegment), Duration.ofMillis(1000));
+        CachePolicy cachePolicy = new CachePolicy(cacheMaxSize, 1.0, Duration.ofMillis(1000 * 2 * entriesPerSegment), Duration.ofMillis(1000));
 
         // To properly test this, we want predictable storage reads.
         ReadIndexConfig config = ReadIndexConfig.builder().with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, appendSize).build();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -811,7 +811,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         final int cacheMaxSize = SEGMENT_COUNT * entriesPerSegment * appendSize;
         final int postStorageEntryCount = entriesPerSegment / 4; // 25% of the entries are beyond the StorageOffset
         final int preStorageEntryCount = entriesPerSegment - postStorageEntryCount; // 75% of the entries are before the StorageOffset.
-        CachePolicy cachePolicy = new CachePolicy(cacheMaxSize, 1.0, Duration.ofMillis(1000 * 2 * entriesPerSegment), Duration.ofMillis(1000));
+        CachePolicy cachePolicy = new CachePolicy(cacheMaxSize, 1.0, 1.0, Duration.ofMillis(1000 * 2 * entriesPerSegment), Duration.ofMillis(1000));
 
         // To properly test this, we want predictable storage reads.
         ReadIndexConfig config = ReadIndexConfig.builder().with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, appendSize).build();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/ServiceBuilderConfigTests.java
@@ -106,7 +106,7 @@ public class ServiceBuilderConfigTests {
         testClasses.put(ServiceConfig.class, ServiceConfig::builder);
 
         // Value generator.
-        val nextValue = new AtomicInteger(1000 * 1000 * 1000);
+        val nextValue = new AtomicInteger(10);
 
         // Create instances of each test class and dynamically assign their properties some arbitrary values
         val expectedValues = new HashMap<Class<?>, Object>();


### PR DESCRIPTION
**Change log description**  
- Logging max-delay throttling and Commit Backlog throttling as WARN (everything else stays as DEBUG).
- Changed Commit Backlog Throttling slightly to begin at 100 and reach max delay at 500.
- Changed the Cache Utilization Throttling to begin throttling at 90% and reach a max delay at 98%.
- Changed the Cache Manager to begin evicting items from the cache when it reaches a target utilization (85%)
    - Both the Cache Manager and the Cache Utilization Throttler are now pegged to the same configuration value (`pravegaservice.cacheTargetUtilzationPercent`) which defines both when the throttling begins and what the Cache Manager should aim to keep the cache at. 

**Purpose of the change**  
Fixes #4034.

**What the code does**  
- Logging will help us spot slowdowns due to throttling in case metrics are unavailable and logging is set to INFO or WARN.
- Commit Backlog Throttling and Cache Utilization throttlers have been changed so that it's easier to configure:
    - A (min) threshold over which throttling will begin
    - A (max) threshold over which maximum throttling will apply
    - A function that determines the throttling value. For both of these, it's a linear function, but this will enable us to change it easier in the future.
- The Cache Manager has been changed so that instead of starting to evict items when the cache reaches (or exceeds) 100%, it does so at 90% (configurable).
- Why?
    - Cache: 
        - We currently define a cache limit, but the cache throttler will only kick in once we exceeded that limit(!); in addition the delay is insufficient to make a measurable impact. 
        - This has been changed so it kicks in gradually at 90%, and after 98%, it will completely stop the ingestion pipeline, leaving a 2% buffer for any ongoing operations to complete or Tier-2 reads.
    - Commit backlog
        - The current approach was making it hard to predict when the max throttling will kick in.
        - This has been made consistent with the cache throttler. Starts at 100, and when it reaches 500 (which is a pretty big backlog), it will completely stop the ingestion pipeline. This is slightly more aggressive than the old method, which would have maxed out at 600.
    - Cache Manager
        - Both the Cache Manager and the Cache Throttler aim to do the same thing: keep the Cache under control and less than its maximum defined size (`pravegaservice.cacheMaxSize`). In order for this to be successful, they both must be pegged to the same config value (`pravegaservice.cacheTargetUtilzationPercent`) which will:
            - Cause throttling to begin occurring when utilization reaches Target + 5% (90%)
            - Cause the Cache Manager to begin evicting whatever it can (so that we may have room to eventually get stuff in).
    - The Target has been set at 85%, with throttling kicking in at 90% and max throttling at 98%. This means that the Cache Manager will do its best to keep the cache below the limit where throttling is applied. However, if the Cache Manager cannot evict sufficient items (maybe due to them not being applied to Tier 2 yet) the utilization may rise and the throttling will kick in later to keep more data from coming in.
    - The maximum limit has been set to 98% so that even if we completely stall the ingestion pipeline, we still have a small buffer where random operations can still execute (a Tier 2 read, a Table update/get, etc.) without causing serious side effects. The current cache, implemented by RocksDB does not have a max size, however if we choose to move to a different implementation which does enforce a max size, we want to have a good mechanism in place to try not to reach that limit.

**How to verify it**  
Unit tests and system tests must pass.
