### PR TITLE
Issue 4182: Feature watermarking fix system test

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
@@ -113,7 +113,9 @@ public class WatermarkingTest extends AbstractSystemTest {
     public void setup() {
         controllerInstance = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = controllerInstance.getServiceDetails();
-        controllerURI = ctlURIs.get(0);
+        final List<String> uris = ctlURIs.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
+
+        controllerURI = URI.create("tcp://" + String.join(",", uris));
         streamManager = StreamManager.create(Utils.buildClientConfig(controllerURI));
         assertTrue("Creating Scope", streamManager.createScope(SCOPE));
         assertTrue("Creating stream", streamManager.createStream(SCOPE, STREAM, config));
@@ -236,11 +238,13 @@ public class WatermarkingTest extends AbstractSystemTest {
         assertNotNull(currentTimeWindow);
         assertNotNull(currentTimeWindow.getLowerTimeBound());
         assertNotNull(currentTimeWindow.getUpperTimeBound());
-        
+        log.info("current time window = {}", currentTimeWindow);
+
         while (event.getEvent() != null) {
             Long time = event.getEvent();
+            log.info("event read = {}", time);
+            event.getPosition();
             assertTrue(time >= currentTimeWindow.getLowerTimeBound());
-            assertTrue(time <= currentTimeWindow.getUpperTimeBound());
             event = reader.readNextEvent(10000L);
             if (event.isCheckpoint()) {
                 event = reader.readNextEvent(10000L);

--- a/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
@@ -193,9 +193,9 @@ public class WatermarkingTest extends AbstractSystemTest {
         assertTrue(watermark3.getLowerTimeBound() <= watermark3.getUpperTimeBound());
 
         // verify that watermarks are increasing in time.
-        assertTrue(watermark0.getLowerTimeBound() <= watermark1.getLowerTimeBound());
-        assertTrue(watermark1.getLowerTimeBound() <= watermark2.getLowerTimeBound());
-        assertTrue(watermark2.getLowerTimeBound() <= watermark3.getLowerTimeBound());
+        assertTrue(watermark0.getLowerTimeBound() < watermark1.getLowerTimeBound());
+        assertTrue(watermark1.getLowerTimeBound() < watermark2.getLowerTimeBound());
+        assertTrue(watermark2.getLowerTimeBound() < watermark3.getLowerTimeBound());
         
         // use watermark as lower and upper bounds.
         Map<Segment, Long> positionMap0 = watermark0.getStreamCut()

--- a/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/WatermarkingTest.java
@@ -185,15 +185,15 @@ public class WatermarkingTest extends AbstractSystemTest {
         Watermark watermark2 = watermarks.take();
         Watermark watermark3 = watermarks.take();
         
-        assertTrue(watermark0.getLowerTimeBound() < watermark0.getUpperTimeBound());
-        assertTrue(watermark1.getLowerTimeBound() < watermark1.getUpperTimeBound());
-        assertTrue(watermark2.getLowerTimeBound() < watermark2.getUpperTimeBound());
-        assertTrue(watermark3.getLowerTimeBound() < watermark3.getUpperTimeBound());
+        assertTrue(watermark0.getLowerTimeBound() <= watermark0.getUpperTimeBound());
+        assertTrue(watermark1.getLowerTimeBound() <= watermark1.getUpperTimeBound());
+        assertTrue(watermark2.getLowerTimeBound() <= watermark2.getUpperTimeBound());
+        assertTrue(watermark3.getLowerTimeBound() <= watermark3.getUpperTimeBound());
 
         // verify that watermarks are increasing in time.
-        assertTrue(watermark0.getLowerTimeBound() < watermark1.getLowerTimeBound());
-        assertTrue(watermark1.getLowerTimeBound() < watermark2.getLowerTimeBound());
-        assertTrue(watermark2.getLowerTimeBound() < watermark3.getLowerTimeBound());
+        assertTrue(watermark0.getLowerTimeBound() <= watermark1.getLowerTimeBound());
+        assertTrue(watermark1.getLowerTimeBound() <= watermark2.getLowerTimeBound());
+        assertTrue(watermark2.getLowerTimeBound() <= watermark3.getLowerTimeBound());
         
         // use watermark as lower and upper bounds.
         Map<Segment, Long> positionMap0 = watermark0.getStreamCut()
@@ -255,6 +255,7 @@ public class WatermarkingTest extends AbstractSystemTest {
             Iterator<Map.Entry<Revision, Watermark>> marks = watermarkReader.readFrom(revision.get());
             if (marks.hasNext()) {
                 Map.Entry<Revision, Watermark> next = marks.next();
+                log.info("watermark = {}", next.getValue());
                 watermarks.add(next.getValue());
                 revision.set(next.getKey());
             }


### PR DESCRIPTION
**Change log description**  
Fixes following issues in WatermarkingSystemTest

1.     Watermarking system test's assertion on watermark.lowerTimebound <watermark.upperTimebound should be made <=
2.    We start two controllers but take uri of only one of them that we pass around. Use composite uri.
3.    Remove assertion for TimeWindow.upperbound with respect to event time bound.

**Purpose of the change**  
Fixes #4182 

**What the code does**  
System test has 2 sets of incorrect assertions that are fixed. 
It also creates two controllers and shutsdown one of them. However, it uses a controller uri which takes IP of one of them arbitrarily. So if the controller with the specified uri is shutdown then any client instantiated after that is unable to connect to controller. 
So we use the composite uri like all other system tests. 

**How to verify it**  
The system test should pass
