### PR TITLE
Issue 4334: Fix auth and related exception handling

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHandlerManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHandlerManager.java
@@ -119,7 +119,7 @@ public class AuthHandlerManager {
      *
      * @return Returns true if the entity represented by the credentials has given level of access to the resource.
      *      Returns false if the entity does not have access.
-     * @throws AuthException if an authentication failure occurred.
+     * @throws AuthException if an authentication or authorization failure occurred.
      */
     public boolean authorize(String resource, Principal principal, String credentials, AuthHandler.Permissions level) throws AuthException {
         Preconditions.checkNotNull(credentials, "credentials");

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHandlerManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/AuthHandlerManager.java
@@ -121,12 +121,14 @@ public class AuthHandlerManager {
      *      Returns false if the entity does not have access.
      * @throws AuthException if an authentication or authorization failure occurred.
      */
-    public boolean authorize(String resource, Principal principal, String credentials, AuthHandler.Permissions level) throws AuthException {
+    public boolean authorize(String resource, Principal principal, String credentials, AuthHandler.Permissions level)
+            throws AuthException {
         Preconditions.checkNotNull(credentials, "credentials");
-        String[] parts = extractMethodAndToken(credentials);
-        String method = parts[0];
+
+        String method = extractMethodAndToken(credentials)[0];
         AuthHandler handler = getHandler(method);
         Preconditions.checkNotNull( handler, "Can not find handler.");
+
         return handler.authorize(resource, principal).ordinal() >= level.ordinal();
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server.rpc.auth;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.pravega.auth.AuthHandler;
+import io.pravega.auth.AuthenticationException;
 import io.pravega.auth.AuthorizationException;
 import io.pravega.shared.security.token.JsonWebToken;
 
@@ -60,11 +61,11 @@ public class GrpcAuthHelper {
         if (isAuthorized(resource, expectedLevel, ctx)) {
             return "";
         } else {
-            if (ctx == null) {
-                log.warn("AuthContext is null");
+            if (ctx == null || ctx.getPrincipal() == null) {
+                throw new AuthenticationException("Could't extract Principal");
             }
             String message = String.format("Principal [%s] not allowed [%s] access for resource [%s]",
-                    ctx != null ? ctx.getPrincipal() : null, expectedLevel, resource);
+                    ctx.getPrincipal(), expectedLevel, resource);
             throw new AuthorizationException(message);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/GrpcAuthHelper.java
@@ -65,7 +65,7 @@ public class GrpcAuthHelper {
             }
             String message = String.format("Principal [%s] not allowed [%s] access for resource [%s]",
                     ctx != null ? ctx.getPrincipal() : null, expectedLevel, resource);
-            throw new RuntimeException(new AuthorizationException(message));
+            throw new AuthorizationException(message);
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/auth/RESTAuthHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/auth/RESTAuthHelper.java
@@ -106,8 +106,8 @@ public class RESTAuthHelper {
         if (isAuthEnabled()) {
             String credentials = parseCredentials(authHeader);
             if (!pravegaAuthManager.authenticateAndAuthorize(resource, credentials, permission)) {
-                throw new AuthException(
-                        String.format("Failed to authenticate or authorize for resource [%s]", resource),
+                throw new AuthorizationException(
+                        String.format("Failed to authorize for resource [%s]", resource),
                         Response.Status.FORBIDDEN.getStatusCode());
             }
         }

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -557,7 +557,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         logAndUntrackRequestTag(requestTag);
                     });
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            log.error("Encountered exception in authenticateExecuteAndProcessResults: {}", e.getMessage(), e);
             logAndUntrackRequestTag(requestTag);
             streamObserver.onError(Status.UNAUTHENTICATED
                     .withDescription("Authentication failed")

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -548,10 +548,12 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         if (ex != null) {
                             Throwable cause = Exceptions.unwrap(ex);
                             logError(requestTag, cause);
-                            String errorDescription = replyWithStackTraceOnError ? "controllerStackTrace=" + Throwables.getStackTraceAsString(ex) : cause.getMessage();
-                            streamObserver.onError(getStatusFromException(cause).withCause(cause)
-                                                                                .withDescription(errorDescription)
-                                                                                .asRuntimeException());
+                            String stackTrace = "controllerStackTrace=" + Throwables.getStackTraceAsString(ex);
+                            String errorDescription = replyWithStackTraceOnError ? stackTrace : cause.getMessage();
+                            streamObserver.onError(getStatusFromException(cause)
+                                    .withCause(cause)
+                                    .withDescription(errorDescription)
+                                    .asRuntimeException());
                         } else if (value != null) {
                             streamObserver.onNext(value);
                             streamObserver.onCompleted();
@@ -577,7 +579,6 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         log.error("Encountered {} in authenticateExecuteAndProcessResults", e.getClass().getSimpleName(), e);
         logAndUntrackRequestTag(requestTag);
         streamObserver.onError(status.withDescription(message).asRuntimeException());
-
     }
     
     @SuppressWarnings("checkstyle:ReturnCount")

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -550,8 +550,8 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                             logError(requestTag, cause);
                             String errorDescription = replyWithStackTraceOnError ? "controllerStackTrace=" + Throwables.getStackTraceAsString(ex) : cause.getMessage();
                             streamObserver.onError(getStatusFromException(cause).withCause(cause)
-                                    .withDescription(errorDescription)
-                                    .asRuntimeException());
+                                                                                .withDescription(errorDescription)
+                                                                                .asRuntimeException());
                         } else if (value != null) {
                             streamObserver.onNext(value);
                             streamObserver.onCompleted();

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -561,6 +561,8 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                         logAndUntrackRequestTag(requestTag);
                     });
         } catch (AuthenticationException e) {
+            // Empty credentials when Auth is enabled may lead to this exception here. When credentials are present in
+            // the client call but are incorrect, the client is returned the same status from AuthInterceptor.
             handleException(e, streamObserver, requestTag, Status.UNAUTHENTICATED, "Authentication failed");
         } catch (AuthorizationException e) {
             handleException(e, streamObserver, requestTag, Status.PERMISSION_DENIED, "Authorization failed");

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -456,6 +456,24 @@ public class ControllerGrpcAuthFocusedTest {
                 e -> e.getMessage().contains("PERMISSION_DENIED"));
     }
 
+    @Test
+    public void listStreamThrowsExceptionWhenUserIsNonExistent() {
+        // Arrange
+        createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
+                prepareFromFixedScaleTypePolicy(2));
+
+        ControllerServiceBlockingStub stub = prepareBlockingCallStub(UserNames.SCOPE2_READ, "wrong-password");
+        Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
+                .newBuilder().setScope(
+                        Controller.ScopeInfo.newBuilder().setScope("scope1").build())
+                .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
+
+        // Act and assert
+        AssertExtensions.assertThrows("Expected auth failure.",
+                () -> stub.listStreamsInScope(request),
+                e -> e.getMessage().contains("UNAUTHENTICATED"));
+    }
+
     //region Private methods
 
     private TxnId createTransaction(StreamInfo streamInfo, int lease) {

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -462,7 +462,7 @@ public class ControllerGrpcAuthFocusedTest {
         createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
                 prepareFromFixedScaleTypePolicy(2));
 
-        ControllerServiceBlockingStub stub = prepareBlockingCallStub(UserNames.SCOPE2_READ, "wrong-password");
+        ControllerServiceBlockingStub stub = prepareBlockingCallStubWithNoCredentials();
         Controller.StreamsInScopeRequest request = Controller.StreamsInScopeRequest
                 .newBuilder().setScope(
                         Controller.ScopeInfo.newBuilder().setScope("scope1").build())
@@ -501,6 +501,10 @@ public class ControllerGrpcAuthFocusedTest {
                 .setStreamInfo(StreamInfo.newBuilder().setScope(scope).setStream(stream).build())
                 .setSegmentId(segmentId)
                 .build();
+    }
+
+    private ControllerServiceBlockingStub prepareBlockingCallStubWithNoCredentials() {
+        return ControllerServiceGrpc.newBlockingStub(inProcessChannel);
     }
 
     private ControllerServiceBlockingStub prepareBlockingCallStub(String username, String password) {

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -93,6 +93,7 @@ import static io.pravega.controller.auth.AuthFileUtils.credentialsAndAclAsString
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -467,11 +468,13 @@ public class ControllerGrpcAuthFocusedTest {
                 .newBuilder().setScope(
                         Controller.ScopeInfo.newBuilder().setScope("scope1").build())
                 .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
-
-        // Act and assert
-        AssertExtensions.assertThrows("Expected auth failure.",
-                () -> stub.listStreamsInScope(request),
-                e -> e.getMessage().contains("UNAUTHENTICATED"));
+        try {
+            stub.listStreamsInScope(request);
+        } catch (RuntimeException e) {
+            if (!e.getMessage().contains("UNAUTHENTICATED")) {
+                fail("Expected auth failure.");
+            }
+        }
     }
 
     //region Private methods

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -93,7 +93,6 @@ import static io.pravega.controller.auth.AuthFileUtils.credentialsAndAclAsString
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -468,13 +467,11 @@ public class ControllerGrpcAuthFocusedTest {
                 .newBuilder().setScope(
                         Controller.ScopeInfo.newBuilder().setScope("scope1").build())
                 .setContinuationToken(Controller.ContinuationToken.newBuilder().build()).build();
-        try {
-            stub.listStreamsInScope(request);
-        } catch (RuntimeException e) {
-            if (!e.getMessage().contains("UNAUTHENTICATED")) {
-                fail("Expected auth failure.");
-            }
-        }
+
+        // Act and assert
+        AssertExtensions.assertThrows("Expected auth failure.",
+                () -> stub.listStreamsInScope(request),
+                e -> e.getMessage().contains("UNAUTHENTICATED"));
     }
 
     //region Private methods

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -236,7 +236,7 @@ public class ControllerGrpcAuthFocusedTest {
 
         //Verify
         thrown.expect(StatusRuntimeException.class);
-        thrown.expectMessage("UNAUTHENTICATED");
+        thrown.expectMessage("PERMISSION_DENIED");
 
         //Act
         blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
@@ -317,7 +317,7 @@ public class ControllerGrpcAuthFocusedTest {
         //Set the expected exception
         thrown.expect(StatusRuntimeException.class);
         //thrown.expectMessage();
-        thrown.expectMessage("UNAUTHENTICATED");
+        thrown.expectMessage("PERMISSION_DENIED");
 
         stub.isSegmentValid(segmentId(scope, stream, 0));
     }
@@ -352,7 +352,7 @@ public class ControllerGrpcAuthFocusedTest {
 
         //Set the expected exception
         thrown.expect(StatusRuntimeException.class);
-        thrown.expectMessage("UNAUTHENTICATED: Authentication failed");
+        thrown.expectMessage("PERMISSION_DENIED");
 
         PingTxnStatus status = stub.pingTransaction(Controller.PingTxnRequest.newBuilder()
                 .setStreamInfo(StreamInfo.newBuilder().setScope(scope).setStream(stream).build())
@@ -453,7 +453,7 @@ public class ControllerGrpcAuthFocusedTest {
         // Act and assert
         AssertExtensions.assertThrows("Expected auth failure.",
                 () -> stub.listStreamsInScope(request),
-                e -> e.getMessage().contains("UNAUTHENTICATED"));
+                e -> e.getMessage().contains("PERMISSION_DENIED"));
     }
 
     //region Private methods

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -274,7 +274,6 @@ class RocksDBCache implements Cache {
                 .setMaxBackgroundFlushes(INTERNAL_ROCKSDB_PARALLELISM / 2)
                 .setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)
                 .setCompactionStyle(CompactionStyle.LEVEL)
-                .optimizeLevelStyleCompaction()
                 .setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM)
                 .setLevelCompactionDynamicLevelBytes(true);
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/rocksdb/RocksDBCache.java
@@ -26,10 +26,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Env;
-import org.rocksdb.BloomFilter;
-import org.rocksdb.CompactionStyle;
-import org.rocksdb.IndexType;
-import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -251,10 +247,7 @@ class RocksDBCache implements Cache {
         BlockBasedTableConfig tableFormatConfig = new BlockBasedTableConfig()
                 .setBlockSize(cacheBlockSizeKB * 1024L)
                 .setBlockCacheSize(readCacheSizeMB * 1024L * 1024L)
-                .setBlockCache(new LRUCache(readCacheSizeMB * 1024L * 1024L, 4))
-                .setCacheIndexAndFilterBlocks(true)
-                .setIndexType(IndexType.kHashSearch)
-                .setFilter(new BloomFilter());
+                .setCacheIndexAndFilterBlocks(true);
 
         Options options = new Options()
                 .setCreateIfMissing(true)
@@ -269,13 +262,10 @@ class RocksDBCache implements Cache {
                 .setOptimizeFiltersForHits(true)
                 .setUseDirectReads(this.directReads)
                 .setSkipStatsUpdateOnDbOpen(true)
-                .optimizeForPointLookup(readCacheSizeMB * 1024L * 1024L)
                 .setIncreaseParallelism(INTERNAL_ROCKSDB_PARALLELISM)
                 .setMaxBackgroundFlushes(INTERNAL_ROCKSDB_PARALLELISM / 2)
                 .setMaxBackgroundJobs(INTERNAL_ROCKSDB_PARALLELISM)
-                .setCompactionStyle(CompactionStyle.LEVEL)
-                .setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM)
-                .setLevelCompactionDynamicLevelBytes(true);
+                .setMaxBackgroundCompactions(INTERNAL_ROCKSDB_PARALLELISM);
 
         if (this.memoryOnly) {
             Env env = new RocksMemEnv();

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthException.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthException.java
@@ -11,7 +11,7 @@ package io.pravega.auth;
 
 //Represents exceptions during authorization/authentication
 
-public class AuthException extends Exception {
+public abstract class AuthException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     private final int responseCode;
 

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientAuthTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientAuthTest.java
@@ -115,7 +115,7 @@ public class BatchClientAuthTest extends BatchClientTest {
 
         AssertExtensions.assertThrows("Auth exception did not occur.",
                 () -> this.listAndReadSegmentsUsingBatchClient("testScope", "testBatchStream", config),
-                e -> hasAuthExceptionAsRootCause(e));
+                e -> hasAuthorizationExceptionAsRootCause(e));
     }
 
     @Test(timeout = 250000)
@@ -127,7 +127,7 @@ public class BatchClientAuthTest extends BatchClientTest {
 
         AssertExtensions.assertThrows("Auth exception did not occur.",
                 () -> this.listAndReadSegmentsUsingBatchClient("testScope", "testBatchStream", config),
-                e -> hasAuthExceptionAsRootCause(e));
+                e -> hasAuthenticationExceptionAsRootCause(e));
     }
 
     @Test(timeout = 250000)
@@ -143,7 +143,7 @@ public class BatchClientAuthTest extends BatchClientTest {
 
             AssertExtensions.assertThrows("Auth exception did not occur.",
                     () -> this.listAndReadSegmentsUsingBatchClient("testScope", "testBatchStream", config),
-                    e -> hasAuthExceptionAsRootCause(e));
+                    e -> hasAuthorizationExceptionAsRootCause(e));
             unsetClientAuthProperties();
         } finally {
             sequential.unlock();
@@ -183,7 +183,17 @@ public class BatchClientAuthTest extends BatchClientTest {
         System.clearProperty("pravega.client.auth.token");
     }
 
-    private boolean hasAuthExceptionAsRootCause(Throwable e) {
+    private boolean hasAuthorizationExceptionAsRootCause(Throwable e) {
+        Throwable innermostException = ExceptionUtils.getRootCause(e);
+
+        // Depending on an exception message for determining whether the given exception represents auth failure
+        // is not a good thing to do, but we have no other choice here because auth failures are represented as the
+        // overly general io.grpc.StatusRuntimeException.
+        return innermostException instanceof StatusRuntimeException &&
+                innermostException.getMessage().toUpperCase().contains("PERMISSION_DENIED");
+    }
+
+    private boolean hasAuthenticationExceptionAsRootCause(Throwable e) {
         Throwable innermostException = ExceptionUtils.getRootCause(e);
 
         // Depending on an exception message for determining whether the given exception represents auth failure

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientAuthTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientAuthTest.java
@@ -115,7 +115,7 @@ public class BatchClientAuthTest extends BatchClientTest {
 
         AssertExtensions.assertThrows("Auth exception did not occur.",
                 () -> this.listAndReadSegmentsUsingBatchClient("testScope", "testBatchStream", config),
-                e -> hasAuthorizationExceptionAsRootCause(e));
+                e -> hasAuthenticationExceptionAsRootCause(e));
     }
 
     @Test(timeout = 250000)


### PR DESCRIPTION
**Change log description**  
Improve exception handling and logging in gRPC interface to distinguish clearly among these three error conditions: 

1. A condition representing an authentication failure
2. A condition representing an authorization failure
3. A condition representing an internal failure

This enables easier debugging of issues, as well as enables the client to handle these different conditions properly. For example, the client can retry upon encountering the 3rd failure, but avoid doing that for the 1st and the 2nd.

**Purpose of the change**  
Fixes #4334 & #3814. 

**What the code does**  
The code does the following: 
* Makes `AuthException` (the parent of both `AuthenticationException` and `AuthorizationException`) abstract, so that it cannot be thrown (but can be caught in the calling code). 
* Makes `AuthException` a runtime exception, so that the places where the subclasses are throws do not have to wrap them in a RuntimeException (like was done before). Doing this makes it possible to just catch these exceptions directly in the  `ControllerServiceImpl` and perform the necessary handling. 
* Modify a `ControllerServiceImpl` method to throw specific exceptions disambiguating the three error conditions.  

**How to verify it**  
All tests must pass. 
