### PR TITLE
Issue 4020: Expose additional apis on StreamMetadataStore interface for Pravega Cli

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -25,7 +25,9 @@ import io.pravega.controller.store.stream.records.ActiveTxnRecord;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
 import io.pravega.controller.store.stream.records.RetentionSet;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
@@ -802,6 +804,22 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     public CompletableFuture<Map<String, WriterMark>> getAllWriterMarks(String scope, String stream,
                                                                         OperationContext context, Executor executor) {
         return withCompletion(getStream(scope, stream, context).getAllWriterMarks(), executor);
+    }
+
+
+    @Override
+    public CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(String scope, String streamName, int chunkNumber, OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, streamName, context).getHistoryTimeSeriesChunk(chunkNumber), executor);
+    }
+
+    @Override
+    public CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(String scope, String streamName, int shardNumber, OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, streamName, context).getSealedSegmentSizeMapShard(shardNumber), executor);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getSegmentSealedEpoch(String scope, String streamName, long segmentId, OperationContext context, Executor executor) {
+        return withCompletion(getStream(scope, streamName, context).getSegmentSealedEpoch(segmentId), executor);
     }
 
     protected Stream getStream(String scope, final String name, OperationContext context) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -395,7 +395,8 @@ public abstract class PersistentStreamBase implements Stream {
                 segment -> targetSegmentsList.stream().filter(target -> target.overlaps(segment)).count() > 1 ).count();
     }
 
-    private CompletableFuture<Integer> getSegmentSealedEpoch(long segmentId) {
+    @Override
+    public CompletableFuture<Integer> getSegmentSealedEpoch(long segmentId) {
         return getSegmentSealedRecordData(segmentId).handle((x, e) -> {
             if (e != null) {
                 if (Exceptions.unwrap(e) instanceof DataNotFoundException) {
@@ -1714,8 +1715,8 @@ public abstract class PersistentStreamBase implements Stream {
         return createSealedSegmentSizesMapShardDataIfAbsent(shardNumber, shard);
     }
 
-    @VisibleForTesting
-    CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(int shard) {
+    @Override
+    public CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(int shard) {
         return getSealedSegmentSizesMapShardData(shard)
                 .handle((r, e) -> {
                     if (e != null) {
@@ -1886,6 +1887,11 @@ public abstract class PersistentStreamBase implements Stream {
                 });
     }
 
+    @Override
+    public CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(int chunkNumber) {
+        return getHistoryTimeSeriesChunk(chunkNumber, true);
+    }
+    
     private CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(int chunkNumber, boolean ignoreCached) {
         return getHistoryTimeSeriesChunkData(chunkNumber, ignoreCached)
                 .thenCompose(x -> {

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -14,7 +14,9 @@ import io.pravega.controller.store.stream.records.ActiveTxnRecord;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
 import io.pravega.controller.store.stream.records.RetentionSet;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
@@ -615,4 +617,29 @@ interface Stream {
      * This allows us reuse of stream object without having to recreate a new stream object for each new operation
      */
     void refresh();
+
+    /**
+     * Method to get the requested chunk of the HistoryTimeSeries.
+     *
+     * @param chunkNumber chunk number.
+     * @return Completable future that, upon completion, holds the requested HistoryTimeSeries chunk.
+     */
+    CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(int chunkNumber);
+
+    /**
+     * Method to get the requested shard of sealed segments map.
+     *
+     * @param shardNumber shard number.
+     * @return Completable future that, upon completion, holds the requested sealed segment map shard.
+     */
+    CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(int shardNumber);
+
+    /**
+     * Method to get epoch in which a segment was sealed.
+     * Returns a negative number if segment is not sealed.  
+     *
+     * @param segmentId  segment id.
+     * @return Completable future that, upon completion, holds the epoch in which the segment was sealed.
+     */
+    CompletableFuture<Integer> getSegmentSealedEpoch(long segmentId);
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -14,7 +14,9 @@ import io.pravega.controller.store.stream.records.ActiveTxnRecord;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
 import io.pravega.controller.store.stream.records.RetentionSet;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
@@ -1155,4 +1157,47 @@ public interface StreamMetadataStore extends AutoCloseable {
      * @return A completableFuture, which when completed, will contain map of writer to respective marks.  
      */
     CompletableFuture<Map<String, WriterMark>> getAllWriterMarks(String scope, String stream, OperationContext context, Executor executor);
+    
+    /**
+     * Method to get the requested chunk of the HistoryTimeSeries.
+     *
+     * @param scope      stream scope.
+     * @param streamName stream name.
+     * @param chunkNumber chunk number.
+     * @param context    operation context.
+     * @param executor   callers executor.
+     * @return Completable future that, upon completion, holds the requested HistoryTimeSeries chunk.
+     */
+    CompletableFuture<HistoryTimeSeries> getHistoryTimeSeriesChunk(final String scope, final String streamName,
+                                                                   final int chunkNumber, final OperationContext context,
+                                                                   final Executor executor);
+
+    /**
+     * Method to get the requested shard of sealed segments map.
+     *
+     * @param scope      stream scope.
+     * @param streamName stream name.
+     * @param shardNumber shard number.
+     * @param context    operation context.
+     * @param executor   callers executor.
+     * @return Completable future that, upon completion, holds the requested sealed segment map shard.
+     */
+    CompletableFuture<SealedSegmentsMapShard> getSealedSegmentSizeMapShard(final String scope, final String streamName,
+                                                                           final int shardNumber, final OperationContext context,
+                                                                           final Executor executor);
+
+    /**
+     * Method to get epoch in which a segment was sealed.
+     * Returns a negative number if segment is not sealed.  
+     *
+     * @param scope      stream scope.
+     * @param streamName stream name.
+     * @param segmentId  segment id.
+     * @param context    operation context.
+     * @param executor   callers executor.
+     * @return Completable future that, upon completion, holds the epoch in which the segment was sealed.
+     */
+    CompletableFuture<Integer> getSegmentSealedEpoch(final String scope, final String streamName, final long segmentId,
+                                                     final OperationContext context, final Executor executor);
+
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -1188,14 +1188,14 @@ public interface StreamMetadataStore extends AutoCloseable {
 
     /**
      * Method to get epoch in which a segment was sealed.
-     * Returns a negative number if segment is not sealed.  
      *
      * @param scope      stream scope.
      * @param streamName stream name.
      * @param segmentId  segment id.
      * @param context    operation context.
      * @param executor   callers executor.
-     * @return Completable future that, upon completion, holds the epoch in which the segment was sealed.
+     * @return Completable future that, upon completion, holds the epoch in which the segment was sealed OR
+     * a negative number if segment is not sealed.
      */
     CompletableFuture<Integer> getSegmentSealedEpoch(final String scope, final String streamName, final long segmentId,
                                                      final OperationContext context, final Executor executor);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -22,7 +22,9 @@ import io.pravega.controller.store.stream.records.ActiveTxnRecord;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
 import io.pravega.controller.store.stream.records.RecordHelper;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
@@ -1539,5 +1541,66 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(mark.getPosition().size(), 1);
         assertTrue(mark.getPosition().containsKey(0L));
         assertEquals(mark.getPosition().get(0L).longValue(), 1L);
+    }
+    
+    @Test
+    public void testHistoryTimeSeriesChunk() throws Exception {
+        String scope = "history";
+        String stream = "history";
+        createAndScaleStream(store, scope, stream, 2);
+        HistoryTimeSeries chunk = store.getHistoryTimeSeriesChunk(scope, stream, 0, null, executor).join();
+        assertEquals(chunk.getLatestRecord().getEpoch(), 2);
+    }
+    
+    @Test
+    public void testSealedSegmentSizeMapShard() throws Exception {
+        String scope = "sealedMap";
+        String stream = "sealedMap";
+        createAndScaleStream(store, scope, stream, 2);
+        SealedSegmentsMapShard shard = store.getSealedSegmentSizeMapShard(scope, stream, 0, null, executor).join();
+        assertEquals(shard.getSize(StreamSegmentNameUtils.computeSegmentId(0, 0)).longValue(), 0L);
+        assertEquals(shard.getSize(StreamSegmentNameUtils.computeSegmentId(1, 1)).longValue(), 1L);
+        assertNull(shard.getSize(StreamSegmentNameUtils.computeSegmentId(2, 2)));
+    }
+    
+    @Test
+    public void testSegmentSealedEpoch() throws Exception {
+        String scope = "sealedMap";
+        String stream = "sealedMap";
+        createAndScaleStream(store, scope, stream, 2);
+        long segmentId = StreamSegmentNameUtils.computeSegmentId(0, 0);
+        int epoch = store.getSegmentSealedEpoch(scope, stream, segmentId, null, executor).join();
+        assertEquals(epoch, 1);
+        segmentId = StreamSegmentNameUtils.computeSegmentId(1, 1);
+        epoch = store.getSegmentSealedEpoch(scope, stream, segmentId, null, executor).join();
+        assertEquals(epoch, 2);
+        segmentId = StreamSegmentNameUtils.computeSegmentId(2, 2);
+        epoch = store.getSegmentSealedEpoch(scope, stream, segmentId, null, executor).join();
+        assertEquals(epoch, -1);
+    }
+    
+    private void createAndScaleStream(StreamMetadataStore store, String scope, String stream, int times) {
+        long time = System.currentTimeMillis();
+        store.createScope(scope).join();
+        store.createStream(scope, stream, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1))
+                                                             .build(), time, null, executor).join();
+        VersionedMetadata<State> state = store.getVersionedState(scope, stream, null, executor).join();
+        store.updateVersionedState(scope, stream, State.ACTIVE, state, null, executor).join();
+
+        for (int i = 0; i < times; i++) {
+            long scaleTs = time + i;
+            List<Long> sealedSegments = Collections.singletonList(StreamSegmentNameUtils.computeSegmentId(i, i));
+            VersionedMetadata<EpochTransitionRecord> etr = store.submitScale(scope, stream, sealedSegments,
+                    Collections.singletonList(new SimpleEntry<>(0.0, 1.0)), scaleTs, null, null, executor).join();
+            state = store.getVersionedState(scope, stream, null, executor).join();
+            state = store.updateVersionedState(scope, stream, State.SCALING, state, null, executor).join();
+            etr = store.startScale(scope, stream, false, etr, state, null, executor).join();
+            store.scaleCreateNewEpochs(scope, stream, etr, null, executor).join();
+            long size = i;
+            store.scaleSegmentsSealed(scope, stream, sealedSegments.stream().collect(Collectors.toMap(x -> x, x -> size)), etr,
+                    null, executor).join();
+            store.completeScale(scope, stream, etr, null, executor).join();
+            store.setState(scope, stream, State.ACTIVE, null, executor).join();
+        }
     }
 }


### PR DESCRIPTION
**Change log description**  
To expose additional apis on StreamMetadataStore interface to get all relevant metadata

**Purpose of the change**  
Fixes #4020 

**What the code does**  
There are three metadata record types that are part of internal metadata schema but are not exposed over StreamMetadataStore interface. 
However, for purposes of pravega cli, we need to expose all such records so that they can be accessed by the admin tool. 

**How to verify it**  
Unit test added
