### PR TITLE
Issue 4230: Fix flaky test DeleteSegmentOperationTests.

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/DeleteSegmentOperationTests.java
@@ -17,7 +17,7 @@ import java.util.Random;
 public class DeleteSegmentOperationTests extends OperationTestsBase<DeleteSegmentOperation> {
     @Override
     protected DeleteSegmentOperation createOperation(Random random) {
-        DeleteSegmentOperation result = new DeleteSegmentOperation(random.nextInt(1000));
+        DeleteSegmentOperation result = new DeleteSegmentOperation(1 + random.nextInt(1000)); // segmentId must not be zero.
         result.setStreamSegmentOffset(random.nextInt(1000));
         return result;
     }


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Make sure test does not generate invalid segmentId. Earlier the DeleteSegmentOperationTests created a DeleteSegmentOperation with a segment id between [0-1000). This generated invalid id 0, every once in a while.

**Purpose of the change**  
Fixes #4230 

**What the code does**  
Makes sure test does not generate invalid segmentId by selecting segment ids between [1-1001)

**How to verify it**  
Unit tests should continue to pass.
