### PR TITLE
Issue 3503: Disable HDFSIntegrationTest.

### DIFF
--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -22,10 +22,12 @@ import lombok.val;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 
 /**
  * End-to-end tests for SegmentStore, with integrated Storage and DurableDataLog.
  */
+@Ignore ("Short term mitigation for #3503 until HDFSIntegrationTest gets completely rewritten/replaced as part of PDP-34.")
 public class HDFSIntegrationTest extends BookKeeperIntegrationTestBase {
     //region Test Configuration and Setup
 


### PR DESCRIPTION
Issue 3503: Disable HDFSIntegrationTest.
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
The HDFSIntegrationTest has been unstable and fails with intermittent failures. This causes builds with changes unrelated to HDFS to fail. 
Disabling HDFSIntegrationTest for a short while until it gets completely rewritten/replaced as part of PDP-34.

**Purpose of the change**  
Short term mitigation for #3503 until HDFSIntegrationTest gets completely rewritten/replaced as part of PDP-34

**What the code does**  
Disable HDFSIntegrationTest.

**How to verify it**  
HDFSIntegrationTest should not be invoked.
