### PR TITLE
Issue 4075: Remove `lombok.var` usage.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -58,7 +58,7 @@ import lombok.Cleanup;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import lombok.var;
+import lombok.val;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.pravega.common.concurrent.Futures.allOfWithResults;
@@ -119,7 +119,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
             ReaderGroupConfig config = state.getConfig();
             CheckpointState checkpointState = state.getCheckpointState();
             int maxOutstandingCheckpointRequest = config.getMaxOutstandingCheckpointRequest();
-            var outstandingCheckpoints = checkpointState.getOutstandingCheckpoints();
+            val outstandingCheckpoints = checkpointState.getOutstandingCheckpoints();
             int currentOutstandingCheckpointRequest = outstandingCheckpoints.size();
             if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
                 log.warn("Current outstanding checkpoints are : {}, " +


### PR DESCRIPTION
**Change log description**  
Remove `lombok.var` usage which causes a compilation failure 

**Purpose of the change**  
Fixes #4075 
Related to https://github.com/pravega/pravega/issues/4078 

**What the code does**  
No changes to functionality. 
As of Java release 10, 'var' is a restricted local variable type and cannot be used for type declarations. This causes the jenkins build job on Java 11 to fail. The PR removes the usage of `lombok.var`.

**How to verify it**  
The java 11 based jenkins build should succeed.
