### PR TITLE
Issue 4352: Turn retrieve token operation of DelegationTokenProvider asynchronous

### DIFF
--- a/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
+++ b/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
@@ -22,7 +22,7 @@ public interface DelegationTokenProvider {
     /**
      * Retrieve delegation token.
      *
-     * @return a delegation token
+     * @return a CompletableFuture that, when completed, will return the retrieved delegation token
      */
     CompletableFuture<String> retrieveToken();
 

--- a/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
+++ b/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
@@ -9,6 +9,8 @@
  */
 package io.pravega.client.security.auth;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * A client-side proxy for obtaining a delegation token from the server.
  *
@@ -22,7 +24,7 @@ public interface DelegationTokenProvider {
      *
      * @return a delegation token
      */
-    String retrieveToken();
+    CompletableFuture<String> retrieveToken();
 
     /**
      * Populates the object with the specified delegation token.

--- a/client/src/main/java/io/pravega/client/security/auth/EmptyTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/EmptyTokenProviderImpl.java
@@ -9,14 +9,16 @@
  */
 package io.pravega.client.security.auth;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Provides empty delegation tokens. This provider is useful when auth is disabled.
  */
 public class EmptyTokenProviderImpl implements DelegationTokenProvider {
 
     @Override
-    public String retrieveToken() {
-        return "";
+    public CompletableFuture<String> retrieveToken() {
+        return CompletableFuture.completedFuture("");
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -176,7 +176,7 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
      * Returns the delegation token. It returns existing delegation token if it is not close to expiry. If the token
      * is close to expiry, it obtains a new delegation token and returns that one instead.
      *
-     * @return String the delegation token JWT compact value
+     * @return a CompletableFuture that, when completed, will return the delegation token JWT compact value
      */
     @Override
     public CompletableFuture<String> retrieveToken() {

--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -179,18 +179,18 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
      * @return String the delegation token JWT compact value
      */
     @Override
-    public String retrieveToken() {
+    public CompletableFuture<String> retrieveToken() {
         DelegationToken currentToken = this.delegationToken.get();
 
         if (currentToken == null) {
             return this.refreshToken();
         } else if (currentToken.getExpiryTime() == null) {
-            return currentToken.getValue();
+            return CompletableFuture.completedFuture(currentToken.getValue());
         } else if (isTokenNearingExpiry(currentToken)) {
             log.debug("Token is nearing expiry for scope/stream {}/{}", this.scopeName, this.streamName);
             return refreshToken();
         } else {
-            return currentToken.getValue();
+            return CompletableFuture.completedFuture(currentToken.getValue());
         }
     }
 
@@ -222,7 +222,7 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
     }
 
     @VisibleForTesting
-    String refreshToken() {
+    CompletableFuture<String> refreshToken() {
         long traceEnterId = LoggerHelpers.traceEnter(log, "refreshToken", this.scopeName, this.streamName);
         CompletableFuture<Void> currentRefreshFuture = tokenRefreshFuture.get();
         if (currentRefreshFuture == null) {
@@ -232,13 +232,14 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
         } else {
             log.debug("Token is already under refresh for scope {} and stream {}", this.scopeName, this.streamName);
         }
-        try {
-            currentRefreshFuture.join(); // Block until the token is refreshed
-        } finally {
-            this.tokenRefreshFuture.compareAndSet(currentRefreshFuture, null); // Token is already refreshed, so resetting the future to null.
-        }
-        LoggerHelpers.traceLeave(log, "refreshToken", traceEnterId, this.scopeName, this.streamName);
-        return delegationToken.get().getValue();
+
+        final CompletableFuture<Void> handleToCurrentRefreshFuture  = currentRefreshFuture;
+        return currentRefreshFuture.thenApply(v -> {
+                    // Token is already refreshed, so resetting the future to null.
+                    this.tokenRefreshFuture.compareAndSet(handleToCurrentRefreshFuture, null);
+                    LoggerHelpers.traceLeave(log, "refreshToken", traceEnterId, this.scopeName, this.streamName);
+                    return delegationToken.get().getValue();
+                });
     }
 
     private CompletableFuture<Void> recreateToken() {

--- a/client/src/main/java/io/pravega/client/security/auth/StringTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/StringTokenProviderImpl.java
@@ -11,6 +11,7 @@ package io.pravega.client.security.auth;
 
 import io.pravega.common.Exceptions;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -26,8 +27,8 @@ public class StringTokenProviderImpl implements DelegationTokenProvider {
     }
 
     @Override
-    public String retrieveToken() {
-        return this.token.get();
+    public CompletableFuture<String> retrieveToken() {
+        return CompletableFuture.completedFuture(this.token.get());
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -168,7 +168,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
     public CompletableFuture<SegmentRead> read(long offset, int length) {
         Exceptions.checkNotClosed(closed.get(), this);
 
-        return this.tokenProvider.retrieveToken().thenCompose(token -> {
+        return this.tokenProvider.retrieveToken().thenComposeAsync(token -> {
             WireCommands.ReadSegment request = new WireCommands.ReadSegment(segmentId.getScopedName(), offset, length,
                     token, requestId);
             return backoffSchedule.retryWhen(t -> {

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -195,7 +195,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
                                 })
                         );
             }, connectionFactory.getInternalExecutor());
-        });
+        }, connectionFactory.getInternalExecutor());
     }
         
     private CompletableFuture<SegmentRead> sendRequestOverConnection(WireCommands.ReadSegment request, ClientConnection c) {

--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -167,32 +167,35 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
     @Override
     public CompletableFuture<SegmentRead> read(long offset, int length) {
         Exceptions.checkNotClosed(closed.get(), this);
-        WireCommands.ReadSegment request = new WireCommands.ReadSegment(segmentId.getScopedName(), offset, length,
-                                                                        this.tokenProvider.retrieveToken(), requestId);
-        return backoffSchedule.retryWhen(t -> {
-            Throwable ex = Exceptions.unwrap(t);
-            if (closed.get()) {
-                log.debug("Exception while reading from Segment : {}", segmentId, ex);
-            } else {
-                log.warn("Exception while reading from Segment : {}", segmentId, ex);
-            }
-            return ex instanceof Exception && !(ex instanceof ConnectionClosedException) && !(ex instanceof SegmentTruncatedException);
-        }).runAsync(() -> {
-            return getConnection()
-                    .whenComplete((connection, ex) -> {
-                        if (ex != null) {
-                            log.warn("Exception while establishing connection with Pravega node", ex);
-                            closeConnection(new ConnectionFailedException(ex));
-                        }
-                    }).thenCompose(c -> sendRequestOverConnection(request, c)
-                            .whenComplete((reply, ex) -> {
-                                if (ex instanceof ConnectionFailedException) {
-                                    log.debug("ConnectionFailedException observed when sending request {}", request, ex);
-                                    closeConnection((ConnectionFailedException) ex);
-                                }
-                            })
-                    );
-        }, connectionFactory.getInternalExecutor());
+
+        return this.tokenProvider.retrieveToken().thenCompose(token -> {
+            WireCommands.ReadSegment request = new WireCommands.ReadSegment(segmentId.getScopedName(), offset, length,
+                    token, requestId);
+            return backoffSchedule.retryWhen(t -> {
+                Throwable ex = Exceptions.unwrap(t);
+                if (closed.get()) {
+                    log.debug("Exception while reading from Segment : {}", segmentId, ex);
+                } else {
+                    log.warn("Exception while reading from Segment : {}", segmentId, ex);
+                }
+                return ex instanceof Exception && !(ex instanceof ConnectionClosedException) && !(ex instanceof SegmentTruncatedException);
+            }).runAsync(() -> {
+                return getConnection()
+                        .whenComplete((connection, ex) -> {
+                            if (ex != null) {
+                                log.warn("Exception while establishing connection with Pravega node", ex);
+                                closeConnection(new ConnectionFailedException(ex));
+                            }
+                        }).thenCompose(c -> sendRequestOverConnection(request, c)
+                                .whenComplete((reply, ex) -> {
+                                    if (ex instanceof ConnectionFailedException) {
+                                        log.debug("ConnectionFailedException observed when sending request {}", request, ex);
+                                        closeConnection((ConnectionFailedException) ex);
+                                    }
+                                })
+                        );
+            }, connectionFactory.getInternalExecutor());
+        });
     }
         
     private CompletableFuture<SegmentRead> sendRequestOverConnection(WireCommands.ReadSegment request, ClientConnection c) {

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -134,28 +134,33 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         log.debug("Getting segment info for segment: {}", segmentId);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
-        return connection.sendRequest(requestId, new GetStreamSegmentInfo(
-                requestId, segmentId.getScopedName(), tokenProvider.retrieveToken()))
-                         .thenApply(r -> transformReply(r, StreamSegmentInfo.class));
+
+        return tokenProvider.retrieveToken()
+                .thenCompose(token -> connection.sendRequest(requestId, new GetStreamSegmentInfo(
+                        requestId, segmentId.getScopedName(), token)))
+                .thenApply(r -> transformReply(r, StreamSegmentInfo.class));
     }
     
     private CompletableFuture<WireCommands.SegmentAttribute> getPropertyAsync(UUID attributeId) {
         log.debug("Getting segment attribute: {}", attributeId);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
-        return connection.sendRequest(requestId, new GetSegmentAttribute(requestId, segmentId.getScopedName(),
-                                                    attributeId, tokenProvider.retrieveToken()))
-                         .thenApply(r -> transformReply(r, WireCommands.SegmentAttribute.class));
+
+        return tokenProvider.retrieveToken()
+                .thenCompose(token -> connection.sendRequest(requestId, new GetSegmentAttribute(requestId,
+                        segmentId.getScopedName(), attributeId, token)))
+                .thenApply(r -> transformReply(r, WireCommands.SegmentAttribute.class));
     }
 
     private CompletableFuture<SegmentAttributeUpdated> updatePropertyAsync(UUID attributeId, long expected, long value) {
         log.trace("Updating segment attribute: {}", attributeId);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
-        return connection.sendRequest(requestId,
-                                      new UpdateSegmentAttribute(requestId, segmentId.getScopedName(), attributeId,
-                                                                 value, expected, tokenProvider.retrieveToken()))
-                         .thenApply(r -> transformReply(r, SegmentAttributeUpdated.class));
+
+        return tokenProvider.retrieveToken()
+                .thenCompose(token -> connection.sendRequest(requestId, new UpdateSegmentAttribute(requestId,
+                        segmentId.getScopedName(), attributeId, value, expected, token)))
+                .thenApply(r -> transformReply(r, SegmentAttributeUpdated.class));
     }
 
     private CompletableFuture<SegmentTruncated> truncateSegmentAsync(Segment segment, long offset,
@@ -163,16 +168,22 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         log.trace("Truncating segment: {}", segment);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
-        return connection.sendRequest(requestId, new TruncateSegment(requestId, segment.getScopedName(), offset, tokenProvider.retrieveToken()))
-                         .thenApply(r -> transformReply(r, SegmentTruncated.class));
+
+        return tokenProvider.retrieveToken()
+                .thenCompose(token -> connection.sendRequest(requestId,
+                        new TruncateSegment(requestId, segment.getScopedName(), offset, token)))
+                .thenApply(r -> transformReply(r, SegmentTruncated.class));
     }
     
     private CompletableFuture<SegmentSealed> sealSegmentAsync(Segment segment, DelegationTokenProvider tokenProvider) {
         log.trace("Sealing segment: {}", segment);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
-        return connection.sendRequest(requestId, new SealSegment(requestId, segment.getScopedName(), tokenProvider.retrieveToken()))
-                         .thenApply(r -> transformReply(r, SegmentSealed.class));
+
+        return tokenProvider.retrieveToken()
+                .thenCompose(token -> connection.sendRequest(requestId, new SealSegment(requestId,
+                        segment.getScopedName(), token)))
+                .thenApply(r -> transformReply(r, SegmentSealed.class));
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -576,7 +576,6 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                      log.info("Fetching endpoint for segment {}, writer {}", segmentName, writerId);
 
                      return controller.getEndpointForSegment(segmentName)
-
                          // Establish and return a connection to segment store
                          .thenComposeAsync((PravegaNodeUri uri) -> {
                              log.info("Establishing connection to {} for {}, writerID: {}", uri, segmentName, writerId);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -566,42 +566,50 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                                              t -> log.warn(writerId + " Failed to connect: ", t))
                  .runAsync(() -> {
                      log.debug("Running reconnect for segment {} writer {}", segmentName, writerId);
+
                      if (state.isClosed() || state.needSuccessors.get()) {
                          // stop reconnect when writer is closed or resend inflight to successors has been triggered.
                          return CompletableFuture.completedFuture(null);
                      }
                      Preconditions.checkState(state.getConnection() == null);
                      log.info("Fetching endpoint for segment {}, writer {}", segmentName, writerId);
-                     return controller.getEndpointForSegment(segmentName).thenComposeAsync((PravegaNodeUri uri) -> {
-                         log.info("Establishing connection to {} for {}, writerID: {}", uri, segmentName, writerId);
-                         return establishConnection(uri);
-                     }, connectionFactory.getInternalExecutor()).thenComposeAsync(connection -> {
-                         CompletableFuture<Void> connectionSetupFuture = state.newConnection(connection);
-                         SetupAppend cmd = new SetupAppend(requestId, writerId, segmentName, tokenProvider.retrieveToken());
-                         try {
-                             connection.send(cmd);
-                         } catch (ConnectionFailedException e1) {
-                             // This needs to be invoked here because call to failConnection from netty may occur before state.newConnection above.
-                             state.failConnection(e1);
-                             throw Exceptions.sneakyThrow(e1);
-                         }
-                         return connectionSetupFuture.exceptionally(t -> {
-                             Throwable exception = Exceptions.unwrap(t);
-                             if (exception instanceof TokenException) {
-                                 log.info("Ending reconnect attempts on writer {} to {} because token verification failed",
-                                         writerId, segmentName);
-                                 return null;
+
+                     return controller.getEndpointForSegment(segmentName)
+
+                         // Establish and return a connection to segment store
+                         .thenComposeAsync((PravegaNodeUri uri) -> {
+                             log.info("Establishing connection to {} for {}, writerID: {}", uri, segmentName, writerId);
+                             return establishConnection(uri);
+                         }, connectionFactory.getInternalExecutor())
+
+                         // Retrieve the token, then setup append command and send the command over the connection.
+                         .thenCombineAsync(tokenProvider.retrieveToken(), (connection, token) -> {
+                             CompletableFuture<Void> connectionSetupFuture = state.newConnection(connection);
+                             SetupAppend cmd = new SetupAppend(requestId, writerId, segmentName, token);
+                             try {
+                                connection.send(cmd);
+                             } catch (ConnectionFailedException e1) {
+                                // This needs to be invoked here because call to failConnection from netty may occur before state.newConnection above.
+                                state.failConnection(e1);
+                                throw Exceptions.sneakyThrow(e1);
                              }
-                             if (exception instanceof SegmentSealedException) {
-                                 log.info("Ending reconnect attempts on writer {} to {} because segment is sealed", writerId, segmentName);
-                                 return null;
-                             }
-                             if (exception instanceof NoSuchSegmentException) {
-                                 log.info("Ending reconnect attempts on writer {} to {} because segment is truncated", writerId, segmentName);
-                                 return null;
-                             }
-                             throw Exceptions.sneakyThrow(t);
-                         });
+                             return connectionSetupFuture.exceptionally(t -> {
+                                 Throwable exception = Exceptions.unwrap(t);
+                                 if (exception instanceof TokenException) {
+                                     log.info("Ending reconnect attempts on writer {} to {} because token verification failed",
+                                             writerId, segmentName);
+                                     return null;
+                                 }
+                                 if (exception instanceof SegmentSealedException) {
+                                     log.info("Ending reconnect attempts on writer {} to {} because segment is sealed", writerId, segmentName);
+                                     return null;
+                                 }
+                                 if (exception instanceof NoSuchSegmentException) {
+                                     log.info("Ending reconnect attempts on writer {} to {} because segment is truncated", writerId, segmentName);
+                                     return null;
+                                 }
+                                 throw Exceptions.sneakyThrow(t);
+                             });
                      }, connectionFactory.getInternalExecutor());
                  }, connectionFactory.getInternalExecutor());
         }, new CompletableFuture<ClientConnection>());

--- a/client/src/test/java/io/pravega/client/security/auth/DelegationTokenProviderFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/security/auth/DelegationTokenProviderFactoryTest.java
@@ -30,7 +30,7 @@ public class DelegationTokenProviderFactoryTest {
     @Test
     public void testCreateWithEmptyToken() {
        DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.createWithEmptyToken();
-       assertEquals("", tokenProvider.retrieveToken());
+       assertEquals("", tokenProvider.retrieveToken().join());
        assertFalse(tokenProvider.populateToken("new-token"));
     }
 
@@ -77,11 +77,11 @@ public class DelegationTokenProviderFactoryTest {
         String nonJwtDelegationToken = "non-jwt-token";
         DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(nonJwtDelegationToken,
                 dummyController, new Segment("test-scope", "test-stream", 1));
-        assertEquals(nonJwtDelegationToken, tokenProvider.retrieveToken());
+        assertEquals(nonJwtDelegationToken, tokenProvider.retrieveToken().join());
 
         String newNonJwtDelegationToken = "new-non-jwt-token";
         tokenProvider.populateToken(newNonJwtDelegationToken);
-        assertEquals("new-non-jwt-token", tokenProvider.retrieveToken());
+        assertEquals("new-non-jwt-token", tokenProvider.retrieveToken().join());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class DelegationTokenProviderFactoryTest {
                 JwtBody.builder().expirationTime(Instant.now().plusSeconds(10000).getEpochSecond()).build()));
         DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(jwtDelegationToken,
                 dummyController, new Segment("test-scope", "test-stream", 1));
-        assertEquals(jwtDelegationToken, tokenProvider.retrieveToken());
+        assertEquals(jwtDelegationToken, tokenProvider.retrieveToken().join());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
+++ b/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
@@ -51,7 +51,7 @@ public class JwtTokenProviderImplTest {
                 JwtBody.builder().expirationTime(Instant.now().plusSeconds(10000).getEpochSecond()).build()));
         JwtTokenProviderImpl objectUnderTest = new JwtTokenProviderImpl(
                 token, mock(Controller.class), "somescope", "somestream");
-        assertEquals(token, objectUnderTest.retrieveToken());
+        assertEquals(token, objectUnderTest.retrieveToken().join());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class JwtTokenProviderImplTest {
                 token, mockController, "somescope", "somestream");
 
         // Act
-        String newToken = objectUnderTest.retrieveToken();
+        String newToken = objectUnderTest.retrieveToken().join();
         log.debug("new token: {}", newToken);
 
         assertTrue(newToken.startsWith("newtokenheader"));
@@ -139,13 +139,15 @@ public class JwtTokenProviderImplTest {
 
     @Test
     public void testRetrievesSameTokenOutsideOfTokenRefreshThresholdWhenTokenIsNull() {
+
+        final String token = String.format("newtokenheader.%s.signature", createJwtBody(
+                JwtBody.builder().expirationTime(Instant.now().plusSeconds(10000).getEpochSecond()).build()));
         // Setup mock
         Controller mockController = mock(Controller.class);
         CompletableFuture<String> future = CompletableFuture.supplyAsync(new Supplier<String>() {
             @Override
             public String get() {
-                return String.format("newtokenheader.%s.signature", createJwtBody(
-                        JwtBody.builder().expirationTime(Instant.now().plusSeconds(10000).getEpochSecond()).build()));
+                return token;
             }
         });
         when(mockController.getOrRefreshDelegationTokenFor("somescope", "somestream"))
@@ -155,9 +157,7 @@ public class JwtTokenProviderImplTest {
         DelegationTokenProvider objectUnderTest = new JwtTokenProviderImpl(mockController,
                 "somescope", "somestream");
 
-        // Act
-        String token = objectUnderTest.retrieveToken();
-        assertEquals(token, objectUnderTest.retrieveToken());
+        assertEquals(token, objectUnderTest.retrieveToken().join());
     }
 
     @Test
@@ -191,7 +191,7 @@ public class JwtTokenProviderImplTest {
 
         JwtTokenProviderImpl objectUnderTest = new JwtTokenProviderImpl(token, dummyController, "testscope",
                 "teststream");
-        assertEquals(token, objectUnderTest.retrieveToken());
+        assertEquals(token, objectUnderTest.retrieveToken().join());
     }
 
     @Test
@@ -254,7 +254,7 @@ public class JwtTokenProviderImplTest {
         DelegationTokenProvider objectUnderTest = new JwtTokenProviderImpl(mockController, "somescope", "somestream");
 
         // Act
-        String token = objectUnderTest.retrieveToken();
+        String token = objectUnderTest.retrieveToken().join();
         log.debug(token);
 
         assertTrue(token.startsWith("newtokenheader"));

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -15,6 +15,7 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetector.Level;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ClientConnection.CompletedCallback;
+import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
@@ -40,11 +41,14 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.Cleanup;
+import lombok.Getter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +74,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-
 
 public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
@@ -113,6 +116,28 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
         sendAndVerifyEvent(cid, connection, output, getBuffer("test"), 1);
         verifyNoMoreInteractions(connection);
+    }
+
+    @Test(timeout = 10000)
+    public void testReconnectWorksWithTokenTaskInInternalExecutor() {
+        UUID cid = UUID.randomUUID();
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        // create one thread on connection factory
+        cf.setExecutor(Executors.newSingleThreadScheduledExecutor());
+        CompletableFuture<Void> signal = new CompletableFuture<>();
+        MockControllerWithTokenTask controller = new MockControllerWithTokenTask(uri.getEndpoint(), uri.getPort(), cf,
+                true, signal);
+
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(uri, connection);
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
+                RETRY_SCHEDULE, DelegationTokenProviderFactory.create(controller, "scope", "stream"));
+        output.reconnect();
+
+        signal.join();
+        assertEquals(1, controller.countOfDelegationTokenCalls.get());
     }
 
     @Test(timeout = 10000)
@@ -1080,5 +1105,29 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
         sendAndVerifyEvent(cid, connection, output, getBuffer("test"), 1);
         verifyNoMoreInteractions(connection);
+    }
+
+    private static class MockControllerWithTokenTask extends MockController {
+        final ConnectionFactory cf;
+        final CompletableFuture<Void> signal;
+
+        @Getter
+        final AtomicInteger countOfDelegationTokenCalls = new AtomicInteger(0);
+
+        public MockControllerWithTokenTask(String endpoint, int port, ConnectionFactory connectionFactory,
+                                           boolean callServer, CompletableFuture<Void> signal) {
+            super(endpoint, port, connectionFactory, callServer);
+            this.cf = connectionFactory;
+            this.signal = signal;
+        }
+
+        @Override
+        public CompletableFuture<String> getOrRefreshDelegationTokenFor(String scope, String streamName) {
+            return CompletableFuture.supplyAsync(() -> {
+                countOfDelegationTokenCalls.incrementAndGet();
+                signal.complete(null);
+                return "my-test-token";
+            }, cf.getInternalExecutor());
+        }
     }
 }


### PR DESCRIPTION
**Change log description**  
Make the `DelegationTokenProvider` interface operation `retrieveToken()` asynchronous and make its invocations in client non-blocking, in order to avoid client-side deadlocks. 

**Purpose of the change**  
Fixes #4352 

**What the code does**  
* Makes the `retrieveToken()` operation of the `DelegationTokenProvider` interface asynchronous, and modifies the following implementation classes accordingly: 
  * `JwtTokenProviderImpl` 
  * `EmptyTokenProviderImpl` 
  * `StringTokenProviderImpl`
* Modifies the following client classes to avoid blocking, by leveraging `CompletableFuture`'s `CompletionStage` tasks: 
  * `AsyncSegmentInputStreamImpl`
  * `ConditionalOutputStreamImpl.java`
  * `SegmentMetadataClientImpl.java`
  * `SegmentOutputStreamImpl.java`
* Modifies existing tests to account for the above items. 

* Modifies existing code 

**How to verify it**  
All existing tests - unit, integration and system tests - should pass. `Auth` enabled autoscale system tests should pass.  

Here's a subset of unit and integration tests I use to quickly verify the changes: 
```java
package io.pravega.test.integration;

import io.pravega.client.security.auth.DelegationTokenProviderFactoryTest;
import io.pravega.client.security.auth.JwtBodyTest;
import io.pravega.client.security.auth.JwtTokenProviderImplTest;
import io.pravega.client.segment.impl.AsyncSegmentInputStreamTest;
import io.pravega.client.segment.impl.ConditionalOutputStreamTest;
import io.pravega.client.segment.impl.SegmentMetadataClientTest;
import io.pravega.client.segment.impl.SegmentOutputStreamTest;
import io.pravega.client.state.impl.RevisionedStreamClientTest;
import io.pravega.client.stream.impl.EventStreamReaderTest;
import io.pravega.client.stream.impl.SegmentSelectorTest;
import io.pravega.segmentstore.server.host.handler.PravegaRequestProcessorAuthFailedTest;
import io.pravega.shared.protocol.netty.WireCommandsTest;
import org.junit.runner.RunWith;
import org.junit.runners.Suite;

@RunWith(Suite.class)
@Suite.SuiteClasses({
        JwtTokenProviderImplTest.class,
        DelegationTokenProviderFactoryTest.class,
        JwtBodyTest.class,
        EventStreamReaderTest.class,
        RevisionedStreamClientTest.class,
        AppendTest.class,
        AppendReconnectTest.class,
        ReadTest.class,
        SegmentSelectorTest.class,
        ConditionalOutputStreamTest.class,
        PravegaRequestProcessorAuthFailedTest.class,
        WireCommandsTest.class,
        AsyncSegmentInputStreamTest.class,
        SegmentMetadataClientTest.class,
        SegmentOutputStreamTest.class,
        DelegationTokenTest.class
})

public class DelegationTokenTestSuite {
}
```