### PR TITLE
Issue 4164: (SegmentStore) Bugfix for possible ingestion pipeline starvation due to throttling

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -125,7 +125,7 @@ pravegaservice.dataLogImplementation=BOOKKEEPER
 # pravegaservice.cacheTargetUtilizationPercent will cause the Segment Store to apply maximum throttling as soon as that
 # limit is reached, which may cause it to have sudden, multi-second stalls in the ingestion pipeline. It is not recommended
 # to set this value ever to 100, since that would mean the cache is already full when max throttling kicks in, and the
-# Segment Store will begin shuting down Segment Containers in order to alleviate cache pressure.
+# Segment Store will begin shutting down Segment Containers in order to alleviate cache pressure.
 #pravegaservice.cacheMaxUtilizationPercent=98
 
 # Maximum amount of time (in seconds) to keep a block of data in the Cache.
@@ -140,7 +140,7 @@ pravegaservice.dataLogImplementation=BOOKKEEPER
 # Valid values: positive integer.
 # Recommended values: multiples of 1 second. Choosing lower values will cause Cache evictions to happen more frequently,
 # thus increasing overhead, but it will provide more granularity for busy systems.
-#pravegaservice.cacheGenerationTimeSeconds=5
+#pravegaservice.cacheGenerationTimeSeconds=1
 
 # This setting allows Pravega to send server-side stack traces to client as part of the response message on errors. This
 # setting may be useful for debugging purposes, as users may understand the root cause of a server exception inspecting

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -55,6 +56,8 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     private final CachePolicy policy;
     private final AtomicBoolean closed;
     private final SegmentStoreMetrics.CacheManager metrics;
+    @GuardedBy("cleanupListeners")
+    private final HashSet<CleanupListener> cleanupListeners;
 
     //endregion
 
@@ -78,6 +81,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         this.executorService = executorService;
         this.closed = new AtomicBoolean();
         this.metrics = new SegmentStoreMetrics.CacheManager();
+        this.cleanupListeners = new HashSet<>();
     }
 
     //endregion
@@ -117,7 +121,10 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         }
 
         try {
-            applyCachePolicy();
+            boolean anythingEvicted = applyCachePolicy();
+            if (anythingEvicted) {
+                notifyCleanupListeners();
+            }
         } catch (Throwable ex) {
             if (Exceptions.mustRethrow(ex)) {
                 throw ex;
@@ -152,6 +159,19 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     @Override
     public double getCacheMaxUtilization() {
         return this.policy.getMaxUtilization();
+    }
+
+    @Override
+    public void registerCleanupListener(@NonNull CleanupListener listener) {
+        if (listener.isClosed()) {
+            log.warn("{} Attempted to register a closed Cleanup Listener ({}).", TRACE_OBJECT_ID, listener);
+            System.out.println("registered closed listener");
+            return;
+        }
+
+        synchronized (this.cleanupListeners) {
+            this.cleanupListeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
+        }
     }
 
     //endregion
@@ -199,13 +219,13 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
 
     //region Helpers
 
-    protected void applyCachePolicy() {
+    protected boolean applyCachePolicy() {
         // Run through all the active clients and gather status.
         CacheStatus currentStatus = collectStatus();
         if (currentStatus == null || currentStatus.getSize() == 0) {
             // This indicates we have no clients or those clients have no data.
             this.cacheSize.set(0);
-            return;
+            return false;
         }
 
         // Increment current generation (if needed).
@@ -216,22 +236,25 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
 
         if (!currentChanged && !oldestChanged) {
             // Nothing changed, nothing to do.
-            return;
+            return false;
         }
 
         // Notify clients that something changed (if any of the above got changed). Run in a loop, until either we can't
         // adjust the oldest anymore or we are unable to trigger any changes to the clients.
         long sizeReduction;
+        boolean reducedOverall = false;
         do {
             sizeReduction = updateClients();
             if (sizeReduction > 0) {
                 currentStatus = currentStatus.withUpdatedSize(-sizeReduction);
                 logCurrentStatus(currentStatus);
                 oldestChanged = adjustOldestGeneration(currentStatus);
+                reducedOverall = true;
             }
         } while (sizeReduction > 0 && oldestChanged);
         this.cacheSize.set(currentStatus.getSize());
         this.metrics.report(currentStatus.getSize(), currentStatus.getNewestGeneration() - currentStatus.getOldestGeneration());
+        return reducedOverall;
     }
 
     private CacheStatus collectStatus() {
@@ -360,6 +383,34 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
                 this.oldestGeneration,
                 size,
                 status.getSize() / 1048576);
+    }
+
+    private void notifyCleanupListeners() {
+        ArrayList<CacheUtilizationProvider.CleanupListener> toNotify = new ArrayList<>();
+        ArrayList<CacheUtilizationProvider.CleanupListener> toRemove = new ArrayList<>();
+        synchronized (this.cleanupListeners) {
+            for (CacheUtilizationProvider.CleanupListener l : this.cleanupListeners) {
+                if (l.isClosed()) {
+                    toRemove.add(l);
+                } else {
+                    toNotify.add(l);
+                }
+            }
+
+            this.cleanupListeners.removeAll(toRemove);
+        }
+
+        for (CacheUtilizationProvider.CleanupListener l : toNotify) {
+            try {
+                l.cacheCleanupComplete();
+            } catch (Throwable ex) {
+                if (Exceptions.mustRethrow(ex)) {
+                    throw ex;
+                }
+
+                log.error("{}: Error while notifying cleanup listener {}.", TRACE_OBJECT_ID, l, ex);
+            }
+        }
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -165,7 +165,6 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     public void registerCleanupListener(@NonNull CleanupListener listener) {
         if (listener.isClosed()) {
             log.warn("{} Attempted to register a closed Cleanup Listener ({}).", TRACE_OBJECT_ID, listener);
-            System.out.println("registered closed listener");
             return;
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -44,4 +44,12 @@ public interface CacheUtilizationProvider {
      * @return The maximum cache utilization.
      */
     double getCacheMaxUtilization();
+
+    void registerCleanupListener(CleanupListener listener);
+
+    interface CleanupListener {
+        void cacheCleanupComplete();
+
+        boolean isClosed();
+    }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -45,11 +45,31 @@ public interface CacheUtilizationProvider {
      */
     double getCacheMaxUtilization();
 
+    /**
+     * Registers the given {@link CleanupListener}, which will be notified of all subsequent Cache Cleanup events that
+     * result in at least one entry being evicted from the cache.
+     *
+     * @param listener The {@link CleanupListener} to register. This will be auto-unregistered on the first Cache Cleanup
+     *                 run that detects {@link CleanupListener#isClosed()} to be true.
+     */
     void registerCleanupListener(CleanupListener listener);
 
+    /**
+     * Defines a listener that will be notified by the {@link CacheManager} after every normally scheduled Cache Cleanup
+     * event that resulted in at least one entry being evicted from the cache.
+     */
     interface CleanupListener {
+        /**
+         * Notifies this {@link CleanupListener} that a normally scheduled Cache Cleanup event that resulted in at least
+         * one entry being evicted from the cache has just finished.
+         */
         void cacheCleanupComplete();
 
+        /**
+         * Gets a value indicating whether this {@link CleanupListener} is closed and should be unregistered.
+         *
+         * @return True if need to be unregistered (no further notifications will be sent), false otherwise.
+         */
         boolean isClosed();
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -81,6 +81,11 @@ class MemoryStateUpdater implements CacheUtilizationProvider {
         return this.readIndex.getCacheMaxUtilization();
     }
 
+    @Override
+    public void registerCleanupListener(CleanupListener listener) {
+        this.readIndex.registerCleanupListener(listener);
+    }
+
     /**
      * Puts the Log Updater in Recovery Mode, using the given Metadata Source as interim.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -37,7 +37,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
@@ -69,7 +68,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
     private final DataFrameBuilder<Operation> dataFrameBuilder;
     @Getter
     private final SegmentStoreMetrics.OperationProcessor metrics;
-    private final ThrottlerCalculator throttlerCalculator;
+    private final Throttler throttler;
 
     //endregion
 
@@ -97,11 +96,14 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         val args = new DataFrameBuilder.Args(this.state::frameSealed, this.state::commit, this.state::fail, this.executor);
         this.dataFrameBuilder = new DataFrameBuilder<>(durableDataLog, OperationSerializer.DEFAULT, args);
         this.metrics = new SegmentStoreMetrics.OperationProcessor(this.metadata.getContainerId());
-        this.throttlerCalculator = ThrottlerCalculator.builder()
+        val throttlerCalculator = ThrottlerCalculator
+                .builder()
                 .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheTargetUtilization(), stateUpdater.getCacheMaxUtilization())
                 .commitBacklogThrottler(this.commitQueue::size)
                 .batchingThrottler(durableDataLog::getQueueStatistics)
                 .build();
+        this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, executor, this.metrics);
+        this.stateUpdater.registerCleanupListener(this.throttler);
     }
 
     //endregion
@@ -119,9 +121,9 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         // OperationProcessor starts and is shut down as soon as doStop() is invoked.
         val queueProcessor = Futures
                 .loop(this::isRunning,
-                        () -> throttle()
-                                .thenComposeAsync(v -> this.operationQueue.take(MAX_READ_AT_ONCE), this.executor)
-                                .thenAcceptAsync(this::processOperations, this.executor),
+                        () -> this.throttler.throttle()
+                                            .thenComposeAsync(v -> this.operationQueue.take(MAX_READ_AT_ONCE), this.executor)
+                                            .thenAcceptAsync(this::processOperations, this.executor),
                         this.executor);
 
         // The CommitProcessor is responsible with the processing of those Operations that have already been committed to
@@ -157,6 +159,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         }
 
         this.state.fail(ex, null);
+        this.throttler.close();
         this.metrics.close();
         super.doStop();
     }
@@ -225,40 +228,6 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         return result;
     }
 
-    //endregion
-
-    //region Queue Processing
-
-    private CompletableFuture<Void> throttle() {
-        val delay = new AtomicReference<ThrottlerCalculator.DelayResult>(this.throttlerCalculator.getThrottlingDelay());
-        if (!delay.get().isMaximum()) {
-            // We are not delaying the maximum amount. We only need to do this once.
-            return throttleOnce(delay.get());
-        } else {
-            // The initial delay calculation indicated that we need to throttle to the maximum, which means there's
-            // significant pressure. In order to protect downstream components, we need to run in a loop and delay as much
-            // as needed until the pressure is relieved.
-            return Futures.loop(
-                    () -> !delay.get().isMaximum(),
-                    () -> throttleOnce(delay.get())
-                            .thenRun(() -> delay.set(this.throttlerCalculator.getThrottlingDelay())),
-                    this.executor);
-        }
-    }
-
-    private CompletableFuture<Void> throttleOnce(ThrottlerCalculator.DelayResult delay) {
-        this.metrics.processingDelay(delay.getDurationMillis());
-        if (delay.isMaximum() || delay.getThrottlerName() == ThrottlerCalculator.ThrottlerName.CommitBacklog) {
-            // Increase logging visibility if we throttle at the maximum limit (which means we're likely to fully block
-            // processing of operations) or if this is due to the Commit Processor not being able to keep up.
-            log.warn("{}: Processing delay = {}.", this.traceObjectId, delay);
-        } else {
-            log.debug("{}: Processing delay = {}.", this.traceObjectId, delay);
-        }
-
-        return Futures.delayedFuture(Duration.ofMillis(delay.getDurationMillis()), this.executor);
-    }
-
     /**
      * Processes a set of pending operations (essentially a single iteration of the QueueProcessor).
      * Steps:
@@ -309,7 +278,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                     this.metrics.processOperations(count, processTimer.getElapsedMillis());
                     processTimer = new Timer(); // Reset this timer since we may be pulling in new operations.
                     count = 0;
-                    if (!this.throttlerCalculator.isThrottlingRequired()) {
+                    if (!this.throttler.isThrottlingRequired()) {
                         // Only pull in new operations if we do not require throttling. If we do, we need to go back to
                         // the main OperationProcessor loop and delay processing the next batch of operations.
                         operations = this.operationQueue.poll(MAX_READ_AT_ONCE);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -122,8 +122,8 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
         val queueProcessor = Futures
                 .loop(this::isRunning,
                         () -> this.throttler.throttle()
-                                            .thenComposeAsync(v -> this.operationQueue.take(MAX_READ_AT_ONCE), this.executor)
-                                            .thenAcceptAsync(this::processOperations, this.executor),
+                                .thenComposeAsync(v -> this.operationQueue.take(MAX_READ_AT_ONCE), this.executor)
+                                .thenAcceptAsync(this::processOperations, this.executor),
                         this.executor);
 
         // The CommitProcessor is responsible with the processing of those Operations that have already been committed to

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -113,11 +113,11 @@ class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseab
         if (!delay.get().isMaximum()) {
             // We are not delaying the maximum amount. We only need to do this once.
             val existingDelay = this.currentDelay.get();
-            if (existingDelay != null && existingDelay.source == delay.get().getThrottlerName()) {
-                // Looks like a previous throttle cycle was interrupted (due to cache evictions). In order to prevent
-                // endless throttling (cache evictions happen frequently and there is no guarantee that the size of the
-                // cache actually decreased in the meantime), we should only wait the minimum of the newly calculated
-                // delay and whatever was left from the previous one (if anything).
+            if (existingDelay != null) {
+                // Looks like a previous throttle cycle was interrupted. In order to prevent endless throttling (cache
+                // evictions happen frequently and there is no guarantee that the size of the cache actually decreased in
+                // the meantime), we should only wait the minimum of the newly calculated delay and whatever was left
+                // from the previous one (if anything).
                 int remaining = (int) existingDelay.remaining.getRemaining().toMillis();
                 if (remaining > 0 && remaining < delay.get().getDurationMillis()) {
                     delay.set(delay.get().withNewDelay(remaining));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.logs;
+
+import io.pravega.common.TimeoutTimer;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.segmentstore.server.CacheUtilizationProvider;
+import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+/**
+ * Throttler utilities for the {@link OperationProcessor} class.
+ */
+@Slf4j
+class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseable {
+    //region Members
+
+    private final ThrottlerCalculator throttlerCalculator;
+    private final String traceObjectId;
+    private final ScheduledExecutorService executor;
+    private final SegmentStoreMetrics.OperationProcessor metrics;
+    private final AtomicReference<InterruptibleDelay> currentDelay;
+    private final AtomicBoolean closed;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the {@link Throttler} class.
+     *
+     * @param containerId Id of the Segment Container for this Throttler. Used for logging purposes only.
+     * @param calculator  A {@link ThrottlerCalculator} to be used for determining how much to throttle.
+     * @param executor    An Executor for async operations.
+     * @param metrics     Metrics for reporting.
+     */
+    Throttler(int containerId, @NonNull ThrottlerCalculator calculator, @NonNull ScheduledExecutorService executor,
+              @NonNull SegmentStoreMetrics.OperationProcessor metrics) {
+        this.throttlerCalculator = calculator;
+        this.executor = executor;
+        this.metrics = metrics;
+        this.traceObjectId = String.format("Throttler[%d]", containerId);
+        this.currentDelay = new AtomicReference<>();
+        this.closed = new AtomicBoolean(false);
+    }
+
+    //endregion
+
+    //region AutoCloseable Implementation
+
+    @Override
+    public void close() {
+        this.closed.set(true);
+    }
+
+    //endregion
+
+    //region CacheUtilizationProvider.CleanupListener Implementation
+
+    @Override
+    public void cacheCleanupComplete() {
+        val currentDelay = this.currentDelay.get();
+        if (currentDelay != null && isInterruptible(currentDelay.source)) {
+            // We were actively throttling due to a reason that is eligible for re-throttling. Terminate the current
+            // throttle cycle, which should force the throttler to re-evaluate the situation.
+            log.debug("{}: Cache Cleanup complete while actively throttling ({}).", this.traceObjectId, currentDelay);
+            currentDelay.delayFuture.completeExceptionally(new ThrottlingInterruptedException());
+        }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.closed.get();
+    }
+
+    //endregion
+
+    //region Throttling
+
+    /**
+     * Determines whether there is an immediate need to introduce a throttling delay.
+     *
+     * @return True if throttling is required, false otherwise.
+     */
+    boolean isThrottlingRequired() {
+        return this.throttlerCalculator.isThrottlingRequired();
+    }
+
+    /**
+     * Throttles if necessary using the {@link ThrottlerCalculator} passed to this class' constructor as input.
+     *
+     * @return A CompletableFuture that is either already completed (if no throttling is required) or will complete at
+     * some time in the future based on the throttling delay value returned by {@link ThrottlerCalculator}.
+     */
+    CompletableFuture<Void> throttle() {
+        val delay = new AtomicReference<ThrottlerCalculator.DelayResult>(this.throttlerCalculator.getThrottlingDelay());
+        if (!delay.get().isMaximum()) {
+            // We are not delaying the maximum amount. We only need to do this once.
+            val existingDelay = this.currentDelay.get();
+            if (existingDelay != null && existingDelay.source == delay.get().getThrottlerName()) {
+                // Looks like a previous throttle cycle was interrupted (due to cache evictions). In order to prevent
+                // endless throttling (cache evictions happen frequently and there is no guarantee that the size of the
+                // cache actually decreased in the meantime), we should only wait the minimum of the newly calculated
+                // delay and whatever was left from the previous one (if anything).
+                int remaining = (int) existingDelay.remaining.getRemaining().toMillis();
+                if (remaining > 0 && remaining < delay.get().getDurationMillis()) {
+                    delay.set(delay.get().withNewDelay(remaining));
+                }
+            }
+
+            return throttleOnce(delay.get());
+        } else {
+            // The initial delay calculation indicated that we need to throttle to the maximum, which means there's
+            // significant pressure. In order to protect downstream components, we need to run in a loop and delay as much
+            // as needed until the pressure is relieved.
+            return Futures.loop(
+                    () -> delay.get().isMaximum(),
+                    () -> throttleOnce(delay.get())
+                            .thenRun(() -> delay.set(this.throttlerCalculator.getThrottlingDelay())),
+                    this.executor);
+        }
+    }
+
+    private CompletableFuture<Void> throttleOnce(ThrottlerCalculator.DelayResult delay) {
+        this.metrics.processingDelay(delay.getDurationMillis());
+        if (delay.isMaximum() || delay.getThrottlerName() == ThrottlerCalculator.ThrottlerName.CommitBacklog) {
+            // Increase logging visibility if we throttle at the maximum limit (which means we're likely to fully block
+            // processing of operations) or if this is due to the Commit Processor not being able to keep up.
+            log.warn("{}: Processing delay = {}.", this.traceObjectId, delay);
+        } else {
+            log.debug("{}: Processing delay = {}.", this.traceObjectId, delay);
+        }
+
+        val delayFuture = Futures.delayedFuture(Duration.ofMillis(delay.getDurationMillis()), this.executor);
+        if (isInterruptible(delay.getThrottlerName())) {
+            // This throttling source is eligible for interruption. Set it up so that a call to cacheCleanupComplete()
+            // may find it and act on it.
+            val result = new InterruptibleDelay(delayFuture, delay.getDurationMillis(), delay.getThrottlerName());
+            this.currentDelay.set(result);
+            return Futures
+                    .exceptionallyComposeExpecting(
+                            result.delayFuture,
+                            ex -> ex instanceof ThrottlingInterruptedException,
+                            this::throttle)
+                    .whenComplete((r, e) -> this.currentDelay.set(null));
+        } else {
+            return delayFuture;
+        }
+    }
+
+    private boolean isInterruptible(ThrottlerCalculator.ThrottlerName name) {
+        return name == ThrottlerCalculator.ThrottlerName.Cache;
+    }
+
+    //endregion
+
+    //region Helper Classes
+
+    private static class InterruptibleDelay {
+        final CompletableFuture<Void> delayFuture;
+        final ThrottlerCalculator.ThrottlerName source;
+        final TimeoutTimer remaining;
+
+        InterruptibleDelay(CompletableFuture<Void> delayFuture, int delayMillis, ThrottlerCalculator.ThrottlerName source) {
+            this.delayFuture = delayFuture;
+            this.source = source;
+            this.remaining = new TimeoutTimer(Duration.ofMillis(delayMillis));
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Source = %s, Remaining = %d", this.source, this.remaining.getRemaining().toMillis());
+        }
+    }
+
+    private static class ThrottlingInterruptedException extends CancellationException {
+    }
+
+    //endregion
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -331,6 +331,12 @@ class ThrottlerCalculator {
          */
         private final boolean maximum;
 
+        /**
+         * Creates a new {@link DelayResult} with the same information as this instance but the new given value as duration.
+         *
+         * @param durationMillis The new duration value, in milliseconds.
+         * @return A new {@link DelayResult} object.
+         */
         DelayResult withNewDelay(int durationMillis) {
             return new DelayResult(this.throttlerName, durationMillis, false);
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -331,6 +331,10 @@ class ThrottlerCalculator {
          */
         private final boolean maximum;
 
+        DelayResult withNewDelay(int durationMillis) {
+            return new DelayResult(this.throttlerName, durationMillis, false);
+        }
+
         @Override
         public String toString() {
             return String.format("%dms (Max=%s, Reason=%s)", this.durationMillis, this.maximum, this.throttlerName);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -339,6 +339,11 @@ public class ContainerReadIndex implements ReadIndex {
         return this.cacheManager.getCacheMaxUtilization();
     }
 
+    @Override
+    public void registerCleanupListener(CleanupListener listener) {
+        this.cacheManager.registerCleanupListener(listener);
+    }
+
     //endregion
 
     //region Helpers

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -49,7 +49,7 @@ public class ServiceConfig {
     public static final Property<Integer> CACHE_POLICY_TARGET_UTILIZATION = Property.named("cacheTargetUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_TARGET_UTILIZATION));
     public static final Property<Integer> CACHE_POLICY_MAX_UTILIZATION = Property.named("cacheMaxUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_MAX_UTILIZATION));
     public static final Property<Integer> CACHE_POLICY_MAX_TIME = Property.named("cacheMaxTimeSeconds", 30 * 60);
-    public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cacheGenerationTimeSeconds", 5);
+    public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cacheGenerationTimeSeconds", 1);
     public static final Property<Boolean> REPLY_WITH_STACK_TRACE_ON_ERROR = Property.named("replyWithStackTraceOnError", false);
     public static final Property<String> INSTANCE_ID = Property.named("instanceId", "");
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -20,6 +20,8 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import lombok.Cleanup;
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -182,7 +184,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
      * Tests the ability of the CacheManager to auto-unregister a client that was detected as having been closed.
      */
     @Test
-    public void testAutoUnregister() {
+    public void testClientAutoUnregister() {
         final CachePolicy policy = new CachePolicy(1024, Duration.ofHours(1), Duration.ofHours(1));
         @Cleanup
         TestCacheManager cm = new TestCacheManager(policy, executorService());
@@ -230,6 +232,49 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             return -1L;
         });
         cm.applyCachePolicy();
+    }
+
+    /**
+     * Tests the ability to register, invoke and auto-unregister {@link CacheUtilizationProvider.CleanupListener} instances.
+     */
+    @Test
+    public void testCleanupListeners() {
+        final CachePolicy policy = new CachePolicy(1024, Duration.ofHours(1), Duration.ofHours(1));
+        @Cleanup
+        TestCacheManager cm = new TestCacheManager(policy, executorService());
+        TestClient client = new TestClient();
+        cm.register(client);
+        TestCleanupListener l1 = new TestCleanupListener();
+        TestCleanupListener l2 = new TestCleanupListener();
+        cm.registerCleanupListener(l1);
+        cm.registerCleanupListener(l2);
+        client.setUpdateGenerationsImpl((current, oldest) -> 1L); // We always remove something.
+
+        // In the first iteration, we should invoke both listeners.
+        client.setCacheStatus(policy.getMaxSize() + 1, 0, 0);
+        cm.runOneIteration();
+        Assert.assertEquals("Expected cleanup listener to be invoked the first time.", 1, l1.getCallCount());
+        Assert.assertEquals("Expected cleanup listener to be invoked the first time.", 1, l2.getCallCount());
+
+        // Close one of the listeners, and verify that only the other one is invoked now.
+        l2.setClosed(true);
+        client.setCacheStatus(policy.getMaxSize() + 1, 0, 1);
+        cm.runOneIteration();
+        Assert.assertEquals("Expected cleanup listener to be invoked the second time.", 2, l1.getCallCount());
+        Assert.assertEquals("Not expecting cleanup listener to be invoked the second time for closed listener.", 1, l2.getCallCount());
+    }
+
+    private static class TestCleanupListener implements CacheUtilizationProvider.CleanupListener {
+        @Getter
+        private int callCount = 0;
+        @Setter
+        @Getter
+        private boolean closed;
+
+        @Override
+        public void cacheCleanupComplete() {
+            this.callCount++;
+        }
     }
 
     private static class TestClient implements CacheManager.Client {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
@@ -20,7 +20,7 @@ public class TestCacheManager extends CacheManager {
     }
 
     @Override
-    public void applyCachePolicy() {
-        super.applyCachePolicy();
+    public boolean applyCachePolicy() {
+        return super.applyCachePolicy();
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -281,6 +281,11 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public void registerCleanupListener(CleanupListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
         private void invoke(MethodInvocation methodInvocation) {
             Exceptions.checkNotClosed(this.closed, this);
             if (this.methodInvokeCallback != null) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.logs;
+
+import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import lombok.Cleanup;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.val;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link Throttler} class.
+ */
+public class ThrottlerTests extends ThreadPooledTestSuite {
+    private static final int CONTAINER_ID = 1;
+    private static final ThrottlerCalculator.ThrottlerName THROTTLER_NAME = ThrottlerCalculator.ThrottlerName.Cache;
+    private static final int MAX_THROTTLE_MILLIS = ThrottlerCalculator.MAX_DELAY_MILLIS;
+    private static final int NON_MAX_THROTTLE_MILLIS = MAX_THROTTLE_MILLIS - 1;
+    private static final int TIMEOUT_MILLIS = 10000;
+    private static final int SHORT_TIMEOUT_MILLIS = 50;
+    private SegmentStoreMetrics.OperationProcessor metrics;
+
+    @Override
+    protected int getThreadPoolSize() {
+        return 1;
+    }
+
+    @Before
+    public void setUp() {
+        this.metrics = new SegmentStoreMetrics.OperationProcessor(CONTAINER_ID);
+    }
+
+    @After
+    public void tearDown() {
+        this.metrics.close();
+    }
+
+    /**
+     * Tests the {@link Throttler#isThrottlingRequired()} method.
+     */
+    @Test
+    public void testThrottlingRequired() {
+        val delays = Collections.<Integer>synchronizedList(new ArrayList<>());
+        val calculator = new TestCalculatorThrottler(THROTTLER_NAME);
+        @Cleanup
+        Throttler t = new AutoCompleteTestThrottler(CONTAINER_ID, wrap(calculator), executorService(), metrics, delays::add);
+
+        calculator.setThrottlingRequired(false);
+        Assert.assertFalse("Not expecting any throttling to be required.", t.isThrottlingRequired());
+        calculator.setThrottlingRequired(true);
+        Assert.assertTrue("Expected throttling to be required.", t.isThrottlingRequired());
+
+        Assert.assertFalse("Unexpected value from isClosed() before closing.", t.isClosed());
+        t.close();
+        Assert.assertTrue("Unexpected value from isClosed() after closing.", t.isClosed());
+    }
+
+    /**
+     * Tests the case when {@link ThrottlerCalculator#getThrottlingDelay()} returns a value which does not warrant repeated
+     * delays (i.e., not maximum delay)
+     */
+    @Test
+    public void testSingleDelay() throws Exception {
+        val delays = Collections.<Integer>synchronizedList(new ArrayList<>());
+        val calculator = new TestCalculatorThrottler(THROTTLER_NAME);
+        @Cleanup
+        Throttler t = new AutoCompleteTestThrottler(CONTAINER_ID, wrap(calculator), executorService(), metrics, delays::add);
+
+        // Set a non-maximum delay and ask to throttle, then verify we throttled the correct amount.
+        calculator.setDelayMillis(NON_MAX_THROTTLE_MILLIS);
+        t.throttle().get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Expected exactly one delay to be recorded.", 1, delays.size());
+        Assert.assertEquals("Unexpected delay recorded.", NON_MAX_THROTTLE_MILLIS, (int) delays.get(0));
+    }
+
+    /**
+     * Tests the case when {@link ThrottlerCalculator#getThrottlingDelay()} returns a value which requires repeated
+     * delays (Maximum Delay == True).
+     */
+    @Test
+    public void testMaximumDelay() throws Exception {
+        final int repeatCount = 3;
+        val delays = Collections.<Integer>synchronizedList(new ArrayList<>());
+        val calculator = new TestCalculatorThrottler(THROTTLER_NAME);
+
+        val nextDelay = new AtomicInteger(MAX_THROTTLE_MILLIS + repeatCount - 1);
+        Consumer<Integer> recordDelay = delayMillis -> {
+            delays.add(delayMillis);
+            calculator.setDelayMillis(nextDelay.decrementAndGet());
+        };
+
+        // Request a throttling delay. Since we begin with a value higher than the MAX, we expect the throttler to
+        // block as long as necessary; at each throttle cycle it should check the calculator for a new value, which we
+        // will decrease an expect to unblock once we got a value smaller than MAX.
+        @Cleanup
+        Throttler t = new AutoCompleteTestThrottler(CONTAINER_ID, wrap(calculator), executorService(), metrics, recordDelay);
+        calculator.setDelayMillis(nextDelay.get());
+        t.throttle().get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected number of delays recorded.", repeatCount, delays.size());
+        for (int i = 0; i < repeatCount; i++) {
+            int expectedDelay = MAX_THROTTLE_MILLIS + Math.min(0, repeatCount - i); // Delays are capped.
+            Assert.assertEquals("Unexpected delay recorded for step " + i, expectedDelay, (int) delays.get(i));
+        }
+    }
+
+    /**
+     * Tests the case when {@link Throttler#throttle()} returns a delay that can be interrupted using {@link Throttler#cacheCleanupComplete()}.
+     */
+    @Test
+    public void testInterruptedCacheDelay() throws Exception {
+        //val suppliedDelays = Arrays.asList(NON_MAX_THROTTLE_MILLIS, NON_MAX_THROTTLE_MILLIS / 2, NON_MAX_THROTTLE_MILLIS);
+        val suppliedDelays = Arrays.asList(5000, 2500, 5000);
+        val delays = Collections.<Integer>synchronizedList(new ArrayList<>());
+        val calculator = new TestCalculatorThrottler(THROTTLER_NAME);
+        val nextDelay = suppliedDelays.iterator();
+        Consumer<Integer> recordDelay = delayMillis -> {
+            delays.add(delayMillis);
+            calculator.setDelayMillis(nextDelay.hasNext() ? nextDelay.next() : 0); // 0 means we're done (no more throttling).
+        };
+        @Cleanup
+        TestThrottler t = new TestThrottler(CONTAINER_ID, wrap(calculator), executorService(), metrics, recordDelay);
+
+        // Set a non-maximum delay and ask to throttle, then verify we throttled the correct amount.
+        calculator.setDelayMillis(nextDelay.next());
+        val t1 = t.throttle();
+        Assert.assertFalse("Not expected throttle future to be completed yet.", t1.isDone());
+
+        // For every delay that we want to submit, notify that the cache cleanup has completed, which should cancel the
+        // currently running throttle cycle and request the next throttling value.
+        for (int i = 1; i < suppliedDelays.size(); i++) {
+            // Interrupt the current throttle cycle.
+            t.cacheCleanupComplete();
+            Assert.assertFalse("Not expected throttle future to be completed yet.", t1.isDone());
+
+            // Wait for the new cycle to begin (we use the recordDelay consumer above to figure this out).
+            int expectedDelayCount = i + 1;
+            TestUtils.await(() -> delays.size() == expectedDelayCount, 5, TIMEOUT_MILLIS);
+        }
+
+        // When we are done, complete the last throttle cycle and check final results.
+        t.completeDelayFuture();
+        TestUtils.await(t1::isDone, 5, TIMEOUT_MILLIS);
+        Assert.assertEquals("Unexpected number of delays recorded.", suppliedDelays.size(), delays.size());
+
+        Assert.assertEquals("Unexpected first delay value.", suppliedDelays.get(0), delays.get(0));
+
+        // Subsequent delays cannot be predicted due to them being real time values and, as such, vary greatly between
+        // runs and different environments. We can only check that they decrease in value (by design).
+        for (int i = 1; i < delays.size(); i++) {
+            AssertExtensions.assertLessThanOrEqual("Expected delays to be decreasing.", delays.get(i - 1), delays.get(i));
+        }
+    }
+
+    private ThrottlerCalculator wrap(ThrottlerCalculator.Throttler calculatorThrottler) {
+        return ThrottlerCalculator.builder().throttler(calculatorThrottler).build();
+    }
+
+    //region Helper Classes
+
+    @RequiredArgsConstructor
+    @Getter
+    @Setter
+    private static class TestCalculatorThrottler extends ThrottlerCalculator.Throttler {
+        private final ThrottlerCalculator.ThrottlerName name;
+        private boolean throttlingRequired;
+        private int delayMillis;
+    }
+
+    private static class TestThrottler extends Throttler {
+        private final Consumer<Integer> newDelay;
+        private final AtomicReference<CompletableFuture<Void>> lastDelayFuture = new AtomicReference<>();
+
+        TestThrottler(int containerId, ThrottlerCalculator calculator, ScheduledExecutorService executor,
+                      SegmentStoreMetrics.OperationProcessor metrics, Consumer<Integer> newDelay) {
+            super(containerId, calculator, executor, metrics);
+            this.newDelay = newDelay;
+        }
+
+        @Override
+        protected CompletableFuture<Void> createDelayFuture(int millis) {
+            this.newDelay.accept(millis);
+            val oldDelay = this.lastDelayFuture.getAndSet(null);
+            Assert.assertTrue(oldDelay == null || oldDelay.isDone());
+            val result = super.createDelayFuture(millis);
+            this.lastDelayFuture.set(result);
+            return result;
+        }
+
+        void completeDelayFuture() {
+            val delayFuture = this.lastDelayFuture.getAndSet(null);
+            Assert.assertNotNull(delayFuture);
+            delayFuture.complete(null);
+        }
+    }
+
+    /**
+     * Overrides the {@link Throttler#createDelayFuture(int)} method to return a completed future and record the delay
+     * requested. This is necessary to avoid having to wait indeterminate amounts of time to actually verify the throttling
+     * mechanism.
+     */
+    private static class AutoCompleteTestThrottler extends TestThrottler {
+        AutoCompleteTestThrottler(int containerId, ThrottlerCalculator calculator, ScheduledExecutorService executor,
+                                  SegmentStoreMetrics.OperationProcessor metrics, Consumer<Integer> newDelay) {
+            super(containerId, calculator, executor, metrics, newDelay);
+        }
+
+        @Override
+        protected CompletableFuture<Void> createDelayFuture(int millis) {
+            val delayFuture = super.createDelayFuture(millis);
+            super.completeDelayFuture();
+            return delayFuture;
+        }
+    }
+
+    //endregion
+}


### PR DESCRIPTION
**Change log description**  
- Changed `CacheManager` to run every 1 second (down from 5). 
    - This will cause more frequent cache evictions and with higher granularity.
- Added the ability to cancel a throttling delay, if that delay was due to the cache being over-utilized and if the cache utilization has since dropped below the throttling threshold.
    - This will enable us to more quickly resume the ingestion pipeline if the data in the cache has been moved to Tier 2 before the throttling delay expired.

**Purpose of the change**  
Fixes #4164.

**What the code does**  
- `CacheManager` will now accept `CacheCleanupListeners`; anyone interested in being notified when the cache evicts at least one item can register itself here. The `CacheManager` will notify these listeners after every scheduled run that resulted in at least one entry being evicted.
- Moved throttling logic out of `OperationProcessor` into its own class to ease testing.
- Differentiating between interruptible throttle delays (currently only Cache) and non-interruptible. The latter will be carried over to their completion. The former can be cancelled if conditions permit, prior to their expiration.
    - Every throttle due to a Cache reason is recorded.
    - If the `Throttler` is notified by the `CacheManager` (via the `CacheCleanupListener` interface) that the cache has been cleaned up, then it will 
        - Cancel any throttling that was caused due to Caching (leaves any others in place).
        - Either allow operations to proceed (no more throttling) or throttling with a smaller delay than before. Both of these would be an effect of improved conditions (cache utilization was significantly reduced than before so no need to wait that long anymore). 

A few examples of how this might play out:
1. Initial delay is 20s. After 2s, the CacheManager evicts a lot of data. The Throttler determines there is no need to throttle anymore and cancels the initial throttling (saving 18s).
2. Initial delay is 20s. After 2s, the CacheManager evicts some data. The throttle determines that the new delay (based on current utilization) is now 10s; it sets the new delay to be 10s, thus saving 8s in total (20s - 2s - min(10s, 18s)).
3. Initial delay is 5s. After 2s, the CacheManager evicts a little bit of data, but some other actor added a lot more, thus increasing the utilization compared to before. The new throttle delay would be 20s, but the Throttler will only wait 3s (what was left of the initial delay).
    - This sounds counter intuitive, but it is necessary in order to avoid an infinite starvation situation (where each time we check, we simply extend the throttling by some amount). If the situation does get "worse" after the initial expiration, then whenever this pipeline resumes it will add a bit of data and then halt based on the new situation (which could be a maximum delay).

**How to verify it**  
New unit tests added.
