### PR TITLE
Issue 4349: Complete partially created scopes before throwing ScopeExists

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -214,8 +214,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
             if (ex == null) {
                 return CreateScopeStatus.newBuilder().setStatus(CreateScopeStatus.Status.SUCCESS).build();
             }
-            if (ex instanceof StoreException.DataExistsException ||
-                    Exceptions.unwrap(ex) instanceof StoreException.DataExistsException) {
+            if (Exceptions.unwrap(ex) instanceof StoreException.DataExistsException) {
                 return CreateScopeStatus.newBuilder().setStatus(CreateScopeStatus.Status.SCOPE_EXISTS).build();
             } else {
                 log.debug("Create scope failed due to ", ex);

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -215,7 +215,7 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
                 return CreateScopeStatus.newBuilder().setStatus(CreateScopeStatus.Status.SUCCESS).build();
             }
             if (ex instanceof StoreException.DataExistsException ||
-                    ex.getCause() instanceof StoreException.DataExistsException) {
+                    Exceptions.unwrap(ex) instanceof StoreException.DataExistsException) {
                 return CreateScopeStatus.newBuilder().setStatus(CreateScopeStatus.Status.SCOPE_EXISTS).build();
             } else {
                 log.debug("Create scope failed due to ", ex);

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
@@ -10,14 +10,20 @@
 package io.pravega.controller.store.stream;
 
 import com.google.common.collect.ImmutableMap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.common.util.BitConverter;
 import io.pravega.controller.mocks.SegmentHelperMock;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.rpc.auth.GrpcAuthHelper;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.CompletedTxnRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import org.apache.curator.framework.CuratorFramework;
@@ -29,11 +35,13 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -387,6 +395,49 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
         assertTrue(stale.isEmpty());
     }
 
+    @Test
+    public void testPartiallyCreatedScope() {
+        PravegaTablesStreamMetadataStore store = (PravegaTablesStreamMetadataStore) this.store;
+        PravegaTablesStoreHelper storeHelper = store.getStoreHelper();
+
+        String newScope = "newScope";
+        Controller.CreateScopeStatus status = store.createScope(newScope).join();
+        assertEquals(Controller.CreateScopeStatus.Status.SUCCESS, status.getStatus());
+
+        status = store.createScope(newScope).join();
+        assertEquals(Controller.CreateScopeStatus.Status.SCOPE_EXISTS, status.getStatus());
+
+        // now partially create a scope
+        String scopeName = "partial";
+        byte[] idBytes = new byte[2 * Long.BYTES];
+        UUID id = UUID.randomUUID();
+        BitConverter.writeUUID(idBytes, 0, id);
+
+        // add entry for a scope in scopes table 
+        storeHelper.addNewEntry(PravegaTablesStreamMetadataStore.SCOPES_TABLE, scopeName, idBytes).join();
+        
+        // verify that streams in scope table does not exist
+        PravegaTablesScope scope = (PravegaTablesScope) store.getScope(scopeName);
+        ByteBuf token = Unpooled.wrappedBuffer(Base64.getDecoder().decode(""));
+
+        Supplier<CompletableFuture<Map.Entry<ByteBuf, List<String>>>> tableCheckSupplier = 
+                () -> scope.getStreamsInScopeTableName()
+                           .thenCompose(tableName -> storeHelper.getKeysPaginated(tableName, token, 10));
+        AssertExtensions.assertFutureThrows("Table should not exist", tableCheckSupplier.get(), 
+                e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
+        
+        status = store.createScope(scopeName).join();
+        assertEquals(Controller.CreateScopeStatus.Status.SCOPE_EXISTS, status.getStatus());
+        
+        // verify that table is created. 
+        assertTrue(Futures.await(tableCheckSupplier.get()));
+        
+        // create scope idempotent
+        status = store.createScope(scopeName).join();
+        assertEquals(Controller.CreateScopeStatus.Status.SCOPE_EXISTS, status.getStatus());
+
+    }
+    
     private Set<Integer> getAllBatches(PravegaTablesStreamMetadataStore testStore) {
         Set<Integer> batches = new ConcurrentSkipListSet<>();
         testStore.getStoreHelper().getAllKeys(COMPLETED_TRANSACTIONS_BATCHES_TABLE)

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
@@ -52,8 +52,12 @@ import static io.pravega.controller.store.stream.PravegaTablesStreamMetadataStor
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Zookeeper based stream metadata store tests.
@@ -436,6 +440,13 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
         status = store.createScope(scopeName).join();
         assertEquals(Controller.CreateScopeStatus.Status.SCOPE_EXISTS, status.getStatus());
 
+        PravegaTablesStoreHelper spy = spy(storeHelper);
+        PravegaTablesScope scopeObj = new PravegaTablesScope("thirdScope", spy);
+        StoreException unknown = StoreException.create(StoreException.Type.UNKNOWN, "unknown");
+        doReturn(Futures.failedFuture(unknown)).when(spy).addNewEntry(anyString(), anyString(), any());
+        AssertExtensions.assertFutureThrows("Create scope should have thrown exception",
+                scopeObj.createScope(), 
+                e -> Exceptions.unwrap(e).equals(unknown));
     }
     
     private Set<Integer> getAllBatches(PravegaTablesStreamMetadataStore testStore) {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Complete creation of partially created scopes on pravega tables. 

**Purpose of the change**  
Fixes #4349 

**What the code does**  
On Pravega tables, scope creation has two steps -
1. add new `scope` to scopes table with a unique id
2. create streamsInScope table for the new scope

If scope creation failed after step 1, subsequent attempts to create scope returned SCOPE_EXISTS status because it simply checked the presence of scope in scopes table. 

The fix is to perform all idempotent steps of scope creation upon each request and not throw DataExists if the entry exists in the first table. 

So in `PravegaTableScopes.createScope` method, we catch DataExists and continue creating the `streamsInScope` table for the scope of interest and then throw DataExists. 

**How to verify it**  
Unit test added. 
