### PR TITLE
Issue 4157: Support for Divergent TLS configuration for Controller and Segment Store

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -103,7 +103,7 @@ public class ClientConfig implements Serializable {
     public boolean isEnableTls() {
         if (deriveTlsEnabledFromControllerURI) {
             String scheme = this.controllerURI.getScheme();
-            if (scheme == null) {
+            if (scheme == null) { // scheme is null when URL is of the kind //<hostname>:<port>
                 return false;
             }
             return scheme.equals("tls") || scheme.equals("ssl") || scheme.equals("pravegas");

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -18,8 +18,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -75,6 +78,7 @@ public class ClientConfig implements Serializable {
      * true - if neither {@link #enableTlsToController} or {@link #enableTlsToSegmentStore} are set, or if both are
      *        set to true.
      */
+    @Getter(AccessLevel.NONE) //Omit accessor
     private final boolean deriveTlsEnabledFromControllerURI;
 
     /**
@@ -84,6 +88,7 @@ public class ClientConfig implements Serializable {
      * is {@code tls} or {@code pravegas}, TLS is automatically enabled for both client-to-Controller and
      * client-to-Segment Store communications.
      */
+    @Getter(AccessLevel.NONE) // Omit Lombok accessor as we are creating a custom one
     private final boolean enableTlsToController;
 
     /**
@@ -93,6 +98,7 @@ public class ClientConfig implements Serializable {
      * is {@code tls} or {@code pravegas}, TLS is automatically enabled for both client-to-Controller and
      * client-to-Segment Store communications.
      */
+    @Getter(AccessLevel.NONE) // Omit Lombok accessor as we are creating a custom one
     private final boolean enableTlsToSegmentStore;
 
     /**
@@ -109,6 +115,22 @@ public class ClientConfig implements Serializable {
             return scheme.equals("tls") || scheme.equals("ssl") || scheme.equals("pravegas");
         } else {
             return enableTlsToController && enableTlsToSegmentStore;
+        }
+    }
+
+    public boolean isEnableTlsToController() {
+        if (deriveTlsEnabledFromControllerURI) {
+            return this.isEnableTls();
+        } else {
+            return this.enableTlsToController;
+        }
+    }
+
+    public boolean isEnableTlsToSegmentStore() {
+        if (deriveTlsEnabledFromControllerURI) {
+            return this.isEnableTls();
+        } else {
+            return enableTlsToSegmentStore;
         }
     }
 

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -78,7 +78,7 @@ public class ClientConfig implements Serializable {
      * true - if neither {@link #enableTlsToController} or {@link #enableTlsToSegmentStore} are set, or if both are
      *        set to true.
      */
-    @Getter(AccessLevel.NONE) //Omit accessor
+    @Getter(AccessLevel.NONE) // Omit Lombok accessor
     private final boolean deriveTlsEnabledFromControllerURI;
 
     /**

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -260,6 +260,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
     private SslContext getSslContext() {
         final SslContext sslCtx;
         if (clientConfig.isEnableTls() || clientConfig.isEnableTlsToSegmentStore()) {
+            log.debug("Setting up an SSL/TLS Context");
             try {
                 SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient();
                 if (Strings.isNullOrEmpty(clientConfig.getTrustStore())) {

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -259,7 +259,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
      */
     private SslContext getSslContext() {
         final SslContext sslCtx;
-        if (clientConfig.isEnableTls() || clientConfig.isEnableTlsToSegmentStore()) {
+        if (clientConfig.isEnableTlsToSegmentStore()) {
             log.debug("Setting up an SSL/TLS Context");
             try {
                 SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient();

--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -259,7 +259,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
      */
     private SslContext getSslContext() {
         final SslContext sslCtx;
-        if (clientConfig.isEnableTls()) {
+        if (clientConfig.isEnableTls() || clientConfig.isEnableTlsToSegmentStore()) {
             try {
                 SslContextBuilder clientSslCtxBuilder = SslContextBuilder.forClient();
                 if (Strings.isNullOrEmpty(clientConfig.getTrustStore())) {

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -160,6 +160,7 @@ public class ControllerImpl implements Controller {
                                 .throwingOn(Exception.class);
 
         if (config.getClientConfig().isEnableTls() || config.getClientConfig().isEnableTlsToController()) {
+            log.debug("Setting up a SSL/TLS channel builder");
             SslContextBuilder sslContextBuilder;
             String trustStore = config.getClientConfig().getTrustStore();
             sslContextBuilder = GrpcSslContexts.forClient();
@@ -173,6 +174,7 @@ public class ControllerImpl implements Controller {
                 throw new CompletionException(e);
             }
         } else {
+            log.debug("Using a plaintext channel builder");
             channelBuilder = ((NettyChannelBuilder) channelBuilder).negotiationType(NegotiationType.PLAINTEXT);
         }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -159,7 +159,7 @@ public class ControllerImpl implements Controller {
                                 .retryingOn(StatusRuntimeException.class)
                                 .throwingOn(Exception.class);
 
-        if (config.getClientConfig().isEnableTls()) {
+        if (config.getClientConfig().isEnableTls() || config.getClientConfig().isEnableTlsToController()) {
             SslContextBuilder sslContextBuilder;
             String trustStore = config.getClientConfig().getTrustStore();
             sslContextBuilder = GrpcSslContexts.forClient();

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -159,7 +159,7 @@ public class ControllerImpl implements Controller {
                                 .retryingOn(StatusRuntimeException.class)
                                 .throwingOn(Exception.class);
 
-        if (config.getClientConfig().isEnableTls() || config.getClientConfig().isEnableTlsToController()) {
+        if (config.getClientConfig().isEnableTlsToController()) {
             log.debug("Setting up a SSL/TLS channel builder");
             SslContextBuilder sslContextBuilder;
             String trustStore = config.getClientConfig().getTrustStore();

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -16,15 +16,13 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ClientConfigTest {
 
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
-
-    @Test
-    public void isEnableTls() {
-    }
 
     @Test
     public void serializable() {
@@ -47,5 +45,45 @@ public class ClientConfigTest {
         assertEquals(ClientConfig.DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE, config1.getMaxConnectionsPerSegmentStore());
         ClientConfig config2 = ClientConfig.builder().maxConnectionsPerSegmentStore(1).build();
         assertEquals(1, config2.getMaxConnectionsPerSegmentStore());
+    }
+
+    @Test
+    public void testTlsIsEnabledForControllerURIContainingSchemeTls() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
+        builder.controllerURI(URI.create("tls://hostname:9090"));
+        assertTrue("TLS is disabled", builder.build().isEnableTls());
+    }
+
+    @Test
+    public void testTlsIsDisabledForControllerURIContainingSchemeTcp() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
+        builder.controllerURI(URI.create("tcp://hostname:9090"));
+        assertFalse("TLS is enabled", builder.build().isEnableTls());
+    }
+
+    @Test
+    public void testTlsIsDisabledWhenTlsIsPartiallySet() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
+        builder.controllerURI(URI.create("tcp://hostname:9090"))
+                .enableTlsToController(true);
+        assertFalse("TLS is enabled", builder.build().isEnableTls());
+    }
+
+    @Test
+    public void testTlsIsEnabledWhenAllTlsEnabled() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
+        builder.controllerURI(URI.create("tcp://hostname:9090"))
+                .enableTlsToController(true)
+                .enableTlsToSegmentStore(true);
+        assertTrue("TLS is disabled", builder.build().isEnableTls());
+    }
+
+    @Test
+    public void testTlsIsDisabledWhenAllTlsDisabled() {
+        ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
+        builder.controllerURI(URI.create("tcp://hostname:9090"))
+                .enableTlsToController(false)
+                .enableTlsToSegmentStore(false);
+        assertFalse("TLS is enabled", builder.build().isEnableTls());
     }
 }

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -86,4 +86,12 @@ public class ClientConfigTest {
                 .enableTlsToSegmentStore(false);
         assertFalse("TLS is enabled", builder.build().isEnableTls());
     }
+
+    @Test
+    public void testTlsIsDisabledWhenSchemeIsNull() {
+        ClientConfig clientConfig = ClientConfig.builder()
+                .controllerURI(URI.create("//hostname:9090"))
+                .build();
+        assertFalse("TLS is enabled", clientConfig.isEnableTls());
+    }
 }

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -82,9 +82,9 @@ public class ClientConfigTest {
     public void testTlsIsDisabledWhenAllTlsDisabled() {
         ClientConfig.ClientConfigBuilder builder = ClientConfig.builder();
         builder.controllerURI(URI.create("tcp://hostname:9090"))
-                .enableTlsToController(false)
-                .enableTlsToSegmentStore(false);
-        assertFalse("TLS is enabled", builder.build().isEnableTls());
+                .enableTlsToController(true)
+                .enableTlsToSegmentStore(true);
+        assertTrue("TLS is disabled", builder.build().isEnableTls());
     }
 
     @Test

--- a/common/src/main/java/io/pravega/common/util/BooleanUtils.java
+++ b/common/src/main/java/io/pravega/common/util/BooleanUtils.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import java.util.Optional;
+
+public class BooleanUtils {
+
+    /**
+     * Extracts an optional boolean from a String {@code value}.
+     *
+     * @param value the value to extract the boolean from
+     * @return an {@link Optional} instance wrapping a {@link Boolean} instance, if {@code value} isn't null, empty or
+     * a non-boolean string. Otherwise, returns {@code Optional.empty()}.
+     */
+    public static Optional<Boolean> extract(String value) {
+
+        if (value == null || value.trim().equals("")) {
+            return Optional.empty();
+        }
+
+        String trimmedValue = value.trim();
+
+        if (trimmedValue.equalsIgnoreCase("yes")
+                || trimmedValue.equalsIgnoreCase("y")
+                || trimmedValue.equalsIgnoreCase("true")) {
+            return Optional.of(true);
+        } else if (trimmedValue.equalsIgnoreCase("no")
+                || trimmedValue.equalsIgnoreCase("n")
+                || trimmedValue.equalsIgnoreCase("false")) {
+            return Optional.of(false);
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/common/src/main/java/io/pravega/common/util/BooleanUtils.java
+++ b/common/src/main/java/io/pravega/common/util/BooleanUtils.java
@@ -21,13 +21,11 @@ public class BooleanUtils {
      * a non-boolean string. Otherwise, returns {@code Optional.empty()}.
      */
     public static Optional<Boolean> extract(String value) {
-
         if (value == null || value.trim().equals("")) {
             return Optional.empty();
         }
 
         String trimmedValue = value.trim();
-
         if (trimmedValue.equalsIgnoreCase("yes")
                 || trimmedValue.equalsIgnoreCase("y")
                 || trimmedValue.equalsIgnoreCase("true")) {

--- a/common/src/test/java/io/pravega/common/util/BooleanUtilsTests.java
+++ b/common/src/test/java/io/pravega/common/util/BooleanUtilsTests.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BooleanUtilsTests {
+
+    @Test
+    public void testExtractReturnsEmptyInstanceIfInputIsNullOrEmpty() {
+        assertFalse(BooleanUtils.extract(null).isPresent());
+        assertFalse(BooleanUtils.extract("").isPresent());
+    }
+
+    @Test
+    public void testExtractReturnsEmptyInstanceIfInputIsNonBoolean() {
+        assertFalse(BooleanUtils.extract("whatever").isPresent());
+    }
+
+    @Test
+    public void testExtractReturnsTrueIfInputContainsPositiveValue() {
+        assertTrue(BooleanUtils.extract("yes").get());
+        assertTrue(BooleanUtils.extract("YES").get());
+        assertTrue(BooleanUtils.extract("y").get());
+        assertTrue(BooleanUtils.extract("true").get());
+        assertTrue(BooleanUtils.extract("true ").get());
+    }
+
+    @Test
+    public void testExtractReturnsTrueIfInputContainsNegativeValue() {
+        assertFalse(BooleanUtils.extract("no").get());
+        assertFalse(BooleanUtils.extract("nO ").get());
+        assertFalse(BooleanUtils.extract("n").get());
+        assertFalse(BooleanUtils.extract("false").get());
+        assertFalse(BooleanUtils.extract("False").get());
+    }
+}

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
@@ -50,6 +50,8 @@ public interface ControllerServiceConfig {
      */
     boolean isControllerClusterListenerEnabled();
 
+    String getTlsEnabledForSegmentStore();
+
     /**
      * Fetches the configuration of service managing transaction timeouts.
      *

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
@@ -50,6 +50,23 @@ public interface ControllerServiceConfig {
      */
     boolean isControllerClusterListenerEnabled();
 
+    /**
+     * Fetches the optional configuration item that, if specified, represents whether segment store TLS is enabled. This
+     * is useful only in configuration where the Controller is not TLS enabled, but the segment store is. In the
+     * configuration where both Controller and Segment Store have TLS enabled, this value is expected to be left
+     * unspecified/empty.
+     *
+     * The returned value may take these values:
+     *
+     * - true/yes/y (case insensitive) - Indicating TLS is enabled for Segment Store (even if it is disabled for
+     *                                   the Controller based on Controller URI)
+     * - false/no/n (case insensitive) - Indicating TLS is disabled for Segment Store (even if it is enabled for the
+     *                                   Controller, based on Controller URI)
+     * - "" - Indicating the value was not set.  Should be interpreted from Controller URI.
+     * - Any other non-empty value - Should be interpreted from Controller URI.
+     *
+     * @return Specified configuration value
+     */
     String getTlsEnabledForSegmentStore();
 
     /**

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -21,6 +21,7 @@ import io.pravega.common.cluster.Host;
 import io.pravega.common.cluster.zkImpl.ClusterZKImpl;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.tracing.RequestTracker;
+import io.pravega.common.util.BooleanUtils;
 import io.pravega.controller.fault.ControllerClusterListener;
 import io.pravega.controller.fault.FailoverSweeper;
 import io.pravega.controller.fault.SegmentContainerMonitor;
@@ -57,6 +58,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
@@ -173,20 +175,25 @@ public class ControllerServiceStarter extends AbstractIdleService {
                 monitor.startAsync();
             }
 
-            ClientConfig clientConfig = ClientConfig.builder()
-                                                    .controllerURI(URI.create((serviceConfig.getGRPCServerConfig().get().isTlsEnabled() ?
-                                                                          "tls://" : "tcp://") + "localhost"))
-                                                    .trustStore(serviceConfig.getGRPCServerConfig().get().getTlsTrustStore())
-                                                    .validateHostName(false)
-                                                    .build();
+            // This client config is used by the segment store helper (SegmentHelper) to connect to the segment store.
+            ClientConfig.ClientConfigBuilder clientConfigBuilder = ClientConfig.builder()
+                    .controllerURI(URI.create((serviceConfig.getGRPCServerConfig().get().isTlsEnabled() ?
+                            "tls://" : "tcp://") + "localhost"))
+                    .trustStore(serviceConfig.getGRPCServerConfig().get().getTlsTrustStore())
+                    .validateHostName(false);
 
-            connectionFactory = new ConnectionFactoryImpl(clientConfig);
+            Optional<Boolean> tlsEnabledForSegmentStore = BooleanUtils.extract(serviceConfig.getTlsEnabledForSegmentStore());
+            if (tlsEnabledForSegmentStore.isPresent()) {
+                clientConfigBuilder.enableTlsToSegmentStore(tlsEnabledForSegmentStore.get());
+            }
+
+            connectionFactory = new ConnectionFactoryImpl(clientConfigBuilder.build());
             segmentHelperRef.compareAndSet(null, new SegmentHelper(connectionFactory, hostStore));
 
             GrpcAuthHelper authHelper = new GrpcAuthHelper(serviceConfig.getGRPCServerConfig().get().isAuthorizationEnabled(),
                     serviceConfig.getGRPCServerConfig().get().getTokenSigningKey(),
                     serviceConfig.getGRPCServerConfig().get().getAccessTokenTTLInSeconds());
-            
+
             SegmentHelper segmentHelper = segmentHelperRef.get();
             log.info("Creating the stream store");
             streamStore = StreamStoreFactory.createStore(storeClient, segmentHelper, authHelper, controllerExecutor);
@@ -195,7 +202,7 @@ public class ControllerServiceStarter extends AbstractIdleService {
                     segmentHelper, controllerExecutor, host.getHostId(), authHelper, requestTracker);
             streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore,
                     segmentHelper, controllerExecutor, host.getHostId(), serviceConfig.getTimeoutServiceConfig(), authHelper);
-            
+
             BucketServiceFactory bucketServiceFactory = new BucketServiceFactory(host.getHostId(), bucketStore, 1000, retentionExecutor);
             Duration executionDuration = Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES);
 

--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -100,6 +100,7 @@ public class Main {
                     .eventProcessorConfig(Optional.of(eventProcessorConfig))
                     .grpcServerConfig(Optional.of(grpcServerConfig))
                     .restServerConfig(Optional.of(restServerConfig))
+                    .tlsEnabledForSegmentStore(Config.TLS_ENABLED_FOR_SEGMENT_STORE)
                     .build();
 
             setUncaughtExceptionHandler(Main::logUncaughtException);

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -63,6 +63,9 @@ import static io.pravega.shared.segment.StreamSegmentNameUtils.getQualifiedStrea
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
 import static io.pravega.shared.segment.StreamSegmentNameUtils.getTransactionNameFromId;
 
+/**
+ * Used by the Controller for interacting with Segment Store. Think of this class as a 'SegmentStoreHelper'. 
+ */
 public class SegmentHelper implements AutoCloseable {
 
     private static final TagLogger log = new TagLogger(LoggerFactory.getLogger(SegmentHelper.class));

--- a/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
@@ -38,6 +38,8 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
     private final boolean controllerClusterListenerEnabled;
     private final TimeoutServiceConfig timeoutServiceConfig;
 
+    private final String tlsEnabledForSegmentStore;
+
     private final Optional<ControllerEventProcessorConfig> eventProcessorConfig;
 
     private final Optional<GRPCServerConfig> gRPCServerConfig;
@@ -49,6 +51,7 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
                                 final StoreClientConfig storeClientConfig,
                                 final HostMonitorConfig hostMonitorConfig,
                                 final boolean controllerClusterListenerEnabled,
+                                final String tlsEnabledForSegmentStore,
                                 final TimeoutServiceConfig timeoutServiceConfig,
                                 final Optional<ControllerEventProcessorConfig> eventProcessorConfig,
                                 final Optional<GRPCServerConfig> grpcServerConfig,
@@ -78,6 +81,7 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
         this.storeClientConfig = storeClientConfig;
         this.hostMonitorConfig = hostMonitorConfig;
         this.controllerClusterListenerEnabled = controllerClusterListenerEnabled;
+        this.tlsEnabledForSegmentStore = tlsEnabledForSegmentStore;
         this.timeoutServiceConfig = timeoutServiceConfig;
         this.eventProcessorConfig = eventProcessorConfig;
         this.gRPCServerConfig = grpcServerConfig;

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -74,6 +74,7 @@ public final class Config {
     public static final String TLS_TRUST_STORE;
     public static final String TOKEN_SIGNING_KEY;
     public static final int ACCESS_TOKEN_TTL_IN_SECONDS;
+    public static final String TLS_ENABLED_FOR_SEGMENT_STORE;
 
     public static final boolean REPLY_WITH_STACK_TRACE_ON_ERROR;
     public static final boolean REQUEST_TRACING_ENABLED;
@@ -140,7 +141,6 @@ public final class Config {
     private static final Property<String> PROPERTY_RPC_HOST = Property.named("service.publishedRPCHost", NULL_VALUE);
     private static final Property<Integer> PROPERTY_RPC_PORT = Property.named("service.publishedRPCPort", 9090);
     private static final Property<String> PROPERTY_CLUSTER_NAME = Property.named("service.cluster", "pravega-cluster");
-
     private static final Property<String> PROPERTY_REST_IP = Property.named("service.restIp", "0.0.0.0");
     private static final Property<Integer> PROPERTY_REST_PORT = Property.named("service.restPort", 9091);
     private static final Property<String> PROPERTY_REST_KEYSTORE_FILE_PATH = Property.named("rest.tlsKeyStoreFile", "");
@@ -155,6 +155,7 @@ public final class Config {
     private static final Property<String> PROPERTY_TLS_CERT_FILE = Property.named("auth.tlsCertFile", "");
     private static final Property<String> PROPERTY_TLS_TRUST_STORE = Property.named("auth.tlsTrustStore", "");
     private static final Property<String> PROPERTY_TLS_KEY_FILE = Property.named("auth.tlsKeyFile", "");
+    private static final Property<String> PROPERTY_TLS_ENABLED_FOR_SEGMENT_STORE = Property.named("auth.segmentStoreTlsEnabled", "");
 
     private static final Property<String> PROPERTY_ZK_URL = Property.named("zk.url", "localhost:2181");
     private static final Property<Integer> PROPERTY_ZK_RETRY_MILLIS = Property.named("zk.retryIntervalMillis", 5000);
@@ -204,6 +205,7 @@ public final class Config {
         TLS_KEY_FILE = p.get(PROPERTY_TLS_KEY_FILE);
         TLS_CERT_FILE = p.get(PROPERTY_TLS_CERT_FILE);
         TLS_TRUST_STORE = p.get(PROPERTY_TLS_TRUST_STORE);
+        TLS_ENABLED_FOR_SEGMENT_STORE = p.get(PROPERTY_TLS_ENABLED_FOR_SEGMENT_STORE);
 
         REPLY_WITH_STACK_TRACE_ON_ERROR = p.getBoolean(PROPERTY_REPLY_WITH_STACK_TRACE_ON_ERROR);
         REQUEST_TRACING_ENABLED = p.getBoolean(PROPERTY_REQUEST_TRACING_ENABLED);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -174,7 +174,8 @@ public class AutoScaleProcessor implements AutoCloseable {
                     .validateHostName(configuration.isValidateHostName());
 
             if (!hasTlsEnabled(configuration.getControllerUri())) {
-                log.debug("Auto scale TLS is enabled, but Controller URI has a non-TLS scheme");
+                log.debug("Auto scale Controller URI [{}] has a non-TLS scheme, although auto scale TLS is enabled",
+                        configuration.getControllerUri());
                 clientConfigBuilder.enableTlsToSegmentStore(true);
             }
         }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessor.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.server.host.stat;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalCause;
@@ -28,6 +29,7 @@ import io.pravega.common.util.Retry;
 import io.pravega.shared.NameUtils;
 import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.controller.event.ControllerEventSerializer;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
@@ -157,16 +159,36 @@ public class AutoScaleProcessor implements AutoCloseable {
     }
 
     private static EventStreamClientFactory createFactory(AutoScalerConfig configuration) {
+        return EventStreamClientFactory.withScope(NameUtils.INTERNAL_SCOPE_NAME, prepareClientConfig(configuration));
+    }
+
+    @VisibleForTesting
+    static ClientConfig prepareClientConfig(AutoScalerConfig configuration) {
+        // Auth credentials are passed via system properties or environment variables at deployment time, when needed.
+        ClientConfig.ClientConfigBuilder clientConfigBuilder =
+                ClientConfig.builder().controllerURI(configuration.getControllerUri());
+
         if (configuration.isTlsEnabled()) {
-            return EventStreamClientFactory.withScope(NameUtils.INTERNAL_SCOPE_NAME,
-                    ClientConfig.builder().controllerURI(configuration.getControllerUri())
-                                .trustStore(configuration.getTlsCertFile())
-                                .validateHostName(configuration.isValidateHostName())
-                                .build());
-        } else {
-            return EventStreamClientFactory.withScope(NameUtils.INTERNAL_SCOPE_NAME,
-                    ClientConfig.builder().controllerURI(configuration.getControllerUri()).build());
+            log.debug("Auto scale TLS is enabled");
+            clientConfigBuilder.trustStore(configuration.getTlsCertFile())
+                    .validateHostName(configuration.isValidateHostName());
+
+            if (!hasTlsEnabled(configuration.getControllerUri())) {
+                log.debug("Auto scale TLS is enabled, but Controller URI has a non-TLS scheme");
+                clientConfigBuilder.enableTlsToSegmentStore(true);
+            }
         }
+        return clientConfigBuilder.build();
+    }
+
+    @VisibleForTesting
+    static boolean hasTlsEnabled(@NonNull final URI controllerURI) {
+        Preconditions.checkNotNull(controllerURI);
+        String uriScheme = controllerURI.getScheme();
+        if (uriScheme == null) {
+            return false;
+        }
+        return uriScheme.equals("tls") || uriScheme.equals("pravegas");
     }
 
     private boolean isInitialized() {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -9,20 +9,28 @@
  */
 package io.pravega.segmentstore.server.host.stat;
 
+import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Transaction;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.segment.StreamSegmentNameUtils;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.test.common.ThreadPooledTestSuite;
+
+import java.net.URI;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -129,6 +137,79 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
 
         assertNull(monitor.get(streamSegmentName1));
     }
+
+    @Test
+    public void testHasTlsEnabledThrowsExceptionWhenInputIsNull() {
+        AssertExtensions.assertThrows("Accepted null argument",
+                () -> AutoScaleProcessor.hasTlsEnabled(null),
+                e -> e instanceof NullPointerException);
+    }
+
+    @Test
+    public void testHasTlsEnabledReturnsFalseWhenSchemeIsNull() {
+        assertFalse(AutoScaleProcessor.hasTlsEnabled(URI.create("//localhost:9090")));
+    }
+
+    @Test
+    public void testHasTlsEnabledReturnsFalseWhenSchemeIsTlsIncompatible() {
+        assertFalse(AutoScaleProcessor.hasTlsEnabled(URI.create("tcp://localhost:9090")));
+
+        assertFalse(AutoScaleProcessor.hasTlsEnabled(URI.create("pravega://localhost:9090")));
+
+        assertFalse(AutoScaleProcessor.hasTlsEnabled(URI.create("unsupported://localhost:9090")));
+    }
+
+    @Test
+    public void testHasTlsEnabledReturnsTrueWhenSchemeIsTlsCompatible() {
+        assertTrue(AutoScaleProcessor.hasTlsEnabled(URI.create("tls://localhost:9090")));
+
+        assertTrue(AutoScaleProcessor.hasTlsEnabled(URI.create("pravegas://localhost:9090")));
+    }
+
+    @Test
+    public void testPrepareClientConfigForTlsDisabledInput() {
+        AutoScalerConfig config = AutoScalerConfig.builder()
+                .with(AutoScalerConfig.CONTROLLER_URI, "tcp://localhost:9090")
+                .with(AutoScalerConfig.TLS_ENABLED, false)
+                .build();
+        ClientConfig objectUnderTest = AutoScaleProcessor.prepareClientConfig(config);
+
+        assertFalse(objectUnderTest.isEnableTls());
+        assertEquals("tcp://localhost:9090", objectUnderTest.getControllerURI().toString());
+    }
+
+    @Test
+    public void testPrepareClientConfigForMixedTlsInput() {
+        // Notice that we are setting non-TLS scheme for the Controller, but enabling TLS for the auto scaler.
+        AutoScalerConfig config = AutoScalerConfig.builder()
+                .with(AutoScalerConfig.CONTROLLER_URI, "tcp://localhost:9090")
+                .with(AutoScalerConfig.TLS_ENABLED, true)
+                .with(AutoScalerConfig.TLS_CERT_FILE, SecurityConfigDefaults.TLS_SERVER_CERT_FILE_NAME)
+                .with(AutoScalerConfig.VALIDATE_HOSTNAME, false)
+                .build();
+        ClientConfig objectUnderTest = AutoScaleProcessor.prepareClientConfig(config);
+
+        assertFalse(objectUnderTest.isEnableTls());
+        assertFalse(objectUnderTest.isEnableTlsToController());
+        assertTrue(objectUnderTest.isEnableTlsToSegmentStore());
+    }
+
+    @Test
+    public void testPrepareClientConfigWhenTlsIsEnabled() {
+        // Notice that we are setting non-TLS scheme for the Controller, but enabling TLS for the auto scaler.
+        AutoScalerConfig config = AutoScalerConfig.builder()
+                .with(AutoScalerConfig.CONTROLLER_URI, "tls://localhost:9090")
+                .with(AutoScalerConfig.TLS_ENABLED, true)
+                .with(AutoScalerConfig.TLS_CERT_FILE, SecurityConfigDefaults.TLS_SERVER_CERT_FILE_NAME)
+                .with(AutoScalerConfig.VALIDATE_HOSTNAME, false)
+                .build();
+        ClientConfig objectUnderTest = AutoScaleProcessor.prepareClientConfig(config);
+
+        assertTrue(objectUnderTest.isEnableTls());
+        assertFalse(objectUnderTest.isEnableTlsToController());
+        assertFalse(objectUnderTest.isEnableTlsToSegmentStore());
+    }
+
 
     private EventStreamWriter<AutoScaleEvent> createWriter(Consumer<AutoScaleEvent> consumer) {
         return new EventStreamWriter<AutoScaleEvent>() {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -206,8 +206,8 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
         ClientConfig objectUnderTest = AutoScaleProcessor.prepareClientConfig(config);
 
         assertTrue(objectUnderTest.isEnableTls());
-        assertFalse(objectUnderTest.isEnableTlsToController());
-        assertFalse(objectUnderTest.isEnableTlsToSegmentStore());
+        assertTrue(objectUnderTest.isEnableTlsToController());
+        assertTrue(objectUnderTest.isEnableTlsToSegmentStore());
     }
 
 


### PR DESCRIPTION
**Change log description**  
Adds support for enabling TLS for segment store while keeping it disabled for Controller. 

See the description section of issue #4157 to understand the motivation. 

**Purpose of the change**  
Resolves #4157  

**What the code does**  
1. Adds an optional Controller configuration to declare that Segment Store has TLS enabled, even while it is not so for the Controller. This can be set by declaring using one of the following: 
   * Java system property `controller.auth.segmentStoreTlsEnabled=true` via the manifest (containerized deployments) or command line (manual deloyments)
   * `controller.auth.segmentStoreTlsEnabled=true` in Controller config file
   * Environment variable `TLS_ENABLED_FOR_SEGMENT_STORE=true`
2. Adds additional flags in Client Config to support cases where the Controller URI has non-TLS schemes (`tcp` and `pravega`), but Segment Store has TLS enabled. See `ClientConfig` for these changes. 
3. Use a new Client Config flag in `AutoScaleProcessor` to connect to Controller over Plaintext channel, even while AutoScaleProcessor itself has TLS enabled. 
4. Modify the client-side Controller proxy `ControllerImpl` to use the new flags suitably. The same proxy is used by both external clients (on the application side), as well as internal clients (AutoScaleProcessor-to-Controller communications).
5. Modify the client-side Segment Store proxy `ConnectonPoolImpl` to use the new flag that determines whether segment store TLS is enabled. 


**How to verify it**  
See [this](https://gist.github.com/ravisharda/22312836b4692d93e864b50177e85e6e) Gist on how to verify it. 
