### PR TITLE
Issue 4267: (SegmentStore) Made StorageWriter Tier 1 Truncation Async

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -18,6 +18,7 @@ import io.pravega.common.ObjectClosedException;
 import io.pravega.common.Timer;
 import io.pravega.common.concurrent.AbstractThreadPoolService;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.common.concurrent.SequentialProcessor;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentOperation;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
@@ -60,6 +61,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     private final Timer timer;
     private final AckCalculator ackCalculator;
     private final WriterFactory.CreateProcessors createProcessors;
+    private final SequentialProcessor ackProcessor;
 
     //endregion
 
@@ -88,6 +90,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
         this.state = new WriterState();
         this.timer = new Timer();
         this.ackCalculator = new AckCalculator(this.state);
+        this.ackProcessor = new SequentialProcessor(this.executor);
     }
 
     //endregion
@@ -115,7 +118,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
                         .thenComposeAsync(this::readData, this.executor)
                         .thenComposeAsync(this::processReadResult, this.executor)
                         .thenComposeAsync(this::flush, this.executor)
-                        .thenComposeAsync(this::acknowledge, this.executor)
+                        .thenRunAsync(this::triggerAcknowledge, this.executor)
                         .exceptionally(this::iterationErrorHandler)
                         .thenRunAsync(this::endIteration, this.executor),
                 this.executor)
@@ -164,6 +167,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     private void closeProcessors() {
         this.processors.values().forEach(ProcessorCollection::close);
         this.processors.clear();
+        this.ackProcessor.close();
     }
 
     //endregion
@@ -345,25 +349,35 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     /**
      * Acknowledges operations that were flushed to storage
      */
-    private CompletableFuture<Void> acknowledge(Void ignored) {
+    private void triggerAcknowledge() {
         checkRunning();
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "acknowledge");
-
         long highestCommittedSeqNo = this.ackCalculator.getHighestCommittedSequenceNumber(this.processors.values());
         long ackSequenceNumber = this.dataSource.getClosestValidTruncationPoint(highestCommittedSeqNo);
+
         if (ackSequenceNumber > this.state.getLastTruncatedSequenceNumber()) {
-            // Issue the truncation and update the state (when done).
-            return this.dataSource
-                    .acknowledge(ackSequenceNumber, this.config.getAckTimeout())
-                    .thenRun(() -> {
-                        this.state.setLastTruncatedSequenceNumber(ackSequenceNumber);
-                        logStageEvent("Acknowledged", "SeqNo=" + ackSequenceNumber);
-                        LoggerHelpers.traceLeave(log, this.traceObjectId, "acknowledge", traceId, ackSequenceNumber);
-                    });
+            this.ackProcessor.add(() -> {
+                // If the StorageWriter completes an iteration faster than the data source can process the acknowledgment,
+                // then the State's LastTruncatedSequenceNumber may not be updated in time and we can re-queue the same
+                // truncation multiple times, which is undesirable. However, the ackProcessor serializes all invocations
+                // to its add() method so at this point we are guaranteed to have completed the callback below that updates
+                // that value.
+                if (ackSequenceNumber <= this.state.getLastTruncatedSequenceNumber()) {
+                    return CompletableFuture.completedFuture(null);
+                }
+
+                // Issue the truncation and update the state (when done).
+                return this.dataSource
+                        .acknowledge(ackSequenceNumber, this.config.getAckTimeout())
+                        .thenRun(() -> {
+                            this.state.setLastTruncatedSequenceNumber(ackSequenceNumber);
+                            logStageEvent("Acknowledged", "SeqNo=" + ackSequenceNumber);
+                            LoggerHelpers.traceLeave(log, this.traceObjectId, "acknowledge", traceId, ackSequenceNumber);
+                        });
+            }).exceptionally(this::iterationErrorHandler);
         } else {
             // Nothing to do.
             LoggerHelpers.traceLeave(log, this.traceObjectId, "acknowledge", traceId, Operation.NO_SEQUENCE_NUMBER);
-            return CompletableFuture.completedFuture(null);
         }
     }
 


### PR DESCRIPTION
**Change log description**  
- The StorageWriter no longer waits for Tier 1 ack/truncation to complete before moving on.

**Purpose of the change**  
Fixes #4267. 

**What the code does**  
See #4267 for the problem this is trying to fix.
- By making Tier 1 ack/truncation async, the StorageWriter is no longer subject to any Tier 1 throttling delays and is free to continue moving data to Tier 2, which will make more cache entries eligible for eviction, and thus unblock throttling.
- However the Tier 1 ack must be executed sequentially (we don't want two or more acks to overlap) since they check and update local state. Having the possibility of concurrent execution would potentially cause unwanted side effects or false errors (such as "already truncated at this point).

**How to verify it**  
All unit tests and system tests must pass. No new tests are needed since functionality hasn't changed and existing tests do verify that ack-ing/truncation is performed.
