### PR TITLE
Issue 4310: Change Pravega version in master to 0.7.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.6.0-SNAPSHOT
+pravegaVersion=0.7.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Updates Pravega version in master to 0.7.0-SNAPSHOT

**Purpose of the change**  
Fixes #4310 

**What the code does**  
 There is no code change. It updates the Pravega version in gradle.properties.

**How to verify it**  
 ./gradlew install should produce the correct version.
