### PR TITLE
Issue 4445: Check to ensure a stream does not scale below minimum configured segments

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -40,6 +40,7 @@ import io.pravega.controller.store.stream.VersionedMetadata;
 import io.pravega.controller.store.stream.VersionedTransactionData;
 import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.TaskStoreFactory;
@@ -156,6 +157,13 @@ public abstract class ScaleRequestHandlerTest {
                                                         .scalingPolicy(ScalingPolicy.byEventRate(1, 2, 3))
                                                         .build();
         streamMetadataTasks.createStream(scope, stream, config, createTimestamp).get();
+        // set minimum number of segments to 1 so that we can also test scale downs
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(1, 2, 1))
+                                    .build();
+        streamStore.startUpdateConfiguration(scope, stream, config, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = streamStore.getConfigurationRecord(scope, stream, null, executor).join();
+        streamStore.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
     }
 
     @After
@@ -266,6 +274,95 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(activeSegments.size() == 3);
 
         assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID()))));
+    }
+
+    @Test(timeout = 30000)
+    public void testScaleRequestWithMinimumSegment() throws ExecutionException, InterruptedException {
+        AutoScaleTask requestHandler = new AutoScaleTask(streamMetadataTasks, streamStore, executor);
+        ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
+        StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler, null, null, null, null, streamStore, executor);
+        EventWriterMock writer = new EventWriterMock();
+        streamMetadataTasks.setRequestEventWriter(writer);
+
+        String stream = "mystream";
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scalingPolicy(ScalingPolicy.byEventRate(1, 2, 5))
+                                                        .build();
+        streamMetadataTasks.createStream(scope, stream, config, System.currentTimeMillis()).get();
+
+        // change stream configuration to min segment count = 4
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(1, 2, 4))
+                                    .build();
+        streamStore.startUpdateConfiguration(scope, stream, config, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = streamStore.getConfigurationRecord(scope, stream, null, executor).join();
+        streamStore.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
+        
+        // process first auto scale down event. it should only mark the segment as cold
+        multiplexer.process(new AutoScaleEvent(scope, stream, 1L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
+                0, false, System.currentTimeMillis())).join();
+        assertTrue(writer.queue.isEmpty());
+
+        assertTrue(streamStore.isCold(scope, stream, 1L, null, executor).join());
+
+        // process second auto scale down event. since its not for an immediate neighbour so it should only mark the segment as cold
+        multiplexer.process(new AutoScaleEvent(scope, stream, 3L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
+                0, false, System.currentTimeMillis())).join();
+        assertTrue(streamStore.isCold(scope, stream, 3L, null, executor).join());
+        // no scale event should be posted
+        assertTrue(writer.queue.isEmpty());
+
+        // process third auto scale down event. This should result in a scale op event being posted to merge segments 0, 1 
+        multiplexer.process(new AutoScaleEvent(scope, stream, 0L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
+                0, false, System.currentTimeMillis())).join();
+        assertTrue(streamStore.isCold(scope, stream, 0L, null, executor).join());
+        
+        // verify that a new event has been posted
+        assertEquals(1, writer.queue.size());
+        ControllerEvent event = writer.queue.take();
+        assertTrue(event instanceof ScaleOpEvent);
+        ScaleOpEvent scaleDownEvent1 = (ScaleOpEvent) event;
+        assertEquals(1, scaleDownEvent1.getNewRanges().size());
+        assertEquals(2, scaleDownEvent1.getSegmentsToSeal().size());
+        assertTrue(scaleDownEvent1.getSegmentsToSeal().contains(0L));
+        assertTrue(scaleDownEvent1.getSegmentsToSeal().contains(1L));
+
+        // process fourth auto scale down event. This should result in a scale op event being posted to merge segments 3, 4 
+        multiplexer.process(new AutoScaleEvent(scope, stream, 4L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
+                0, false, System.currentTimeMillis())).join();
+        assertTrue(streamStore.isCold(scope, stream, 4L, null, executor).join());
+        // verify that a new event has been posted
+        assertEquals(1, writer.queue.size());
+        event = writer.queue.take();
+        assertTrue(event instanceof ScaleOpEvent);
+        ScaleOpEvent scaleDownEvent2 = (ScaleOpEvent) event;
+        assertEquals(1, scaleDownEvent2.getNewRanges().size());
+        assertEquals(2, scaleDownEvent2.getSegmentsToSeal().size());
+        assertTrue(scaleDownEvent2.getSegmentsToSeal().contains(3L));
+        assertTrue(scaleDownEvent2.getSegmentsToSeal().contains(4L));
+
+        // process first scale down event, this should submit scale and scale the stream down to 4 segments
+        multiplexer.process(scaleDownEvent1).join();
+        EpochRecord activeEpoch = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
+        List<StreamSegmentRecord> segments = activeEpoch.getSegments();
+        assertEquals(1, activeEpoch.getEpoch());
+        assertEquals(4, segments.size());
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 2));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 3));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 4));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 5));
+
+        // process second scale down event, this should submit scale and scale the stream down to 4 segments
+        multiplexer.process(scaleDownEvent2).join();
+        // verify that no scale has happened
+        activeEpoch = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
+        // verify that no scale has happened. 
+        assertEquals(1, activeEpoch.getEpoch());
+        assertEquals(4, segments.size());
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 2));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 3));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 4));
+        assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 5));
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStoreTest.java
@@ -23,6 +23,7 @@ import io.pravega.controller.server.rpc.auth.GrpcAuthHelper;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.CompletedTxnRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
@@ -116,6 +117,12 @@ public class PravegaTablesStreamMetadataStoreTest extends StreamMetadataStoreTes
         store.createScope(scope).get();
         store.createStream(scope, stream, configuration, System.currentTimeMillis(), null, executor).get();
         store.setState(scope, stream, State.ACTIVE, null, executor).get();
+
+        // set minimum number of segments to 1 so that we can also test scale downs
+        configuration = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        store.startUpdateConfiguration(scope, stream, configuration, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = store.getConfigurationRecord(scope, stream, null, executor).join();
+        store.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
 
         List<ScaleMetadata> scaleIncidents = store.getScaleMetadata(scope, stream, 0, Long.MAX_VALUE, null, executor).get();
         assertTrue(scaleIncidents.size() == 1);

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -422,6 +422,12 @@ public abstract class StreamMetadataStoreTest {
         store.createStream(scope, stream, configuration, start, null, executor).get();
         store.setState(scope, stream, State.ACTIVE, null, executor).get();
 
+        // set minimum number of segments to 1 so that we can also test scale downs
+        StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        store.startUpdateConfiguration(scope, stream, config, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = store.getConfigurationRecord(scope, stream, null, executor).join();
+        store.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
+
         // region idempotent
 
         long scaleTs = System.currentTimeMillis();
@@ -572,6 +578,11 @@ public abstract class StreamMetadataStoreTest {
 
         store.createStream(scope, stream, configuration, start, null, executor).get();
         store.setState(scope, stream, State.ACTIVE, null, executor).get();
+        // set minimum number of segments to 1
+        StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        store.startUpdateConfiguration(scope, stream, config, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = store.getConfigurationRecord(scope, stream, null, executor).join();
+        store.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
 
         // region concurrent start scale
         // Test scenario where one request starts and completes as the other is waiting on StartScale.createEpochTransition

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTestBase.java
@@ -20,6 +20,7 @@ import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.HistoryTimeSeries;
 import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
 import io.pravega.controller.store.stream.records.WriterMark;
@@ -81,6 +82,11 @@ public abstract class StreamTestBase {
                                                         .scalingPolicy(ScalingPolicy.fixed(numOfSegments)).build();
         stream.create(config, time, startingSegmentNumber)
               .thenCompose(x -> stream.updateState(State.ACTIVE)).join();
+
+        // set minimum number of segments to 1 so that we can also test scale downs
+        stream.startUpdateConfiguration(StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build()).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = stream.getVersionedConfigurationRecord().join();
+        stream.completeUpdateConfiguration(configRecord).join();
 
         return stream;
     }
@@ -586,8 +592,29 @@ public abstract class StreamTestBase {
         etrRef.set(stream.getEpochTransition().join());
         AssertExtensions.assertSuppliedFutureThrows("", () -> stream.submitScale(Lists.newArrayList(s1), newRangesRef.get(), timestamp, etrRef.get()),
                 e -> Exceptions.unwrap(e) instanceof EpochTransitionOperationExceptions.PreConditionFailureException);
-    }
 
+        etrRef.set(stream.getEpochTransition().join());
+
+        // get current number of segments.
+        List<Long> segments = stream.getActiveSegments().join().stream()
+                                    .map(StreamSegmentRecord::segmentId).collect(Collectors.toList());
+
+        // set minimum number of segments to segments.size. 
+        stream.startUpdateConfiguration(
+                StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(segments.size())).build()).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = stream.getVersionedConfigurationRecord().join();
+        stream.completeUpdateConfiguration(configRecord).join();
+
+        // attempt a scale down which should be rejected in submit scale. 
+        newRanges = new ArrayList<>();
+        newRanges.add(new AbstractMap.SimpleEntry<>(0.0, 1.0));
+        newRangesRef.set(newRanges);
+
+        AssertExtensions.assertSuppliedFutureThrows("", () -> stream.submitScale(segments, newRangesRef.get(), 
+                timestamp, etrRef.get()),
+                e -> Exceptions.unwrap(e) instanceof EpochTransitionOperationExceptions.PreConditionFailureException);
+    }
+    
     private VersionedMetadata<EpochTransitionRecord> resetScale(VersionedMetadata<EpochTransitionRecord> etr, Stream stream) {
         stream.completeScale(etr).join();
         stream.updateState(State.ACTIVE).join();

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKStreamMetadataStoreTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.task.TxnResource;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.client.stream.StreamConfiguration;
@@ -232,6 +233,12 @@ public class ZKStreamMetadataStoreTest extends StreamMetadataStoreTest {
         store.createScope(scope).get();
         store.createStream(scope, stream, configuration, System.currentTimeMillis(), null, executor).get();
         store.setState(scope, stream, State.ACTIVE, null, executor).get();
+
+        // set minimum number of segments to 1 so that we can also test scale downs
+        configuration = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        store.startUpdateConfiguration(scope, stream, configuration, null, executor).join();
+        VersionedMetadata<StreamConfigurationRecord> configRecord = store.getConfigurationRecord(scope, stream, null, executor).join();
+        store.completeUpdateConfiguration(scope, stream, configRecord, null, executor).join();
 
         List<ScaleMetadata> scaleIncidents = store.getScaleMetadata(scope, stream, 0, Long.MAX_VALUE, null, executor).get();
         assertTrue(scaleIncidents.size() == 1);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTruncationTest.java
@@ -261,6 +261,12 @@ public class EndToEndTruncationTest {
         LocalController controller = (LocalController) controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
         controller.createStream("test", "test", config).get();
+        
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                    .build();
+        controller.updateStream("test", "test", config).get();
+
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
                 .controllerURI(URI.create("tcp://" + serviceHost))
@@ -326,6 +332,11 @@ public class EndToEndTruncationTest {
         LocalController controller = (LocalController) controllerWrapper.getController();
         controllerWrapper.getControllerService().createScope("test").get();
         controller.createStream("test", "test", config).get();
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                    .build();
+        controller.updateStream("test", "test", config).get();
+
         @Cleanup
         ConnectionFactory connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder()
                                                                                     .controllerURI(URI.create("tcp://" + serviceHost))


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Enforce stream configuration for minimum number of segments before scale workflow execution. 

**Purpose of the change**  
Fixes #4445 

**What the code does**  
Currently the check for ensuring that a stream does not scale below minimum number of segments is only performed during auto-scale. 
And even that had a bug where if two concurrent auto-scale requests are processed, then two scale events are submitted, each independently thinking it will honor the minimum segment count. 
This had two problems:
1. there is no min segment enforcement for manual scale
2. two auto scale requests could result in two submissions. The request that will be executed second should be rejected.  

So the fix for both these is to basically enforce minimum segment count while submitting the scale request into metadata store. 
This is done in Persistent Stream Base class. 

**How to verify it**  
Unit test added in StreamTestBase and StreamRequestHandlerTest. 
Other tests that performed manual scale by submitting a scaledown below minimum segment count had to also be updated to change their configuration to lower value. 