### PR TITLE
Issue 4263: Ensure Epoll transport is used by Pravega client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,9 @@ project('client') {
         compile project(':shared:authplugin')
         compile project(':shared:protocol')
         compile project(":shared:controller-api")
-        compile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion
+        // Ensure epoll native transport is used for linux-x86_64 architecture systems.
+        // The client fallsback to NIO based transport if epoll is not available.
+        compile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion


### PR DESCRIPTION
**Change log description**  
Ensure ePoll native transport is used by Pravega client on linux_x86_64.  

**Purpose of the change**  
Fixes #4263

**What the code does**  
The Pravega client already has a dependency on `netty-transport-native-epoll`, which provides platform-specific transports i.e the jar already contains the shared library files. Also, the client dynamically switches back to NIO if EPOLL transport is not available. 
The PR ensures the `classifier ` is set `x86_64` to ensure epoll is used on linux based x86_64 systems.

**How to verify it**  
All the tests should continue to pass. Inspect the pravega-client logs to ensure ePoll is infact used.
e.g: log snippets
```
2019-10-10 01:50:21,812 2273 [epollEventLoopGroup-4-1] INFO  i.p.s.p.netty.FailingReplyProcessor - Received hello: WireCommands.Hello(type=HELLO, highVersion=8, lowVersion=5)

```
