### PR TITLE
Issue 4256: bring back the ignored test with openJDK 8

### DIFF
--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -54,6 +54,9 @@ public class MetricsTagsTest {
         //Scenario 2: system property not defined, env var is defined - env var is taken
         String envVarDefined = System.getenv().keySet().iterator().next();
         originalProperty = System.getProperty(envVarDefined);
+
+        assertEquals("which env var popped up first?", originalProperty);
+
         System.clearProperty(envVarDefined);
         assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);
         if (!Strings.isNullOrEmpty(originalProperty)) {

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.net.InetAddress;
+import java.util.Iterator;
 
 import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
 import static io.pravega.shared.MetricsTags.containerTag;
@@ -51,16 +52,25 @@ public class MetricsTagsTest {
             System.setProperty(DEFAULT_HOSTNAME_KEY, originalProperty);
         }
 
-        //Scenario 2: system property not defined, env var is defined - env var is taken
-        String envVarDefined = System.getenv().keySet().iterator().next();
-        originalProperty = System.getProperty(envVarDefined);
-
-        assertEquals("The value of env var TRAVIS_TAG", System.getenv("TRAVIS_TAG"));
-
-        System.clearProperty(envVarDefined);
-        assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);
-        if (!Strings.isNullOrEmpty(originalProperty)) {
-            System.setProperty(envVarDefined, originalProperty);
+        //Scenario 2: environment var is defined, and system property not defined - env var is taken
+        String envVarDefined = null;
+        //go through the list to find the env var with non empty/null value
+        Iterator<String> envIterator = System.getenv().keySet().iterator();
+        while (envIterator.hasNext()) {
+            String envVarName = envIterator.next();
+            if (!Strings.isNullOrEmpty(System.getenv(envVarName))) {
+                envVarDefined = envVarName;
+                break;
+            }
+        }
+        //test scenario 2 only if there is env var with non empty/null value; otherwise skip scenario 2
+        if (envVarDefined != null) {
+            originalProperty = System.getProperty(envVarDefined);
+            System.clearProperty(envVarDefined);
+            assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);
+            if (!Strings.isNullOrEmpty(originalProperty)) {
+                System.setProperty(envVarDefined, originalProperty);
+            }
         }
 
         //Scenario 3: system property not defined, env var not defined - localhost config is taken

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -55,9 +55,7 @@ public class MetricsTagsTest {
         //Scenario 2: environment var is defined, and system property not defined - env var is taken
         String envVarDefined = null;
         //go through the list to find the env var with non empty/null value
-        Iterator<String> envIterator = System.getenv().keySet().iterator();
-        while (envIterator.hasNext()) {
-            String envVarName = envIterator.next();
+        for (String envVarName: System.getenv().keySet()) {
             if (!Strings.isNullOrEmpty(System.getenv(envVarName))) {
                 envVarDefined = envVarName;
                 break;

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.net.InetAddress;
-import java.util.Iterator;
 
 import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
 import static io.pravega.shared.MetricsTags.containerTag;

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -55,7 +55,7 @@ public class MetricsTagsTest {
         String envVarDefined = System.getenv().keySet().iterator().next();
         originalProperty = System.getProperty(envVarDefined);
 
-        assertEquals("which env var popped up first?", originalProperty);
+        assertEquals("which env var popped up first?", envVarDefined);
 
         System.clearProperty(envVarDefined);
         assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -11,7 +11,6 @@ package io.pravega.shared;
 
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -43,7 +42,6 @@ public class MetricsTagsTest {
     }
 
     @Test
-    @Ignore // TODO: FIX THIS.
     public void testCreateHostTag() throws Exception {
         //Scenario 1: system property is defined - property is taken
         String originalProperty = System.getProperty(DEFAULT_HOSTNAME_KEY);

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -55,7 +55,7 @@ public class MetricsTagsTest {
         String envVarDefined = System.getenv().keySet().iterator().next();
         originalProperty = System.getProperty(envVarDefined);
 
-        assertEquals("which env var popped up first?", envVarDefined);
+        assertEquals("The value of env var TRAVIS_TAG", System.getenv("TRAVIS_TAG"));
 
         System.clearProperty(envVarDefined);
         assertEquals(System.getenv(envVarDefined), createHostTag(envVarDefined)[1]);


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
(2-3 concise points about the changes in this PR. When committing this PR, the committer is expected to copy the content of this section to the merge description box)
. Un-ignore MetricsTagsTest:testCreateHostTag which was failing due to switching from OracleJDK to openJDK 8.
. No further change yet as local test with openJDK is working.

**Purpose of the change**  
Fixes #4256 

**What the code does**  
Un-ignore MetricsTagsTest:testCreateHostTag which was failing due to switching from OracleJDK to openJDK 8

**How to verify it**  
All unit tests should pass.