### PR TITLE
Non-blocking event writing, limit the pending events count

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ClientConnection.java
@@ -47,6 +47,13 @@ public interface ClientConnection extends AutoCloseable {
     void sendAsync(WireCommand cmd, CompletedCallback callback);
 
     /**
+     Sends the provided append request.
+     @param append The append command to send.
+     @param callback A callback to be invoked when the operation is complete
+     */
+    void sendAsync(Append append, CompletedCallback callback);
+
+    /**
      * Sends the provided append commands.
      *
      * @param appends A list of append command to send.

--- a/client/src/main/java/io/pravega/client/segment/impl/LimitedConcurrentSkipListMap.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/LimitedConcurrentSkipListMap.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.segment.impl;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Semaphore;
+
+public class LimitedConcurrentSkipListMap<K, V>
+extends ConcurrentSkipListMap<K, V>
+implements LimitedNavigableMap<K, V> {
+
+	private final int sizeLimit;
+	private final Semaphore insertPermits;
+
+	public LimitedConcurrentSkipListMap(final int sizeLimit) {
+		this.sizeLimit = sizeLimit;
+		this.insertPermits = new Semaphore(sizeLimit, true);
+	}
+
+	@Override
+	public final int size() {
+		return sizeLimit - insertPermits.availablePermits();
+	}
+
+	@Override
+	public final boolean isEmpty() {
+		return sizeLimit == insertPermits.availablePermits();
+	}
+
+	@Override
+	public final boolean putIfNotFull(final K k, final V v) {
+		if(insertPermits.tryAcquire()) {
+			super.put(k, v);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public final V remove(final Object o) {
+		insertPermits.release();
+		return super.remove(o);
+	}
+
+	@Override
+	public final boolean remove(final Object o, final Object o1) {
+		insertPermits.release();
+		return super.remove(o, o1);
+	}
+
+	@Override
+	public final void clear() {
+		insertPermits.release(sizeLimit);
+		super.clear();
+	}
+}

--- a/client/src/main/java/io/pravega/client/segment/impl/LimitedNavigableMap.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/LimitedNavigableMap.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.segment.impl;
+
+import java.util.NavigableMap;
+
+public interface LimitedNavigableMap<K, V>
+extends NavigableMap<K, V> {
+
+    /**
+     A method allowing to insert the entry conditionally (until the map meets the size limit)
+     @param k key
+     @param v value
+     @return true if the entry was inserted, false otherwise
+     */
+    boolean putIfNotFull(K k, V v);
+}

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStream.java
@@ -19,6 +19,8 @@ import java.util.List;
  */
 public interface SegmentOutputStream extends AutoCloseable {
 
+    int LIMIT_INFLIGHT = 100_000;
+
     /**
      * Returns the name of the segment associated to this output stream.
      *


### PR DESCRIPTION
Signed-off-by: Andrey Kurilov <andrey.kurilov@emc.com>

**Change log description**  

* Replace the blocking send call with the new sendAsync call in `io.pravega.client.segment.impl.SegmentOutputStreamImpl#write`
* Make inflight map limited by size (100K)


**Purpose of the change**  
Fixes #4304, #4305

**What the code does**  
* Allow the client to write events asynchronously
* Protect the client from OOM

**How to verify it**  
 The client performance is expected to become better.
