### PR TITLE
Issue 4135: Additional logging in Controller for easier debugging of missing delegation token issues

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
@@ -75,7 +75,13 @@ public class GrpcAuthHelper {
 
     public String checkAuthorizationAndCreateToken(String resource, AuthHandler.Permissions expectedLevel) {
         if (isAuthEnabled) {
-            checkAuthorization(resource, expectedLevel);
+            try {
+                checkAuthorization(resource, expectedLevel);
+            } catch (RuntimeException e) {
+                // An auth handler plugin loaded in the system may throw this exception.
+                log.warn("Authorization failed", e);
+                throw e;
+            }
             return createDelegationToken(resource, expectedLevel, tokenSigningKey);
         }
         return "";

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -497,18 +497,9 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
 
     private void logIfEmpty(String delegationToken, String requestName, String scopeName,
                             String streamName) {
-        if (isAuthEnabled()) {
-            String message = String.format("Delegation token for request [%s] with scope [%s] and stream [%s], is: [%s]",
+        if (isAuthEnabled() && (delegationToken == null || delegationToken.equals(""))) {
+            log.warn("Delegation token for request [{}] with scope [{}] and stream [{}], is: [{}]",
                     requestName, scopeName, streamName, delegationToken);
-            logIfEmpty(delegationToken, message);
-        }
-    }
-
-    private void logIfEmpty(String delegationToken, String message) {
-        if (isAuthEnabled()) {
-            if (delegationToken == null || delegationToken.equals("")) {
-                log.warn(message);
-            }
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -197,8 +197,8 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         request.getStreamInfo().getStream()),
                 AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> {
-                    logIfEmpty("getSegments", request.getStreamInfo().getScope(),
-                            request.getStreamInfo().getStream(), delegationToken);
+                    logIfEmpty(delegationToken, "getSegments", request.getStreamInfo().getScope(),
+                            request.getStreamInfo().getStream());
                     return controllerService.getSegmentsAtHead(request.getStreamInfo().getScope(),
                             request.getStreamInfo().getStream())
                             .thenApply(segments -> {
@@ -246,8 +246,8 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorizationAndCreateToken(
                 AuthResourceRepresentation.ofStreamInScope(scope, stream), AuthHandler.Permissions.READ),
                 delegationToken -> {
-                    logIfEmpty("getSegmentsBetween", request.getStreamInfo().getScope(),
-                            request.getStreamInfo().getStream(), delegationToken);
+                    logIfEmpty(delegationToken, "getSegmentsBetween", request.getStreamInfo().getScope(),
+                            request.getStreamInfo().getStream());
                     return controllerService.getSegmentsBetweenStreamCuts(request)
                             .thenApply(segments -> ModelHelper.createStreamCutRangeResponse(scope, stream,
                                     segments.stream().map(x -> ModelHelper.createSegmentId(scope, stream, x.segmentId()))
@@ -486,7 +486,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 AuthResourceRepresentation.ofStreamInScope(request.getScope(), request.getStream()),
                 AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> {
-                    logIfEmpty("getDelegationToken", request.getScope(), request.getStream(), delegationToken);
+                    logIfEmpty(delegationToken, "getDelegationToken", request.getScope(), request.getStream());
                     return CompletableFuture.completedFuture(DelegationToken
                             .newBuilder()
                             .setDelegationToken(delegationToken)
@@ -498,7 +498,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     private void logIfEmpty(String delegationToken, String requestName, String scopeName,
                             String streamName) {
         if (isAuthEnabled()) {
-            String message = String.format("Delegation token for request [%s] with scope [%s] and stream [%s] is: [%s]",
+            String message = String.format("Delegation token for request [%s] with scope [%s] and stream [%s], is: [%s]",
                     requestName, scopeName, streamName, delegationToken);
             logIfEmpty(delegationToken, message);
         }


### PR DESCRIPTION
**Change log description**  
Adds logging statements in the Controller to aid debugging of failure scenarios where delegation token might be null or empty. 

**Purpose of the change**  
Resolved #4135 

**What the code does**  
Adds logging statements that will emit log entries under these circumstances:
1. When an auth handler plugin throws `RuntimeException` upon invocation of authorization operation.
2.  When auth is enabled, but the delegation token being generated is observed as null or empty, at some key points in the Controller gRPC service implementation class. 

The new logging statements being added log at `WARN` level, so it can be alarming for the admins/operators if the logging is unnecessary and excessive. The conditions mentioned above should be few if any, and therefore the new log statements should in turn occur under rare circumstances. 

**How to verify it**  
NA
