### PR TITLE
Issue 4319: Conflicting RocksDB config option in Windows (lib linkage problem)

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -274,7 +274,6 @@ class RocksDBCache implements Cache {
                 .setMaxBackgroundFlushes(INTERNAL_ROCKSDB_PARALLELISM / 2)
                 .setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)
                 .setCompactionStyle(CompactionStyle.LEVEL)
-                .optimizeLevelStyleCompaction()
                 .setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM)
                 .setLevelCompactionDynamicLevelBytes(true);
 


### PR DESCRIPTION
**Change log description**  
Remove RocksDB option that induces library linkage conflicts in Windows.

**Purpose of the change**  
Fixes #4319.

**What the code does**  
Removes a RocksDB config option that seems to induce a library linkage problem in Windows. All our tests in Linux-based OS did not show that problem.

**How to verify it**  
All tests should be passing as usual.
