### PR TITLE
Issue 4211: Fix backward compatibility bug allowing unread fields

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandDecoder.java
@@ -52,7 +52,9 @@ public class CommandDecoder extends ByteToMessageDecoder {
         }
         WireCommandType type = readType(is);
         int length = readLength(is, readableBytes);
+        int readIndex = in.readerIndex();
         WireCommand command = type.readFrom(is, length);
+        in.readerIndex(readIndex + length);
         return command;
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.shared.protocol.netty;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.Channel;
@@ -386,7 +387,8 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
     }
 
     @SneakyThrows(IOException.class)
-    private int writeMessage(WireCommand msg, ByteBuf out) {
+    @VisibleForTesting
+    static int writeMessage(WireCommand msg, ByteBuf out) {
         int startIdx = out.writerIndex();
         ByteBufOutputStream bout = new ByteBufOutputStream(out);
         bout.writeInt(msg.getType().getCode());

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/CommandDecoderTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/CommandDecoderTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ */        
+package io.pravega.shared.protocol.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.pravega.shared.protocol.netty.WireCommands.Hello;
+import java.io.IOException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommandDecoderTest {
+
+    @Test
+    public void testDecode() throws IOException {
+        ByteBuf buffer = Unpooled.buffer(16);
+        Hello command = new WireCommands.Hello(10, 1);     
+        CommandEncoder.writeMessage(command, buffer);
+        assertEquals(16, buffer.readableBytes());
+
+        command = (Hello) CommandDecoder.parseCommand(buffer);
+        assertEquals(0, buffer.readableBytes());
+        assertEquals(WireCommandType.HELLO, command.getType());    
+        assertEquals(10, command.highVersion); 
+        assertEquals(1, command.lowVersion);    
+    }
+
+    @Test
+    public void testDecodeLargeBuffer() throws IOException {
+        ByteBuf buffer = Unpooled.buffer(100);
+        Hello command = new WireCommands.Hello(10, 1);     
+        CommandEncoder.writeMessage(command, buffer);
+        buffer.writeLong(1); //Bonus data
+        buffer.writeLong(2);
+        buffer.writeLong(3);
+        assertEquals(16 + 24, buffer.readableBytes());
+
+        command = (Hello) CommandDecoder.parseCommand(buffer);
+        assertEquals(24, buffer.readableBytes());
+        assertEquals(WireCommandType.HELLO, command.getType());    
+        assertEquals(10, command.highVersion); 
+        assertEquals(1, command.lowVersion);          
+    }
+    
+    @Test
+    public void testUnknownFields() throws IOException {
+        ByteBuf buffer = Unpooled.buffer(100);
+        Hello command = new WireCommands.Hello(10, 1);     
+        CommandEncoder.writeMessage(command, buffer);
+        buffer.writeLong(1); //Bonus data
+        buffer.writeLong(2);
+        buffer.writeLong(3);
+        buffer.setInt(4, 8 + 24);
+        assertEquals(16 + 24, buffer.readableBytes());
+
+        command = (Hello) CommandDecoder.parseCommand(buffer);
+        assertEquals(0, buffer.readableBytes());
+        assertEquals(WireCommandType.HELLO, command.getType());    
+        assertEquals(10, command.highVersion); 
+        assertEquals(1, command.lowVersion);          
+    }
+}


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* In CommandDecoder: advance readerIndex to reflect data read.

**Purpose of the change**  
Fixes #4211

**What the code does**  
Ensures that is there is an extra field in a wire command from the server to the client that the client does not attempt to interpret these extra bytes as a separate command.
