### PR TITLE
Issue 4204: (SegmentStore) Fixed excessive cache eviction bug

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -226,19 +226,10 @@ public class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.
 
     @Override
     public CacheManager.CacheStatus getCacheStatus() {
-        int minGen = 0;
-        int maxGen = 0;
         synchronized (this.cacheEntries) {
-            for (CacheEntry e : this.cacheEntries.values()) {
-                if (e != null) {
-                    int g = e.getGeneration();
-                    minGen = Math.min(minGen, g);
-                    maxGen = Math.max(maxGen, g);
-                }
-            }
+            return CacheManager.CacheStatus.fromGenerations(
+                    this.cacheEntries.values().stream().filter(Objects::nonNull).map(CacheEntry::getGeneration).iterator());
         }
-
-        return new CacheManager.CacheStatus(minGen, maxGen);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
@@ -12,7 +12,6 @@ package io.pravega.segmentstore.server.reading;
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.server.CacheManager;
 import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -103,18 +102,6 @@ class ReadIndexSummary {
      * Generates a CacheManager.CacheStatus object with the information in this ReadIndexSummary object.
      */
     synchronized CacheManager.CacheStatus toCacheStatus() {
-        AtomicInteger oldestGeneration = new AtomicInteger(Integer.MAX_VALUE);
-        AtomicInteger newestGeneration = new AtomicInteger(0);
-        this.generations.keySet().forEach(g -> {
-            if (oldestGeneration.get() > g) {
-                oldestGeneration.set(g);
-            }
-
-            if (newestGeneration.get() < g) {
-                newestGeneration.set(g);
-            }
-        });
-
-        return new CacheManager.CacheStatus(Math.min(newestGeneration.get(), oldestGeneration.get()), newestGeneration.get());
+        return CacheManager.CacheStatus.fromGenerations(this.generations.keySet().iterator());
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -76,19 +77,13 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
 
     @Override
     public CacheManager.CacheStatus getCacheStatus() {
-        int minGen = 0;
-        int maxGen = 0;
         synchronized (this.segmentCaches) {
-            for (SegmentKeyCache e : this.segmentCaches.values()) {
-                if (e != null) {
-                    val cs = e.getCacheStatus();
-                    minGen = Math.min(minGen, cs.getOldestGeneration());
-                    maxGen = Math.max(maxGen, cs.getNewestGeneration());
-                }
-            }
+            return CacheManager.CacheStatus.combine(
+                    this.segmentCaches.values().stream()
+                                      .filter(Objects::nonNull)
+                                      .map(SegmentKeyCache::getCacheStatus)
+                                      .iterator());
         }
-
-        return new CacheManager.CacheStatus(minGen, maxGen);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -448,7 +448,7 @@ class SegmentKeyCache {
 
         /**
          * Removes the contents of this entry from the cache, if anything was stored there in the first place. Invoking
-         * this will cause {@link #storeInCache} to throw an {@link IllegalStateException} going forward.
+         * this method will cause {@link #storeInCache} to throw an {@link IllegalStateException} going forward.
          *
          * @return True if there was anything evicted, false otherwise.
          */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -463,8 +463,7 @@ class SegmentKeyCache {
             return false;
         }
 
-        @GuardedBy("this")
-        private byte[] getFromCache() {
+        private synchronized byte[] getFromCache() {
             BufferView data = null;
             if (this.cacheAddress >= 0) {
                 data = SegmentKeyCache.this.cacheStorage.get(this.cacheAddress);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server;
 
+import com.google.common.collect.Iterators;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.common.util.ByteArraySegment;
@@ -20,6 +21,7 @@ import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +53,42 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests {@link CacheManager.CacheStatus#fromGenerations}.
+     */
+    @Test
+    public void testCacheStatusFromGenerations() {
+        val empty = CacheManager.CacheStatus.fromGenerations(Collections.emptyIterator());
+        Assert.assertTrue("Unexpected isEmpty() when provided empty iterator.", empty.isEmpty());
+        Assert.assertEquals("Unexpected OG when provided empty iterator.", CacheManager.CacheStatus.EMPTY_VALUE, empty.getOldestGeneration());
+        Assert.assertEquals("Unexpected NG when provided empty iterator.", CacheManager.CacheStatus.EMPTY_VALUE, empty.getNewestGeneration());
+
+        val nonEmpty = CacheManager.CacheStatus.fromGenerations(Iterators.forArray(1, 2, 3, 100));
+        Assert.assertFalse("Unexpected isEmpty() when provided non-empty iterator.", nonEmpty.isEmpty());
+        Assert.assertEquals("Unexpected OG when provided non-empty iterator.", 1, nonEmpty.getOldestGeneration());
+        Assert.assertEquals("Unexpected NG when provided non-empty iterator.", 100, nonEmpty.getNewestGeneration());
+    }
+
+    /**
+     * Tests {@link CacheManager.CacheStatus#combine}.
+     */
+    @Test
+    public void testCacheStatusCombine() {
+        val empty = CacheManager.CacheStatus.combine(Collections.emptyIterator());
+        Assert.assertTrue("Unexpected isEmpty() when provided empty iterator.", empty.isEmpty());
+        Assert.assertEquals("Unexpected OG when provided empty iterator.", CacheManager.CacheStatus.EMPTY_VALUE, empty.getOldestGeneration());
+        Assert.assertEquals("Unexpected NG when provided empty iterator.", CacheManager.CacheStatus.EMPTY_VALUE, empty.getNewestGeneration());
+
+        val nonEmpty = CacheManager.CacheStatus.combine(Iterators.forArray(
+                new CacheManager.CacheStatus(1, 10),
+                new CacheManager.CacheStatus(2, 11),
+                new CacheManager.CacheStatus(3, 9),
+                new CacheManager.CacheStatus(5, 5)));
+        Assert.assertFalse("Unexpected isEmpty() when provided non-empty iterator.", nonEmpty.isEmpty());
+        Assert.assertEquals("Unexpected OG when provided non-empty iterator.", 1, nonEmpty.getOldestGeneration());
+        Assert.assertEquals("Unexpected NG when provided non-empty iterator.", 11, nonEmpty.getNewestGeneration());
+    }
+
+    /**
      * Tests the ability to increment the current generation (or not) based on the activity of the clients.
      */
     @Test
@@ -68,6 +106,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
 
         // Register a number of clients
         ArrayList<TestClient> clients = new ArrayList<>();
+        cm.register(new EmptyCacheClient()); // Register, but don't keep track of it.
         for (int i = 0; i < clientCount; i++) {
             TestClient c = new TestClient();
             clients.add(c);
@@ -140,6 +179,9 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         // Use a single client (we tested multiple clients with Newest Generation).
         TestClient client = new TestClient();
         cm.register(client);
+
+        // Register an Empty Cache Client to validate behavior in its presence.
+        cm.register(new EmptyCacheClient());
 
         // First do a dry-run - we need this to make sure the current generation advances enough.
         AtomicInteger currentGeneration = new AtomicInteger();
@@ -244,32 +286,44 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         val cache = new TestCache(policy.getMaxSize());
         @Cleanup
         TestCacheManager cm = new TestCacheManager(policy, cache, executorService());
-        TestClient client = new TestClient();
+        TestClient client = new EmptyCacheClient();
         cm.register(client);
 
-        // Setup the client so that it throws ObjectClosedException when updateGenerations is called.
+        // Test the case when we have more data in the cache than allowed by our policy (so CacheManager is forced to
+        // do something) but our client reports that it has no data in the cache.
         cache.setStoredBytes(policy.getMaxSize() + 1);
         cache.setUsedBytes(policy.getMaxSize() + 1);
-        client.setCacheStatus(0, 0);
+        AtomicInteger updatedOldest = new AtomicInteger(-1);
+        AtomicInteger updatedCurrent = new AtomicInteger(-1);
         client.setUpdateGenerationsImpl((current, oldest) -> {
-            Assert.assertEquals("Expected current generation to change.", 1, (long) current);
-            Assert.assertEquals("Expected oldest generation to change.", 1, (long) oldest);
+            updatedOldest.set(oldest);
+            updatedCurrent.set(current);
             return true;
         });
+        Assert.assertTrue(client.getCacheStatus().isEmpty()); // Verify before we execute.
         cm.applyCachePolicy();
-        cache.setStoredBytes(0);
-        cache.setUsedBytes(0);
-        client.setCacheStatus(0, 0);
+        Assert.assertEquals("Expected current generation to change.", 1, updatedCurrent.get());
+        Assert.assertEquals("Expected oldest generation to change.", 1, updatedOldest.get());
+
+        // Test the case when we have some data in the cache (so this is not why the CacheManager would not run), but our
+        // client reports that it has no data in the cache.
+        cache.setStoredBytes(10);
+        cache.setUsedBytes(10);
+        updatedCurrent.set(-1);
+        updatedOldest.set(-1);
         client.setUpdateGenerationsImpl((current, oldest) -> {
-            Assert.fail("Not expecting any updates in generations.");
+            updatedOldest.set(oldest);
+            updatedCurrent.set(current);
             return false;
         });
+        Assert.assertTrue(client.getCacheStatus().isEmpty()); // Verify before we execute.
         cm.applyCachePolicy();
+        Assert.assertTrue("Not expecting any updates in generations.", updatedCurrent.get() == -1 && updatedOldest.get() == -1);
     }
 
     /**
      * Tests the ability to auto-cleanup the cache if it indicates it has reached capacity and needs some eviction(s)
-     * in order to accomodate more data.
+     * in order to accommodate more data.
      */
     @Test
     public void testCacheFullCleanup() {
@@ -451,6 +505,13 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             return this.updateGenerationsImpl.apply(currentGeneration, oldestGeneration);
         }
     }
+
+    private static class EmptyCacheClient extends TestClient {
+        EmptyCacheClient() {
+            setCacheStatus(CacheManager.CacheStatus.EMPTY_VALUE, CacheManager.CacheStatus.EMPTY_VALUE);
+        }
+    }
+
 
     @RequiredArgsConstructor
     @Getter

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ReadIndexSummaryTests.java
@@ -21,7 +21,6 @@ import org.junit.rules.Timeout;
 public class ReadIndexSummaryTests {
     private static final int GENERATION_COUNT = 100;
     private static final int ITEMS_PER_GENERATION = 100;
-    private static final int MAX_ITEM_SIZE = 1000;
     @Rule
     public Timeout globalTimeout = Timeout.seconds(10);
 
@@ -93,7 +92,7 @@ public class ReadIndexSummaryTests {
                     Assert.assertEquals("Unexpected newest generation.", maxGeneration, currentStatus.getNewestGeneration());
                 } else {
                     // We are done; newest generation doesn't make any sense, so expect 0.
-                    Assert.assertEquals("Unexpected newest generation.", 0, currentStatus.getNewestGeneration());
+                    Assert.assertTrue("Expecting an empty status.", currentStatus.isEmpty());
                 }
             }
         }
@@ -150,7 +149,6 @@ public class ReadIndexSummaryTests {
         }
 
         currentStatus = s.toCacheStatus();
-        Assert.assertEquals("Unexpected newest generation after removing all items.", 0, currentStatus.getNewestGeneration());
-        Assert.assertEquals("Unexpected oldest generation after removing all items.", 0, currentStatus.getOldestGeneration());
+        Assert.assertTrue("Expected cache to be empty after removing all items.", currentStatus.isEmpty());
     }
 }


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in `CacheManager` where it could excessively evict items from the cache as soon as they become eligible even if there was no cache pressure present.

**Purpose of the change**  
Fixes #4204.

**What the code does**  
- Unified the reporting logic of all Cache Clients (`StreamSegmentReadIndex`, `SegmentAttributeBTreeIndex` and `SegmentKeyCache`) into a common method that is now subject to unit tests.
- Updated the `Cache Manager` to
    - Better handle inconsistent input from its clients
        - This is slightly redundant with the unification logic above, but it provides a failsafe in case we add new types of clients in the future which may exhibit this bug.
    - Be more active in case the cache utilization exceeds configured thresholds.
        - Previously, the cache would not necessarily increment the `Current Generation` if there was no activity in the cache. Doing so when there is pressure creates more granularity in the cache generations, making eviction easier (evicting fewer items more times instead of a lot of items fewer times).
    - Better report empty caches in the logs

**How to verify it**  
All tests must pass.