### PR TITLE
Issue 4409: Reset tokenRefreshFuture upon exception in obtaining a new delegation token

### DIFF
--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -245,7 +245,7 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
                     this.tokenRefreshFuture.compareAndSet(handleToCurrentRefreshFuture, null);
                     log.warn("Encountered an exception in refreshToken", ex);
                     LoggerHelpers.traceLeave(log, "refreshToken", traceEnterId, this.scopeName, this.streamName);
-                    throw ex instanceof CompletionException ? (CompletionException)ex: new CompletionException(ex);
+                    throw ex instanceof CompletionException ? (CompletionException) ex : new CompletionException(ex);
                 });
     }
 

--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -227,7 +227,7 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
         long traceEnterId = LoggerHelpers.traceEnter(log, "refreshToken", this.scopeName, this.streamName);
         CompletableFuture<Void> currentRefreshFuture = tokenRefreshFuture.get();
         if (currentRefreshFuture == null) {
-            log.debug("Initiated token refresh for scope {} and stream {}", this.scopeName, this.streamName);
+            log.debug("Initiating token refresh for scope {} and stream {}", this.scopeName, this.streamName);
             currentRefreshFuture = this.recreateToken();
             this.tokenRefreshFuture.compareAndSet(null, currentRefreshFuture);
         } else {

--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -70,6 +70,8 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
 
     private final AtomicReference<DelegationToken> delegationToken = new AtomicReference<>();
 
+    @VisibleForTesting
+    @Getter(AccessLevel.PACKAGE)
     private final AtomicReference<CompletableFuture<Void>> tokenRefreshFuture = new AtomicReference<>();
 
     JwtTokenProviderImpl(Controller controllerClient, String scopeName, String streamName) {

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -1109,9 +1109,9 @@ public class ControllerImpl implements Controller {
         return result.thenApply( token -> token.getDelegationToken())
         .whenComplete((x, e) -> {
             if (e != null) {
-                log.warn("getCurrentSegments failed: ", e);
+                log.warn("getOrRefreshDelegationTokenFor failed: ", e);
             }
-            LoggerHelpers.traceLeave(log, "getCurrentSegments", traceId);
+            LoggerHelpers.traceLeave(log, "getOrRefreshDelegationTokenFor", traceId);
         });
     }
 

--- a/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
+++ b/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
@@ -25,7 +25,13 @@ import org.junit.Test;
 
 import static io.pravega.client.security.auth.JwtTestUtils.createJwtBody;
 import static io.pravega.client.security.auth.JwtTestUtils.dummyToken;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -353,7 +359,7 @@ public class JwtTokenProviderImplTest {
                 ControllerImplConfig.builder().clientConfig(config).retryAttempts(1).build(),
                 Executors.newScheduledThreadPool(1));
 
-        JwtTokenProviderImpl tokenProvider = (JwtTokenProviderImpl)DelegationTokenProviderFactory.create(controllerClient,
+        JwtTokenProviderImpl tokenProvider = (JwtTokenProviderImpl) DelegationTokenProviderFactory.create(controllerClient,
                 "bob-0", "bob-0");
 
         try {
@@ -365,7 +371,7 @@ public class JwtTokenProviderImplTest {
         }
         try {
             tokenProvider.retrieveToken().join();
-        } catch(CompletionException e) {
+        } catch (CompletionException e) {
             log.info("Encountered CompletionException as expected");
             assertNull("Expected a null tokenRefreshFuture", tokenProvider.getTokenRefreshFuture().get());
         }

--- a/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
+++ b/client/src/test/java/io/pravega/client/security/auth/JwtTokenProviderImplTest.java
@@ -25,12 +25,7 @@ import org.junit.Test;
 
 import static io.pravega.client.security.auth.JwtTestUtils.createJwtBody;
 import static io.pravega.client.security.auth.JwtTestUtils.dummyToken;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -337,8 +332,8 @@ public class JwtTokenProviderImplTest {
     public void testRefreshTokenCompletesUponFailure() {
         ClientConfig config = ClientConfig.builder().controllerURI(URI.create("tcp://non-existent-cluster:9090")).build();
         Controller controllerClient = new ControllerImpl(
-                ControllerImplConfig.builder().clientConfig(config).retryAttempts(3).build(),
-                Executors.newScheduledThreadPool(3));
+                ControllerImplConfig.builder().clientConfig(config).retryAttempts(1).build(),
+                Executors.newScheduledThreadPool(1));
 
         DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(controllerClient, "bob-0", "bob-0");
         try {
@@ -349,23 +344,30 @@ public class JwtTokenProviderImplTest {
         }
     }
 
-    @Test(expected = CompletionException.class)
-    public void testRefreshTokenCompletesUponFailureUponAConcurrentRefresh() throws InterruptedException {
+    @Test
+    public void testTokenRefreshFutureIsClearedUponFailure() throws InterruptedException {
         ClientConfig config = ClientConfig.builder().controllerURI(
                 URI.create("tcp://non-existent-cluster:9090")).build();
 
         Controller controllerClient = new ControllerImpl(
-                ControllerImplConfig.builder().clientConfig(config).retryAttempts(3).build(),
-                Executors.newScheduledThreadPool(3));
+                ControllerImplConfig.builder().clientConfig(config).retryAttempts(1).build(),
+                Executors.newScheduledThreadPool(1));
 
-        DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(controllerClient, "bob-0", "bob-0");
+        JwtTokenProviderImpl tokenProvider = (JwtTokenProviderImpl)DelegationTokenProviderFactory.create(controllerClient,
+                "bob-0", "bob-0");
+
         try {
-            tokenProvider.retrieveToken();
-            Thread.sleep(20);
-            tokenProvider.retrieveToken().join();
+            String token = tokenProvider.retrieveToken().join();
+            fail("Didn't expect the control to come here");
         } catch (CompletionException e) {
-            assertEquals(RetriesExhaustedException.class.getName(), e.getCause().getClass().getName());
-            throw e;
+            log.info("Encountered CompletionException as expected");
+            assertNull("Expected a null tokenRefreshFuture", tokenProvider.getTokenRefreshFuture().get());
+        }
+        try {
+            tokenProvider.retrieveToken().join();
+        } catch(CompletionException e) {
+            log.info("Encountered CompletionException as expected");
+            assertNull("Expected a null tokenRefreshFuture", tokenProvider.getTokenRefreshFuture().get());
         }
     }
 }


### PR DESCRIPTION
**Change log description**  
Fix a bug that prevents `tokenRefreshFuture` from getting reset, preventing the `DelegationTokenProvider` from working properly after errors such as a failed attempt to obtain a new delegation token.  The `tokenRefreshFuture` remained in `iscompletedExceptionally` state forever, and therefore the `JwtTokenProviderImpl` failed to retrieve token post that event. 

**Purpose of the change**  
Fixes #4409 

**What the code does**  
Resets `tokenRefreshFuture` shared variable to `null` if there is an exception in obtaining a new delegation token, so that the logic to refresh the token will be executed again on next attempt. 

**How to verify it**  
All existing and new tests must pass. 
System tests must pass, with and without `auth` enabled. 
