### PR TITLE
Issue 4291: txn.commit without time should default to Long.Min instead of 0

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -951,6 +951,8 @@ public class ControllerImpl implements Controller {
                                                       .setTxnId(ModelHelper.decode(txId));
             if (timestamp != null) {
                 txnRequest.setTimestamp(timestamp);
+            } else {
+                txnRequest.setTimestamp(Long.MIN_VALUE);
             }
             client.commitTransaction(txnRequest.build(), callback);
             return callback.getFuture();


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Send Long.MIN instead of 0 as default value if txn.commit does not supply time. 

**Purpose of the change**  
Fixes #4291 

**What the code does**  
Transaction writers have two apis for committing - commit() and commit(time).
If first is called, it currently does not set the time in the TxnRequestBuilder which results in Long.default value to be serialized by protobuf whereby sending 0L as the time.

The controller records this time as writer's mark because it checks for greater than equal to 0.
This results in an unnecessary watermark being emitted which is completely avoidable.

**How to verify it**  
Unit test added
