### PR TITLE
Issue 4056: Reduce creation of new CompletionStage while trying to fill read buffer.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
@@ -76,7 +77,7 @@ public interface EventSegmentReader extends AutoCloseable {
      * 
      * @return A future that completes when the request to fill the buffer has returned.
      */
-    public abstract CompletableFuture<Void> fillBuffer();
+    public abstract CompletableFuture<SegmentRead> fillBuffer();
     
     /**
      * Closes this reader. No further methods may be called after close.

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -14,6 +14,7 @@ import io.pravega.common.LoggerHelpers;
 import io.pravega.shared.protocol.netty.InvalidMessageException;
 import io.pravega.shared.protocol.netty.WireCommandType;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.concurrent.GuardedBy;
@@ -99,7 +100,7 @@ class EventSegmentReaderImpl implements EventSegmentReader {
 
     @Override
     @Synchronized
-    public CompletableFuture<Void> fillBuffer() {
+    public CompletableFuture<SegmentRead> fillBuffer() {
         return in.fillBuffer();
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.segment.impl;
 
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
@@ -62,7 +63,7 @@ public interface SegmentInputStream extends AutoCloseable {
      * 
      * @return A future that will be completed when there is data available to read.
      */
-    public abstract CompletableFuture<Void> fillBuffer();
+    public abstract CompletableFuture<SegmentRead> fillBuffer();
     
     /**
      * Closes this InputStream. No further methods may be called after close.

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -10,7 +10,6 @@
 package io.pravega.client.segment.impl;
 
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Runnables;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.CircularBuffer;
@@ -205,7 +204,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
 
     @Override
     @Synchronized
-    public CompletableFuture<Void> fillBuffer() {
+    public CompletableFuture<SegmentRead> fillBuffer() {
         log.trace("Filling buffer {}", this);
         Exceptions.checkNotClosed(asyncInput.isClosed(), this);
         try {      
@@ -217,7 +216,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
             log.warn("Encountered exception filling buffer", e);
             return CompletableFuture.completedFuture(null);
         }
-        return outstandingRequest == null ? CompletableFuture.completedFuture(null) : outstandingRequest.thenRun(Runnables.doNothing());
+        return outstandingRequest == null ? CompletableFuture.completedFuture(null) : outstandingRequest;
     }
     
     @Override

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +43,7 @@ public class OrdererTest {
         }
 
         @Override
-        public CompletableFuture<Void> fillBuffer() {
+        public CompletableFuture<SegmentRead> fillBuffer() {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -24,6 +24,7 @@ import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.common.util.ByteBufferUtils;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -179,7 +180,7 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     }
 
     @Override
-    public CompletableFuture<Void> fillBuffer() {
+    public CompletableFuture<SegmentRead> fillBuffer() {
         return CompletableFuture.completedFuture(null);
     }
 


### PR DESCRIPTION
(Longevity tests are still in progress)

**Change log description**  
Reduce the creation of new `java.util.concurrent.CompletionStage` inside `SegmentInputStreamImpl#fillBuffer()`

**Purpose of the change**  
Fixes #4056 

**What the code does**  
If a reader attempts to read from a Segment which has no data then a new `java.util.concurrent.CompletionStage` is created for every execution of `SegmentInputStream#fillBuffer`.  These new `CompletionStage`s will never be garbage collected and can lead to increased usage of heap memory in a long running application.

**How to verify it**  
All the existing tests should continue to pass. 
Also, we should verify that the memory consumption by the readers is reduced in the case of segments with no new data. e.g: this scenario can arise when events written to an auto scale enabled stream with a small set of keys.