### PR TITLE
Issue 4213: (SegmentStore) Fixing error message for `ReplaceIfEquals`

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -466,8 +466,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
                     // Verify value against existing value, if any.
                     if (u.getComparisonValue() != previousValue || !hasValue) {
                         throw new BadAttributeUpdateException(this.name, u, !hasValue,
-                                String.format("Expected existing value to be '%s', actual '%s'.",
-                                        u.getComparisonValue(), previousValue));
+                                String.format("Expected '%s', given '%s'.", previousValue, u.getComparisonValue()));
                     }
 
                     break;


### PR DESCRIPTION
**Change log description**  
- Fixing error message for `AttributeUpdateType.ReplaceIfEquals`.

**Purpose of the change**  
Fixes #4213.

**What the code does**  
- The previous message format swapped the value of the expected and given values of an attribute. This change rephrases the error message to make it correct.

**How to verify it**  
Not verifiable via any tests. Verify the `String.format` looks ok.
