### PR TITLE
Issue 4351: Removed assertion check from ConnectionTracker

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ConnectionTracker.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ConnectionTracker.java
@@ -87,9 +87,9 @@ public class ConnectionTracker {
      * @return True if the connection should continue reading, false if it should pause.
      */
     private boolean shouldContinueReading(long deltaBytes, long connectionOutstandingBytes) {
-        // Perform quick sanity checks as assertions: these should pop up during tests but since this method is invoked
-        // very frequently we do not want them enabled for production use.
-        // Sanity Check #1: If a connection increased by an amount, its total outstanding should be at least that value.
+        // Perform a sanity check as an assertion: it should pop up during tests but since this method is invoked
+        // very frequently we do not want it enabled for production use.
+        // If a connection increased by an amount, its total outstanding should be at least that value.
         assert deltaBytes <= connectionOutstandingBytes : "connection delta greater than connection outstanding";
         long total = this.totalOutstanding.updateAndGet(p -> Math.max(0, p + deltaBytes));
         if (total >= this.allConnectionsLimit) {
@@ -97,8 +97,6 @@ public class ConnectionTracker {
             return false;
         }
 
-        // Sanity check #2: No connection may have more outstanding than the total.
-        assert connectionOutstandingBytes <= total : "single connection outstanding greater than total outstanding";
         return connectionOutstandingBytes < LOW_WATERMARK
                 || connectionOutstandingBytes < (this.singleConnectionDoubleLimit - total);
     }


### PR DESCRIPTION
**Change log description**  
- Removed an assertion check that could incorrectly fire in concurrent tests.

**Purpose of the change**  
Fixes #4133 

**What the code does**  
- Removed an assertion check that was meant to perform a sanity check, enabled only during tests.
- In a concurrent environment, it would have been possible that two or more calls for the same "connection" (`AppendProcessor`) would update the `AppendProcessor`'s outstanding bytes in one order yet invoke `ConnectionTracker.updateOutstandingBytes` in a different order. Even though the resulting data is correct, such a sequence of events would have this assertion incorrectly fire if the `AppendProcessor`'s outstanding value is greater than the total outstanding value
- Example:
    - Call 1: `AppendProcessor.adjustOutstanding(delta=10)`
    - Call 2: `AppendProcessor.adjustOutstanding(delta=-10)` (i.e., another append completed or errorred out)
    - Call 1 updates `AppendProcessor.outstanding` to 10, and invokes `ConnectionTracker.updateOutstandingBytes(delta=10, connectionOutstanding=10) (this call doesn't complete yet)
    - Call 2 updates `AppendProcessor.outstanding` to 0, and invokes `ConnectionTracker.updateOutstandingBytes(delta=-10, connectionOutstanding=0)`. This call completes, so it sets totalOutstanding to 0
    - Call 1's suspended call is resumed, but it reports that its `connectionOutstanding` is 10, which is greater than 0, so the assertion incorrectly fires.
    - In the end, after both calls complete, the state of the system is consistent: both the connection and the total are 0.


**How to verify it**  
All tests must pass. There is no functional change here.
