### PR TITLE
Issue 4372: Split controller thread pools to avoid potential deadlock.

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -228,9 +228,9 @@ public class ControllerServiceStarter extends AbstractIdleService {
             streamStore = streamMetadataStoreRef.orElse(StreamStoreFactory.createStore(storeClient, segmentHelper, authHelper, controllerExecutor));
 
             streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, taskMetadataStore,
-                    segmentHelper, controllerExecutor, host.getHostId(), authHelper, requestTracker);
+                    segmentHelper, controllerExecutor, eventExecutor, host.getHostId(), authHelper, requestTracker);
             streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore,
-                    segmentHelper, controllerExecutor, host.getHostId(), serviceConfig.getTimeoutServiceConfig(), authHelper);
+                    segmentHelper, controllerExecutor, eventExecutor, host.getHostId(), serviceConfig.getTimeoutServiceConfig(), authHelper);
 
             BucketServiceFactory bucketServiceFactory = new BucketServiceFactory(host.getHostId(), bucketStore, 1000);
             Duration executionDurationRetention = Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES);

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -440,8 +440,8 @@ public class ControllerServiceStarter extends AbstractIdleService {
             // lingering threads that prevent our process from exiting.
 
             // Next stop all executors
-            log.info("Stopping controller executor");
-            ExecutorServiceHelpers.shutdown(Duration.ofSeconds(5), controllerExecutor, retentionExecutor, watermarkingExecutor);
+            log.info("Stopping controller executors");
+            ExecutorServiceHelpers.shutdown(Duration.ofSeconds(5), controllerExecutor, retentionExecutor, watermarkingExecutor, eventExecutor);
 
             if (cluster != null) {
                 log.info("Closing controller cluster instance");

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -114,20 +114,33 @@ public class StreamMetadataTasks extends TaskBase {
     private final AtomicReference<EventStreamWriter<ControllerEvent>> requestEventWriterRef = new AtomicReference<>();
     private final GrpcAuthHelper authHelper;
     private final RequestTracker requestTracker;
+    private final ScheduledExecutorService eventExecutor;
 
     public StreamMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                BucketStore bucketStore, final TaskMetadataStore taskMetadataStore,
-                               final SegmentHelper segmentHelper, final ScheduledExecutorService executor, final String hostId,
+                               final SegmentHelper segmentHelper, final ScheduledExecutorService executor,
+                               final ScheduledExecutorService eventExecutor, final String hostId,
                                GrpcAuthHelper authHelper, RequestTracker requestTracker) {
-        this(streamMetadataStore, bucketStore, taskMetadataStore, segmentHelper, executor, new Context(hostId),
+        this(streamMetadataStore, bucketStore, taskMetadataStore, segmentHelper, executor, eventExecutor, new Context(hostId),
                 authHelper, requestTracker);
+    }
+
+    @VisibleForTesting
+    public StreamMetadataTasks(final StreamMetadataStore streamMetadataStore,
+                               BucketStore bucketStore, final TaskMetadataStore taskMetadataStore,
+                               final SegmentHelper segmentHelper, final ScheduledExecutorService executor,
+                               final String hostId, GrpcAuthHelper authHelper, RequestTracker requestTracker) {
+        this(streamMetadataStore, bucketStore, taskMetadataStore, segmentHelper, executor, executor, new Context(hostId),
+             authHelper, requestTracker);
     }
 
     private StreamMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                 BucketStore bucketStore, final TaskMetadataStore taskMetadataStore,
-                                final SegmentHelper segmentHelper, final ScheduledExecutorService executor, final Context context,
+                                final SegmentHelper segmentHelper, final ScheduledExecutorService executor,
+                                final ScheduledExecutorService eventExecutor, final Context context,
                                 GrpcAuthHelper authHelper, RequestTracker requestTracker) {
         super(taskMetadataStore, executor, context);
+        this.eventExecutor = eventExecutor;
         this.streamMetadataStore = streamMetadataStore;
         this.bucketStore = bucketStore;
         this.segmentHelper = segmentHelper;
@@ -407,7 +420,7 @@ public class StreamMetadataTasks extends TaskBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.warn(requestId, "Exception thrown in trying to update stream configuration {}", ex);
+                    log.warn(requestId, "Exception thrown in trying to update stream configuration", ex);
                     return handleUpdateStreamError(ex, requestId);
                 });
     }
@@ -710,23 +723,22 @@ public class StreamMetadataTasks extends TaskBase {
     public CompletableFuture<Void> writeEvent(ControllerEvent event) {
         CompletableFuture<Void> result = new CompletableFuture<>();
 
-        writerInitFuture.thenCompose(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event)).whenComplete((r, e) -> {
-            if (e != null) {
-                log.warn("exception while posting event {} {}", e.getClass().getName(), e.getMessage());
-                if (e instanceof TaskExceptions.ProcessingDisabledException) {
-                    result.completeExceptionally(e);
-                } else {
-                    // transform any other event write exception to retryable exception
-                    result.completeExceptionally(new TaskExceptions.PostEventException("Failed to post event", e));
-                }
-            } else {
-                log.info("event posted successfully");
-                result.complete(null);
-            }
-        });
-
+        writerInitFuture.thenComposeAsync(v -> requestEventWriterRef.get().writeEvent(event.getKey(), event), eventExecutor)
+                        .whenComplete((r, e) -> {
+                            if (e != null) {
+                                log.warn("exception while posting event {} {}", e.getClass().getName(), e.getMessage());
+                                if (e instanceof TaskExceptions.ProcessingDisabledException) {
+                                    result.completeExceptionally(e);
+                                } else {
+                                    // transform any other event write exception to retryable exception
+                                    result.completeExceptionally(new TaskExceptions.PostEventException("Failed to post event", e));
+                                }
+                            } else {
+                                log.info("event posted successfully");
+                                result.complete(null);
+                            }
+                        });
         return result;
-
     }
 
     @VisibleForTesting
@@ -1028,6 +1040,7 @@ public class StreamMetadataTasks extends TaskBase {
                 taskMetadataStore,
                 segmentHelper,
                 executor,
+                eventExecutor,
                 context,
                 authHelper,
                 requestTracker);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -80,6 +80,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
 
     protected final String hostId;
     protected final ScheduledExecutorService executor;
+    protected final ScheduledExecutorService eventExecutor;
 
     private final StreamMetadataStore streamMetadataStore;
     private final SegmentHelper segmentHelper;
@@ -97,12 +98,14 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
     public StreamTransactionMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                           final SegmentHelper segmentHelper,
                                           final ScheduledExecutorService executor,
+                                          final ScheduledExecutorService eventExecutor,
                                           final String hostId,
                                           final TimeoutServiceConfig timeoutServiceConfig,
                                           final BlockingQueue<Optional<Throwable>> taskCompletionQueue,
                                           final GrpcAuthHelper authHelper) {
         this.hostId = hostId;
         this.executor = executor;
+        this.eventExecutor = eventExecutor;
         this.streamMetadataStore = streamMetadataStore;
         this.segmentHelper = segmentHelper;
         this.authHelper = authHelper;
@@ -112,21 +115,34 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
         this.abortWriterFuture = new CompletableFuture<>();
     }
 
+    @VisibleForTesting
     public StreamTransactionMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                           final SegmentHelper segmentHelper,
                                           final ScheduledExecutorService executor,
                                           final String hostId,
                                           final TimeoutServiceConfig timeoutServiceConfig,
+                                          final BlockingQueue<Optional<Throwable>> taskCompletionQueue,
                                           final GrpcAuthHelper authHelper) {
-        this(streamMetadataStore, segmentHelper, executor, hostId, timeoutServiceConfig, null, authHelper);
+        this(streamMetadataStore, segmentHelper, executor, executor, hostId, timeoutServiceConfig, taskCompletionQueue, authHelper);
     }
 
     public StreamTransactionMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                           final SegmentHelper segmentHelper,
                                           final ScheduledExecutorService executor,
+                                          final ScheduledExecutorService eventExecutor,
+                                          final String hostId,
+                                          final TimeoutServiceConfig timeoutServiceConfig,
+                                          final GrpcAuthHelper authHelper) {
+        this(streamMetadataStore, segmentHelper, executor, eventExecutor, hostId, timeoutServiceConfig, null, authHelper);
+    }
+
+    @VisibleForTesting
+    public StreamTransactionMetadataTasks(final StreamMetadataStore streamMetadataStore,
+                                          final SegmentHelper segmentHelper,
+                                          final ScheduledExecutorService executor,
                                           final String hostId,
                                           final GrpcAuthHelper authHelper) {
-        this(streamMetadataStore, segmentHelper, executor, hostId, TimeoutServiceConfig.defaultConfig(), authHelper);
+        this(streamMetadataStore, segmentHelper, executor, executor, hostId, TimeoutServiceConfig.defaultConfig(), authHelper);
     }
 
     private void setReady() {
@@ -637,7 +653,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
 
     public CompletableFuture<Void> writeCommitEvent(CommitEvent event) {
         return commitWriterFuture
-                .thenCompose(commitWriter -> commitWriter.writeEvent(event.getKey(), event));
+                .thenComposeAsync(commitWriter -> commitWriter.writeEvent(event.getKey(), event), eventExecutor);
     }
 
     CompletableFuture<TxnStatus> writeCommitEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {
@@ -656,7 +672,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
 
     public CompletableFuture<Void> writeAbortEvent(AbortEvent event) {
         return abortWriterFuture
-                .thenCompose(abortWriter -> abortWriter.writeEvent(event.getKey(), event));
+                .thenComposeAsync(abortWriter -> abortWriter.writeEvent(event.getKey(), event), eventExecutor);
     }
 
     CompletableFuture<TxnStatus> writeAbortEvent(String scope, String stream, int epoch, UUID txnId, TxnStatus status) {


### PR DESCRIPTION
**Change log description**  
Split controller thread pools on the controller to avoid a potential deadlock.

**Purpose of the change**  
Fix #4372 on master

**What the code does**  

  *  SegmentSelector.refreshSegmentEventWriters is invoking the controller and blocking on it in the current thread. If this code is executed on the controller this might cause a potential deadlock.
  *  StreamMetadataTasks and StreamMetadataTransaction tasks invoke writes on the ForkJoinPool threads. With this PR the invocation is performed on the eventExecutor threadpool.

**How to verify it**  
All the existing tests should continue to pass.
