### PR TITLE
Issue 4390: Ensure retries by client when delegation token expires

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.pravega.auth.InvalidTokenException;
 import io.pravega.auth.TokenException;
 import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.netty.impl.ConnectionFactory;
@@ -127,7 +128,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
                 throw new ConnectionFailedException(new TokenExpiredException(authTokenCheckReply.toString()));
             } else {
                 log.info("Delegation token invalid");
-                throw new TokenException(authTokenCheckReply.toString());
+                throw new InvalidTokenException(authTokenCheckReply.toString());
             }
         } else {
             throw new ConnectionFailedException("Unexpected reply of " + reply + " when expecting a "

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.segment.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.auth.TokenException;
 import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.netty.impl.ConnectionFactory;
@@ -122,7 +123,8 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             WireCommands.AuthTokenCheckFailed authTokenCheckReply = (WireCommands.AuthTokenCheckFailed) reply;
             if (authTokenCheckReply.isTokenExpired()) {
                 log.info("Delegation token expired");
-                throw new TokenExpiredException(authTokenCheckReply.toString());
+                // We want to have the request retried by the client in this case.
+                throw new ConnectionFailedException(new TokenExpiredException(authTokenCheckReply.toString()));
             } else {
                 log.info("Delegation token invalid");
                 throw new TokenException(authTokenCheckReply.toString());
@@ -133,7 +135,8 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
         }
     }
 
-    private CompletableFuture<StreamSegmentInfo> getStreamSegmentInfo() {
+    @VisibleForTesting
+    CompletableFuture<StreamSegmentInfo> getStreamSegmentInfo() {
         log.debug("Getting segment info for segment: {}", segmentId);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -214,7 +214,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 }
             }
             if (throwable instanceof SegmentSealedException || throwable instanceof NoSuchSegmentException
-                    || (throwable instanceof TokenException && !(throwable instanceof TokenExpiredException))) {
+                    || isTokenExceptionUnrelatedToExpiry(throwable)) {
                 setupConnection.releaseExceptionally(throwable);
             } else if (failSetupConnection) {
                 setupConnection.releaseExceptionallyAndReset(throwable);
@@ -600,7 +600,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                              }
                              return connectionSetupFuture.exceptionally(t -> {
                                  Throwable exception = Exceptions.unwrap(t);
-                                 if (exception instanceof TokenException && !(exception instanceof TokenExpiredException)) {
+                                 if (isTokenExceptionUnrelatedToExpiry(exception)) {
                                      log.info("Ending reconnect attempts on writer {} to {} because token verification failed",
                                              writerId, segmentName);
                                      return null;
@@ -650,6 +650,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
     public long getLastObservedWriteOffset() {
         return state.getLastSegmentLength();
     }
-    
-    
+
+    @VisibleForTesting
+    static boolean isTokenExceptionUnrelatedToExpiry(Throwable e)  {
+        return (e instanceof TokenException) && !(e instanceof TokenExpiredException);
+    }
 }

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -214,7 +214,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 }
             }
             if (throwable instanceof SegmentSealedException || throwable instanceof NoSuchSegmentException
-                    || throwable instanceof TokenException) {
+                    || (throwable instanceof TokenException && !(throwable instanceof TokenExpiredException))) {
                 setupConnection.releaseExceptionally(throwable);
             } else if (failSetupConnection) {
                 setupConnection.releaseExceptionallyAndReset(throwable);
@@ -600,7 +600,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                              }
                              return connectionSetupFuture.exceptionally(t -> {
                                  Throwable exception = Exceptions.unwrap(t);
-                                 if (exception instanceof TokenException) {
+                                 if (exception instanceof TokenException && !(exception instanceof TokenExpiredException)) {
                                      log.info("Ending reconnect attempts on writer {} to {} because token verification failed",
                                              writerId, segmentName);
                                      return null;

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -10,7 +10,7 @@
  */
 package io.pravega.client.segment.impl;
 
-import io.pravega.auth.TokenException;
+import io.pravega.auth.InvalidTokenException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.Flow;
@@ -422,7 +422,7 @@ public class SegmentMetadataClientTest {
 
         AssertExtensions.assertThrows("TokenException was not thrown or server stacktrace contained unexpected content.",
                 () -> client.fetchCurrentSegmentLength(),
-                e -> e instanceof TokenException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
+                e -> e instanceof InvalidTokenException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
     }
 
     @Test(timeout = 10000)
@@ -455,6 +455,6 @@ public class SegmentMetadataClientTest {
 
         AssertExtensions.assertThrows("TokenException was not thrown or server stacktrace contained unexpected content.",
                 () -> client.fetchCurrentSegmentLength(),
-                e -> e instanceof TokenException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
+                e -> e instanceof InvalidTokenException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
     }
 }

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentMetadataClientTest.java
@@ -11,7 +11,6 @@
 package io.pravega.client.segment.impl;
 
 import io.pravega.auth.TokenException;
-import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.Flow;
@@ -388,9 +387,9 @@ public class SegmentMetadataClientTest {
         }).when(connection).sendAsync(any(WireCommands.GetStreamSegmentInfo.class),
                 Mockito.any(ClientConnection.CompletedCallback.class));
 
-        AssertExtensions.assertThrows("TokenExpiredException was not thrown or server stacktrace contained unexpected content.",
-                () -> client.fetchCurrentSegmentLength(),
-                e -> e instanceof TokenExpiredException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
+        AssertExtensions.assertThrows("ConnectionFailedException was not thrown or server stacktrace contained unexpected content.",
+                () -> client.getStreamSegmentInfo().join(),
+                e -> e instanceof ConnectionFailedException && e.getMessage().contains("serverStackTrace=server-stacktrace"));
     }
 
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -462,6 +462,77 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 10000)
+    public void testReconnectSendsSetupAppendOnTokenExpiration() throws ConnectionFailedException {
+        UUID writerId = UUID.randomUUID();
+        PravegaNodeUri segmentStoreUri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+
+        MockConnectionFactoryImpl mockConnectionFactory = spy(new MockConnectionFactoryImpl());
+
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        mockConnectionFactory.setExecutor(executor);
+
+        MockController controller = new MockController(segmentStoreUri.getEndpoint(),
+                segmentStoreUri.getPort(), mockConnectionFactory, true);
+        ClientConnection mockConnection = mock(ClientConnection.class);
+
+        mockConnectionFactory.provideConnection(segmentStoreUri, mockConnection);
+
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller,
+                mockConnectionFactory, writerId, segmentSealedCallback,  RETRY_SCHEDULE,
+                DelegationTokenProviderFactory.createWithEmptyToken());
+
+        output.reconnect();
+        verify(mockConnection).send(new SetupAppend(output.getRequestId(), writerId, SEGMENT, ""));
+
+        reset(mockConnection);
+
+        // Simulate token expiry
+        WireCommands.AuthTokenCheckFailed authTokenCheckFailed = new WireCommands.AuthTokenCheckFailed(
+                1, "server-stacktrace", WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED);
+        mockConnectionFactory.getProcessor(segmentStoreUri).authTokenCheckFailed(authTokenCheckFailed);
+
+        // Upon token expiry we expect that the SetupAppend will occur again.
+        verify(mockConnection).send(new SetupAppend(output.getRequestId(), writerId, SEGMENT, ""));
+    }
+
+    @Test(timeout = 10000)
+    public void testReconnectDoesNotSetupAppendOnTokenCheckFailure() throws ConnectionFailedException {
+        UUID writerId = UUID.randomUUID();
+        PravegaNodeUri segmentStoreUri = new PravegaNodeUri("endpoint", SERVICE_PORT);
+
+        MockConnectionFactoryImpl mockConnectionFactory = spy(new MockConnectionFactoryImpl());
+
+        ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        implementAsDirectExecutor(executor); // Ensure task submitted to executor is run inline.
+        mockConnectionFactory.setExecutor(executor);
+
+        MockController controller = new MockController(segmentStoreUri.getEndpoint(),
+                segmentStoreUri.getPort(), mockConnectionFactory, true);
+        ClientConnection mockConnection = mock(ClientConnection.class);
+
+        mockConnectionFactory.provideConnection(segmentStoreUri, mockConnection);
+
+        SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller,
+                mockConnectionFactory, writerId, segmentSealedCallback,  RETRY_SCHEDULE,
+                DelegationTokenProviderFactory.createWithEmptyToken());
+
+        output.reconnect();
+        verify(mockConnection).send(new SetupAppend(output.getRequestId(), writerId, SEGMENT, ""));
+
+        reset(mockConnection);
+
+        // Simulate token check failure
+        WireCommands.AuthTokenCheckFailed authTokenCheckFailed = new WireCommands.AuthTokenCheckFailed(
+                1, "server-stacktrace", WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_CHECK_FAILED);
+        mockConnectionFactory.getProcessor(segmentStoreUri).authTokenCheckFailed(authTokenCheckFailed);
+
+        // Verify that SetupAppend is NOT sent. We expect the client to get an exception.
+        verify(mockConnection, times(0)).send(
+                new SetupAppend(output.getRequestId(), writerId, SEGMENT, ""));
+    }
+
+    @Test(timeout = 10000)
     public void testReconnectOnBadAcks() throws ConnectionFailedException, SegmentSealedException {
         UUID cid = UUID.randomUUID();
         PravegaNodeUri uri = new PravegaNodeUri("endpoint", SERVICE_PORT);

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -13,8 +13,6 @@ import com.google.common.collect.ImmutableList;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetector.Level;
-import io.pravega.auth.TokenException;
-import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ClientConnection.CompletedCallback;
 import io.pravega.client.netty.impl.ConnectionFactory;
@@ -1177,13 +1175,6 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
         sendAndVerifyEvent(cid, connection, output, getBuffer("test"), 1);
         verifyNoMoreInteractions(connection);
-    }
-
-    @Test
-    public void testIsTokenExceptionUnrelatedToExpiry() {
-        assertTrue(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new TokenException("Token exception")));
-        assertFalse(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new TokenExpiredException("Token expiry exception")));
-        assertFalse(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new Exception("Exception")));
     }
 
     private static class MockControllerWithTokenTask extends MockController {

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableList;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetector.Level;
+import io.pravega.auth.TokenException;
+import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ClientConnection.CompletedCallback;
 import io.pravega.client.netty.impl.ConnectionFactory;
@@ -1104,6 +1106,13 @@ public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
 
         sendAndVerifyEvent(cid, connection, output, getBuffer("test"), 1);
         verifyNoMoreInteractions(connection);
+    }
+
+    @Test
+    public void testIsTokenExceptionUnrelatedToExpiry() {
+        assertTrue(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new TokenException("Token exception")));
+        assertFalse(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new TokenExpiredException("Token expiry exception")));
+        assertFalse(SegmentOutputStreamImpl.isTokenExceptionUnrelatedToExpiry(new Exception("Exception")));
     }
 
     private static class MockControllerWithTokenTask extends MockController {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorAuthFailedTest.java
@@ -9,7 +9,7 @@
  */
 package io.pravega.segmentstore.server.host.handler;
 
-import io.pravega.auth.TokenException;
+import io.pravega.auth.InvalidTokenException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.shared.protocol.netty.WireCommands;
 import java.util.UUID;
@@ -34,7 +34,7 @@ public class AppendProcessorAuthFailedTest {
                                    .store(store)
                                    .connection(connection)
                                    .tokenVerifier((resource, token, expectedLevel) -> {
-                                       throw new TokenException("Token verification failed.");
+                                       throw new InvalidTokenException("Token verification failed.");
                                    }).build();
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorAuthFailedTest.java
@@ -9,7 +9,7 @@
  */
 package io.pravega.segmentstore.server.host.handler;
 
-import io.pravega.auth.TokenException;
+import io.pravega.auth.InvalidTokenException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
@@ -35,7 +35,7 @@ public class PravegaRequestProcessorAuthFailedTest {
         processor = new PravegaRequestProcessor(store, mock(TableStore.class), connection, SegmentStatsRecorder.noOp(),
                 TableSegmentStatsRecorder.noOp(),
                 (resource, token, expectedLevel) -> {
-                    throw new TokenException("Token verification failed.");
+                    throw new InvalidTokenException("Token verification failed.");
                 }, false);
     }
 

--- a/shared/authplugin/src/main/java/io/pravega/auth/TokenException.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/TokenException.java
@@ -10,9 +10,9 @@
 package io.pravega.auth;
 
 /**
- * Superclass for exceptions that can be thrown while handling delegation tokens.
+ * An abstract superclass for exceptions that can be thrown while handling delegation tokens.
  */
-public class TokenException extends AuthException {
+public abstract class TokenException extends AuthException {
 
     private static final long serialVersionUID = 1L;
 

--- a/shared/security/src/main/java/io/pravega/shared/security/token/JsonWebToken.java
+++ b/shared/security/src/main/java/io/pravega/shared/security/token/JsonWebToken.java
@@ -18,11 +18,8 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
 import io.pravega.auth.InvalidTokenException;
-import io.pravega.auth.TokenException;
 import io.pravega.auth.TokenExpiredException;
 import java.time.Instant;
 import java.util.Date;
@@ -143,7 +140,7 @@ public class JsonWebToken {
 
     @VisibleForTesting
     static Claims parseClaims(String token, byte[] signingKey) throws TokenExpiredException,
-            InvalidTokenException, TokenException {
+            InvalidTokenException {
 
         if (Strings.isNullOrEmpty(token)) {
             throw new InvalidTokenException("Token is null or empty");
@@ -159,10 +156,8 @@ public class JsonWebToken {
             return claimsJws.getBody();
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException(e);
-        } catch (MalformedJwtException | SignatureException e) {
-            throw new InvalidTokenException(e);
         } catch (JwtException e) {
-            throw new TokenException(e);
+            throw new InvalidTokenException(e);
         }
     }
 
@@ -173,10 +168,12 @@ public class JsonWebToken {
      * @param signingKey the key that was used for signing the token
      * @return a Set view of the mappings contained in this Claims map extracted from the token.
      *
-     * @throws TokenException if any failure in parsing the token or extracting the claims occurs
+     * @throws TokenExpiredException if the token has expired
+     * @throws InvalidTokenException if any failure in parsing the token, verifying the signature or
+     *                               extracting the claims occurs
      */
     public static Set<Map.Entry<String, Object>> fetchClaims(String token, byte[] signingKey)
-            throws TokenException {
+            throws TokenExpiredException, InvalidTokenException {
         return parseClaims(token, signingKey).entrySet();
     }
 }

--- a/shared/security/src/test/java/io/pravega/shared/security/token/JsonWebTokenTest.java
+++ b/shared/security/src/test/java/io/pravega/shared/security/token/JsonWebTokenTest.java
@@ -93,4 +93,11 @@ public class JsonWebTokenTest {
                 () ->  JsonWebToken.parseClaims("abx.mno.xyz", null)
         );
     }
+
+    @Test
+    public void testParseClaimsThrowsExceptionWhenSigningKeyIsInvalid() {
+        assertThrows(InvalidTokenException.class,
+                () ->  JsonWebToken.parseClaims("abx.mno.xyz", "abc".getBytes())
+        );
+    }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.test.integration;
 
-import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
@@ -34,8 +33,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.pravega.test.common.AssertExtensions.assertThrows;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * As the package + name might suggest, this class is intended to hold integration tests for verifying delegation token
@@ -53,15 +53,6 @@ public class DelegationTokenTest {
     public void testWriteSucceedsWhenTokenTtlIsMinusOne() throws ExecutionException, InterruptedException {
         // A Token TTL -1 indicates to the Controller to not set any expiry on the delegation token.
         writeAnEvent(-1);
-    }
-
-    @Test(timeout = 30000)
-    public void testWriteFailsWhenTokenExpires() {
-        // To ensure the token is certainly expired when it reaches the segment store, we are setting Controller TTL
-        // as 0, so that the token expiry is set as the same time as the time it is issued in the Controller.
-        assertThrows("Token expiration didn't cause write failure.",
-                () -> writeAnEvent(0),
-                e -> e instanceof TokenExpiredException);
     }
 
     private void writeAnEvent(int tokenTtlInSeconds) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
**Change log description**  
Ensure that the client retries the request to segment store if the segment store throws an error indicating token expiry. Doing so will ensure that a new delegation token will be obtained after reauthentication and reauthorization with the Controller and used in the retried request. 

**Purpose of the change**  
Resolves #4390. 

**What the code does**  
- Modifies `io.pravega.client.segment.impl.SegmentMetadataClientImpl` class to throw `ConnectionFailedException` upon receiving a response from the segment store indicating delegation token expiry. This will ensure that the request is retried. 
- Modifies `io.pravega.client.segment.impl.SegmentOutputStreamImpl` class to not release the connection upon encountering token expiry indicator from the segment store. 
- Makes `TokenException` abstract in order to prevent any code from throwing that exception. It was originally intended to be a base class for all token related exceptions, and since it wasn't abstract some of the code - including what was initially developed for this PR - ended up throwing it (instead of the subclasses that represent specific conditions) inadvertently. 

**How to verify it**  
All existing tests should verify. 

I also used this test suite temporarily to quickly verify changes. 

```java
package io.pravega.test.integration;

import io.pravega.client.security.auth.DelegationTokenProviderFactoryTest;
import io.pravega.client.security.auth.JwtBodyTest;
import io.pravega.client.security.auth.JwtTokenProviderImplTest;
import io.pravega.client.segment.impl.AsyncSegmentInputStreamTest;
import io.pravega.client.segment.impl.ConditionalOutputStreamTest;
import io.pravega.client.segment.impl.SegmentMetadataClientTest;
import io.pravega.client.segment.impl.SegmentOutputStreamTest;
import io.pravega.client.state.impl.RevisionedStreamClientTest;
import io.pravega.client.stream.impl.EventStreamReaderTest;
import io.pravega.client.stream.impl.SegmentSelectorTest;
import io.pravega.segmentstore.server.host.handler.PravegaRequestProcessorAuthFailedTest;
import io.pravega.shared.protocol.netty.WireCommandsTest;
import org.junit.runner.RunWith;
import org.junit.runners.Suite;

@RunWith(Suite.class)
@Suite.SuiteClasses({
        JwtTokenProviderImplTest.class,
        DelegationTokenProviderFactoryTest.class,
        JwtBodyTest.class,
        EventStreamReaderTest.class,
        RevisionedStreamClientTest.class,
        AppendTest.class,
        AppendReconnectTest.class,
        ReadTest.class,
        SegmentSelectorTest.class,
        ConditionalOutputStreamTest.class,
        PravegaRequestProcessorAuthFailedTest.class,
        WireCommandsTest.class,
        AsyncSegmentInputStreamTest.class,
        SegmentMetadataClientTest.class,
        SegmentOutputStreamTest.class,
        DelegationTokenTest.class,
})

public class DelegationTokenTestSuite {
}
```

