### PR TITLE
Issue 4122: Retry in case of multiple TruncatedDataException are thrown during StateSynchronizer.fetchUpdates()

### DIFF
--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -532,10 +532,9 @@ public class SynchronizerTest {
         assertEquals(0, syncA.bytesWrittenSinceCompaction());
     }
 
-
     @Test(timeout = 20000)
     @SuppressWarnings("unchecked")
-    public void testCompactWithMultipledTruncation() {
+    public void testFetchUpdatesWithMultipleTruncation() {
         String streamName = "streamName";
         String scope = "scope";
 
@@ -558,8 +557,9 @@ public class SynchronizerTest {
                 .thenThrow(new TruncatedDataException())
                 .thenThrow(new TruncatedDataException())
                 .thenReturn(iterator);
+        when(revisionedClient.readFrom(secondMark)).thenReturn(iterator);
 
-        syncA.fetchUpdates();
+        syncA.fetchUpdates(); // invoke fetchUpdates which will encounter TruncatedDataException from RevisionedStreamClient.
         assertEquals("x", syncA.getState().getValue());
     }
 }


### PR DESCRIPTION
**Change log description**  
Ensure the StateSynchronizer retries in case of multiple TruncatedDataException observed when trying to fetch updates on the state.

**Purpose of the change**  
Fixes #4122 

**What the code does**  
It was observed that when a ReaderGroup has a large number of readers (1000 in case of the issue) multiple readers can trigger a compaction. This will lead to multiple `TruncatedDataException` being thrown when the StateSyncronizer is trying to fetch updates. This PR ensures the client retries in case of such repeated `TruncatedDataException`.

**How to verify it**  
All the existing and newly added tests should continue to pass.
