### PR TITLE
Issue 4312: Change pravega version to 0.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.6.0-SNAPSHOT
+pravegaVersion=0.6.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
    Removes -SNAPSHOT suffix from Pravega version in gradle.properties in preparation to release 0.6.0.

**Purpose of the change**  
Fixes #4312 

**What the code does**  
There is no code change, only a change to the Pravega version in gradle.properties.

**How to verify it**  
Build should succeed regularly and artifacts should not contain the commit id suffix.
