### PR TITLE
Avoid split in client

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
@@ -16,6 +16,8 @@ import io.pravega.shared.NameUtils;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility methods for StreamSegment Names.
@@ -32,6 +34,8 @@ public final class StreamSegmentNameUtils {
     static final String TAG_EPOCH = "epoch";
     static final String TAG_DEFAULT = "default";
     static final String TAG_WRITER = "writer";
+    static final Pattern SEGMENT_TAGS_PATTERN =
+        Pattern.compile("((([\\w\\-\\\\.]+)/)?(([\\w\\-\\\\.]+)/))?(\\d+)(\\.#epoch\\.(\\d+))?");
 
     /**
      * This is appended to the end of the Segment/Transaction name to indicate it stores its extended attributes.
@@ -417,28 +421,16 @@ public final class StreamSegmentNameUtils {
     }
 
     private static String[] updateSegmentTags(String qualifiedSegmentName, String[] tags) {
-        String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
-        String[] tokens = segmentBaseName.split("[/]");
-
-        int segmentIdIndex = (tokens.length == 1) ? 0 : (tokens.length) == 2 ? 1 : 2;
-        if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {
-            String[] segmentIdTokens = tokens[segmentIdIndex].split(EPOCH_DELIMITER);
-            tags[5] = segmentIdTokens[0];
-            tags[7] = segmentIdTokens[1];
-        } else {
-            tags[5] = tokens[segmentIdIndex];
-            tags[7] = "0";
-        }
-        if (tokens.length == 3) {
-            tags[1] = tokens[0];
-            tags[3] = tokens[1];
-        } else if (tokens.length == 1) {
-            tags[1] = TAG_DEFAULT;
-            tags[3] = TAG_DEFAULT;
-        } else {
-            tags[1] = TAG_DEFAULT;
-            tags[3] = tokens[0];
-        }
+        final String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
+        final Matcher m = SEGMENT_TAGS_PATTERN.matcher(segmentBaseName);
+        m.find();
+        final String scope = m.group(3);
+        tags[1] = scope == null ? TAG_DEFAULT : scope;
+        final String stream = m.group(5);
+        tags[3] = stream == null ? TAG_DEFAULT : stream;
+        tags[5] = m.group(6);
+        final String epoch = m.group(8);
+        tags[7] = epoch == null ? "0" : epoch;
         return tags;
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
@@ -34,8 +34,6 @@ public final class StreamSegmentNameUtils {
     static final String TAG_EPOCH = "epoch";
     static final String TAG_DEFAULT = "default";
     static final String TAG_WRITER = "writer";
-    static final Pattern SEGMENT_TAGS_PATTERN =
-        Pattern.compile("((([\\w\\-\\\\.]+)/)?(([\\w\\-\\\\.]+)/))?(\\w+)(\\.#epoch\\.(\\d+))?");
 
     /**
      * This is appended to the end of the Segment/Transaction name to indicate it stores its extended attributes.
@@ -88,7 +86,14 @@ public final class StreamSegmentNameUtils {
     private static final String TABLES = "_tables";
     private static final String MARK = "_MARK";
 
-    //endregion
+    /**
+	 * This is used to parse the segment name.
+	 */
+	static final Pattern SEGMENT_TAGS_PATTERN =
+        Pattern.compile("((([\\w\\-\\\\.]+)/)?(([\\w\\-\\\\.]+)/))?(\\w+)(" + Pattern.quote(EPOCH_DELIMITER) + "(\\d+))?");
+
+
+	//endregion
 
     /**
      * Returns the transaction name for a TransactionStreamSegment based on the name of the current Parent StreamSegment, and the transactionId.

--- a/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/segment/StreamSegmentNameUtils.java
@@ -87,13 +87,13 @@ public final class StreamSegmentNameUtils {
     private static final String MARK = "_MARK";
 
     /**
-	 * This is used to parse the segment name.
-	 */
-	static final Pattern SEGMENT_TAGS_PATTERN =
+     * This is used to parse the segment name.
+     */
+    static final Pattern SEGMENT_TAGS_PATTERN =
         Pattern.compile("((([\\w\\-\\\\.]+)/)?(([\\w\\-\\\\.]+)/))?(\\w+)(" + Pattern.quote(EPOCH_DELIMITER) + "(\\d+))?");
 
 
-	//endregion
+    //endregion
 
     /**
      * Returns the transaction name for a TransactionStreamSegment based on the name of the current Parent StreamSegment, and the transactionId.


### PR DESCRIPTION
**Change log description**  
 Optimize the `updateSegmentTags()` method for better small events write performance.

**Purpose of the change**  
Fixes #4375 

**What the code does**  
 Avoid using `String.split` in `updateSegmentTags`, use the precompiled regexp instead.

**How to verify it**  
Basic testing shows that the updateSegmentTags takes twice less CPU time. The resulting small (1 byte) events rate is higher by 7%.
