### PR TITLE
Issue 4396: Respond with meaningful status to ping transaction if transaction is already committed or aborted

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ModelHelper.java
@@ -10,6 +10,8 @@
 package io.pravega.client.stream.impl;
 
 import com.google.common.base.Preconditions;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.RetentionPolicy;
@@ -200,6 +202,8 @@ public final class ModelHelper {
             case ABORTED:
                 result = Transaction.PingStatus.ABORTED;
                 break;
+            case UNKNOWN:
+                throw new StatusRuntimeException(Status.NOT_FOUND);
             default:
                 throw new PingFailedException("Ping transaction for " + logString + " failed with status " + status);
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
@@ -10,6 +10,8 @@
 package io.pravega.client.stream.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.Transaction;
@@ -22,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.GuardedBy;
+
+import io.pravega.common.Exceptions;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -107,6 +111,12 @@ public class Pinger implements AutoCloseable {
                     controller.pingTransaction(stream, uuid, txnLeaseMillis)
                               .whenComplete((status, e) -> {
                                   if (e != null) {
+                                      Throwable unwrap = Exceptions.unwrap(e);
+                                      if (unwrap instanceof StatusRuntimeException && 
+                                              ((StatusRuntimeException) unwrap).getStatus().equals(Status.NOT_FOUND)) {
+                                          log.info("Ping Transaction for txn ID:{} did not find the transaction");
+                                          completedTxns.add(uuid);
+                                      }
                                       log.warn("Ping Transaction for txn ID:{} failed", uuid, unwrap(e));
                                   } else if (Transaction.PingStatus.ABORTED.equals(status) || Transaction.PingStatus.COMMITTED.equals(status)) {
                                       completedTxns.add(uuid);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasks.java
@@ -477,7 +477,7 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
         // Step 3. Update txn node data in the store,thus updating its version
         //         and fencing other processes from tracking this txn's timeout.
         // Step 4. Add this txn to timeout service and start managing timeout for this txn.
-        return streamMetadataStore.getTransactionData(scope, stream, txnId, ctx, executor).thenComposeAsync(txnData -> {
+        CompletableFuture<PingTxnStatus> pingTxnFuture = streamMetadataStore.getTransactionData(scope, stream, txnId, ctx, executor).thenComposeAsync(txnData -> {
             final TxnStatus txnStatus = txnData.getStatus();
             if (!txnStatus.equals(TxnStatus.OPEN)) { // transaction is not open, dont ping it
                 return CompletableFuture.completedFuture(getPingTxnStatus(txnStatus));
@@ -534,6 +534,11 @@ public class StreamTransactionMetadataTasks implements AutoCloseable {
                 }, executor);
             }
         }, executor);
+        return Futures.exceptionallyComposeExpecting(pingTxnFuture,
+                e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException,
+                () -> streamMetadataStore.transactionStatus(scope, stream, txnId, ctx, executor)
+                                   .thenApply(this::getPingTxnStatus)
+                );
     }
 
     private PingTxnStatus getPingTxnStatus(final TxnStatus txnStatus) {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
For completed transactions, `pingTransaction` calls into controller will no longer throw exception, instead it will either return the completion status (COMMITTED or ABORTED) or if the transaction is not found it will return UNKNOWN. 

**Purpose of the change**  
Fixes #4396 

**What the code does**  

In StreamTransactionMetadataTask.pingTransaction method, if it gets DNF exception while attempting to read activeTxnRecord, it fetches the completed txn record for the given txn and returns the txn status accordingly. If completedTxn does not have the record for the transaction, return status.UNKNOWN. 

Controller Client:
Controller client translates the status.UNKNOWN to throw NOT_FOUND exception. 

Pinger, which calls pingTransaction now handles NOT_FOUND exception where it then puts the txn in completed txn list so that no subsequent pings are sent for the said transaction. 

**How to verify it**  
unit tests added