### PR TITLE
Issue 4054: Lookup Metrics Hostname in Env Var in case it's not defined as a system property

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -17,7 +17,8 @@ import java.net.UnknownHostException;
 
 public final class MetricsTags {
 
-    public static final String HOSTNAME_PROPERTY_NAME = "HOSTNAME";
+    //The default key to lookup hostname system property or env var.
+    public static final String DEFAULT_HOSTNAME_KEY = "HOSTNAME";
 
     // Metric Tag Names
     public static final String TAG_CONTAINER = "container";
@@ -137,18 +138,26 @@ public final class MetricsTags {
     }
 
     /**
-     * Create host tag based on the local host.
+     * Create host tag based on the system property, env var or local host config.
+     * @param hostnameKey the lookup key for hostname system property or env var.
      * @return host tag.
      */
-    public static String[] createHostTag() {
+    public static String[] createHostTag(String hostnameKey) {
         String[] hostTag = {MetricsTags.TAG_HOST, null};
 
-        //Always take property "HOSTNAME" if it's defined.
-        hostTag[1] = System.getProperty(HOSTNAME_PROPERTY_NAME);
+        //Always take system property if it's defined.
+        hostTag[1] = System.getProperty(hostnameKey);
         if (!Strings.isNullOrEmpty(hostTag[1])) {
             return hostTag;
         }
 
+        //Then take env variable if it's defined.
+        hostTag[1] = System.getenv(hostnameKey);
+        if (!Strings.isNullOrEmpty(hostTag[1])) {
+            return hostTag;
+        }
+
+        //Finally use the resolved hostname based on localhost config.
         try {
             hostTag[1] = InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/StatsProviderImpl.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 
+import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
 import static io.pravega.shared.MetricsTags.createHostTag;
 
 @Slf4j
@@ -66,7 +67,7 @@ class StatsProviderImpl implements StatsProvider {
         if (conf.isEnableInfluxDBReporter()) {
             metrics.add(new InfluxMeterRegistry(RegistryConfigUtil.createInfluxConfig(conf), Clock.SYSTEM));
         }
-        metrics.config().commonTags(createHostTag());
+        metrics.config().commonTags(createHostTag(DEFAULT_HOSTNAME_KEY));
         Preconditions.checkArgument(metrics.getRegistries().size() != 0,
                 "No meter register bound hence no storage for metrics!");
     }
@@ -78,7 +79,7 @@ class StatsProviderImpl implements StatsProvider {
             metrics.remove(registry);
         }
         Metrics.addRegistry(new SimpleMeterRegistry());
-        metrics.config().commonTags(createHostTag());
+        metrics.config().commonTags(createHostTag(DEFAULT_HOSTNAME_KEY));
     }
 
     @Synchronized

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -13,14 +13,15 @@ import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
-import static io.pravega.shared.MetricsTags.HOSTNAME_PROPERTY_NAME;
+import java.net.InetAddress;
+
+import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
 import static io.pravega.shared.MetricsTags.containerTag;
 import static io.pravega.shared.MetricsTags.createHostTag;
 import static io.pravega.shared.MetricsTags.hostTag;
 import static io.pravega.shared.MetricsTags.segmentTags;
 import static io.pravega.shared.MetricsTags.streamTags;
 import static io.pravega.shared.MetricsTags.transactionTags;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
 @Slf4j
@@ -41,13 +42,31 @@ public class MetricsTagsTest {
     }
 
     @Test
-    public void testCreateHostTag() {
-        System.setProperty(HOSTNAME_PROPERTY_NAME, "testHostName");
-        assertEquals("testHostName", createHostTag()[1]);
-        System.setProperty(HOSTNAME_PROPERTY_NAME, "");
-        assertFalse(Strings.isNullOrEmpty(createHostTag()[1]));
-        System.clearProperty(HOSTNAME_PROPERTY_NAME);
-        assertFalse(Strings.isNullOrEmpty(createHostTag()[1]));
+    public void testCreateHostTag() throws Exception {
+        //Scenario 1: system property is defined - property is taken
+        String originalProperty = System.getProperty(DEFAULT_HOSTNAME_KEY);
+        System.setProperty(DEFAULT_HOSTNAME_KEY, "expectedHostname");
+        assertEquals("expectedHostname", createHostTag(DEFAULT_HOSTNAME_KEY)[1]);
+        if (!Strings.isNullOrEmpty(originalProperty)) {
+            System.setProperty(DEFAULT_HOSTNAME_KEY, originalProperty);
+        }
+
+        //Scenario 2: system property not defined, env var is defined - env var is taken
+        String envVarDefined = System.getenv().keySet().iterator().next();
+        originalProperty = System.getProperty(envVarDefined);
+        System.clearProperty(envVarDefined);
+        assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);
+        if (!Strings.isNullOrEmpty(originalProperty)) {
+            System.setProperty(envVarDefined, originalProperty);
+        }
+
+        //Scenario 3: system property not defined, env var not defined - localhost config is taken
+        originalProperty = System.getProperty("NON_EXIST_ENV");
+        System.clearProperty("NON_EXIST_ENV");
+        assertEquals(InetAddress.getLocalHost().getHostName(), createHostTag("NON_EXIST_ENV")[1]);
+        if (!Strings.isNullOrEmpty(originalProperty)) {
+            System.setProperty("NON_EXIST_ENV", originalProperty);
+        }
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
This is a bug fix: missed the env var lookup for hostname in the previous PR.
Also add hostname lookup key as input parameter of createHostTag(), so in the future we could make the lookup key configurable.

**Purpose of the change**  
Fixes #4054 

**What the code does**  
(Detailed description of the code changes)
Changed createHostTag method signature, added hostnameLookupKey as input parameter. This is to make the lookup key configurable in the future.
Added env var lookup in the createHostTag method. This scenario was tested but the code was missed in the previous PR.
Updated the corresponding unit test to reflect the changes.

**How to verify it**  
Metric dashboard should see consistent and short hostname tag.
Test cases should pass.
