### PR TITLE
Issue 3679: Increase maximum event size limit.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/Serializer.java
+++ b/client/src/main/java/io/pravega/client/stream/Serializer.java
@@ -24,7 +24,7 @@ public interface Serializer<T> {
     /**
      * The maximum event size, in bytes.
      */
-    int MAX_EVENT_SIZE = 1024 * 1024;
+    int MAX_EVENT_SIZE = 8 * 1024 * 1024;
 
     /**
      * Serializes the given event.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -56,7 +56,7 @@ public final class WireCommands {
     public static final int OLDEST_COMPATIBLE_VERSION = 5;
     public static final int TYPE_SIZE = 4;
     public static final int TYPE_PLUS_LENGTH_SIZE = 8;
-    public static final int MAX_WIRECOMMAND_SIZE = 0x007FFFFF; // 8MB
+    public static final int MAX_WIRECOMMAND_SIZE = 0x00FFFFFF; // 16MB-1
     
     public static final long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as Attributes.NULL_ATTRIBUTE_VALUE
     

--- a/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.system;
+
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ByteBufferSerializer;
+import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.stream.impl.ControllerImplConfig;
+import io.pravega.test.system.framework.Environment;
+import io.pravega.test.system.framework.SystemTestRunner;
+import io.pravega.test.system.framework.Utils;
+import io.pravega.test.system.framework.services.Service;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.UUID;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+@RunWith(SystemTestRunner.class)
+public class LargeEventTest extends AbstractReadWriteTest {
+
+    private final static String STREAM_NAME = "testStreamSampleY";
+    private final static String STREAM_SCOPE = "testScopeSampleY" + randomAlphanumeric(5);
+    private final static String READER_GROUP = "ExampleReaderGroupY";
+    private final static int NUM_EVENTS = 100;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60);
+
+    private final ScalingPolicy scalingPolicy = ScalingPolicy.fixed(4);
+    private final StreamConfiguration config = StreamConfiguration.builder()
+                                                                  .scalingPolicy(scalingPolicy)
+                                                                  .build();
+
+    /**
+     * This is used to setup the various services required by the system test framework.
+     */
+    @Environment
+    public static void initialize() {
+        URI zkUri = startZookeeperInstance();
+        startBookkeeperInstances(zkUri);
+        URI controllerUri = ensureControllerRunning(zkUri);
+        ensureSegmentStoreRunning(zkUri, controllerUri);
+    }
+
+    /**
+     * Invoke the simpleTest, ensure we are able to produce  events.
+     * The test fails incase of exceptions while writing to the stream.
+     *
+     */
+    @Test
+    public void simpleTest() {
+        Service conService = Utils.createPravegaControllerService(null);
+        List<URI> ctlURIs = conService.getServiceDetails();
+        URI controllerUri = ctlURIs.get(0);
+
+        log.info("Invoking create stream with Controller URI: {}", controllerUri);
+
+        @Cleanup
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(Utils.buildClientConfig(controllerUri));
+        @Cleanup
+        ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder()
+                                                                           .clientConfig(Utils.buildClientConfig(controllerUri))
+                                                                           .build(), connectionFactory.getInternalExecutor());
+
+        assertTrue(controller.createScope(STREAM_SCOPE).join());
+        assertTrue(controller.createStream(STREAM_SCOPE, STREAM_NAME, config).join());
+
+        @Cleanup
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(STREAM_SCOPE, Utils.buildClientConfig(controllerUri));
+        log.info("Invoking Writer test with Controller URI: {}", controllerUri);
+
+        @Cleanup
+        EventStreamWriter<ByteBuffer> writer = clientFactory.createEventWriter(STREAM_NAME,
+                                                                                 new ByteBufferSerializer(),
+                                                                                 EventWriterConfig.builder().build());
+        byte[] payload = new byte[Serializer.MAX_EVENT_SIZE];
+        for (int i = 0; i < NUM_EVENTS; i++) {
+            log.debug("Producing event: {} ", i);
+            // any exceptions while writing the event will fail the test.
+            writer.writeEvent("", ByteBuffer.wrap(payload));
+            writer.flush();
+        }
+
+        log.info("Invoking Reader test.");
+        ReaderGroupManager groupManager = ReaderGroupManager.withScope(STREAM_SCOPE, Utils.buildClientConfig(controllerUri));
+        groupManager.createReaderGroup(READER_GROUP, ReaderGroupConfig.builder().stream(Stream.of(STREAM_SCOPE, STREAM_NAME)).build());
+        @Cleanup
+        EventStreamReader<ByteBuffer> reader = clientFactory.createReader(UUID.randomUUID().toString(),
+                                                                      READER_GROUP,
+                                                                      new ByteBufferSerializer(),
+                                                                      ReaderConfig.builder().build());
+        int readCount = 0;
+
+        EventRead<ByteBuffer> event = null;
+        do {
+            event = reader.readNextEvent(10_000);
+            log.debug("Read event: {}.", event.getEvent());
+            if (event.getEvent() != null) {
+                readCount++;
+            }
+            // try reading until all the written events are read, else the test will timeout.
+        } while ((event.getEvent() != null || event.isCheckpoint()) && readCount < NUM_EVENTS);
+        assertEquals("Read count should be equal to write count", NUM_EVENTS, readCount);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
* Increases the size limit for an event from 1MB to 8MB
* Increases the wire command size limit from 8MB to 16MB

**Purpose of the change**  
Address low hanging fruit on #3679

**What the code does**  
Changes size limit constants.

**How to verify it**  
Everything should continue to work as normal. We should complete system tests runs before merging.
