### PR TITLE
Issue 4005:  Performance Latency improvements of Pravega Client

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -18,6 +18,12 @@ import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.common.util.Retry;
 import io.pravega.common.util.Retry.RetryWithBackoff;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.UUID;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +37,19 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     private final Controller controller;
     private final ConnectionFactory cf;
     private final Consumer<Segment> nopSegmentSealedCallback = s -> log.error("Transaction segment: {} cannot be sealed", s);
+    private final Map<String, Map.Entry<SegmentOutputStreamImpl, SegmentSealedCallbacks>> setupSegments = new HashMap<>();
+
+    private  static class SegmentSealedCallbacks {
+        private final List<Consumer<Segment>> callbackList = new ArrayList<>();
+
+        public void add(Consumer<Segment> segmentSealedCallback) {
+            callbackList.add(segmentSealedCallback);
+        }
+
+        public void callBack(Segment segment) {
+            callbackList.forEach(s -> s.accept(segment));
+        }
+    }
 
     @Override
     public SegmentOutputStream createOutputStreamForTransaction(Segment segment, UUID txId, EventWriterConfig config,
@@ -42,13 +61,35 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
 
     @Override
     public SegmentOutputStream createOutputStreamForSegment(Segment segment, Consumer<Segment> segmentSealedCallback, EventWriterConfig config, String delegationToken) {
-        SegmentOutputStreamImpl result =
-                new SegmentOutputStreamImpl(segment.getScopedName(), config.isEnableConnectionPooling(), controller, cf, UUID.randomUUID(), segmentSealedCallback,
-                                            getRetryFromConfig(config), delegationToken);
-        try {
-            result.getConnection();
-        } catch (RetriesExhaustedException | SegmentSealedException | NoSuchSegmentException e) {
-            log.warn("Initial connection attempt failure. Suppressing.", e);
+        SegmentOutputStreamImpl result;
+        SegmentSealedCallbacks segmentSeal;
+
+        String key = segment.toString();
+        if (config.isEnableConnectionPooling()) {
+            final Map.Entry<SegmentOutputStreamImpl, SegmentSealedCallbacks> entry = setupSegments.get(key);
+            if (entry == null) {
+                segmentSeal = new SegmentSealedCallbacks();
+                result = new SegmentOutputStreamImpl(key, config.isEnableConnectionPooling(),
+                        controller, cf, UUID.randomUUID(), segmentSeal::callBack, getRetryFromConfig(config), delegationToken);
+                try {
+                    result.getConnection();
+                } catch (RetriesExhaustedException | SegmentSealedException | NoSuchSegmentException e) {
+                    log.warn("Initial connection attempt failure. Suppressing.", e);
+                }
+                setupSegments.put(key, new SimpleImmutableEntry<>(result, segmentSeal));
+            } else {
+                segmentSeal = setupSegments.get(key).getValue();
+                result = entry.getKey();
+            }
+            segmentSeal.add(segmentSealedCallback);
+        } else {
+            result = new SegmentOutputStreamImpl(key, config.isEnableConnectionPooling(), controller, cf,
+                    UUID.randomUUID(), segmentSealedCallback, getRetryFromConfig(config), delegationToken);
+            try {
+                result.getConnection();
+            } catch (RetriesExhaustedException | SegmentSealedException | NoSuchSegmentException e) {
+                log.warn("Initial connection attempt failure. Suppressing.", e);
+            }
         }
         return result;
     }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -55,8 +55,7 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     
     @Override
     public SegmentOutputStream createOutputStreamForSegment(Segment segment, EventWriterConfig config, String delegationToken) {
-        return new SegmentOutputStreamImpl(segment.getScopedName(), config.isEnableConnectionPooling(), controller, cf, UUID.randomUUID(),
-                                           Callbacks::doNothing, getRetryFromConfig(config), delegationToken);
+        return createOutputStreamForSegment(segment, Callbacks::doNothing, config, delegationToken);
     }
     
     private RetryWithBackoff getRetryFromConfig(EventWriterConfig config) {

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -427,7 +427,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      *
      */
     @Override
-    public void write(PendingEvent event) {
+    synchronized public void write(PendingEvent event) {
         //State is set to sealed during a Transaction abort and the segment writer should not throw an {@link IllegalStateException} in such a case.
         checkState(StreamSegmentNameUtils.isTransactionSegment(segmentName) || !state.isAlreadySealed(), "Segment: %s is already sealed", segmentName);
         synchronized (writeOrderLock) {
@@ -475,7 +475,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      * @see SegmentOutputStream#close()
      */
     @Override
-    public void close() throws SegmentSealedException {
+    synchronized public void close() throws SegmentSealedException {
         if (state.isClosed()) {
             return;
         }
@@ -493,7 +493,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
      * @see SegmentOutputStream#flush()
      */
     @Override
-    public void flush() throws SegmentSealedException {
+    synchronized  public void flush() throws SegmentSealedException {
         int numInflight = state.getNumInflight();
         log.debug("Flushing writer: {} with {} inflight events", writerId, numInflight);
         if (numInflight != 0) {


### PR DESCRIPTION
**Change log description**  
The segment output stream is reused by the all the writers.  There will be single segment out stream per segment. The segment output stream does not grow as the number of  writers.

**Purpose of the change**  
Fixes #4005

**What the code does**  
Currently in the pravega client, the segment output stream creation is with complexity O(M*N) ; where M is number of Writers and N is number of segments.
This code reduces the complexity by O(N). The number of segment output streams are limited only by number of segments.
For example, in the earlier code , if the there are 10 producers and 10 segments ; its used to created 10 * 10 = 100 flow ids; which in turn consume more memory and CPU.
with this PR, if there are 10 producers and 10 segments ; it creates only 10 flowIds. 
This has the following advantages
1. Reduces the resource consumption by Pravega client.
2. In case , if the connection pooling is disabled, then it reduces the number of connections too.
3. The performance is stable
       Even after running the performance bench-marking , the performance number are consistent. The is NO gradual performance degradation.
4. The latency is improved (lower latency) with out impacting the throughput.

TODO:
1. Need to find a design to handle the  delegation token per writer id.
2. Need to design to handle the client config parameters. It should be specific to client factory ; not specific to writer id.
3. Fix the integration tests; if the flush happens after the segment seal ; then such test cases need to rewritten.

**How to verify it**  
1. Unit testing executed; some integration tests are failing; need to fix them.
2. Pravega bench-marking is conducted on bare metal ; the latency improvements are observed and performance is stable. 
