### PR TITLE
Issue 4222: In ControllerImpl transaction.commit should also send writer id to controller

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -947,6 +947,7 @@ public class ControllerImpl implements Controller {
             TxnRequest.Builder txnRequest = TxnRequest.newBuilder()
                                                       .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
                                                                                                   stream.getStreamName()))
+                                                      .setWriterId(writerId)
                                                       .setTxnId(ModelHelper.decode(txId));
             if (timestamp != null) {
                 txnRequest.setTimestamp(timestamp);


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Controller client is not using the writerId while calling commit grpc to controller. 

**Purpose of the change**  
Fixes #4222

**What the code does**  
Fixes issue where controller client does not send writer id to controller. 

**How to verify it**  
Added integration test to test transaction watermarking scenario. 