### PR TITLE
Issue 4079: Keep Alive failure should invoke `ProcessingFailure` for all clients immediately.

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -277,6 +277,7 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
                 final int openFlowCount = flowIdReplyProcessorMap.size();
                 if (openFlowCount != 0) {
                     log.warn("{} flows are not closed", openFlowCount);
+                    // ensure all the ReplyProcessors are informed immediately about the channel being closed.
                     invokeProcessingFailureForAllFlows(new ConnectionClosedException());
                 }
                 final int appendTrackerCount = flowIDBatchSizeTrackerMap.size();

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -58,7 +58,7 @@ import lombok.Cleanup;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import lombok.var;
+import lombok.val;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.pravega.common.concurrent.Futures.allOfWithResults;
@@ -119,7 +119,7 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
             ReaderGroupConfig config = state.getConfig();
             CheckpointState checkpointState = state.getCheckpointState();
             int maxOutstandingCheckpointRequest = config.getMaxOutstandingCheckpointRequest();
-            var outstandingCheckpoints = checkpointState.getOutstandingCheckpoints();
+            val outstandingCheckpoints = checkpointState.getOutstandingCheckpoints();
             int currentOutstandingCheckpointRequest = outstandingCheckpoints.size();
             if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
                 log.warn("Current outstanding checkpoints are : {}, " +

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -16,6 +16,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.channel.ChannelPromise;
+import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.Append;
@@ -23,7 +24,9 @@ import io.pravega.shared.protocol.netty.AppendBatchSizeTracker;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.Reply;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
+import io.pravega.shared.protocol.netty.WireCommand;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.test.common.AssertExtensions;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
@@ -320,5 +323,26 @@ public class FlowHandlerTest {
         flowHandler.channelUnregistered(ctx);
         verify(processor).connectionDropped();
         verify(errorProcessor).connectionDropped();
+    }
+
+    @Test
+    public void keepAliveTest() throws Exception {
+        ReplyProcessor replyProcessor = mock(ReplyProcessor.class);
+        @Cleanup
+        ClientConnection connection1 = flowHandler.createFlow(flow, processor);
+        @Cleanup
+        ClientConnection connection2 = flowHandler.createFlow(new Flow(11, 0), replyProcessor);
+        flowHandler.channelRegistered(ctx);
+
+        // simulate a KeepAlive connection failure.
+        flowHandler.close();
+
+        // ensure all the reply processors are informed immediately of the channel being closed due to KeepAlive Failure.
+        verify(processor).processingFailure(any(ConnectionFailedException.class));
+        verify(replyProcessor).processingFailure(any(ConnectionFailedException.class));
+
+        // verify any attempt to send msg over the connection will throw a ConnectionFailedException.
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection1.send(mock(WireCommand.class))  );
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection2.send(mock(WireCommand.class))  );
     }
 }

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -16,11 +16,9 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.channel.ChannelPromise;
-import io.pravega.client.stream.impl.ConnectionClosedException;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.Append;
-import io.pravega.shared.protocol.netty.AppendBatchSizeTracker;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.Reply;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
@@ -69,8 +67,6 @@ public class FlowHandlerTest {
     private FlowHandler flowHandler;
     @Mock
     private ReplyProcessor processor;
-    @Mock
-    private AppendBatchSizeTracker tracker;
     @Mock
     private Append appendCmd;
     @Mock
@@ -326,7 +322,7 @@ public class FlowHandlerTest {
     }
 
     @Test
-    public void keepAliveTest() throws Exception {
+    public void keepAliveFailureTest() throws Exception {
         ReplyProcessor replyProcessor = mock(ReplyProcessor.class);
         @Cleanup
         ClientConnection connection1 = flowHandler.createFlow(flow, processor);


### PR DESCRIPTION
**Change log description**  
- Ensure all the `ReplyProcessor`s are intimated immediately in the case that sending a `WireCommands.KeepAlive` fails.

**Purpose of the change**  
Fixes #4079 

**What the code does**  
Pravega client sends periodic `KeepAlives` and sending a `KeepAlive` will fail if the connection is dropped. Also, netty invokes `io.pravega.client.netty.impl.FlowHandler#channelUnregistered` as soon as the connection is disconnected.

It was observed during a system test run( https://jenkins-server/jenkins/job/test-pravega-continuous/2182/)  that `channelUnregistered()`, which is used to communicate the connection failure, was never invoked as the `KeepAliveTask` task failed. This can cause writers waiting for the connection setup to complete (waiting for `SetupAppend`) to wait until the netty call back is invoked.

This PR ensures the client immediately intimates all the `ReplyProcessor`s about the connection failure before closing the `Channel`

**How to verify it**  
All the existing and newly added tests should continue to pass.
(System tests have passed with this change `/job/test-pravega-continuous/2190/`)