### PR TITLE
Issue 4189: Add timeouts to integration tests

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -99,7 +99,7 @@ public class AppendTest {
         ResourceLeakDetector.setLevel(originalLevel);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testSetupOnNonExistentSegment() throws Exception {
         String segment = "123";
         StreamSegmentStore store = this.serviceBuilder.createStreamSegmentService();
@@ -112,7 +112,7 @@ public class AppendTest {
         assertEquals(segment, setup.getSegment());
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void sendReceivingAppend() throws Exception {
         String segment = "123";
         ByteBuf data = Unpooled.wrappedBuffer("Hello world\n".getBytes());
@@ -198,7 +198,7 @@ public class AppendTest {
         return channel;
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void appendThroughSegmentClient() throws Exception {
         String endpoint = "localhost";
         int port = TestUtils.getAvailableListenPort();
@@ -227,7 +227,7 @@ public class AppendTest {
         ack.get(5, TimeUnit.SECONDS);
     }
     
-    @Test
+    @Test(timeout = 10000)
     public void appendThroughConditionalClient() throws Exception {
         String endpoint = "localhost";
         int port = TestUtils.getAvailableListenPort();
@@ -255,7 +255,7 @@ public class AppendTest {
         assertTrue(out.write(ByteBuffer.wrap(testString.getBytes()), 0));
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void appendThroughStreamingClient() throws InterruptedException, ExecutionException, TimeoutException {
         String endpoint = "localhost";
         String streamName = "abc";
@@ -278,7 +278,7 @@ public class AppendTest {
         ack.get(5, TimeUnit.SECONDS);
     }
     
-    @Test(timeout = 40000)
+    @Test(timeout = 20000)
     public void miniBenchmark() throws InterruptedException, ExecutionException, TimeoutException {
         String endpoint = "localhost";
         String streamName = "abc";

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -102,7 +102,7 @@ public class ReadTest {
         ResourceLeakDetector.setLevel(originalLevel);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testReadDirectlyFromStore() throws Exception {
         String segmentName = "testReadFromStore";
         final int entries = 10;
@@ -133,7 +133,7 @@ public class ReadTest {
         assertEquals(entries * data.length, index);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testReceivingReadCall() throws Exception {
         String segmentName = "testReceivingReadCall";
         int entries = 10;
@@ -171,7 +171,7 @@ public class ReadTest {
         assertEquals(expected, actual);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void readThroughSegmentClient() throws SegmentSealedException, EndOfSegmentException, SegmentTruncatedException {
         String endpoint = "localhost";
         String scope = "scope";
@@ -255,7 +255,7 @@ public class ReadTest {
         assertNull(in.read(100));
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void readThroughStreamClient() throws ReinitializationRequiredException {
         String endpoint = "localhost";
         String streamName = "abc";

--- a/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReaderGroupTest.java
@@ -113,7 +113,7 @@ public class ReaderGroupTest {
         streamManager.deleteReaderGroup(READER_GROUP);
     }
     
-    @Test
+    @Test(timeout = 10000)
     public void testMultiSegmentsPerReader() throws Exception {
         String endpoint = "localhost";
         int servicePort = TestUtils.getAvailableListenPort();

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -136,7 +136,7 @@ public class StreamMetricsTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testSegmentSplitMerge() throws Exception {
 
         ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();

--- a/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
@@ -60,7 +60,7 @@ public class TransactionTest {
         ResourceLeakDetector.setLevel(originalLevel);
     }
 
-    @Test
+    @Test(timeout = 10000)
     @SuppressWarnings("deprecation")
     public void testTransactionalWritesOrderedCorrectly() throws TxnFailedException, ReinitializationRequiredException {
         int readTimeout = 5000;
@@ -135,7 +135,7 @@ public class TransactionTest {
         assertEquals(nonTxEvent, consumer.readNextEvent(readTimeout).getEvent());
     }
 
-    @Test
+    @Test(timeout = 10000)
     @SuppressWarnings("deprecation")
     public void testDoubleCommit() throws TxnFailedException {
         String endpoint = "localhost";
@@ -165,7 +165,7 @@ public class TransactionTest {
         AssertExtensions.assertThrows(TxnFailedException.class, () -> transaction.commit());
     }
 
-    @Test
+    @Test(timeout = 10000)
     @SuppressWarnings("deprecation")
     public void testDrop() throws TxnFailedException, ReinitializationRequiredException {
         String endpoint = "localhost";

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/DebugStreamSegmentsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/DebugStreamSegmentsTest.java
@@ -109,7 +109,7 @@ public class DebugStreamSegmentsTest {
         zkTestServer.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testOutOfSequence() throws Exception {
         // 1. Prepare
         createScope(SCOPE);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/AbstractEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/AbstractEndToEndTest.java
@@ -34,7 +34,8 @@ import lombok.Cleanup;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +52,9 @@ public class AbstractEndToEndTest extends ThreadPooledTestSuite {
     protected static final String SCOPE = "testScope";
     protected static final String STREAM = "testStream1";
 
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
+    
     protected final int controllerPort = TestUtils.getAvailableListenPort();
     protected final String serviceHost = "localhost";
     protected final URI controllerURI = URI.create("tcp://" + serviceHost + ":" + controllerPort);


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Add timeouts to integration tests

**Purpose of the change**  
Fixes #4189.

**What the code does**  
Adds timeouts to tests. No functional changes.
