### PR TITLE
Issue 4238: StreamSeekTest.testStreamSeek fails sporadically because it attempts to create mark stream explicitly

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/WatermarkReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/WatermarkReaderImpl.java
@@ -35,7 +35,9 @@ import io.pravega.shared.watermarks.Watermark;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.Synchronized;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class WatermarkReaderImpl implements AutoCloseable {
 
     private final Stream stream;
@@ -64,6 +66,7 @@ public class WatermarkReaderImpl implements AutoCloseable {
             if (iter != null && iter.hasNext()) {
                 Entry<Revision, Watermark> next = iter.next();
                 location = next.getKey();
+                log.debug("fetch next mark found: {}", next.getValue());
                 return next.getValue();
             }
             if (location == null) {
@@ -73,8 +76,11 @@ public class WatermarkReaderImpl implements AutoCloseable {
             if (iter.hasNext()) {
                 Entry<Revision, Watermark> next = iter.next();
                 location = next.getKey();
+                log.debug("fetch next mark found: {}", next.getValue());
+
                 return next.getValue();
             }
+            log.debug("fetch next mark found nothing");
             return null;
         }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamSeekTest.java
@@ -32,7 +32,6 @@ import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
-import io.pravega.shared.NameUtils;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
@@ -49,7 +48,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.Cleanup;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
@@ -224,9 +222,6 @@ public class StreamSeekTest {
         StreamConfiguration config = StreamConfiguration.builder()
                                                         .scalingPolicy(ScalingPolicy.fixed(1))
                                                         .build();
-        val f1 = controller.createStream(SCOPE, streamName, config);
-        val f2 = controller.createStream(SCOPE, NameUtils.getMarkStreamForStream(streamName), config);
-        f1.get();
-        f2.get();
+        controller.createStream(SCOPE, streamName, config).join();
     }
 }


### PR DESCRIPTION
**Change log description**  
Fixes the test to not create mark stream, which it should never do explicitly.

**Purpose of the change**  
Fixes #4238 

**What the code does**  
I have explained the problem here: https://github.com/pravega/pravega/issues/4238#issuecomment-537776959
The fix it to not create mark stream using the local controller explicitly by the test which will race with creation of original stream and its corresponding mark stream and hence cause BadKeyVersion errors. 

**How to verify it**  
The test should pass consistently