### PR TITLE
Issue 4258: Fix Lombok related warnings during javadoc generation and spotbug check.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import com.github.spotbugs.SpotBugsTask
 import org.gradle.internal.jvm.Jvm
 
 /**
@@ -95,11 +96,12 @@ allprojects {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
     }
-    tasks.withType(com.github.spotbugs.SpotBugsTask) {
-      reports {
-        xml.enabled = false
-        html.enabled = true
-      }
+    tasks.withType(SpotBugsTask) {
+        classpath += sourceSets."${(it.name - ~/^spotbugs/).uncapitalize()}".compileClasspath
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
     }
     version = getProjectVersion()
     group = "io.pravega"

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -38,8 +38,9 @@ plugins.withId('java') {
     artifacts { archives sourceJar }
 
     task generateJavadoc(type: Javadoc) {
-        source = sourceSets.main.allJava
-        classpath = sourceSets.main.runtimeClasspath
+        dependsOn delombok
+        source = delombok.outputDir
+        classpath = sourceSets.main.compileClasspath
         failOnError = false
     }
     task javadocJar(type: Jar) {


### PR DESCRIPTION
**Change log description**  

- The custom gradle task `generateJavadoc` now depends on `delombok` task.
-  `lombok.Lombok` class missing related warnings are not generated by the SpotBugs check.

**Purpose of the change**  
Fixes #4258 

**What the code does**  
No changes to functionality. 
This PR ensures  the following:
- Custom gradle task `generateJavadoc` also depends on `delombok` task similar to the javadoc task.
- `lombok.Lombok` classes are missing warnings are not generated by the SpotBugs check.

**How to verify it**  
All the tests should pass and Lombok missing warnings should not be generated.
