### PR TITLE
Issue 4383: Fix exception handling during state synchronizer compaction.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -239,7 +239,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             truncateSegmentAsync(segmentId, offset, tokenProvider).exceptionally(t -> {
                 final Throwable ex = Exceptions.unwrap(t);
                 if (ex.getCause() instanceof SegmentTruncatedException) {
-                    log.debug("Segment already truncated at offset " + offset, ex.getCause());
+                    log.debug("Segment already truncated at offset {}. Details: {}", offset, ex.getCause().getMessage());
                     return null;
                 }
                 throw new CompletionException(ex);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -239,7 +239,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             truncateSegmentAsync(segmentId, offset, tokenProvider).exceptionally(t -> {
                 final Throwable ex = Exceptions.unwrap(t);
                 if (ex.getCause() instanceof SegmentTruncatedException) {
-                    log.debug("Segment already truncated at offset " + offset, cause);
+                    log.debug("Segment already truncated at offset " + offset, ex.getCause());
                     return null;
                 }
                 throw new CompletionException(ex);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -36,6 +36,7 @@ import io.pravega.shared.protocol.netty.WireCommands.UpdateSegmentAttribute;
 import io.pravega.shared.protocol.netty.WireCommands.WrongHost;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.RequiredArgsConstructor;
@@ -115,6 +116,8 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             throw new NoSuchSegmentException(reply.toString());
         } else if (reply instanceof WrongHost) {
             throw new ConnectionFailedException(reply.toString());
+        } else if (reply instanceof WireCommands.SegmentIsTruncated) {
+            throw new ConnectionFailedException(new SegmentTruncatedException(reply.toString()));
         } else if (reply instanceof WireCommands.AuthTokenCheckFailed) {
             WireCommands.AuthTokenCheckFailed authTokenCheckReply = (WireCommands.AuthTokenCheckFailed) reply;
             if (authTokenCheckReply.isTokenExpired()) {
@@ -233,7 +236,14 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
     @Override
     public void truncateSegment(long offset) {
         RETRY_SCHEDULE.retryingOn(ConnectionFailedException.class).throwingOn(NoSuchSegmentException.class).run(() -> {
-            truncateSegmentAsync(segmentId, offset, tokenProvider).join();
+            truncateSegmentAsync(segmentId, offset, tokenProvider).exceptionally(t -> {
+                final Throwable ex = Exceptions.unwrap(t);
+                if (ex.getCause() instanceof SegmentTruncatedException) {
+                    log.debug("Segment already truncated at offset " + offset, cause);
+                    return null;
+                }
+                throw new CompletionException(ex);
+            }).join();
             return null;
         });
     }

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -109,7 +109,7 @@ public class SegmentMetadataClientTest {
     }
 
     @Test(timeout = 10000)
-    public void testTruncateError() {
+    public void testTruncateWithSegmentTruncationException() {
         Segment segment = new Segment("scope", "testTruncate", 4);
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 0);
         @Cleanup


### PR DESCRIPTION
**Change log description**  
Ensure we do not retry if the segment is already truncated while attempting to truncate a segment.

**Purpose of the change**  
Fixes #4383 

**What the code does**  
Ensure `SegmentIsTruncated` response from the Segmentstore is handled while attempting to truncate segments using SegmentMetadataClient.

**How to verify it**  
All the existing and newly added tests should continue to pass.
