### PR TITLE
Issue 4399: BookKeeper Write Throttling

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -328,12 +328,22 @@ metrics.enableStatistics=false
 #bookkeeper.bkWriteQuorumSize=3
 
 # Write Timeout, in milliseconds.
+# This value is also used for throttling purposes. Once BookKeeper Write Latencies exceed 10% of this value, the Segment
+# Store will begin throttling in order to manage the BookKeeper write backlog and reduce the chance of write timeouts.
 # Note: BookKeeper only allows multiples of 1 second (1000 millis). This value will be rounded up to the nearest second.
-#bookkeeper.bkWriteTimeoutMillis=5000
+#bookkeeper.bkWriteTimeoutMillis=60000
 
 # Read Timeout, in milliseconds.
 # Note: BookKeeper only allows multiples of 1 second (1000 millis). This value will be rounded up to the nearest second.
-#bookkeeper.bkReadTimeoutMillis=5000
+#bookkeeper.bkReadTimeoutMillis=30000
+
+# Maximum number of bytes that can be outstanding per BookKeeperLog at any given time. This value is used for throttling
+# purposes. This value is not set on the BookKeeper Client Configuration, rather it is used internally by the Segment
+# Store throttler to manage the BookKeeper write backlog and reduce the chance of write timeouts.
+# Recommended Value: 256MB. A smaller value will make throttling more aggressive but increase the overall stability of
+# the system. A larger value will increase the likelihood of BookKeeper write timeouts if BookKeeper is unable to keep
+# up with the load the Segment Store sends its way.
+#bookkeeper.maxOutstandingBytes=268435456
 
 # Maximum Ledger size (bytes) in BookKeeper. Once a Ledger reaches this size, it will be closed and another one open.
 # Note that ledgers will not be cut off at this size, rather them reaching this size will trigger a rollover; in-flight

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -9,6 +9,8 @@
  */
 package io.pravega.segmentstore.server;
 
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
+
 /**
  * Defines an object that can provide information about the Cache utilization.
  */
@@ -46,30 +48,11 @@ public interface CacheUtilizationProvider {
     double getCacheMaxUtilization();
 
     /**
-     * Registers the given {@link CleanupListener}, which will be notified of all subsequent Cache Cleanup events that
+     * Registers the given {@link ThrottleSourceListener}, which will be notified of all subsequent Cache Cleanup events that
      * result in at least one entry being evicted from the cache.
      *
-     * @param listener The {@link CleanupListener} to register. This will be auto-unregistered on the first Cache Cleanup
-     *                 run that detects {@link CleanupListener#isClosed()} to be true.
+     * @param listener The {@link ThrottleSourceListener} to register. This will be auto-unregistered on the first Cache Cleanup
+     *                 run that detects {@link ThrottleSourceListener#isClosed()} to be true.
      */
-    void registerCleanupListener(CleanupListener listener);
-
-    /**
-     * Defines a listener that will be notified by the {@link CacheManager} after every normally scheduled Cache Cleanup
-     * event that resulted in at least one entry being evicted from the cache.
-     */
-    interface CleanupListener {
-        /**
-         * Notifies this {@link CleanupListener} that a normally scheduled Cache Cleanup event that resulted in at least
-         * one entry being evicted from the cache has just finished.
-         */
-        void cacheCleanupComplete();
-
-        /**
-         * Gets a value indicating whether this {@link CleanupListener} is closed and should be unregistered.
-         *
-         * @return True if need to be unregistered (no further notifications will be sent), false otherwise.
-         */
-        boolean isClosed();
-    }
+    void registerCleanupListener(ThrottleSourceListener listener);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrameBuilder.java
@@ -68,7 +68,7 @@ class DataFrameBuilder<T extends SequencedItemList.Element> implements AutoClose
         this.args = Preconditions.checkNotNull(args, "args");
         Preconditions.checkNotNull(args.commitSuccess, "args.commitSuccess");
         Preconditions.checkNotNull(args.commitFailure, "args.commitFailure");
-        this.outputStream = new DataFrameOutputStream(targetLog.getMaxAppendLength(), this::handleDataFrameComplete);
+        this.outputStream = new DataFrameOutputStream(targetLog.getWriteSettings().getMaxWriteLength(), this::handleDataFrameComplete);
         this.lastSerializedSequenceNumber = -1;
         this.lastStartedSequenceNumber = -1;
         this.failureCause = new AtomicReference<>();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -82,7 +83,7 @@ class MemoryStateUpdater implements CacheUtilizationProvider {
     }
 
     @Override
-    public void registerCleanupListener(CleanupListener listener) {
+    public void registerCleanupListener(ThrottleSourceListener listener) {
         this.readIndex.registerCleanupListener(listener);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -101,7 +101,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheTargetUtilization(), stateUpdater.getCacheMaxUtilization())
                 .commitBacklogThrottler(this.commitQueue::size)
                 .batchingThrottler(durableDataLog::getQueueStatistics)
-                .durableDataLogThrottler(durableDataLog::getQueueStatistics)
+                .durableDataLogThrottler(durableDataLog.getWriteSettings(), durableDataLog::getQueueStatistics)
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, executor, this.metrics);
         this.stateUpdater.registerCleanupListener(this.throttler);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -105,6 +105,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, executor, this.metrics);
         this.stateUpdater.registerCleanupListener(this.throttler);
+        durableDataLog.registerQueueStateChangeListener(this.throttler);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -101,7 +101,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheTargetUtilization(), stateUpdater.getCacheMaxUtilization())
                 .commitBacklogThrottler(this.commitQueue::size)
                 .batchingThrottler(durableDataLog::getQueueStatistics)
-                //.durableDataLogThrottler(durableDataLog::getQueueStatistics)
+                .durableDataLogThrottler(durableDataLog::getQueueStatistics)
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, executor, this.metrics);
         this.stateUpdater.registerCleanupListener(this.throttler);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -101,6 +101,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .cacheThrottler(stateUpdater::getCacheUtilization, stateUpdater.getCacheTargetUtilization(), stateUpdater.getCacheMaxUtilization())
                 .commitBacklogThrottler(this.commitQueue::size)
                 .batchingThrottler(durableDataLog::getQueueStatistics)
+                //.durableDataLogThrottler(durableDataLog::getQueueStatistics)
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, executor, this.metrics);
         this.stateUpdater.registerCleanupListener(this.throttler);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -12,8 +12,8 @@ package io.pravega.segmentstore.server.logs;
 import com.google.common.annotations.VisibleForTesting;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
-import io.pravega.segmentstore.server.CacheUtilizationProvider;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -28,7 +28,7 @@ import lombok.val;
  * Throttling utilities for the {@link OperationProcessor} class.
  */
 @Slf4j
-class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseable {
+class Throttler implements ThrottleSourceListener, AutoCloseable {
     //region Members
 
     private final ThrottlerCalculator throttlerCalculator;
@@ -71,10 +71,10 @@ class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseab
 
     //endregion
 
-    //region CacheUtilizationProvider.CleanupListener Implementation
+    //region ThrottleSourceListener Implementation
 
     @Override
-    public void cacheCleanupComplete() {
+    public void notifyThrottleSourceChanged() {
         val currentDelay = this.currentDelay.get();
         if (currentDelay != null && isInterruptible(currentDelay.source)) {
             // We were actively throttling due to a reason that is eligible for re-throttling. Terminate the current
@@ -167,7 +167,8 @@ class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseab
     }
 
     private boolean isInterruptible(ThrottlerCalculator.ThrottlerName name) {
-        return name == ThrottlerCalculator.ThrottlerName.Cache;
+        return name == ThrottlerCalculator.ThrottlerName.Cache
+                || name == ThrottlerCalculator.ThrottlerName.DurableDataLog;
     }
 
     @VisibleForTesting

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -139,9 +139,11 @@ class Throttler implements CacheUtilizationProvider.CleanupListener, AutoCloseab
 
     private CompletableFuture<Void> throttleOnce(ThrottlerCalculator.DelayResult delay) {
         this.metrics.processingDelay(delay.getDurationMillis());
-        if (delay.isMaximum() || delay.getThrottlerName() == ThrottlerCalculator.ThrottlerName.CommitBacklog) {
+        if (delay.isMaximum()
+                || delay.getThrottlerName() == ThrottlerCalculator.ThrottlerName.CommitBacklog
+                || delay.getThrottlerName() == ThrottlerCalculator.ThrottlerName.DurableDataLog) {
             // Increase logging visibility if we throttle at the maximum limit (which means we're likely to fully block
-            // processing of operations) or if this is due to the Commit Processor not being able to keep up.
+            // processing of operations) or if this is due to us not being able to ingest items quickly enough.
             log.warn("{}: Processing delay = {}.", this.traceObjectId, delay);
         } else {
             log.debug("{}: Processing delay = {}.", this.traceObjectId, delay);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -13,7 +13,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.pravega.common.MathHelpers;
 import io.pravega.segmentstore.storage.QueueStats;
 import java.util.List;
-import java.util.Queue;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.AccessLevel;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -71,15 +71,14 @@ class ThrottlerCalculator {
      * DurableDataLog queue size at or above which the maximum throttling will apply.
      */
     @VisibleForTesting
-    static final int DURABLE_DATALOG_COUNT_THRESHOLD = 20;
+    static final int DURABLE_DATALOG_COUNT_THRESHOLD = 10;
     /**
      * DurableDataLog queue size at or above which the maximum throttling will apply.
      */
     @VisibleForTesting
-    static final int DURABLE_DATALOG_FULL_THROTTLE_THRESHOLD = 250;
+    static final int DURABLE_DATALOG_FULL_THROTTLE_THRESHOLD = 200;
     @VisibleForTesting
-    static final int DURABLE_DATALOG_PROCESSING_TIME_THROTTLE_THRESHOLD_MILLIS = 1000;
-
+    static final int DURABLE_DATALOG_PROCESSING_TIME_THROTTLE_THRESHOLD_MILLIS = 500;
     @Singular
     private final List<Throttler> throttlers;
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -71,12 +71,12 @@ class ThrottlerCalculator {
      * DurableDataLog queue size at or above which the maximum throttling will apply.
      */
     @VisibleForTesting
-    static final int DURABLE_DATALOG_COUNT_THRESHOLD = 10;
+    static final int DURABLE_DATALOG_COUNT_THRESHOLD = 20;
     /**
      * DurableDataLog queue size at or above which the maximum throttling will apply.
      */
     @VisibleForTesting
-    static final int DURABLE_DATALOG_FULL_THROTTLE_THRESHOLD = 100;
+    static final int DURABLE_DATALOG_FULL_THROTTLE_THRESHOLD = 250;
     @VisibleForTesting
     static final int DURABLE_DATALOG_PROCESSING_TIME_THROTTLE_THRESHOLD_MILLIS = 1000;
 
@@ -295,7 +295,10 @@ class ThrottlerCalculator {
         @Override
         int getDelayMillis() {
             QueueStats stats = this.getQueueStats.get();
-            return isThrottlingRequired(stats) ? getDelayMultiplier(stats.getSize()) * BASE_DELAY : 0;
+            if (isThrottlingRequired(stats)) {
+                return getDelayMultiplier(stats.getSize()) * BASE_DELAY;
+            }
+            return 0;
         }
 
         static int getDelayMultiplier(int queueSize) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ContainerReadIndex.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.storage.Cache;
 import io.pravega.segmentstore.storage.CacheFactory;
 import io.pravega.segmentstore.storage.ReadOnlyStorage;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -340,7 +341,7 @@ public class ContainerReadIndex implements ReadIndex {
     }
 
     @Override
-    public void registerCleanupListener(CleanupListener listener) {
+    public void registerCleanupListener(ThrottleSourceListener listener) {
         this.cacheManager.registerCleanupListener(listener);
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -263,6 +263,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         cm.runOneIteration();
         Assert.assertEquals("Expected cleanup listener to be invoked the second time.", 2, l1.getCallCount());
         Assert.assertEquals("Not expecting cleanup listener to be invoked the second time for closed listener.", 1, l2.getCallCount());
+        cm.registerCleanupListener(l2); // This should have no effect.
     }
 
     private static class TestCleanupListener implements ThrottleSourceListener {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server;
 
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.hash.RandomFactory;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
@@ -235,7 +236,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the ability to register, invoke and auto-unregister {@link CacheUtilizationProvider.CleanupListener} instances.
+     * Tests the ability to register, invoke and auto-unregister {@link ThrottleSourceListener} instances.
      */
     @Test
     public void testCleanupListeners() {
@@ -264,7 +265,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         Assert.assertEquals("Not expecting cleanup listener to be invoked the second time for closed listener.", 1, l2.getCallCount());
     }
 
-    private static class TestCleanupListener implements CacheUtilizationProvider.CleanupListener {
+    private static class TestCleanupListener implements ThrottleSourceListener {
         @Getter
         private int callCount = 0;
         @Setter
@@ -272,7 +273,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         private boolean closed;
 
         @Override
-        public void cacheCleanupComplete() {
+        public void notifyThrottleSourceChanged() {
             this.callCount++;
         }
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.segmentstore.storage.mocks.InMemoryDurableDataLogFactory;
 import io.pravega.test.common.ErrorInjector;
 import java.time.Duration;
@@ -117,6 +118,11 @@ public class TestDurableDataLog implements DurableDataLog {
     @Override
     public QueueStats getQueueStatistics() {
         return this.wrappedLog.getQueueStatistics();
+    }
+
+    @Override
+    public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
+        this.wrappedLog.registerQueueStateChangeListener(listener);
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestDurableDataLog.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.WriteSettings;
 import io.pravega.segmentstore.storage.mocks.InMemoryDurableDataLogFactory;
 import io.pravega.test.common.ErrorInjector;
 import java.time.Duration;
@@ -106,8 +107,8 @@ public class TestDurableDataLog implements DurableDataLog {
     }
 
     @Override
-    public int getMaxAppendLength() {
-        return this.wrappedLog.getMaxAppendLength();
+    public WriteSettings getWriteSettings() {
+        return this.wrappedLog.getWriteSettings();
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -28,6 +28,7 @@ import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.InputStream;
@@ -282,7 +283,7 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public void registerCleanupListener(CleanupListener listener) {
+        public void registerCleanupListener(ThrottleSourceListener listener) {
             throw new UnsupportedOperationException();
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -42,6 +42,7 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.segmentstore.storage.mocks.InMemoryCacheFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
 import io.pravega.test.common.AssertExtensions;
@@ -666,6 +667,11 @@ public class OperationProcessorTests extends OperationLogTestBase {
         @Override
         public QueueStats getQueueStatistics() {
             return QueueStats.DEFAULT;
+        }
+
+        @Override
+        public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
+
         }
 
         @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationProcessorTests.java
@@ -43,6 +43,7 @@ import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.WriteSettings;
 import io.pravega.segmentstore.storage.mocks.InMemoryCacheFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
 import io.pravega.test.common.AssertExtensions;
@@ -655,8 +656,8 @@ public class OperationProcessorTests extends OperationLogTestBase {
         }
 
         @Override
-        public int getMaxAppendLength() {
-            return 1024 * 1024;
+        public WriteSettings getWriteSettings() {
+            return new WriteSettings(1024 * 1024, Duration.ofMinutes(1), Integer.MAX_VALUE);
         }
 
         @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
@@ -128,14 +128,30 @@ public class ThrottlerTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the case when {@link Throttler#throttle()} returns a delay that can be interrupted using {@link Throttler#notifyThrottleSourceChanged()} ()}.
+     * Tests interruptible Cache delays.
      */
     @Test
     public void testInterruptedCacheDelay() throws Exception {
-        //val suppliedDelays = Arrays.asList(NON_MAX_THROTTLE_MILLIS, NON_MAX_THROTTLE_MILLIS / 2, NON_MAX_THROTTLE_MILLIS);
+        testInterruptedDelay(ThrottlerCalculator.ThrottlerName.Cache);
+    }
+
+    /**
+     * Tests interruptible DurableDataLog delays.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInterruptedDurableDataLogDelay() throws Exception {
+        testInterruptedDelay(ThrottlerCalculator.ThrottlerName.DurableDataLog);
+    }
+
+    /**
+     * Tests the case when {@link Throttler#throttle()} returns a delay that can be interrupted using {@link Throttler#notifyThrottleSourceChanged()}}.
+     */
+    private void testInterruptedDelay(ThrottlerCalculator.ThrottlerName throttlerName) throws Exception {
         val suppliedDelays = Arrays.asList(5000, 2500, 5000);
         val delays = Collections.<Integer>synchronizedList(new ArrayList<>());
-        val calculator = new TestCalculatorThrottler(THROTTLER_NAME);
+        val calculator = new TestCalculatorThrottler(throttlerName);
         val nextDelay = suppliedDelays.iterator();
         Consumer<Integer> recordDelay = delayMillis -> {
             delays.add(delayMillis);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ThrottlerTests.java
@@ -128,7 +128,7 @@ public class ThrottlerTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Tests the case when {@link Throttler#throttle()} returns a delay that can be interrupted using {@link Throttler#cacheCleanupComplete()}.
+     * Tests the case when {@link Throttler#throttle()} returns a delay that can be interrupted using {@link Throttler#notifyThrottleSourceChanged()} ()}.
      */
     @Test
     public void testInterruptedCacheDelay() throws Exception {
@@ -153,7 +153,7 @@ public class ThrottlerTests extends ThreadPooledTestSuite {
         // currently running throttle cycle and request the next throttling value.
         for (int i = 1; i < suppliedDelays.size(); i++) {
             // Interrupt the current throttle cycle.
-            t.cacheCleanupComplete();
+            t.notifyThrottleSourceChanged();
             Assert.assertFalse("Not expected throttle future to be completed yet.", t1.isDone());
 
             // Wait for the new cycle to begin (we use the recordDelay consumer above to figure this out).

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -14,7 +14,7 @@ import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.InvalidPropertyValueException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import lombok.Getter;
@@ -34,8 +34,9 @@ public class BookKeeperConfig {
     public static final Property<Integer> BK_ENSEMBLE_SIZE = Property.named("bkEnsembleSize", 3);
     public static final Property<Integer> BK_ACK_QUORUM_SIZE = Property.named("bkAckQuorumSize", 2);
     public static final Property<Integer> BK_WRITE_QUORUM_SIZE = Property.named("bkWriteQuorumSize", 3);
-    public static final Property<Integer> BK_WRITE_TIMEOUT = Property.named("bkWriteTimeoutMillis", 5000);
-    public static final Property<Integer> BK_READ_TIMEOUT = Property.named("readTimeoutMillis", 5000);
+    public static final Property<Integer> BK_WRITE_TIMEOUT = Property.named("bkWriteTimeoutMillis", 60000);
+    public static final Property<Integer> BK_READ_TIMEOUT = Property.named("readTimeoutMillis", 30000);
+    public static final Property<Integer> MAX_OUTSTANDING_BYTES = Property.named("maxOutstandingBytes", 256 * 1024 * 1024);
     public static final Property<Integer> BK_LEDGER_MAX_SIZE = Property.named("bkLedgerMaxSize", 1024 * 1024 * 1024);
     public static final Property<String> BK_PASSWORD = Property.named("bkPass", "");
     public static final Property<String> BK_LEDGER_PATH = Property.named("bkLedgerPath", "");
@@ -127,6 +128,13 @@ public class BookKeeperConfig {
     private final int bkReadTimeoutMillis;
 
     /**
+     * The maximum number of bytes that can be outstanding per BookKeeperLog at any given time. This value should be used
+     * for throttling purposes.
+     */
+    @Getter
+    private final int maxOutstandingBytes;
+
+    /**
      * The Maximum size of a ledger, in bytes. On or around this value the current ledger is closed and a new one
      * is created. By design, this property cannot be larger than Int.MAX_VALUE, since we want Ledger Entry Ids to be
      * representable with an Int.
@@ -176,8 +184,9 @@ public class BookKeeperConfig {
 
         this.bkWriteTimeoutMillis = properties.getInt(BK_WRITE_TIMEOUT);
         this.bkReadTimeoutMillis = properties.getInt(BK_READ_TIMEOUT);
+        this.maxOutstandingBytes = properties.getInt(MAX_OUTSTANDING_BYTES);
         this.bkLedgerMaxSize = properties.getInt(BK_LEDGER_MAX_SIZE);
-        this.bkPassword = properties.get(BK_PASSWORD).getBytes(Charset.forName("UTF-8"));
+        this.bkPassword = properties.get(BK_PASSWORD).getBytes(StandardCharsets.UTF_8);
         this.isTLSEnabled = properties.getBoolean(BK_TLS_ENABLED);
         this.tlsTrustStore = properties.get(TLS_TRUST_STORE_PATH);
         this.tlsTrustStorePasswordPath = properties.get(TLS_TRUST_STORE_PASSWORD_PATH);

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.WriteSettings;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -157,8 +158,10 @@ public class DebugLogWrapper implements AutoCloseable {
         }
 
         @Override
-        public int getMaxAppendLength() {
-            return BookKeeperConfig.MAX_APPEND_LENGTH;
+        public WriteSettings getWriteSettings() {
+            return new WriteSettings(BookKeeperConfig.MAX_APPEND_LENGTH,
+                    Duration.ofMillis(BookKeeperConfig.BK_WRITE_TIMEOUT.getDefaultValue()),
+                    BookKeeperConfig.MAX_OUTSTANDING_BYTES.getDefaultValue());
         }
 
         @Override

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/DebugLogWrapper.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -168,6 +169,11 @@ public class DebugLogWrapper implements AutoCloseable {
         @Override
         public QueueStats getQueueStatistics() {
             return null;
+        }
+
+        @Override
+        public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * A specialized queue for BookKeeper writes. Provides methods for adding new items, determining the next items to execute,
@@ -168,11 +170,11 @@ class WriteQueue {
      * Removes all the completed writes (whether successful or failed) from the beginning of the queue, until the first
      * non-completed item is encountered or the queue is empty.
      *
-     * @return A CleanupStatus representing the state of the Operation. If there were failed writes, this will be WriteFailed,
-     * otherwise it will be one of QueueEmpty or QueueNotEmpty, depending on the final state of the queue when this method
-     * finishes.
+     * @return A CleanupResult representing the result of the Operation. If there were failed writes, {@link CleanupResult#getStatus()}
+     * will be {@link CleanupStatus#WriteFailed), otherwise it will be one of {@link CleanupStatus#QueueEmpty} or
+     * {@link CleanupStatus#QueueNotEmpty}, depending on the final state of the queue when this method finishes.
      */
-    synchronized CleanupStatus removeFinishedWrites() {
+    synchronized CleanupResult removeFinishedWrites() {
         Exceptions.checkNotClosed(this.closed, this);
         long currentTime = this.timeSupplier.get();
         long totalElapsed = 0;
@@ -190,9 +192,10 @@ class WriteQueue {
             this.lastDurationMillis = (int) (totalElapsed / removedCount / AbstractTimer.NANOS_TO_MILLIS);
         }
 
-        return failedWrite
+        CleanupStatus status = failedWrite
                 ? CleanupStatus.WriteFailed
                 : this.writes.isEmpty() ? CleanupStatus.QueueEmpty : CleanupStatus.QueueNotEmpty;
+        return new CleanupResult(status, removedCount);
     }
 
     /**
@@ -210,6 +213,13 @@ class WriteQueue {
     }
 
     //endregion
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    static class CleanupResult {
+        private final CleanupStatus status;
+        private final int removedCount;
+    }
 
     //region CleanupStatus
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueue.java
@@ -214,12 +214,25 @@ class WriteQueue {
 
     //endregion
 
+    //region CleanupResult
+
+    /**
+     * The result of a call to {@link #removeFinishedWrites()}.
+     */
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     @Getter
     static class CleanupResult {
+        /**
+         * The final status of the queue.
+         */
         private final CleanupStatus status;
+        /**
+         * The number of removed writes.
+         */
         private final int removedCount;
     }
+
+    //endregion
 
     //region CleanupStatus
 

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -35,6 +35,7 @@ public class BookKeeperConfigTest {
         Assert.assertEquals(3, cfg.getBkWriteQuorumSize());
         Assert.assertEquals(60000, cfg.getBkWriteTimeoutMillis());
         Assert.assertEquals(30000, cfg.getBkReadTimeoutMillis());
+        Assert.assertEquals(256 * 1024 * 1024, cfg.getMaxOutstandingBytes());
         Assert.assertEquals(1024 * 1024 * 1024, cfg.getBkLedgerMaxSize());
         Assert.assertEquals(0, cfg.getBKPassword().length);
         Assert.assertEquals("", cfg.getBkLedgerPath());

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -33,8 +33,8 @@ public class BookKeeperConfigTest {
         Assert.assertEquals(3, cfg.getBkEnsembleSize());
         Assert.assertEquals(2, cfg.getBkAckQuorumSize());
         Assert.assertEquals(3, cfg.getBkWriteQuorumSize());
-        Assert.assertEquals(5000, cfg.getBkWriteTimeoutMillis());
-        Assert.assertEquals(5000, cfg.getBkReadTimeoutMillis());
+        Assert.assertEquals(60000, cfg.getBkWriteTimeoutMillis());
+        Assert.assertEquals(30000, cfg.getBkReadTimeoutMillis());
         Assert.assertEquals(1024 * 1024 * 1024, cfg.getBkLedgerMaxSize());
         Assert.assertEquals(0, cfg.getBKPassword().length);
         Assert.assertEquals("", cfg.getBkLedgerPath());

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/WriteQueueTests.java
@@ -130,7 +130,7 @@ public class WriteQueueTests {
             if (!write.isDone()) {
                 val result1 = q.removeFinishedWrites();
                 Assert.assertEquals("Unexpected value from removeFinishedWrites when there were writes left in the queue.",
-                        WriteQueue.CleanupStatus.QueueNotEmpty, result1);
+                        WriteQueue.CleanupStatus.QueueNotEmpty, result1.getStatus());
                 val stats1 = q.getStatistics();
                 Assert.assertEquals("Unexpected size after removeFinishedWrites with no effect.", writes.size() + 1, stats1.getSize());
 
@@ -150,7 +150,7 @@ public class WriteQueueTests {
 
             val result2 = q.removeFinishedWrites();
             val expectedResult = writes.isEmpty() ? WriteQueue.CleanupStatus.QueueEmpty : WriteQueue.CleanupStatus.QueueNotEmpty;
-            Assert.assertEquals("Unexpected result from removeFinishedWrites.", expectedResult, result2);
+            Assert.assertEquals("Unexpected result from removeFinishedWrites.", expectedResult, result2.getStatus());
             val stats2 = q.getStatistics();
             Assert.assertEquals("Unexpected size after removeFinishedWrites.", writes.size(), stats2.getSize());
             Assert.assertEquals("Unexpected getExpectedProcessingTimeMillis after clear.", expectedElapsed, stats2.getExpectedProcessingTimeMillis());
@@ -162,7 +162,7 @@ public class WriteQueueTests {
         w3.fail(new IntentionalException(), true);
         val result3 = q.removeFinishedWrites();
         Assert.assertEquals("Unexpected value from removeFinishedWrites when there were failed writes.",
-                WriteQueue.CleanupStatus.WriteFailed, result3);
+                WriteQueue.CleanupStatus.WriteFailed, result3.getStatus());
 
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
@@ -150,6 +150,8 @@ public interface DurableDataLog extends AutoCloseable {
      */
     QueueStats getQueueStatistics();
 
+    void registerQueueStateChangeListener(ThrottleSourceListener listener);
+
     /**
      * Closes this instance of a DurableDataLog and releases any resources it holds.
      */

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/DurableDataLog.java
@@ -123,9 +123,10 @@ public interface DurableDataLog extends AutoCloseable {
     CloseableIterator<ReadItem, DurableDataLogException> getReader() throws DurableDataLogException;
 
     /**
-     * Gets the maximum number of bytes allowed for a single append.
+     * Gets a {@link WriteSettings} containing limitations for appends.
+     * @return A new {@link WriteSettings} object.
      */
-    int getMaxAppendLength();
+    WriteSettings getWriteSettings();
 
     /**
      * Gets a value indicating the current Epoch of this DurableDataLog.
@@ -150,6 +151,13 @@ public interface DurableDataLog extends AutoCloseable {
      */
     QueueStats getQueueStatistics();
 
+    /**
+     * Registers a {@link ThrottleSourceListener} that will be invoked every time the internal queue state changes by having
+     * added or removed from it.
+     *
+     * @param listener The {@link ThrottleSourceListener} to register. This listener will be unregistered when its
+     *                 {@link ThrottleSourceListener#isClosed()} is determined to be true.
+     */
     void registerQueueStateChangeListener(ThrottleSourceListener listener);
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottleSourceListener.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottleSourceListener.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+/**
+ * Defines a listener that will be notified every time the state of the a Throttling Source changed.
+ */
+public interface ThrottleSourceListener {
+    /**
+     * Notifies this {@link ThrottleSourceListener} the state of the Throttling Source has changed.
+     */
+    void notifyThrottleSourceChanged();
+
+    /**
+     * Gets a value indicating whether this {@link ThrottleSourceListener} is closed and should be unregistered.
+     *
+     * @return True if need to be unregistered (no further notifications will be sent), false otherwise.
+     */
+    boolean isClosed();
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteSettings.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteSettings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteSettings.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/WriteSettings.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import lombok.Getter;
+
+/**
+ * Provides information about a {@link DurableDataLog}'s write settings and/or limitations.
+ */
+@Getter
+public class WriteSettings {
+    /**
+     * The maximum number of bytes allowed for a single write.
+     */
+    private final int maxWriteLength;
+    /**
+     * The maximum amount of time that a write may be outstanding for before it is timed out.
+     */
+    private final Duration maxWriteTimeout;
+    /**
+     * The maximum number of bytes (across all in-flight appends) that can be outstanding for the {@link DurableDataLog}
+     * at any given time.
+     * This is a suggested value and is not enforced inside the {@link DurableDataLog}.
+     */
+    private final int maxOutstandingBytes;
+
+    /**
+     * Creates a new instance of the {@link WriteSettings} class.
+     *
+     * @param maxWriteLength      The maximum number of bytes allowed for a single write.
+     * @param maxWriteTimeout     The maximum amount of time that a write may be outstanding for before it is timed out.
+     * @param maxOutstandingBytes The maximum number of bytes (across all in-flight appends) that can be outstanding for
+     *                            the {@link DurableDataLog} at any given time.
+     */
+    public WriteSettings(int maxWriteLength, Duration maxWriteTimeout, int maxOutstandingBytes) {
+        Preconditions.checkArgument(maxWriteLength > 0, "maxWriteLength must be a positive integer");
+        Preconditions.checkArgument(!maxWriteTimeout.isNegative(), "maxWriteTimeout must be a non-negative duration.");
+        Preconditions.checkArgument(maxOutstandingBytes > 0, "maxOutstandingBytes must be a positive integer");
+        this.maxWriteLength = maxWriteLength;
+        this.maxWriteTimeout = maxWriteTimeout;
+        this.maxOutstandingBytes = maxOutstandingBytes;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MaxWriteLength = %s, MaxOutstandingBytes = %s, MaxWriteTimeoutMillis = %s",
+                this.maxWriteLength, this.maxOutstandingBytes, this.maxWriteTimeout.toMillis());
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.segmentstore.storage.WriteSettings;
+import io.pravega.segmentstore.storage.WriteTooLongException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
@@ -148,6 +149,10 @@ class InMemoryDurableDataLog implements DurableDataLog {
     @Override
     public CompletableFuture<LogAddress> append(ArrayView data, Duration timeout) {
         ensurePreconditions();
+        if (data.getLength() > getWriteSettings().getMaxWriteLength()) {
+            return Futures.failedFuture(new WriteTooLongException(data.getLength(), getWriteSettings().getMaxWriteLength()));
+        }
+
         CompletableFuture<LogAddress> result;
         try {
             Entry entry = new Entry(data);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
@@ -22,6 +22,7 @@ import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
@@ -136,6 +137,11 @@ class InMemoryDurableDataLog implements DurableDataLog {
     public QueueStats getQueueStatistics() {
         // InMemory DurableDataLog has almost infinite bandwidth, so no need to complicate ourselves with this.
         return QueueStats.DEFAULT;
+    }
+
+    @Override
+    public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
+        // No-op (because getQueueStatistics() doesn't return anything interesting).
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLog.java
@@ -23,6 +23,7 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.WriteSettings;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
@@ -121,8 +122,8 @@ class InMemoryDurableDataLog implements DurableDataLog {
     }
 
     @Override
-    public int getMaxAppendLength() {
-        return this.entries.getMaxAppendSize();
+    public WriteSettings getWriteSettings() {
+        return new WriteSettings(this.entries.getMaxAppendSize(), Duration.ofMinutes(1), Integer.MAX_VALUE);
     }
 
     @Override

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
@@ -9,12 +9,14 @@
  */
 package io.pravega.segmentstore.storage;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.io.StreamHelpers;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.CloseableIterator;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -26,6 +28,9 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
@@ -376,6 +381,45 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
         }
     }
 
+    /**
+     * Tests the ability to register a {@link ThrottleSourceListener} and notify it of updates.
+     */
+    @Test
+    public void testRegisterQueueStateListener() throws Exception {
+        val listener = new TestThrottleSourceListener();
+        try (DurableDataLog log = createDurableDataLog()) {
+            log.initialize(TIMEOUT);
+            log.registerQueueStateChangeListener(listener);
+
+            // Only verify sequence number monotonicity. We'll verify reads in its own test.
+            int writeCount = getWriteCount();
+            for (int i = 0; i < writeCount; i++) {
+                log.append(new ByteArraySegment(getWriteData()), TIMEOUT).join();
+            }
+
+            // Verify the correct number of invocations.
+            TestUtils.await(
+                    () -> listener.getCount() == writeCount,
+                    10,
+                    TIMEOUT.toMillis());
+
+            // Verify that the listener is unregistered when closed.
+            listener.close();
+            log.append(new ByteArraySegment(getWriteData()), TIMEOUT).join();
+            try {
+                TestUtils.await(
+                        () -> listener.getCount() > writeCount,
+                        10,
+                        50);
+                Assert.fail("Listener's count was updated after it was closed.");
+            } catch (TimeoutException tex) {
+                // This is expected. We do not want our condition to hold true.
+            }
+            log.registerQueueStateChangeListener(listener); // This should have no effect as it's already closed.
+            Assert.assertFalse("Not expected the listener to have been notified after closing.", listener.wasNotifiedWhenClosed());
+        }
+    }
+
     //endregion
 
     //region Abstract methods.
@@ -456,6 +500,43 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
             Assert.assertEquals("Unexpected sequence number.", expected.getKey().getSequence(), nextItem.getAddress().getSequence());
             val actualPayload = StreamHelpers.readAll(nextItem.getPayload(), nextItem.getLength());
             Assert.assertArrayEquals("Unexpected payload for sequence number " + expected.getKey(), expected.getValue(), actualPayload);
+        }
+    }
+
+    //endregion
+
+    //region TestThrottleSourceListener
+
+    private static class TestThrottleSourceListener implements ThrottleSourceListener {
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicBoolean notifyWhenClosed = new AtomicBoolean(false);
+
+        void close() {
+            this.closed.set(true);
+        }
+
+        boolean wasNotifiedWhenClosed() {
+            return this.notifyWhenClosed.get();
+        }
+
+        int getCount() {
+            return this.count.get();
+        }
+
+        @Override
+        public void notifyThrottleSourceChanged() {
+            if (this.closed.get()) {
+                this.notifyWhenClosed.set(true);
+            }
+
+            Exceptions.checkNotClosed(this.closed.get(), this);
+            this.count.incrementAndGet();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return this.closed.get();
         }
     }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
@@ -63,6 +63,12 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
 
             log.initialize(TIMEOUT);
 
+            // Check that we cannot append data exceeding the max limit.
+            AssertExtensions.assertSuppliedFutureThrows(
+                    "append() worked with buffer exceeding max size",
+                    () -> log.append(new ByteArraySegment(new byte[log.getWriteSettings().getMaxWriteLength() + 1]), TIMEOUT),
+                    ex -> ex instanceof WriteTooLongException);
+
             // Only verify sequence number monotonicity. We'll verify reads in its own test.
             LogAddress prevAddress = null;
             int writeCount = getWriteCount();

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/DurableDataLogTestBase.java
@@ -383,6 +383,7 @@ public abstract class DurableDataLogTestBase extends ThreadPooledTestSuite {
 
     /**
      * Tests the ability to register a {@link ThrottleSourceListener} and notify it of updates.
+     * @throws Exception If an error occurred.
      */
     @Test
     public void testRegisterQueueStateListener() throws Exception {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/WriteSettingsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/WriteSettingsTests.java
@@ -11,6 +11,8 @@ package io.pravega.segmentstore.storage;
 
 import io.pravega.test.common.AssertExtensions;
 import java.time.Duration;
+import lombok.val;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -33,6 +35,10 @@ public class WriteSettingsTests {
                 ex -> ex instanceof IllegalArgumentException);
 
         // Verify valid args work.
-        new WriteSettings(1, Duration.ofMillis(1), 1);
+        val ws = new WriteSettings(1, Duration.ofMillis(2), 3);
+        Assert.assertEquals(1, ws.getMaxWriteLength());
+        Assert.assertEquals(2, ws.getMaxWriteTimeout().toMillis());
+        Assert.assertEquals(3, ws.getMaxOutstandingBytes());
+        ws.toString();
     }
 }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/WriteSettingsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/WriteSettingsTests.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import io.pravega.test.common.AssertExtensions;
+import java.time.Duration;
+import org.junit.Test;
+
+/**
+ * Tests the WriteSettings class.
+ */
+public class WriteSettingsTests {
+    @Test
+    public void testConstructor() {
+        AssertExtensions.assertThrows(
+                "negative maxWriteLength",
+                () -> new WriteSettings(-1, Duration.ofMillis(1), 1),
+                ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows(
+                "negative maxWriteTimeout",
+                () -> new WriteSettings(1, Duration.ofMillis(-1), 1),
+                ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows(
+                "negative maxOutstandingBytes",
+                () -> new WriteSettings(1, Duration.ofMillis(1), -1),
+                ex -> ex instanceof IllegalArgumentException);
+
+        // Verify valid args work.
+        new WriteSettings(1, Duration.ofMillis(1), 1);
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
@@ -13,10 +13,14 @@ import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.storage.DurableDataLog;
 import io.pravega.segmentstore.storage.DurableDataLogTestBase;
 import io.pravega.segmentstore.storage.LogAddress;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.val;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,10 +49,32 @@ public class InMemoryDurableDataLogTests extends DurableDataLogTestBase {
         }
     }
 
+    @Test
+    public void testWriteSettings() {
+        @Cleanup
+        val log = createDurableDataLog();
+        val ws = log.getWriteSettings();
+        Assert.assertEquals(1024 * 1024 - 8 * 1024, ws.getMaxWriteLength());
+        Assert.assertEquals(Integer.MAX_VALUE, ws.getMaxOutstandingBytes());
+    }
+
     @Override
     @Test
     public void testRegisterQueueStateListener() {
-        // Nothing to test as this functionality is not implemented here.
+        @Cleanup
+        val log = createDurableDataLog();
+
+        // Following should have no effect.
+        log.registerQueueStateChangeListener(new ThrottleSourceListener() {
+            @Override
+            public void notifyThrottleSourceChanged() {
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+        });
     }
 
     @Override

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemoryDurableDataLogTests.java
@@ -46,6 +46,12 @@ public class InMemoryDurableDataLogTests extends DurableDataLogTestBase {
     }
 
     @Override
+    @Test
+    public void testRegisterQueueStateListener() {
+        // Nothing to test as this functionality is not implemented here.
+    }
+
+    @Override
     protected DurableDataLog createDurableDataLog() {
         return this.factory.createDurableDataLog(this.nextContainerId.get());
     }


### PR DESCRIPTION
**Change log description**  
- Changed configuration defaults: `bookkeeper.bkWriteTimeoutMillis=60000`, `bookkeeper.readTimeoutMillis=30000`
- Added another throttler to the Segment Store that manages the in-flight data sent to BookKeeper.

**Purpose of the change**  
Fixes #4399.

**What the code does**  
- Increased the defaults for BK Write and Read timeouts to larger values. This helps reduce instability in those deployments where BK is very slow. A write timeout would cause a Ledger to be closed, thus triggering an avalanche of Ledger Rollovers and retries, further overwhelming the system.
- Added a new Throttler in the Segment Store's `OperationProcessor` that works along the following lines
    - Throttling is triggered only if the recent BK Write Latencies exceed 10% of `bookkeeper.bkWriteTimeoutMillis`. The 10% is hardcoded as a constant.
    - If triggered, the throttle delay is a gradual measurement as a function of the amount of data outstanding in the BK queue
    - The maximum delay is applied when the outstanding data exceeds `bookkeeper.maxOutstandingBytes`.
    - There is no delay if the outstanding data is below 10% (same constant as above) of `bookkeeper.maxOutstandingBytes`.
    - The delay increases gradually between these values, as a function of the amount of outstanding data.
- A bit of refactoring to consolidate similar patterns that relate to throttling interruption by using a unified `ThrottleSourceListener`.

**How to verify it**  
All unit tests must pass.
System tests must pass.
