### PR TITLE
Issue 4147 : Increase default Transaction timeout.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -39,7 +39,7 @@ public class EventWriterConfig implements Serializable {
      *
      * The maximum allowed lease time by default is 120s, see:
      *
-     * controller/src/main/resources/reference.conf
+     * {@link io.pravega.controller.util.Config.PROPERTY_TXN_MAX_LEASE}
      *
      * The maximum allowed lease time is a configuration parameter of the controller
      * and can be changed accordingly. Note that being a controller-wide parameter,
@@ -52,7 +52,7 @@ public class EventWriterConfig implements Serializable {
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
-        private long transactionTimeoutTime = 30 * 1000 - 1;
+        private long transactionTimeoutTime = 90 * 1000 - 1;
         // connection pooling for event writers is enabled by default.
         private boolean enableConnectionPooling = true;
     }


### PR DESCRIPTION
**Change log description**  
Increase the default transaction timeout from 30 seconds to 90 seconds.

**Purpose of the change**  
Related to #4147 

**What the code does**  
It was observed in mid scale longevity workloads that transactions could be aborted due to shorter transaction timeouts. When the controller receives the ping request the controller is already racing to abort the transaction. The shorter transaction timeout would lead to aborted transactions in scenario of Segment container fail-overs too.
The PR changes the default transaction timeout to 90 seconds to handle this.

**How to verify it**  
All the existing tests should continue to pass.
