### PR TITLE
Issue 4101: Prevent users from canceling checkpoint completion

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -140,7 +140,8 @@ public class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         }
 
         return waitForCheckpointComplete(checkpointName, backgroundExecutor)
-                .thenApply(v -> completeCheckpoint(checkpointName));
+                .thenApply(v -> completeCheckpoint(checkpointName))
+                .thenApply(checkpoint -> checkpoint); //Added to prevent users from canceling completeCheckpoint
     }
 
     /**

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -25,6 +25,8 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.ReaderGroupState.ClearCheckpointsBefore;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.InlineExecutor;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,12 +35,14 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static io.pravega.test.common.AssertExtensions.assertSuppliedFutureThrows;
@@ -47,6 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,6 +85,7 @@ public class ReaderGroupImplTest {
     public void setUp() throws Exception {
         when(clientFactory.createStateSynchronizer(anyString(), any(Serializer.class), any(Serializer.class),
                                                    any(SynchronizerConfig.class))).thenReturn(synchronizer);
+        when(synchronizer.getState()).thenReturn(state);
         readerGroup = new ReaderGroupImpl(SCOPE, GROUP_NAME, synchronizerConfig, initSerializer,
                 updateSerializer, clientFactory, controller, connectionFactory);
     }
@@ -227,5 +233,22 @@ public class ReaderGroupImplTest {
         });
 
         return new StreamCutImpl(Stream.of(SCOPE, streamName), builder.build());
+    }
+    
+    @Test
+    public void testFutureCancelation() throws Exception {
+        AtomicBoolean completed = new AtomicBoolean(false);
+        when(synchronizer.updateState(any(StateSynchronizer.UpdateGeneratorFunction.class))).thenReturn(true);
+        when(state.isCheckpointComplete("test")).thenReturn(false).thenReturn(true);
+        Mockito.doAnswer(invocation -> {
+            completed.set(true);
+            return null;
+        }).when(synchronizer).updateStateUnconditionally(eq(new ClearCheckpointsBefore("test")));
+        @Cleanup("shutdown")
+        InlineExecutor executor = new InlineExecutor();
+        CompletableFuture<Checkpoint> result = readerGroup.initiateCheckpoint("test", executor);
+        assertFalse(result.isDone());
+        result.cancel(false);
+        AssertExtensions.assertEventuallyEquals(true, completed::get, 5000);
     }
 }

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -55,13 +55,15 @@ public class AssertExtensions {
      * @param timeoutMillis         The timeout in milliseconds after which an assertion error should be thrown.
      * @throws Exception            If the is an assertion error, and exception from `eval`, or the thread is interrupted.
      */
-    public static <T> void assertEventuallyEquals(T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
-        long remainingMillis = timeoutMillis;
-        while (remainingMillis > 0) {
+    private static <T> void assertEventuallyEquals(T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
+        long currentTime = System.currentTimeMillis();
+        long endTime = currentTime + timeoutMillis;
+        while (currentTime < endTime) {
             if ((expected == null && eval.call() == null) || (expected != null && expected.equals(eval.call()))) {
                 return;
             }
             Thread.sleep(checkIntervalMillis);
+            currentTime = System.currentTimeMillis();
         }
         assertEquals(expected, eval.call());
     }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Prevent canceling of future returned from initiateCheckpoint() from impacting the checkpoint.

**Purpose of the change**  
Fixes #4101, Closes #2258

**What the code does**  
Adds an additional stage to the returned future to prevent the call to cancel from influencing the computation.

**How to verify it**  
Added a test to verify the effectiveness and also fixed a test code bug introduced in #3844 which prevented verification.
