### PR TITLE
Issue 4169: (SegmentStore) Fixed a concurrency issue with segment id assignment when it doesn't exist.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -243,17 +243,11 @@ public abstract class MetadataStore implements AutoCloseable {
         CompletableFuture<SegmentProperties> result;
         if (isValidSegmentId(streamSegmentId)) {
             // Looks like the Segment is active and we have it in our Metadata. Return the result from there.
-            SegmentMetadata sm = this.connector.containerMetadata.getStreamSegmentMetadata(streamSegmentId);
-            if (sm.isDeleted() || sm.isMerged()) {
-                result = Futures.failedFuture(new StreamSegmentNotExistsException(segmentName));
-            } else {
-                result = CompletableFuture.completedFuture(sm.getSnapshot());
-            }
+            result = getSegmentSnapshot(streamSegmentId, segmentName);
         } else {
             // The Segment is not yet active.
             // First, check to see if we have a pending assignment. If so, piggyback on that.
-            QueuedCallback<SegmentProperties> queuedCallback = checkConcurrentAssignment(segmentName,
-                    id -> CompletableFuture.completedFuture(this.connector.containerMetadata.getStreamSegmentMetadata(id).getSnapshot()));
+            QueuedCallback<SegmentProperties> queuedCallback = checkConcurrentAssignment(segmentName, id -> getSegmentSnapshot(id, segmentName));
 
             if (queuedCallback != null) {
                 result = queuedCallback.result;
@@ -265,6 +259,23 @@ public abstract class MetadataStore implements AutoCloseable {
         }
 
         return result;
+    }
+
+    /**
+     * Creates a new {@link SegmentProperties} instance representing the current state of the given segment in the metadata.
+     *
+     * @param segmentId   The Id of the Segment.
+     * @param segmentName The Name of the Segment.
+     * @return A CompletableFuture that either contains a {@link SegmentProperties} with the current state of the segment
+     * or is failed with {@link StreamSegmentNotExistsException} if the Segment does not exist anymore.
+     */
+    private CompletableFuture<SegmentProperties> getSegmentSnapshot(long segmentId, String segmentName) {
+        SegmentMetadata sm = this.connector.containerMetadata.getStreamSegmentMetadata(segmentId);
+        if (sm == null || sm.isDeleted() || sm.isMerged()) {
+            return Futures.failedFuture(new StreamSegmentNotExistsException(segmentName));
+        } else {
+            return CompletableFuture.completedFuture(sm.getSnapshot());
+        }
     }
 
     /**
@@ -458,7 +469,7 @@ public abstract class MetadataStore implements AutoCloseable {
      */
     private long completeAssignment(String streamSegmentName, long streamSegmentId) {
         assert streamSegmentId != ContainerMetadata.NO_STREAM_SEGMENT_ID : "no valid streamSegmentId given";
-        finishPendingRequests(streamSegmentName, PendingRequest::complete, streamSegmentId);
+        finishPendingRequests(streamSegmentName, PendingRequest::complete, streamSegmentId, true);
         return streamSegmentId;
     }
 
@@ -466,10 +477,10 @@ public abstract class MetadataStore implements AutoCloseable {
      * Fails the assignment for the given StreamSegment Id with the given reason.
      */
     private void failAssignment(String streamSegmentName, Throwable reason) {
-        finishPendingRequests(streamSegmentName, PendingRequest::completeExceptionally, reason);
+        finishPendingRequests(streamSegmentName, PendingRequest::completeExceptionally, reason, true);
     }
 
-    private <T> void finishPendingRequests(String streamSegmentName, BiConsumer<PendingRequest, T> completionMethod, T completionArgument) {
+    private <T> void finishPendingRequests(String streamSegmentName, BiConsumer<PendingRequest, T> completionMethod, T completionArgument, boolean isSuccess) {
         assert streamSegmentName != null : "no streamSegmentName given";
         // Get any pending requests and complete all of them, in order. We are running this in a loop (and replacing
         // the existing PendingRequest with an empty one) because more requests may come in while we are executing the
@@ -482,12 +493,19 @@ public abstract class MetadataStore implements AutoCloseable {
                 if (pendingRequest == null || pendingRequest.callbacks.size() == 0) {
                     // No more requests. Safe to exit.
                     break;
-                } else {
+                } else if (isSuccess) {
                     this.pendingRequests.put(streamSegmentName, new PendingRequest());
                 }
             }
 
             completionMethod.accept(pendingRequest, completionArgument);
+            if (!isSuccess) {
+                // If failed, we do not guarantee ordering (as it doesn't make any sense). This helps solve a situation
+                // where an inexistent segment is queried, then immediately created and then queried again. If we do not
+                // break here, it is possible that the first rejection (since it doesn't exist) may incorrectly spill over
+                // to the second attempt when the segment actually exists.
+                break;
+            }
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -477,7 +477,7 @@ public abstract class MetadataStore implements AutoCloseable {
      * Fails the assignment for the given StreamSegment Id with the given reason.
      */
     private void failAssignment(String streamSegmentName, Throwable reason) {
-        finishPendingRequests(streamSegmentName, PendingRequest::completeExceptionally, reason, true);
+        finishPendingRequests(streamSegmentName, PendingRequest::completeExceptionally, reason, false);
     }
 
     private <T> void finishPendingRequests(String streamSegmentName, BiConsumer<PendingRequest, T> completionMethod, T completionArgument, boolean isSuccess) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -584,6 +584,37 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the following scenario, which is typical of how the Controller bootstraps its metadata in the Segment Store:
+     * 0. Metadata segment does not currently exist.
+     * 1. Metadata segment is queried (StreamSegmentNotExists is returned).
+     * 2. Metadata segment is immediately created.
+     * 3. Metadata segment is queried again (in which case it should be returned normally).
+     */
+    @Test
+    public void testCreateSegmentAfterFailedAssignment() {
+        final String segmentName = "Segment";
+
+        @Cleanup
+        TestContext context = createTestContext();
+
+        // 1. Query for an inexistent segment, and pass a completion callback that is not yet completed.
+        val f1 = new CompletableFuture<Void>();
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expecting assignment to be rejected.",
+                () -> context.getMetadataStore().getOrAssignSegmentId(segmentName, TIMEOUT, id -> f1),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        // 2. Create the segment.
+        context.getMetadataStore().createSegment(segmentName, null, TIMEOUT).join();
+
+        // 3. Issue the second assignment. This should not fail.
+        context.getMetadataStore().getOrAssignSegmentId(segmentName, TIMEOUT).join();
+
+        // Finally, complete the first callback - this should have no effect on anything above.
+        f1.complete(null);
+    }
+
+    /**
      * Tests the ability of the MetadataStore to cancel pending assignment requests when {@link MetadataStore#close} is
      * invoked.
      */


### PR DESCRIPTION
**Change log description**  
- Fixed a "bug" in `MetadataStore.getOrAssignStreamSegmentId` where repeated, continuous invocations on the same segment would incorrectly report it as inexistent even after it gets created.

**Purpose of the change**  
Fixes #4169.

**What the code does**  
Fixes the following scenario, which is induced by how the Controller is bootstrapping its metadata.
0. The segment does not currently exist.
1. The segment is queried (and `MetadataStore.getOrAssignStreamSegmentId` returns StreamSegmentNotExistsException)
2. The segment is immediately created afterwards.
3. The segment is queried again (and `MetadataStore.getOrAssignStreamSegmentId` should return its id).

The problem is that `MetadataStore.getOrAssignStreamSegmentId` needs to guarantee call ordering while not issuing multiple calls to the metadata store even if we get concurrent requests for this segment. This means that concurrent requests for the same segment id must be queued (in the order in which they were received), but also queued correctly if a new request arrives immediately after we completed the initial request but while executing currently registered callbacks.

On slow systems, like Travis CI, the upstream code is immediately notified of failure at step 1 (see above) but the cleanup portion is still ongoing and if step 3 executes before it completes, it will just pick up the result from 1. This is OK if step 1 would have found the segment to exist, but since the segment has changed states in between, step 3 incorrectly inherited the result from 1. 

This "fix" breaks the ordering guarantee in cases of failure (such as when the segment does not exist) since in that case order is irrelevant. It still keeps the ordering for successful calls. Since we do not need to maintain such an order, there is no cleanup to do (after step 1) so there is no longer a risk of the result from that step to spillover to subsequent calls.

**How to verify it**  
The build must pass. If it doesn't pass, it must not fail with the symptoms described in #4169. Added unit test to verify this specific scenario.
