### PR TITLE
Issue 4343: Change pravega version in r0.6 branch to 0.6.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.6.0
+pravegaVersion=0.6.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Change pravega version in r0.6 branch to 0.6.1-SNAPSHOT

**Purpose of the change**  
Fixes #4343 

**What the code does**  
Changes pravega version in gradle.properties

**How to verify it**  
All tests should pass