### PR TITLE
Issue 4369: (SegmentStore) Fix memory leak with Future Reads

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -145,7 +145,7 @@ public class PravegaRequestProcessorTest {
         }
 
         @Override
-        protected void fail(Throwable exception) {
+        public void fail(Throwable exception) {
             super.fail(exception);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.reading;
 
 import io.pravega.segmentstore.contracts.ReadResultEntry;
-
 import java.util.function.Consumer;
 
 /**
@@ -29,6 +28,23 @@ interface CompletableReadResultEntry extends ReadResultEntry {
      * @return The CompletionConsumer that was set using setCompletionCallback.
      */
     CompletionConsumer getCompletionCallback();
+
+    /**
+     * Attempts to fail the content request for this {@link ReadResultEntry} if in progress.
+     *
+     * @param ex The exception to fail with.
+     * @throws IllegalStateException If {@link #isDone()} is true.
+     */
+    void fail(Throwable ex);
+
+    /**
+     * Gets a value indicating whether the content of this {@link ReadResultEntry} is readily available.
+     *
+     * @return True if available, false if not.
+     */
+    default boolean isDone() {
+        return getContent().isDone();
+    }
 
     @FunctionalInterface
     interface CompletionConsumer extends Consumer<Integer> {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntry.java
@@ -9,13 +9,20 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import io.pravega.common.function.Callbacks;
+import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Read Result Entry for data that is not yet available in the StreamSegment (for an offset that is beyond the
  * StreamSegment's Length)
  */
 class FutureReadResultEntry extends ReadResultEntryBase {
+    @GuardedBy("this")
+    private Consumer<FutureReadResultEntry> onCompleteOrFail;
+
     /**
      * Creates a new instance of the FutureReadResultEntry class.
      *
@@ -25,5 +32,37 @@ class FutureReadResultEntry extends ReadResultEntryBase {
      */
     FutureReadResultEntry(long streamSegmentOffset, int requestedReadLength) {
         super(ReadResultEntryType.Future, streamSegmentOffset, requestedReadLength);
+    }
+
+    /**
+     * Registers a callback that will be invoked every time {@link #complete} or {@link #fail} is invoked.
+     *
+     * @param callback A {@link Consumer<FutureReadResultEntry>} to invoke. The argument will be this instance.
+     */
+    synchronized void setOnCompleteOrFail(Consumer<FutureReadResultEntry> callback) {
+        this.onCompleteOrFail = callback;
+    }
+
+    @Override
+    protected void complete(ReadResultEntryContents readResultEntryContents) {
+        super.complete(readResultEntryContents);
+        invokeWhenCompleteOrFail();
+    }
+
+    @Override
+    public void fail(Throwable exception) {
+        super.fail(exception);
+        invokeWhenCompleteOrFail();
+    }
+
+    private void invokeWhenCompleteOrFail() {
+        Consumer<FutureReadResultEntry> callback;
+        synchronized (this) {
+            callback = this.onCompleteOrFail;
+        }
+
+        if (callback != null) {
+            Callbacks.invokeSafely(callback, this, null);
+        }
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.common.Exceptions;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,7 +20,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Organizes PlaceholderReadResultEntries by their starting offset and provides efficient methods for retrieving those
+ * Organizes {@link FutureReadResultEntry} by their starting offset and provides efficient methods for retrieving those
  * whose offsets are below certain values.
  */
 @ThreadSafe
@@ -56,11 +57,13 @@ class FutureReadResultEntryCollection {
                 result = Collections.emptyList();
             } else {
                 result = new ArrayList<>(this.reads);
+                this.reads.remove(null);
                 this.reads.clear();
                 this.closed = true;
             }
         }
 
+        result.forEach(r -> r.setOnCompleteOrFail(null)); // Detach any callbacks pointing to this instance.
         return result;
     }
 
@@ -70,6 +73,9 @@ class FutureReadResultEntryCollection {
      * @param entry The entry to add.
      */
     public void add(FutureReadResultEntry entry) {
+        // Attach a callback that will unregister this entry if it gets completed externally, without being polled from
+        // this collection first.
+        entry.setOnCompleteOrFail(this::onCompleted);
         synchronized (this.reads) {
             Exceptions.checkNotClosed(this.closed, this);
             this.reads.add(entry);
@@ -90,7 +96,9 @@ class FutureReadResultEntryCollection {
             // 'reads' is sorted by Starting Offset, in ascending order. As long as it is not empty and the
             // first entry overlaps the given offset by at least one byte, extract and return it.
             while (this.reads.size() > 0 && this.reads.peek().getStreamSegmentOffset() <= maxOffset) {
-                result.add(this.reads.poll());
+                FutureReadResultEntry e = this.reads.poll();
+                e.setOnCompleteOrFail(null); // We no longer have a reference to it; detach the unregistration callback.
+                result.add(e);
             }
         }
 
@@ -104,6 +112,33 @@ class FutureReadResultEntryCollection {
         return poll(Long.MAX_VALUE);
     }
 
+    /**
+     * Gets a value indicating the number of registered Result Entries.
+     *
+     * @return The count.
+     */
+    int size() {
+        synchronized (this.reads) {
+            return this.reads.size();
+        }
+    }
+
+    /**
+     * Callback that unregisters the given {@link FutureReadResultEntry} from this collection when invoked.
+     *
+     * @param entry The {@link FutureReadResultEntry} to unregister.
+     */
+    private void onCompleted(FutureReadResultEntry entry) {
+        if (entry == null) {
+            return;
+        }
+
+        synchronized (this.reads) {
+            this.reads.remove(entry);
+        }
+    }
+
+    @VisibleForTesting
     static int entryComparator(FutureReadResultEntry e1, FutureReadResultEntry e2) {
         if (e1.getStreamSegmentOffset() < e2.getStreamSegmentOffset()) {
             return -1;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollection.java
@@ -57,7 +57,6 @@ class FutureReadResultEntryCollection {
                 result = Collections.emptyList();
             } else {
                 result = new ArrayList<>(this.reads);
-                this.reads.remove(null);
                 this.reads.clear();
                 this.closed = true;
             }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadResultEntryBase.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadResultEntryBase.java
@@ -116,7 +116,8 @@ public abstract class ReadResultEntryBase implements CompletableReadResultEntry 
      *
      * @param exception The exception to set.
      */
-    protected void fail(Throwable exception) {
+    @Override
+    public void fail(Throwable exception) {
         Preconditions.checkState(!this.contents.isDone(), "ReadResultEntry has already had its result set.");
         this.contents.completeExceptionally(exception);
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/RedirectedReadResultEntry.java
@@ -118,6 +118,11 @@ class RedirectedReadResultEntry implements CompletableReadResultEntry {
         return getActiveEntry().getCompletionCallback();
     }
 
+    @Override
+    public void fail(Throwable ex) {
+        throw new UnsupportedOperationException("fail() not supported on " + this.getClass().getSimpleName());
+    }
+
     //endregion
 
     //region Helpers

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import io.pravega.common.Exceptions;
@@ -289,6 +290,16 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      */
     long getSegmentLength() {
         return this.metadata.getLength();
+    }
+
+    /**
+     * Gets a value representing the number of registered {@link FutureReadResultEntry} instances.
+     *
+     * @return The count.
+     */
+    @VisibleForTesting
+    int getFutureReadCount() {
+        return this.futureReads.size();
     }
 
     private CacheKey getCacheKey(ReadIndexEntry entry) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
@@ -184,7 +184,11 @@ class StreamSegmentReadResult implements ReadResult {
                 this.canRead = false;
             } else {
                 // After the previous entry is done, update the consumedLength value.
-                entry.setCompletionCallback(length -> this.consumedLength += length);
+                entry.setCompletionCallback(length -> {
+                    synchronized (StreamSegmentReadResult.this) {
+                        this.consumedLength += length;
+                    }
+                });
                 this.lastEntry = entry;
 
                 // Check, again, if we are closed. It is possible that this Result was closed after the last check

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -590,10 +590,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         Assert.assertTrue(futureReadEntry.getContent().isCancelled());
 
         AssertExtensions.assertEventuallyEquals("FutureReadResultEntry not unregistered after owning ReadResult closed.",
-                0,
-                () -> context.readIndex.getIndex(segmentId).getFutureReadCount(),
-                10,
-                TIMEOUT.toMillis());
+                0, () -> context.readIndex.getIndex(segmentId).getFutureReadCount(),
+                10, TIMEOUT.toMillis());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -589,8 +589,11 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         rr.close();
         Assert.assertTrue(futureReadEntry.getContent().isCancelled());
 
-        // TODO: check that the read index's FutureReadCollection is empty.
-        Assert.fail("FIX ME");
+        AssertExtensions.assertEventuallyEquals("FutureReadResultEntry not unregistered after owning ReadResult closed.",
+                0,
+                () -> context.readIndex.getIndex(segmentId).getFutureReadCount(),
+                10,
+                TIMEOUT.toMillis());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/FutureReadResultEntryCollectionTests.java
@@ -9,7 +9,10 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import io.pravega.segmentstore.contracts.ReadResultEntryContents;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.IntentionalException;
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -78,6 +81,34 @@ public class FutureReadResultEntryCollectionTests {
         }
 
         AssertExtensions.assertListEquals("Unexpected result from close().", entries, result, Object::equals);
+    }
+
+    /**
+     * Tests the ability to auto-unregister pending reads when they are completed externally.
+     */
+    @Test
+    public void testAutoUnregister() {
+        @Cleanup
+        FutureReadResultEntryCollection c = new FutureReadResultEntryCollection();
+        List<FutureReadResultEntry> entries = generateEntries();
+        entries.forEach(c::add);
+
+        Assert.assertEquals("Unexpected number of entries registered.", entries.size(), c.size());
+        for (FutureReadResultEntry e : entries) {
+            Assert.assertFalse("StorageReadResultEntry is completed.", e.getContent().isDone());
+        }
+
+        for (int i = 0; i < entries.size(); i++) {
+            if (i % 2 == 0) {
+                entries.get(i).complete(new ReadResultEntryContents(new ByteArrayInputStream(new byte[1]), 1));
+            } else {
+                entries.get(i).fail(new IntentionalException());
+            }
+        }
+
+        Assert.assertEquals("Unexpected number of entries after being completed externally.", 0, c.size());
+        val closeResult = c.close();
+        Assert.assertEquals("Not expecting any items to be returned from close().", 0, closeResult.size());
     }
 
     private List<FutureReadResultEntry> generateEntries() {


### PR DESCRIPTION
**Change log description**  
- Fixed a memory leak that can be triggered by abandoning Future Reads without any segment write activity.

**Purpose of the change**  
Fixes #4369.

**What the code does**  
- Every `FutureReadResultEntry` gets assigned a callback to invoke when it is completed (successfully or not). This is assigned when being registered into the `FutureReadResultEntryCollection` (of the Read Index) and unassigned when being polled from that collection.
    - This callback, when invoked, will cause that entry to be unregistered from the collection.
    - The callback should be unregistered when polled out of the collection because the next step that the Read Index would take is to complete it, which means it would have caused the collection to unnecessarily search for it.
- This has been wired up into the `StreamSegmentReadResult` to be invoked when the result itself is closed and thus abandoning any `FutureReadResultEntry` that it might be sitting on. 

**How to verify it**  
All unit tests must pass. New unit tests added.
