### PR TITLE
Issue 4069: (AppendDecoder) Trimming excess allocated memory in decoded appends.

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -159,7 +159,9 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
         // padding around each append. Since this Append ByteBuf is expected to live for as long as the Segment Store
         // needs to process it, we need to compact this so that we don't use an excessive amount of heap memory which could
         // lead to out-of-memory situations.
-        return appendDataBuf.copy();
+        ByteBuf result = appendDataBuf.copy();
+        appendDataBuf.release();
+        return result;
     }
 
     private Segment getSegment(UUID writerId) {


### PR DESCRIPTION
**Change log description**  
- Invoking `ByteBuf.copy()` so that we eliminate excess padding around appends.

**Purpose of the change**  
Fixes #4069 

**What the code does**  
- An append on the Segment Store side may be received from multiple append blocks. With connection pooling, the actual usable data in these blocks may be significantly less than the allocated size of the buffers (with the excess being padding).
- What we pass to the downstream Segment Store is a ByteBuf that is either sliced off a single Append Block or a composite of (slices) of multiple Append Block. As such, we can end up with an Append ByteBuf of length N which actually holds pointers to ByteBufs allocating significantly more memory than N. 
- This can be a problem if the Append ByteBuf is required for a significant amount of time and we have incoming append pressure. For example, if writing to Tier 1 or the Cache slows down for whatever reason, we could accumulate a large number of such buffers in memory that are pending to be written or committed; these buffers' lifetimes could span seconds or dozens of seconds, which would be enough to cause the process to run out of heap memory prematurely.
- A solution to this involves invoking `ByteBuf.copy()` on the bytebuf prior to sending it to the downstream Segment Store. This will create a new HeapByteBuf which uses only the memory it needs. This way we can release the memory from the original Append Blocks and reduce the memory pressure in case of Tier 1/Cache slowdowns.

**How to verify it**  
All tests must pass.
