### PR TITLE
Issue 4144: Change version in gradle properties to 0.5.2-SNAPSHOT in r0.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ gradleGitPluginVersion=2.2.0
 k8ClientVersion=3.0.0
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.5.1
+pravegaVersion=0.5.2-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Flavio Junqueira (fpj) <flavio.junqueira@emc.com>

**Change log description**  
Changes the Pravega version in gradle.properties to 0.5.2-SNAPSHOT

**Purpose of the change**  
Fixes #4144 

**What the code does**  
There is no code change, only a configuration change in `gradle.properties`. Any other change is an spurious change and should not be part of this PR.

**How to verify it**  
`./gradlew install` should push artifacts to the local maven with the correct version.
