### PR TITLE
Issue 4160: Avoid writing to zookeeper for every NoteTime call

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
@@ -79,7 +79,14 @@ public class ZookeeperBucketStore implements BucketStore {
         String bucketPath = getBucketPath(serviceType, bucket);
         String streamPath = ZKPaths.makePath(bucketPath, encodedScopedStreamName(scope, stream));
 
-        return Futures.toVoid(storeHelper.createZNodeIfNotExist(streamPath));
+        return storeHelper.checkExists(streamPath)
+            .thenCompose(exists -> {
+                if (exists) {
+                    return CompletableFuture.completedFuture(null);
+                } else {
+                    return Futures.toVoid(storeHelper.createZNodeIfNotExist(streamPath));
+                }
+            });
     }
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import com.google.common.collect.ImmutableMap;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.shared.segment.StreamSegmentNameUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public abstract class BucketStoreTest {
+    BucketStore bucketStore;
+    ScheduledExecutorService executorService;
+    
+    abstract BucketStore getBucketStore(ImmutableMap<BucketStore.ServiceType, Integer> map);
+    
+    @Before
+    public void setUp() throws Exception {
+        executorService = Executors.newScheduledThreadPool(5);
+
+        ImmutableMap<BucketStore.ServiceType, Integer> map =
+                ImmutableMap.of(BucketStore.ServiceType.RetentionService, 2, BucketStore.ServiceType.WatermarkingService, 3);
+        bucketStore = getBucketStore(map);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        executorService.shutdown();
+    }
+    
+    @Test(timeout = 10000L)
+    public void testBucketStore() {
+        testBucketStore(BucketStore.ServiceType.RetentionService);
+        testBucketStore(BucketStore.ServiceType.WatermarkingService);
+    }
+
+    private void testBucketStore(BucketStore.ServiceType serviceType) {
+        String scope = "scope";
+        String stream1 = "stream1";
+
+        int bucketCount = bucketStore.getBucketCount(serviceType);
+
+        
+        bucketStore.addStreamToBucketStore(serviceType, scope, stream1, executorService).join();
+        int bucket = BucketStore.getBucket(scope, stream1, bucketCount);
+        Set<String> streamsInBucket = bucketStore.getStreamsForBucket(serviceType, bucket, executorService).join();
+        assertTrue(streamsInBucket.contains(BucketStore.getScopedStreamName(scope, stream1)));
+        assertEquals(1, streamsInBucket.size());
+
+        List<String> streams = getAllStreams(serviceType);
+        assertEquals(1, streams.size());
+        
+        String stream2 = "stream2";
+        String stream3 = "stream3";
+        bucketStore.addStreamToBucketStore(serviceType, scope, stream2, executorService).join();
+        bucketStore.addStreamToBucketStore(serviceType, scope, stream3, executorService).join();
+
+        streams = getAllStreams(serviceType);
+
+        assertEquals(3, streams.size());
+
+        bucketStore.removeStreamFromBucketStore(serviceType, scope, stream2, executorService).join();
+
+        streams = getAllStreams(serviceType);
+
+        assertEquals(2, streams.size());
+        assertTrue(streams.contains(StreamSegmentNameUtils.getScopedStreamName(scope, stream1)));
+        assertTrue(streams.contains(StreamSegmentNameUtils.getScopedStreamName(scope, stream3)));
+        assertFalse(streams.contains(StreamSegmentNameUtils.getScopedStreamName(scope, stream2)));
+    }
+
+    private List<String> getAllStreams(BucketStore.ServiceType serviceType) {
+        return Futures.allOfWithResults(
+                IntStream.range(0, bucketStore.getBucketCount(serviceType))
+                         .boxed()
+                         .map(bucket -> bucketStore.getStreamsForBucket(serviceType, bucket, executorService))
+                         .collect(Collectors.toList())).join()
+                      .stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
@@ -59,7 +59,6 @@ public abstract class BucketStoreTest {
         String stream1 = "stream1";
 
         int bucketCount = bucketStore.getBucketCount(serviceType);
-
         
         bucketStore.addStreamToBucketStore(serviceType, scope, stream1, executorService).join();
         int bucket = BucketStore.getBucket(scope, stream1, bucketCount);

--- a/controller/src/test/java/io/pravega/controller/store/stream/InMemoryBucketStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/InMemoryBucketStoreTest.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import com.google.common.collect.ImmutableMap;
+
+public class InMemoryBucketStoreTest extends BucketStoreTest {
+    @Override
+    public BucketStore getBucketStore(ImmutableMap<BucketStore.ServiceType, Integer> map) {
+        return new InMemoryBucketStore(map);
+    }
+}

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkBucketStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkBucketStoreTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.store.stream;
+
+import com.google.common.collect.ImmutableMap;
+import io.pravega.test.common.TestingServerStarter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ZkBucketStoreTest extends BucketStoreTest {
+    private TestingServer zkServer;
+    private CuratorFramework cli;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        zkServer = new TestingServerStarter().start();
+        zkServer.start();
+        cli = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), 10000, 10000,
+                (r, e, s) -> false);
+        cli.start();
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        cli.close();
+        zkServer.close();
+        super.tearDown();
+    }
+
+    @Override
+    public BucketStore getBucketStore(ImmutableMap<BucketStore.ServiceType, Integer> map) {
+        ZookeeperBucketStore store = new ZookeeperBucketStore(map, cli, executorService);
+        map.forEach((service, bucketCount) -> {
+            store.createBucketsRoot(service).join();
+            for (int bucket = 0; bucket < bucketCount; bucket++) {
+                store.createBucket(service, bucket).join();
+            }
+        });
+        
+        return store;
+    }
+    
+    @Test(timeout = 10000L)
+    public void testCheckExists() {
+        ImmutableMap<BucketStore.ServiceType, Integer> map =
+                ImmutableMap.of(BucketStore.ServiceType.RetentionService, 1, BucketStore.ServiceType.WatermarkingService, 1);
+
+        CuratorFramework spied = spy(cli);
+        ZookeeperBucketStore store = new ZookeeperBucketStore(map, spied, executorService);
+        store.addStreamToBucketStore(BucketStore.ServiceType.RetentionService, "scope", "stream", executorService).join();
+        verify(spied, times(1)).create();
+        verify(spied, times(1)).checkExists();
+
+        store.addStreamToBucketStore(BucketStore.ServiceType.RetentionService, "scope", "stream", executorService).join();
+        verify(spied, times(1)).create();
+        verify(spied, times(2)).checkExists();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
For each note time from writer, we call `createIfNotExists` on zookeeper to add stream to the bucket for background watermarking processing. 
With this change we now call checkExists before calling `create` on zookeeper as reads to zk are cheap but writes are expensive. 

**Purpose of the change**  
Fixes #4160

**What the code does**  
Whenever writer calls noteTime controller first attempts to add stream under watermarking bucket idempotently by calling `createIfNotExists` on zookeeper. 
Note: The actual WriterMark is stored in pravega tables and we are not optimizing on that. However, we can avoid writing to zookeeper and merely do a read from zookeeper by calling checkExists before calling create.  

**How to verify it**  
Unit tests added