### PR TITLE
Issue 4393: Fixing error sequencing in AppendProcessor

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -223,6 +223,13 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                         connection.send(dataAppendedAck);
                     }
                 }
+
+                if (append.getEventNumber() > state.getLowestFailedEventNumber()) {
+                    // The Store should not be successfully completing an Append that followed a failed one. If somehow
+                    // this happened, record it in the log.
+                    log.warn("Acknowledged a successful append after a failed one. Segment={}, WriterId={}, FailedEventNumber={}, AppendEventNumber={}",
+                            append.getSegment(), append.getWriterId(), state.getLowestFailedEventNumber(), append.getEventNumber());
+                }
             } else {
                 if (conditionalFailed) {
                     log.debug("Conditional append failed due to incorrect offset: {}, {}", append, exception.getMessage());

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -57,8 +57,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -237,24 +235,15 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                 } else {
                     // Record the exception handling into the Writer State. It will be executed once all the in-flight
                     // appends are drained.
-                    state.appendFailed(append.getEventNumber(), () -> {
+                    state.appendFailed(append.getEventNumber(), () ->
                         handleException(append.getWriterId(), append.getRequestId(), append.getSegment(), append.getEventNumber(),
-                                "appending data", exception);
-
-                        // Clear the state in case of error.
-                        this.writerStates.remove(Pair.of(append.getSegment(), append.getWriterId()));
-                    });
+                                "appending data", exception));
                 }
             }
 
             // After every append completes, check if we are done with this WriterState, and if we were asked to execute
             // something after that happens.
-            Runnable runWhenAllComplete = state.getDelayedErrorHandlerIfEligible();
-            if (runWhenAllComplete != null) {
-                synchronized (state.getAckLock()) {
-                    runWhenAllComplete.run();
-                }
-            }
+            executeDelayedErrorHandler(state, append);
         } catch (Throwable e) {
             success = false;
             handleException(append.getWriterId(), append.getEventNumber(), append.getSegment(), "handling append result", e);
@@ -263,6 +252,22 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         if (success) {
             // Record any necessary metrics or statistics, but after we have sent the ack back and initiated the next append.
             this.statsRecorder.recordAppend(append.getSegment(), append.getDataLength(), append.getEventCount(), elapsedTimer.getElapsed());
+        }
+    }
+
+    private void executeDelayedErrorHandler(WriterState state, Append append) {
+        WriterState.DelayedErrorHandler h = state.getDelayedErrorHandlerIfEligible();
+        if (h != null) {
+            synchronized (state.getAckLock()) {
+                try {
+                    h.getToRun().forEach(Runnable::run);
+                } finally {
+                    if (h.getHandlersRemaining() == 0) {
+                        // Clear the state in case of error.
+                        this.writerStates.remove(Pair.of(append.getSegment(), append.getWriterId()));
+                    }
+                }
+            }
         }
     }
 
@@ -324,147 +329,6 @@ public class AppendProcessor extends DelegatingRequestProcessor {
             log.warn("Error (Segment = '{}', Operation = 'append'): {}.", segment, u.toString());
         } else {
             log.error("Error (Segment = '{}', Operation = 'append')", segment, u);
-        }
-    }
-
-    //endregion
-
-    //region WriterState
-
-    @ThreadSafe
-    private static class WriterState {
-        @Getter
-        private final Object ackLock = new Object();
-        @GuardedBy("this")
-        private long lastStoredEventNumber;
-        @GuardedBy("this")
-        private long lastAckedEventNumber;
-        @GuardedBy("this")
-        private int inFlightCount;
-        @GuardedBy("this")
-        private ErrorContext errorContext;
-
-        WriterState(long initialEventNumber) {
-            this.inFlightCount = 0;
-            this.lastStoredEventNumber = initialEventNumber;
-            this.lastAckedEventNumber = initialEventNumber;
-        }
-
-        /**
-         * Invoked when a new append is initiated.
-         *
-         * @param eventNumber The Append's Event Number.
-         * @return The previously attempted Event Number.
-         */
-        synchronized long beginAppend(long eventNumber) {
-            long previousEventNumber = this.lastStoredEventNumber;
-            Preconditions.checkState(eventNumber >= previousEventNumber, "Event was already appended.");
-            this.lastStoredEventNumber = eventNumber;
-            this.inFlightCount++;
-            return previousEventNumber;
-        }
-
-        /**
-         * Invoked when a conditional append has failed due to {@link BadOffsetException}. If no more appends are in the
-         * pipeline, then the Last Stored Event Number is reverted to the Last (Successfully) Acked Event Number.
-         * @param eventNumber
-         */
-        synchronized void conditionalAppendFailed(long eventNumber) {
-            this.inFlightCount--;
-            if (this.inFlightCount == 0) {
-                this.lastStoredEventNumber = this.lastAckedEventNumber;
-            }
-
-            if (this.errorContext != null) {
-                this.errorContext.appendComplete(eventNumber);
-            }
-        }
-
-        /**
-         * TODO: javadoc if this works well.
-         *
-         * @param eventNumber
-         * @param delayedErrorHandler
-         */
-        synchronized void appendFailed(long eventNumber, Runnable delayedErrorHandler) {
-            this.inFlightCount--;
-            if (this.errorContext == null) {
-                this.errorContext = new ErrorContext(this.lastStoredEventNumber, this.inFlightCount, delayedErrorHandler);
-            } else {
-                this.errorContext.appendComplete(eventNumber);
-            }
-        }
-
-        /**
-         * Invoked when an append has been successfully stored and is about to be ack-ed to the Client.
-         *
-         * This method is designed to be invoked immediately before sending a {@link DataAppended} ack to the client,
-         * however both its invocation and the ack must be sent atomically as the Client expects acks to arrive in order.
-         *
-         * When composing a {@link DataAppended} ack, the value passed to eventNumber should be passed as
-         * {@link DataAppended#getEventNumber()} and the return value from this method should be passed as
-         * {@link DataAppended#getPreviousEventNumber()}.
-         *
-         * @param eventNumber The Append's Event Number. This should correspond to the last successful append in the Store
-         *                    and will be sent in the {@link DataAppended} ack back to the Client. This value will be
-         *                    remembered and returned upon the next invocation of this method. If this value is less
-         *                    than that of a previous invocation of this method (due to out-of-order acks from the Store),
-         *                    it will have no effect as it has already been ack-ed as part of a previous call.
-         * @return The last successful Append's Event Number (prior to this one). This is the value of eventNumber for
-         * the previous invocation of this method.
-         */
-        synchronized long appendSuccessful(long eventNumber) {
-            this.inFlightCount--;
-            long previousLastAcked = this.lastAckedEventNumber;
-            this.lastAckedEventNumber = Math.max(previousLastAcked, eventNumber);
-            if (this.errorContext != null) {
-                this.errorContext.appendComplete(eventNumber);
-            }
-
-            return previousLastAcked;
-        }
-
-        Runnable getDelayedErrorHandlerIfEligible() {
-            synchronized (this) {
-                if (this.errorContext == null) {
-                    return null;
-                } else {
-                    return this.errorContext.getDelayedErrorHandlerIfEligible();
-                }
-            }
-        }
-
-        @Override
-        public synchronized String toString() {
-            return String.format("Stored=%s, Acked=%s, InFlight=%s", this.lastStoredEventNumber, this.lastAckedEventNumber, this.inFlightCount);
-        }
-
-        private static class ErrorContext {
-            private final long erroredEventNumber;
-            private int remainingInFlightCount;
-            private final Runnable delayedErrorHandler;
-
-            ErrorContext(long erroredEventNumber, int remainingInFlightCount, Runnable delayedErrorHandler) {
-                this.erroredEventNumber = erroredEventNumber;
-                this.remainingInFlightCount = remainingInFlightCount;
-                this.delayedErrorHandler = delayedErrorHandler;
-            }
-
-            void appendComplete(long eventNumber) {
-                if (eventNumber < this.erroredEventNumber) {
-                    this.remainingInFlightCount--;
-                    assert this.remainingInFlightCount >= 0;
-                }
-            }
-
-            Runnable getDelayedErrorHandlerIfEligible() {
-                if (this.remainingInFlightCount == 0) {
-                    return this.delayedErrorHandler;
-                }
-
-                return null;
-            }
-
         }
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.handler;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.contracts.BadOffsetException;
+import io.pravega.shared.protocol.netty.WireCommands;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@ThreadSafe
+class WriterState {
+    @Getter
+    private final Object ackLock = new Object();
+    @GuardedBy("this")
+    private long lastStoredEventNumber;
+    @GuardedBy("this")
+    private long lastAckedEventNumber;
+    @GuardedBy("this")
+    private int inFlightCount;
+    @GuardedBy("this")
+    private ArrayList<ErrorContext> errorContexts;
+
+    WriterState(long initialEventNumber) {
+        this.inFlightCount = 0;
+        this.lastStoredEventNumber = initialEventNumber;
+        this.lastAckedEventNumber = initialEventNumber;
+    }
+
+    /**
+     * Invoked when a new append is initiated.
+     *
+     * @param eventNumber The Append's Event Number.
+     * @return The previously attempted Event Number.
+     */
+    synchronized long beginAppend(long eventNumber) {
+        long previousEventNumber = this.lastStoredEventNumber;
+        Preconditions.checkState(eventNumber >= previousEventNumber, "Event was already appended.");
+        this.lastStoredEventNumber = eventNumber;
+        this.inFlightCount++;
+        return previousEventNumber;
+    }
+
+    /**
+     * Invoked when a conditional append has failed due to {@link BadOffsetException}. If no more appends are in the
+     * pipeline, then the Last Stored Event Number is reverted to the Last (Successfully) Acked Event Number.
+     *
+     * @param eventNumber
+     */
+    synchronized void conditionalAppendFailed(long eventNumber) {
+        this.inFlightCount--;
+        if (this.inFlightCount == 0) {
+            this.lastStoredEventNumber = this.lastAckedEventNumber;
+        }
+
+        updateErrorContexts(eventNumber);
+    }
+
+    /**
+     * TODO: javadoc if this works well.
+     *
+     * @param eventNumber
+     * @param delayedErrorHandler
+     */
+    synchronized void appendFailed(long eventNumber, Runnable delayedErrorHandler) {
+        this.inFlightCount--;
+        if (this.errorContexts == null) {
+            this.errorContexts = new ArrayList<>();
+        }
+
+        updateErrorContexts(eventNumber);
+        this.errorContexts.add(new ErrorContext(this.lastStoredEventNumber, this.inFlightCount, delayedErrorHandler));
+    }
+
+    /**
+     * Invoked when an append has been successfully stored and is about to be ack-ed to the Client.
+     * <p>
+     * This method is designed to be invoked immediately before sending a {@link WireCommands.DataAppended} ack to the client,
+     * however both its invocation and the ack must be sent atomically as the Client expects acks to arrive in order.
+     * <p>
+     * When composing a {@link WireCommands.DataAppended} ack, the value passed to eventNumber should be passed as
+     * {@link WireCommands.DataAppended#getEventNumber()} and the return value from this method should be passed as
+     * {@link WireCommands.DataAppended#getPreviousEventNumber()}.
+     *
+     * @param eventNumber The Append's Event Number. This should correspond to the last successful append in the Store
+     *                    and will be sent in the {@link WireCommands.DataAppended} ack back to the Client. This value will be
+     *                    remembered and returned upon the next invocation of this method. If this value is less
+     *                    than that of a previous invocation of this method (due to out-of-order acks from the Store),
+     *                    it will have no effect as it has already been ack-ed as part of a previous call.
+     * @return The last successful Append's Event Number (prior to this one). This is the value of eventNumber for
+     * the previous invocation of this method.
+     */
+    synchronized long appendSuccessful(long eventNumber) {
+        this.inFlightCount--;
+        long previousLastAcked = this.lastAckedEventNumber;
+        this.lastAckedEventNumber = Math.max(previousLastAcked, eventNumber);
+        updateErrorContexts(eventNumber);
+        return previousLastAcked;
+    }
+
+    synchronized DelayedErrorHandler getDelayedErrorHandlerIfEligible() {
+        if (this.errorContexts == null) {
+            return null;
+        }
+
+        ArrayList<Runnable> toRun = new ArrayList<>();
+        Iterator<ErrorContext> i = this.errorContexts.iterator();
+        while (i.hasNext()) {
+            ErrorContext c = i.next();
+            Runnable r = c.getDelayedErrorHandlerIfEligible();
+            if (r != null) {
+                toRun.add(r);
+                i.remove();
+            }
+        }
+
+        return new DelayedErrorHandler(toRun, this.errorContexts.size());
+    }
+
+    @GuardedBy("this")
+    private void updateErrorContexts(long eventNumber) {
+        if (this.errorContexts != null) {
+            this.errorContexts.forEach(c -> c.appendComplete(eventNumber));
+        }
+    }
+
+    @Override
+    public synchronized String toString() {
+        return String.format("Stored=%s, Acked=%s, InFlight=%s", this.lastStoredEventNumber, this.lastAckedEventNumber, this.inFlightCount);
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    static class DelayedErrorHandler {
+        private final List<Runnable> toRun;
+        private final int handlersRemaining;
+    }
+
+    private static class ErrorContext {
+        private final long erroredEventNumber;
+        private int remainingInFlightCount;
+        private final Runnable delayedErrorHandler;
+
+        ErrorContext(long erroredEventNumber, int remainingInFlightCount, Runnable delayedErrorHandler) {
+            this.erroredEventNumber = erroredEventNumber;
+            this.remainingInFlightCount = remainingInFlightCount;
+            this.delayedErrorHandler = delayedErrorHandler;
+        }
+
+        void appendComplete(long eventNumber) {
+            if (eventNumber < this.erroredEventNumber) {
+                this.remainingInFlightCount--;
+                assert this.remainingInFlightCount >= 0;
+            }
+        }
+
+        Runnable getDelayedErrorHandlerIfEligible() {
+            if (this.remainingInFlightCount == 0) {
+                return this.delayedErrorHandler;
+            }
+
+            return null;
+        }
+    }
+}

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -24,6 +24,7 @@ import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
 import io.pravega.segmentstore.contracts.BadOffsetException;
+import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
@@ -519,6 +520,66 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         store1.complete(50L);
         verify(tracker).updateOutstandingBytes(connection, -data1.length, 0);
         verifyNoMoreInteractions(connection);
+        verifyNoMoreInteractions(store);
+    }
+
+    @Test(timeout = 15 * 1000)
+    public void testAppendPipeliningWithSeal() {
+        String streamSegmentName = "scope/stream/testAppendSegment";
+        UUID clientId = UUID.randomUUID();
+        byte[] data1 = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        byte[] data2 = new byte[]{1, 2, 3, 4, 5};
+        byte[] data3 = new byte[]{1, 2, 3};
+        StreamSegmentStore store = mock(StreamSegmentStore.class);
+        ServerConnection connection = mock(ServerConnection.class);
+        ConnectionTracker tracker = mock(ConnectionTracker.class);
+        AppendProcessor processor = AppendProcessor.defaultBuilder().store(store).connection(connection).connectionTracker(tracker).build();
+        InOrder connectionVerifier = Mockito.inOrder(connection);
+
+        setupGetAttributes(streamSegmentName, clientId, store);
+        processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName, ""));
+        verify(store).getAttributes(anyString(), eq(Collections.singleton(clientId)), eq(true), eq(AppendProcessor.TIMEOUT));
+        connectionVerifier.verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
+
+        // Initiate one append.
+        val store1 = new CompletableFuture<Long>();
+        val ac1 = interceptAppend(store, streamSegmentName, updateEventNumber(clientId, 1, 0, 1), store1);
+        processor.append(new Append(streamSegmentName, clientId, 1, 1, Unpooled.wrappedBuffer(data1), null, requestId));
+        verifyStoreAppend(ac1, data1);
+        verify(tracker).updateOutstandingBytes(connection, data1.length, data1.length);
+
+        // Second append will fail with StreamSegmentSealedException (this simulates having one append, immediately followed
+        // by a Seal, then another append).
+        val ac2 = interceptAppend(store, streamSegmentName, updateEventNumber(clientId, 2, 1, 1), Futures.failedFuture(new StreamSegmentSealedException(streamSegmentName)));
+        processor.append(new Append(streamSegmentName, clientId, 2, 1, Unpooled.wrappedBuffer(data2), null, requestId));
+        verifyStoreAppend(ac2, data2);
+        verify(tracker).updateOutstandingBytes(connection, data2.length, data1.length + data2.length);
+        verify(tracker).updateOutstandingBytes(connection, -data2.length, data1.length);
+
+        // Third append should fail just like the second one. However this will have a higher event number than that one
+        // and we use it to verify it won't prevent sending the SegmentIsSealed message or send it multiple times.
+        val ac3 = interceptAppend(store, streamSegmentName, updateEventNumber(clientId, 3, 2, 1), Futures.failedFuture(new StreamSegmentSealedException(streamSegmentName)));
+        processor.append(new Append(streamSegmentName, clientId, 3, 1, Unpooled.wrappedBuffer(data3), null, requestId));
+        verifyStoreAppend(ac3, data3);
+        verify(tracker).updateOutstandingBytes(connection, data3.length, data1.length + data3.length);
+
+        // Complete the first one and verify it is acked properly.
+        store1.complete(100L);
+        connectionVerifier.verify(connection).send(new DataAppended(requestId, clientId, 1, 0L, 100L));
+
+        // Verify that a SegmentIsSealed message is sent AFTER the ack from the first one.
+        connectionVerifier.verify(connection).send(new WireCommands.SegmentIsSealed(requestId, streamSegmentName, "", 2L));
+        verify(tracker).updateOutstandingBytes(connection, -data3.length, data1.length);
+        verify(tracker).updateOutstandingBytes(connection, -data1.length, 0);
+
+        val ac4 = interceptAppend(store, streamSegmentName, updateEventNumber(clientId, 4, 3, 1), Futures.failedFuture(new IntentionalException(streamSegmentName)));
+        AssertExtensions.assertThrows(
+                "append() accepted a new request after sending a SegmentIsSealed message.",
+                () -> processor.append(new Append(streamSegmentName, clientId, 4, 1, Unpooled.wrappedBuffer(data1), null, requestId)),
+                ex -> ex instanceof IllegalStateException);
+
+        // Verify no more messages are sent over the connection.
+        connectionVerifier.verifyNoMoreInteractions();
         verifyNoMoreInteractions(store);
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/WriterStateTests.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/WriterStateTests.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.host.handler;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link WriterState} class.
+ */
+public class WriterStateTests {
+    /**
+     * Tests {@link WriterState#beginAppend} and {@link WriterState#appendSuccessful}.
+     */
+    @Test
+    public void testAppendSuccessful() {
+        // Begin with recording 3 Events.
+        final long initialEventNumber = 1;
+        val ws = new WriterState(initialEventNumber);
+        long event1 = initialEventNumber + 1;
+        val begin1 = ws.beginAppend(event1);
+        Assert.assertEquals("beginAppend(1) returned unexpected LastStoredEventNumber.", initialEventNumber, begin1);
+        long event2 = event1 + 1;
+        val begin2 = ws.beginAppend(event2);
+        Assert.assertEquals("beginAppend(2) returned unexpected LastStoredEventNumber.", event1, begin2);
+        long event3 = event2 + 1;
+        val begin3 = ws.beginAppend(event3);
+        Assert.assertEquals("beginAppend(3) returned unexpected LastStoredEventNumber.", event2, begin3);
+
+        // Ack Event 1. The Previous Last Ack should be the initial event number.
+        val ack1 = ws.appendSuccessful(event1);
+        Assert.assertEquals("appendSuccessful(1) returned unexpected PreviousLastAcked.", initialEventNumber, ack1);
+
+        // Ack Event 3 before Event 2. The previous last ack must be 1 (since that's our last ack).
+        val ack3 = ws.appendSuccessful(event3);
+        Assert.assertEquals("appendSuccessful(3) returned unexpected PreviousLastAcked.", event1, ack3);
+
+        // Ack Event 2. The previous ack was 3, so return that.
+        val ack2 = ws.appendSuccessful(event2);
+        Assert.assertEquals("appendSuccessful(2) returned unexpected PreviousLastAcked.", event3, ack2);
+    }
+
+    /**
+     * Tests {@link WriterState#beginAppend} and {@link WriterState#conditionalAppendFailed}.
+     */
+    @Test
+    public void testConditionalAppendFailed() {
+        // Begin with recording 2 Events.
+        final long initialEventNumber = 1;
+        val ws = new WriterState(initialEventNumber);
+        long event1 = initialEventNumber + 1;
+        ws.beginAppend(event1);
+        long event2 = event1 + 1;
+        ws.beginAppend(event2);
+
+        // Ack Event 1 and conditionally-fail event 2.
+        ws.appendSuccessful(event1);
+        ws.conditionalAppendFailed(event2);
+
+        // Event 3 comes now. Since we conditionally failed the last Event, the Last Stored Event Number should be
+        // restored to Event 1.
+        long event3 = event2 + 1;
+        val begin3 = ws.beginAppend(event3);
+        Assert.assertEquals("beginAppend(3) returned unexpected LastStoredEventNumber.", event1, begin3);
+    }
+
+    /**
+     * Tests {@link WriterState#appendFailed} and {@link WriterState#getDelayedErrorHandlerIfEligible}.
+     * We test the foll0wing scenario:
+     * 1. Begin and successfully complete Event E1.
+     * 2. Begin 2 events (E2 and E3), and fail the second one (E3).
+     * 3. Begin 2 events (E4 and E5), and fail the second one (E5).
+     * 4. Begin 1 event E6, and fail it.
+     * 5. Complete E2 with success and fail E4.
+     * <p>
+     * What we expect:
+     * - E1 has no effect on the test.
+     * - When we fail E3, no callbacks are expected.
+     * - When we complete E2, expect the callback from E3 to be invoked (and no other callbacks).
+     * - When we fail E4, we expect its callback to be invoked, as well as E5's and E6's callback.
+     */
+    @Test
+    public void testAppendFailed() {
+        final long initialEventNumber = 1;
+        long currentEventNumber = initialEventNumber;
+        val ws = new WriterState(initialEventNumber);
+
+        // Begin and complete an event E1.
+        val event1 = ++currentEventNumber;
+        ws.beginAppend(event1);
+        ws.appendSuccessful(event1);
+
+        // Begin 2 events: E2 and E3.
+        val event2 = ++currentEventNumber;
+        ws.beginAppend(event2);
+        val event3 = ++currentEventNumber;
+        ws.beginAppend(event3);
+
+        Assert.assertNull("Not expecting a result yet from getDelayedErrorHandlerIfEligible().", ws.getDelayedErrorHandlerIfEligible());
+
+        // Indicate that E3 failed.
+        val callback1 = new AtomicBoolean();
+        ws.appendFailed(event3, () -> Assert.assertTrue(callback1.compareAndSet(false, true)));
+        checkDelayedErrorHandler(ws.getDelayedErrorHandlerIfEligible(), 0, 1);
+
+        // Begin two more events: E4 and E5.
+        val event4 = ++currentEventNumber;
+        ws.beginAppend(event4);
+        val event5 = ++currentEventNumber;
+        ws.beginAppend(event5);
+
+        // ... and then indicate that E5 failed (nothing yet on E4).
+        val callback2 = new AtomicBoolean();
+        ws.appendFailed(event5, () -> Assert.assertTrue(callback2.compareAndSet(false, true)));
+
+        // Begin one more event (E6)...
+        val event6 = ++currentEventNumber;
+        ws.beginAppend(event6);
+
+        // .. and then indicate it failed.
+        val callback3 = new AtomicBoolean();
+        ws.appendFailed(event6, () -> Assert.assertTrue(callback3.compareAndSet(false, true)));
+
+        checkDelayedErrorHandler(ws.getDelayedErrorHandlerIfEligible(), 0, 3);
+
+        // Complete E2 successfully. E3 is already failed, so we expect its callback to be invoked now
+        ws.appendSuccessful(event2);
+        val deh1 = ws.getDelayedErrorHandlerIfEligible();
+        checkDelayedErrorHandler(deh1, 1, 2);
+        deh1.getToRun().forEach(Runnable::run); // Run the callbacks to validate that we aren't invoking them multiple times.
+
+        // Fail E4. E5 and E6 are already failed, so we expect both their callbacks to be invoked now.
+        val callback4 = new AtomicBoolean();
+        ws.appendFailed(event4, () -> Assert.assertTrue(callback4.compareAndSet(false, true)));
+        val deh2 = ws.getDelayedErrorHandlerIfEligible();
+        checkDelayedErrorHandler(deh2, 3, 0);
+        deh2.getToRun().forEach(Runnable::run); // Run the callbacks to validate that we aren't invoking them multiple times.
+
+        checkDelayedErrorHandler(ws.getDelayedErrorHandlerIfEligible(), 0, 0);
+
+        Arrays.asList(callback1, callback2, callback3, callback4)
+                .forEach(b -> Assert.assertTrue("At least one callback was not invoked.", b.get()));
+    }
+
+    private void checkDelayedErrorHandler(WriterState.DelayedErrorHandler deh, int expectedToRun, int expectedHandlersRemaining) {
+        Assert.assertNotNull("Expecting a result from getDelayedErrorHandlerIfEligible()", deh);
+        Assert.assertEquals("Unexpected number of callbacks returned.", expectedToRun, deh.getToRun().size());
+        Assert.assertEquals("Unexpected number of handlers remaining.", expectedHandlersRemaining, deh.getHandlersRemaining());
+    }
+}


### PR DESCRIPTION
**Change log description**  
- Changed the AppendProcessor to send error messages back to the client only after all appends initiated prior to that error complete.

**Purpose of the change**  
Fixes #4393.

**What the code does**  
- Moved `WriterState` out of `AppendProcessor` in order to write unit tests against it.
- Upon encountering a failed append, the `AppendProcessor` will take note of the current `lastStoredEventNumber` and delay handling the exception until after all Appends with Event Numbers up to that one are completed (successfully or not). 
    - The `AppendProcessor` will record all failed appends and send error message for each such failure. 
- The `AppendProcessor` will keep a `WriterState` registered until there are no more in-flight requests or errors to be handled. This ensures that any retries that the Client may attempt due to a previous error will not be met with a generic `IllegalStateException` or cause a new `setupAppend` to be initiated, which could cause event duplication,

**How to verify it**  
Unit, system and longevity tests must pass. 
- Longevity runs 200, 201 and 202 passed. 
- System test run 2460 passed.
