### PR TITLE
Issue 4412: Fix bug in ExtendedS3StorageConfig to correctly handle missing trailing `/` in root.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -33,6 +33,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<Boolean> USENONEMATCH = Property.named("useNoneMatch", false);
 
     private static final String COMPONENT_CODE = "extendeds3";
+    private static final String PATH_SEPARATOR = "/";
 
     //endregion
 
@@ -91,7 +92,8 @@ public class ExtendedS3StorageConfig {
      * @param properties The TypedProperties object to read Properties from.
      */
     private ExtendedS3StorageConfig(TypedProperties properties) throws ConfigurationException {
-        this.root = properties.get(ROOT);
+        String givenRoot = properties.get(ROOT);
+        this.root = givenRoot.endsWith(PATH_SEPARATOR) ? givenRoot : givenRoot + PATH_SEPARATOR;
         this.accessKey = properties.get(ACCESS_KEY_ID);
         this.secretKey = properties.get(SECRET_KEY);
         this.url = java.net.URI.create(properties.get(URI));

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -14,6 +14,8 @@ import com.emc.object.s3.S3Config;
 import com.emc.object.s3.bean.ObjectKey;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.emc.object.s3.request.DeleteObjectsRequest;
+import io.pravega.common.util.ConfigBuilder;
+import io.pravega.common.util.Property;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
 import io.pravega.segmentstore.storage.Storage;
@@ -32,6 +34,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.pravega.test.common.AssertExtensions.assertFutureThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for ExtendedS3Storage.
@@ -79,6 +83,23 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
         }
     }
     //endregion
+
+    @Test
+    public void testConfigForTrailingCharInRoot() {
+        // Missing trailing '/'
+        ConfigBuilder<ExtendedS3StorageConfig> builder1 = ExtendedS3StorageConfig.builder();
+        builder1.with(Property.named("root"), "test");
+        ExtendedS3StorageConfig config1 = builder1.build();
+        assertTrue(config1.getRoot().endsWith("/"));
+        assertEquals("test/", config1.getRoot());
+
+        // Not missing '/'
+        ConfigBuilder<ExtendedS3StorageConfig> builder2 = ExtendedS3StorageConfig.builder();
+        builder2.with(Property.named("root"), "test/");
+        ExtendedS3StorageConfig config2 = builder2.build();
+        assertTrue(config2.getRoot().endsWith("/"));
+        assertEquals("test/", config2.getRoot());
+    }
 
     private static Storage createStorage(S3Client client, ExtendedS3StorageConfig adapterConfig, Executor executor) {
         // We can't use the factory here because we're setting our own (mock) client.


### PR DESCRIPTION
Current logic in ExtendedS3StorageConfig incorrectly assumes that root has a trailing '/' character. If this is not the case then the S3 storage is wrongly initialized and results in invalid paths/urls.
This change fixes the bug by adding the / char when it is missing.

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Fix bug in ExtendedS3StorageConfig to correctly handle missing trailing `/` in root.

**Purpose of the change**  
Fixes #4412 

**What the code does**  
This change fixes it by adding the / char when it is missing.

**How to verify it**  
All tests should pass.
