### PR TITLE
Issue 4334: Add a message to a log statement to help identify it

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -557,7 +557,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         logAndUntrackRequestTag(requestTag);
                     });
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            log.error("Encountered exception in authenticateExecuteAndProcessResults: {}", e.getMessage(), e);
             logAndUntrackRequestTag(requestTag);
             streamObserver.onError(Status.UNAUTHENTICATED
                     .withDescription("Authentication failed")


### PR DESCRIPTION
**Change log description**  
Add a message to an exception log statement in the Controller, to make it easier to correlate it with auth-related exception logged on the client-side.

**Purpose of the change**  
Fixes #4334. 

**What the code does**  
Adds a message to a log entry.

**How to verify it**  
N/A.
