### PR TITLE
Issue 4217: Support automatically noting time

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
@@ -63,12 +63,12 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
     
     /**
      * Notes a time that can be seen by readers which read from this stream by
-     * {@link EventStreamReader#getCurrentTimeWindow()}. The semantics or meaning of the timestamp
+     * {@link EventStreamReader#getCurrentTimeWindow(Stream)}. The semantics or meaning of the timestamp
      * is left to the application. Readers might expect timestamps to be monotonic. So this is
      * recommended but not enforced.
      * 
      * There is no requirement to call this method. Never doing so will result in readers invoking
-     * {@link EventStreamReader#getCurrentTimeWindow()} receiving a null for both upper and lower times.
+     * {@link EventStreamReader#getCurrentTimeWindow(Stream)} receiving a null for both upper and lower times.
      * 
      * Calling this method can be automated by setting
      * {@link EventWriterConfigBuilder#automaticallyNoteTime(boolean)} to true when creating a
@@ -83,7 +83,7 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
      * Note that transactions can only be open for {@link StreamConfiguration#getTimestampAggregationTimeout()}.
      * 
      * @return A transaction through which multiple events can be written atomically.
-     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
+     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, String, Serializer, EventWriterConfig)} instead
      */
     @Deprecated
     Transaction<Type> beginTxn();
@@ -93,7 +93,7 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
      * 
      * @param transactionId The result retained from calling {@link Transaction#getTxnId()}
      * @return Transaction object with given UUID
-     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
+     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, String, Serializer, EventWriterConfig)} instead
      */
     @Deprecated
     Transaction<Type> getTxn(UUID transactionId);

--- a/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
@@ -9,7 +9,7 @@
  */
 package io.pravega.client.stream;
 
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventWriterConfig.EventWriterConfigBuilder;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -63,12 +63,12 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
     
     /**
      * Notes a time that can be seen by readers which read from this stream by
-     * {@link EventStreamReader#getMostRecentWatermark()}. The semantics or meaning of the timestamp
+     * {@link EventStreamReader#getCurrentTimeWindow()}. The semantics or meaning of the timestamp
      * is left to the application. Readers might expect timestamps to be monotonic. So this is
      * recommended but not enforced.
      * 
      * There is no requirement to call this method. Never doing so will result in readers invoking
-     * {@link EventStreamReader#getMostRecentWatermark()} receiving a null.
+     * {@link EventStreamReader#getCurrentTimeWindow()} receiving a null for both upper and lower times.
      * 
      * Calling this method can be automated by setting
      * {@link EventWriterConfigBuilder#automaticallyNoteTime(boolean)} to true when creating a
@@ -80,10 +80,10 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
 
     /**
      * Start a new transaction on this stream. This allows events written to the transaction be written an committed atomically.
-     * Note that transactions can only be open for {@link EventWriterConfig#getTransactionTimeoutTime()}.
+     * Note that transactions can only be open for {@link StreamConfiguration#getTimestampAggregationTimeout()}.
      * 
      * @return A transaction through which multiple events can be written atomically.
-     * @deprecated Use {@link ClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
+     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
      */
     @Deprecated
     Transaction<Type> beginTxn();
@@ -93,7 +93,7 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
      * 
      * @param transactionId The result retained from calling {@link Transaction#getTxnId()}
      * @return Transaction object with given UUID
-     * @deprecated Use {@link ClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
+     * @deprecated Use {@link EventStreamClientFactory#createTransactionalEventWriter(String, Serializer, EventWriterConfig)} instead
      */
     @Deprecated
     Transaction<Type> getTxn(UUID transactionId);

--- a/client/src/main/java/io/pravega/client/stream/TimeWindow.java
+++ b/client/src/main/java/io/pravega/client/stream/TimeWindow.java
@@ -33,13 +33,15 @@ public class TimeWindow {
     
     /**
      * Returns true if the reader is currently near the tail of the stream and therefore no upper time bound can be obtained.
+     * @return if a upper bound is unavailable.
      */
     public boolean isNearTailOfStream() {
         return upperTimeBound == null;
     }
     
     /**
-     * Returns true if the reader is currently near the head of the stream and therefor no lower time bound can be obtained.
+     * Returns true if the reader is currently near the head of the stream and therefore no lower time bound can be obtained.
+     * @return if a lower bound is unavailable. 
      */
     public boolean isNearHeadOfStream() {
         return lowerTimeBound == null;

--- a/client/src/main/java/io/pravega/client/stream/impl/WriterPosition.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/WriterPosition.java
@@ -13,12 +13,14 @@ import io.pravega.client.segment.impl.Segment;
 import java.util.Collections;
 import java.util.Map;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Builder
 @RequiredArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class WriterPosition {
 
     private final Map<Segment, Long> segments;

--- a/test/testcommon/src/main/java/io/pravega/test/common/CollectingExecutor.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/CollectingExecutor.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.Data;
+
+/**
+ * A mock of an executor service that does not execute tasks but instead collects them in memory.
+ */
+public class CollectingExecutor implements ScheduledExecutorService {
+
+    private final List<Runnable> tasks = Collections.synchronizedList(new ArrayList<>());
+    
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return null;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return true;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return true;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return true;
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(Callable<T> task) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        tasks.add(() -> {
+            try {
+                future.complete(task.call());
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(Runnable task, T result) {
+        return submit(() -> {
+            task.run();
+            return result;
+        });
+    }
+
+    @Override
+    public CompletableFuture<?> submit(Runnable task) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        tasks.add(() -> {
+            try {
+                task.run();
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        List<Future<T>> result = new ArrayList<>(tasks.size());
+        for (Callable<T> task : tasks) {
+            result.add(submit(task));
+        }
+        return result;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return invokeAll(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        for (Callable<T> task : tasks) {
+            try {
+                return task.call();
+            } catch (Exception e) {
+                continue;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return invokeAny(tasks);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        tasks.add(command);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        CompletableFuture<?> future = submit(command);
+        return new NonScheduledFuture<>(future, TimeUnit.MILLISECONDS.convert(delay, unit));
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        CompletableFuture<V> future = submit(callable);
+        return new NonScheduledFuture<>(future, TimeUnit.MILLISECONDS.convert(delay, unit));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        CompletableFuture<?> future = submit(command);
+        return new NonScheduledFuture<>(future, TimeUnit.MILLISECONDS.convert(initialDelay, unit));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        CompletableFuture<?> future = submit(command);
+        return new NonScheduledFuture<>(future, TimeUnit.MILLISECONDS.convert(initialDelay, unit));
+    }
+
+    public List<Runnable> getScheduledTasks() { 
+        return Collections.unmodifiableList(tasks);
+    }
+    
+    @Data
+    private class NonScheduledFuture<T> implements ScheduledFuture<T> {
+        private final CompletableFuture<T> wrappedFuture;
+        private final long delay;
+        
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(delay, TimeUnit.MILLISECONDS);
+        }
+        
+        @Override
+        public int compareTo(Delayed o) {
+            return Long.compare(delay, o.getDelay(TimeUnit.MILLISECONDS));
+        }
+        
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return wrappedFuture.cancel(mayInterruptIfRunning);
+        }
+        
+        @Override
+        public boolean isCancelled() {
+            return wrappedFuture.isCancelled();
+        }
+        
+        @Override
+        public boolean isDone() {
+            return wrappedFuture.isDone();
+        }
+        
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            return wrappedFuture.get();
+        }
+        
+        @Override
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return wrappedFuture.get(timeout, unit);
+        }
+    }
+    
+}


### PR DESCRIPTION
**Change log description**  
* Support automatically noting time
* Cleanup some watermarking related Javadocs

**Purpose of the change**  
Fixes #4217

**What the code does**  
If the user has configured automatic noting of time, the event reader runs a background task every 5 seconds to call the controller to note the time.
Note that this does not resolve: https://github.com/pravega/pravega/issues/4218 which is being put off until the next release.

