### PR TITLE
Issue 3982: Docker Swarm - scale segmentstore with correct version.

### DIFF
--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -23,9 +23,10 @@ try:
     hdfs_url = get_config("HDFS_URL")
     zk_url = get_config("ZK_URL")
 
-    existing = subprocess.check_output("docker service ls -f 'name=pravega_segmentstore_'", shell=True)
+    existing = subprocess.check_output("docker service ls --format '{{.Name}}:{{.Image}}' -f 'name=pravega_segmentstore'", shell=True)
     instances = set([int(instance[1]) for instance in re.findall("(pravega_segmentstore_(\d+))", existing)])
     instances.add(1) # add the first service
+    image=existing.split()[0].split(":")[1]+":"+existing.split()[0].split(":")[2]
 except Exception as e:
     print(e)
     print("pravega_segmentstore isn't running, can't be queried, or is improperly configured for scaling")
@@ -64,13 +65,14 @@ for instance in to_create:
           -e ZK_URL={zk_url} \
           -e CONTROLLER_URL=tcp://controller:9090 \
           -e JAVA_OPTS='-Dmetrics.enableCSVReporter=false -Dpravegaservice.publishedIPAddress={published_address} -Dpravegaservice.listeningPort={port} -Dpravegaservice.listeningIPAddress=0 -Dbookkeeper.bkEnsembleSize=2 -Dbookkeeper.bkAckQuorumSize=2 -Dbookkeeper.bkWriteQuorumSize=2 -Xmx900m -XX:OnError="kill -9 p%" -XX:+ExitOnOutOfMemoryError -XX:+CrashOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError' \
-          pravega/pravega segmentstore"""
+          {image} segmentstore"""
 
     cmd = template.format(
         name=name,
         port=port,
         hdfs_url=hdfs_url,
         zk_url=zk_url,
-        published_address=published_address
+        published_address=published_address,
+        image=image
     )
     subprocess.call(cmd, shell=True)

--- a/docker/compose/swarm/scale_segmentstore
+++ b/docker/compose/swarm/scale_segmentstore
@@ -23,10 +23,10 @@ try:
     hdfs_url = get_config("HDFS_URL")
     zk_url = get_config("ZK_URL")
 
-    existing = subprocess.check_output("docker service ls --format '{{.Name}}:{{.Image}}' -f 'name=pravega_segmentstore'", shell=True)
+    existing = subprocess.check_output("docker service ls --format '{{.Name}},{{.Image}}' -f 'name=pravega_segmentstore'", shell=True)
     instances = set([int(instance[1]) for instance in re.findall("(pravega_segmentstore_(\d+))", existing)])
     instances.add(1) # add the first service
-    image=existing.split()[0].split(":")[1]+":"+existing.split()[0].split(":")[2]
+    image=existing.split()[0].split(",")[1]
 except Exception as e:
     print(e)
     print("pravega_segmentstore isn't running, can't be queried, or is improperly configured for scaling")


### PR DESCRIPTION
**Change log description**  
Scaling the segment store, for external deployment of Pravega on Docker Swarm, would result in image mismatch with the latest segment store image being pulled. Solved this by pulling segment store image consistent with the current deployment. 

**Purpose of the change**  
Fixes #3982 

**What the code does**   

- Format the docker service list command and filter the segment stores.

- Used regex to determine image of the first segment store for the existing deployment. 

- Then modified the docker create service call by adding the image for the segment store. 

**How to verify it**  
Deploy Pravega on Docker Swarm using Published IP (external) and scale the segment store.
