### PR TITLE
Issue 3777: Fixed Auth enabled AutoScale Test

### DIFF
--- a/test/system/src/test/resources/pravega_withAuth.properties
+++ b/test/system/src/test/resources/pravega_withAuth.properties
@@ -20,3 +20,5 @@ controller.auth.userPasswordFile=/opt/pravega/conf/passwd
 controller.auth.tokenSigningKey=secret
 autoScale.authEnabled=true
 autoScale.tokenSigningKey=secret
+pravega.client.auth.token=YWRtaW46MTExMV9hYWFh
+pravega.client.auth.method=Basic


### PR DESCRIPTION
**Change log description**  
Auto scale system test was failing when authentication was enabled this was happening because the token and method that autoscale processor uses to communicate with the controller were not specified.

**Purpose of the change**  
fixes #3777 

**What the code does**  
It specifies both the token and the method for the autoscale processor to use for authentication with the controller

**How to verify it**  
Run the AutoScale test with Auth Enabled
