### PR TITLE
Issue 3344: Update offset order before acking.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -349,8 +349,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
             long previousAckLevel = dataAppended.getPreviousEventNumber();
             try {
                 checkAckLevels(ackLevel, previousAckLevel);
-                ackUpTo(ackLevel);
                 state.noteSegmentLength(dataAppended.getCurrentSegmentWriteOffset());
+                ackUpTo(ackLevel);
             } catch (Exception e) {
                 failConnection(e);
             }


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Update writer position before acking write.

**Purpose of the change**  
In the event that a user chains a `noteTime` call off of an ack of an append, this change will allow the watermark bound to be tighter by including the event that was just appended. (This is not a question of correctness, as watermarks are by definition conservative. However it increases accuracy and is somewhat less surprising)

**What the code does**  
Updates the writer's position before it invokes the callback to notify the application of the ack. (As opposed to after)
