### PR TITLE
Issue 4249: Ensure UpdateDistanceToTail updates ReaderGroupState only if lastReadPosition exists.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -863,8 +863,10 @@ public class ReaderGroupState implements Revisioned {
         @Override
         void update(ReaderGroupState state) {
             state.distanceToTail.put(readerId, Math.max(ASSUMED_LAG_MILLIS, distanceToTail));
-            for (Entry<SegmentWithRange, Long> entry : lastReadPositions.entrySet()) {
-                state.lastReadPosition.replace(entry.getKey(), entry.getValue());
+            if (lastReadPositions != null) { // if state was serialized via the revision 0 then lastReadPositions will be null.
+                for (Entry<SegmentWithRange, Long> entry : lastReadPositions.entrySet()) {
+                    state.lastReadPosition.replace(entry.getKey(), entry.getValue());
+                }
             }
         }
         


### PR DESCRIPTION
**Change log description**  
Ensure `UpdateDistanceToTail` updates `ReaderGroupState` only if `lastReadPosition` exists.

**Purpose of the change**  
Fixes #4249 

**What the code does**  
During an upgrade, it was observed that `ReaderGroupState.UpdateDistanceToTail#update` method was attempting to update `lastReadPosition` even though `lastReadPositions` value after deserialization returned a null. This PR fixes this issue. 

**How to verify it**  
All the existing and newly added tests should pass.
