### PR TITLE
Issue 4158: Potential starvation of Tier 2 writes with unthrottled clients

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -56,6 +56,11 @@ class RocksDBCache implements Cache {
      */
     private static final int MIN_WRITE_BUFFER_NUMBER_TO_MERGE = 2;
 
+    /**
+     * Number of internal parallel threads that RocksDB will use for a specific task.
+     */
+    private static final int INTERNAL_ROCKSDB_PARALLELISM = 8;
+
     @Getter
     private final String id;
     private final Options databaseOptions;
@@ -255,6 +260,8 @@ class RocksDBCache implements Cache {
                 .setCreateIfMissing(true)
                 .setDbLogDir(Paths.get(this.dbDir, DB_LOG_DIR).toString())
                 .setWalTtlSeconds(0)
+                .setWalBytesPerSync(0)
+                .setWalSizeLimitMB(0)
                 .setWriteBufferSize(writeBufferSizeMB * 1024L * 1024L)
                 .setMaxWriteBufferNumber(MAX_WRITE_BUFFER_NUMBER)
                 .setMinWriteBufferNumberToMerge(MIN_WRITE_BUFFER_NUMBER_TO_MERGE)
@@ -262,15 +269,12 @@ class RocksDBCache implements Cache {
                 .setOptimizeFiltersForHits(true)
                 .setUseDirectReads(this.directReads)
                 .setSkipStatsUpdateOnDbOpen(true)
-                .setWalBytesPerSync(0)
-                .setWalSizeLimitMB(0)
-                .setIncreaseParallelism(4)
                 .optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)
+                .setIncreaseParallelism(INTERNAL_ROCKSDB_PARALLELISM)
+                .setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)
                 .setCompactionStyle(CompactionStyle.LEVEL)
-                .setMaxBackgroundCompactions(8)
-                .setMaxBackgroundJobs(8)
-                .setCompactionReadaheadSize(1024L * 1024L)
                 .optimizeLevelStyleCompaction()
+                .setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM)
                 .setLevelCompactionDynamicLevelBytes(true);
 
         if (this.memoryOnly) {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -44,13 +44,6 @@ class RocksDBCache implements Cache {
 
     private static final String FILE_PREFIX = "cache_";
     private static final String DB_LOG_DIR = "log";
-    private static final String DB_WRITE_AHEAD_LOG_DIR = "wal";
-
-    /**
-     * Max RocksDB WAL Size MB.
-     * See this for more info: https://github.com/facebook/rocksdb/wiki/Basic-Operations#purging-wal-files
-     */
-    private static final int MAX_WRITE_AHEAD_LOG_SIZE_MB = 64;
 
     /**
      * Max number of in-memory write buffers (memtables) for the cache (active and immutable).
@@ -215,11 +208,13 @@ class RocksDBCache implements Cache {
     @Override
     public void remove(Key key) {
         ensureInitializedAndNotClosed();
+        Timer timer = new Timer();
         try {
             this.database.get().delete(this.writeOptions, key.serialize());
         } catch (RocksDBException ex) {
             throw convert(ex, "remove key '%s'", key);
         }
+        RocksDBMetrics.delete(timer.getElapsedMillis());
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Env;
 import org.rocksdb.BloomFilter;
+import org.rocksdb.CompactionStyle;
 import org.rocksdb.IndexType;
 import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
@@ -265,8 +266,10 @@ class RocksDBCache implements Cache {
                 .setWalSizeLimitMB(0)
                 .optimizeLevelStyleCompaction()
                 .setIncreaseParallelism(4)
-                .setMaxBackgroundCompactions(4)
                 .optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)
+                //.setCompactionStyle(CompactionStyle.LEVEL)
+                //.setMaxBackgroundCompactions(8)
+                .setDisableAutoCompactions(true)
                 .setLevelCompactionDynamicLevelBytes(true);
 
         if (this.memoryOnly) {

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -264,18 +264,20 @@ class RocksDBCache implements Cache {
                 .setSkipStatsUpdateOnDbOpen(true)
                 .setWalBytesPerSync(0)
                 .setWalSizeLimitMB(0)
-                .optimizeLevelStyleCompaction()
                 .setIncreaseParallelism(4)
                 .optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)
-                //.setCompactionStyle(CompactionStyle.LEVEL)
-                //.setMaxBackgroundCompactions(8)
-                .setDisableAutoCompactions(true)
+                .setCompactionStyle(CompactionStyle.LEVEL)
+                .setMaxBackgroundCompactions(8)
+                .setMaxBackgroundJobs(8)
+                .setCompactionReadaheadSize(1024L * 1024L)
+                .optimizeLevelStyleCompaction()
                 .setLevelCompactionDynamicLevelBytes(true);
 
         if (this.memoryOnly) {
             Env env = new RocksMemEnv();
             options.setEnv(env);
         }
+
         return options;
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -281,7 +281,7 @@ class RocksDBCache implements Cache {
             Env env = new RocksMemEnv();
             options.setEnv(env);
         }
-
+        
         return options;
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -271,6 +271,7 @@ class RocksDBCache implements Cache {
                 .setSkipStatsUpdateOnDbOpen(true)
                 .optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)
                 .setIncreaseParallelism(INTERNAL_ROCKSDB_PARALLELISM)
+                .setMaxBackgroundFlushes(INTERNAL_ROCKSDB_PARALLELISM / 2)
                 .setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)
                 .setCompactionStyle(CompactionStyle.LEVEL)
                 .optimizeLevelStyleCompaction()

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
@@ -21,16 +21,20 @@ import io.pravega.shared.metrics.StatsLogger;
 final class RocksDBMetrics {
     private static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("rocksdb");
     private static final OpStatsLogger INSERT_LATENCY = STATS_LOGGER.createStats(MetricsNames.CACHE_INSERT_LATENCY);
+    private static final OpStatsLogger INSERT_SIZE = STATS_LOGGER.createStats(MetricsNames.CACHE_INSERT_SIZE);
     private static final OpStatsLogger GET_LATENCY = STATS_LOGGER.createStats(MetricsNames.CACHE_GET_LATENCY);
+    private static final OpStatsLogger GET_SIZE = STATS_LOGGER.createStats(MetricsNames.CACHE_GET_SIZE);
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     static void insert(long elapsedMillis, long insertDataSize) {
         DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_WRITE_BYTES, insertDataSize);
         INSERT_LATENCY.reportSuccessValue(elapsedMillis);
+        INSERT_SIZE.reportSuccessValue(insertDataSize);
     }
 
     static void get(long elapsedMillis, long getDataSize) {
         DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_READ_BYTES, getDataSize);
         GET_LATENCY.reportSuccessValue(elapsedMillis);
+        GET_SIZE.reportSuccessValue(getDataSize);
     }
 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBMetrics.java
@@ -24,17 +24,25 @@ final class RocksDBMetrics {
     private static final OpStatsLogger INSERT_SIZE = STATS_LOGGER.createStats(MetricsNames.CACHE_INSERT_SIZE);
     private static final OpStatsLogger GET_LATENCY = STATS_LOGGER.createStats(MetricsNames.CACHE_GET_LATENCY);
     private static final OpStatsLogger GET_SIZE = STATS_LOGGER.createStats(MetricsNames.CACHE_GET_SIZE);
+    private static final OpStatsLogger DELETE_LATENCY = STATS_LOGGER.createStats(MetricsNames.CACHE_DELETE_LATENCY);
     private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
 
     static void insert(long elapsedMillis, long insertDataSize) {
         DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_WRITE_BYTES, insertDataSize);
+        DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_INSERT_COUNT, 1);
         INSERT_LATENCY.reportSuccessValue(elapsedMillis);
         INSERT_SIZE.reportSuccessValue(insertDataSize);
     }
 
     static void get(long elapsedMillis, long getDataSize) {
         DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_READ_BYTES, getDataSize);
+        DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_GET_COUNT, 1);
         GET_LATENCY.reportSuccessValue(elapsedMillis);
         GET_SIZE.reportSuccessValue(getDataSize);
+    }
+
+    public static void delete(long elapsedMillis) {
+        DELETE_LATENCY.reportSuccessValue(elapsedMillis);
+        DYNAMIC_LOGGER.incCounterValue(MetricsNames.CACHE_DELETE_COUNT, 1);
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -100,8 +100,10 @@ public final class MetricsNames {
 
     // Cache (RocksDB) stats
     public static final String CACHE_INSERT_LATENCY = PREFIX + "segmentstore.cache.insert_latency_ms";   // Histogram
+    public static final String CACHE_INSERT_SIZE = PREFIX + "segmentstore.cache.insert_size";            // Histogram
     public static final String CACHE_WRITE_BYTES = PREFIX + "segmentstore.cache.write_bytes";            // Counter
     public static final String CACHE_GET_LATENCY = PREFIX + "segmentstore.cache.get_latency_ms";         // Histogram
+    public static final String CACHE_GET_SIZE = PREFIX + "segmentstore.cache.get_size";                  // Histogram
     public static final String CACHE_READ_BYTES = PREFIX + "segmentstore.cache.read_bytes";              // Counter
     public static final String CACHE_TOTAL_SIZE_BYTES = PREFIX + "segmentstore.cache.size_bytes";        // Gauge
     public static final String CACHE_GENERATION_SPREAD = PREFIX + "segmentstore.cache.gen";              // Histogram

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -101,10 +101,14 @@ public final class MetricsNames {
     // Cache (RocksDB) stats
     public static final String CACHE_INSERT_LATENCY = PREFIX + "segmentstore.cache.insert_latency_ms";   // Histogram
     public static final String CACHE_INSERT_SIZE = PREFIX + "segmentstore.cache.insert_size";            // Histogram
+    public static final String CACHE_INSERT_COUNT = PREFIX + "segmentstore.cache.insert_count";          // Counter
     public static final String CACHE_WRITE_BYTES = PREFIX + "segmentstore.cache.write_bytes";            // Counter
     public static final String CACHE_GET_LATENCY = PREFIX + "segmentstore.cache.get_latency_ms";         // Histogram
     public static final String CACHE_GET_SIZE = PREFIX + "segmentstore.cache.get_size";                  // Histogram
+    public static final String CACHE_GET_COUNT = PREFIX + "segmentstore.cache.get_count";                // Counter
     public static final String CACHE_READ_BYTES = PREFIX + "segmentstore.cache.read_bytes";              // Counter
+    public static final String CACHE_DELETE_LATENCY = PREFIX + "segmentstore.cache.delete_latency_ms";   // Histogram
+    public static final String CACHE_DELETE_COUNT = PREFIX + "segmentstore.cache.delete_count";          // Counter
     public static final String CACHE_TOTAL_SIZE_BYTES = PREFIX + "segmentstore.cache.size_bytes";        // Gauge
     public static final String CACHE_GENERATION_SPREAD = PREFIX + "segmentstore.cache.gen";              // Histogram
 


### PR DESCRIPTION
**Change log description**  
This PR improves RocksDB configuration, specially to prevent compaction to be a bottleneck. Moreover, we have added few metrics to better understand the behavior of the cache.

**Purpose of the change**  
Fixes #4158. 

**What the code does**  
This PR adds some settings to RocksDB configuration to improve its performance in various aspects, but specially regarding data compaction. In the following, we specify the motivation behind each of the changes in configuration:

_Improvement of reads/read amplification_:
- `setBlockCache(new LRUCache(readCacheSizeMB * 1024L * 1024L, 4))`: In our current configuration, we are missing the to instantiate an actual cache. While if we leave this unset RocksDB internally uses an 8MB cache, it is better to expose it as we can have control over it.
- `setIndexType(IndexType.kHashSearch)`: According to the documentation, the hash index is designed to improve the CPU efficiency of point lookup (we basically work with K/V).
- `optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)`: We basically use RocksDB as a KV store, so we can use this option. According to the documentation, we can use this as we don't need to keep the data sorted (i.e. we don't use an iterator, only `Put()` and `Get()` API calls).
- `setFilter(new BloomFilter())`: When doing point lookups it is encouraged to turn bloom filters on. We use bloom filters to avoid unnecessary disk reads.

_Improvement of internal parallelism & compaction throughput_:
- `setIncreaseParallelism(INTERNAL_ROCKSDB_PARALLELISM)`: The documentation states that by default, RocksDB uses only one background thread for flush and compaction. We want to increase this number to allow more internal parallelism in the DB.
- `setCompactionStyle(CompactionStyle.LEVEL)`: Specify the compaction scheme we are using.
- `optimizeLevelStyleCompaction()`: Optimize the compaction settings for large datasets.
- `setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM)` & `setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)`: Sets the maximum number of concurrent background compaction jobs.
- `setLevelCompactionDynamicLevelBytes(true)`: This optimization appears to be useful to limit worse case space amplification.
- `setMaxSubcompactions(INTERNAL_ROCKSDB_PARALLELISM)`: Allow multiple parallel compactions from L0 to L1.

_Miscellaneous:_
- `setWalBytesPerSync(0)` & `setWalSizeLimitMB(0)`: Be sure that all WAL settings are turned off.
- `setSkipStatsUpdateOnDbOpen(true)`: No need to update database stats, as we are not using them.

Apart from the RocksDB configuration, we have added some metrics that have been useful during the investigation of this issue to better understand the behavior of the cache:
- Size of cache operations (`segmentstore.cache.insert_size`, `segmentstore.cache.get_size`).
- Counter of cache operations (`segmentstore.cache.insert_count`, `segmentstore.cache.get_count`, `segmentstore.cache.delete_count`).
- Latency of delete operations (`segmentstore.cache.delete_latency_ms`).

**How to verify it**  
Before this change, Pravega with RocksDB on disk reported a 20MBps throughput with a lot of variability just few seconds after an unthrottled client started to write as fast as possible. With these changes, we have executed 3 unthrottled clients against 3 Segment Stores and Pravega sustained 150MBps for 1 hour. Note that more tests are still in progress.
All other tests should be passing as before.
