### PR TITLE
Issue 4454: Reading BK Ledger Entries in batches

### DIFF
--- a/common/src/main/java/io/pravega/common/util/BufferedIterator.java
+++ b/common/src/main/java/io/pravega/common/util/BufferedIterator.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import com.google.common.base.Preconditions;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.BiFunction;
+import javax.annotation.concurrent.NotThreadSafe;
+import lombok.NonNull;
+
+/**
+ * Fetches items in batches and presents them in the form of an {@link Iterator}. Useful for cases when items need to be
+ * processed in sequence but there are not enough resources to load all of them at once in memory.
+ *
+ * @param <T> Type of the items.
+ */
+@NotThreadSafe
+public class BufferedIterator<T> implements Iterator<T> {
+    //region Members
+
+    private final BiFunction<Long, Long, Iterator<T>> getItemRange;
+    private final long firstIndex;
+    private final long lastIndex;
+    private final int batchSize;
+    private long nextIndex;
+    private Iterator<T> currentEntries;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the {@link BufferedIterator} class.
+     *
+     * @param getItemRange A {@link BiFunction} that returns a range of items that will be buffered next. The first
+     *                     argument is the first index to fetch (inclusive) and the second argument is the last index to
+     *                     fetch (inclusive). This method will always be invoked in sequence with non-overlapping ranges.
+     *                     This method will never be passed invalid args (Arg1 > Arg 2) and it should never return an empty
+     *                     iterator.
+     * @param firstIndex   The index of the first item to return (inclusive).
+     * @param lastIndex    The index of the last item to return (inclusive).
+     * @param batchSize    The size of the batch (number of items to fetch at once).
+     */
+    public BufferedIterator(@NonNull BiFunction<Long, Long, Iterator<T>> getItemRange, long firstIndex, long lastIndex, int batchSize) {
+        Preconditions.checkArgument(batchSize > 0, "batchSize must be a positive integer.");
+        this.getItemRange = getItemRange;
+        this.firstIndex = firstIndex;
+        this.lastIndex = lastIndex;
+        this.batchSize = batchSize;
+        this.nextIndex = firstIndex;
+        this.currentEntries = null;
+    }
+
+    //endregion
+
+    //region Iterator Implementation
+
+    @Override
+    public boolean hasNext() {
+        return this.currentEntries != null || this.nextIndex <= this.lastIndex;
+    }
+
+    @Override
+    public T next() {
+        while (hasNext()) {
+            if (this.currentEntries != null && this.currentEntries.hasNext()) {
+                // We have an active set of entries to read from.
+                T result = this.currentEntries.next();
+                if (!this.currentEntries.hasNext()) {
+                    // After returning this entry, we're done with this set.
+                    this.currentEntries = null;
+                }
+
+                return result;
+            }
+
+            // Fetch the next set of entries to read from.
+            long readFrom = this.nextIndex;
+            long readTo = Math.min(readFrom + this.batchSize, this.lastIndex);
+            this.nextIndex = readTo + 1;
+            assert readFrom <= readTo;
+            this.currentEntries = this.getItemRange.apply(readFrom, readTo);
+            Preconditions.checkState(this.currentEntries.hasNext(), "getItemRange returned empty iterator.");
+        }
+
+        throw new NoSuchElementException();
+    }
+
+    //endregion
+}

--- a/common/src/test/java/io/pravega/common/util/BufferedIteratorTests.java
+++ b/common/src/test/java/io/pravega/common/util/BufferedIteratorTests.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.util;
+
+import io.pravega.test.common.AssertExtensions;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import java.util.stream.LongStream;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link BufferedIterator} class.
+ */
+public class BufferedIteratorTests {
+    private static final int BATCH_SIZE = 16;
+    private static final long MAX_INDEX = 123;
+
+    /**
+     * Tests the case when invalid args are passed to the constructor.
+     */
+    @Test
+    public void testInvalidArgs() {
+        // First Index > Last Index.
+        val i1 = newIterator(10, 9, BATCH_SIZE);
+        Assert.assertFalse("Expected empty iterator.", i1.hasNext());
+        AssertExtensions.assertThrows(
+                "empty iterator should have thrown.",
+                i1::next,
+                ex -> ex instanceof NoSuchElementException);
+
+        // Returning empty iterators (against the contract).
+        val i2 = new BufferedIterator<>((from, to) -> Collections.emptyIterator(), 0, MAX_INDEX, BATCH_SIZE);
+        Assert.assertTrue("Not expected empty iterator.", i2.hasNext());
+        AssertExtensions.assertThrows(
+                "Expected exception when getItemRange returned empty iterator.",
+                i2::next,
+                ex -> ex instanceof IllegalStateException);
+    }
+
+    @Test
+    public void testNoBatching() {
+        testWithBatchSize(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testSingularBatch() {
+        testWithBatchSize(1);
+    }
+
+    @Test
+    public void testMultiBatch() {
+        testWithBatchSize(BATCH_SIZE);
+    }
+
+    private void testWithBatchSize(int batchSize) {
+        for (int firstIndex = 0; firstIndex <= MAX_INDEX; firstIndex++) {
+            for (int lastIndex = firstIndex; lastIndex <= MAX_INDEX; lastIndex++) {
+                val i = newIterator(firstIndex, lastIndex, batchSize);
+
+                String context = String.format("FirstIndex=%d, LastIndex=%d", firstIndex, lastIndex);
+                for (long expected = firstIndex; expected <= lastIndex; expected++) {
+                    Assert.assertTrue("Expecting iterator to have next value " + context, i.hasNext());
+                    long actual = i.next();
+                    Assert.assertEquals("Unexpected value " + context, expected, actual);
+                }
+
+                Assert.assertFalse("Expected iterator to have completed " + context, i.hasNext());
+            }
+        }
+    }
+
+    private BufferedIterator<Long> newIterator(long firstIndex, long lastIndex, int batchSize) {
+        return new BufferedIterator<>((from, to) -> LongStream.rangeClosed(from, to).iterator(), firstIndex, lastIndex, batchSize);
+    }
+
+
+}

--- a/config/config.properties
+++ b/config/config.properties
@@ -336,6 +336,13 @@ metrics.enableStatistics=false
 # Note: BookKeeper only allows multiples of 1 second (1000 millis). This value will be rounded up to the nearest second.
 #bookkeeper.bkReadTimeoutMillis=30000
 
+# Number of Ledger Entries to fetch from BookKeeper at once.
+# Recommended values: between 32 and 256. The more items to read at once, the more Java Heap will be required during
+# Segment Container recovery (hence the large likelihood of running out of Heap). Setting this to Integer.MAX_VALUE will
+# essentially load the entire Ledger in memory before processing it.
+# Valid values: at least 1.
+#bookkeeper.readBatchSize=64
+
 # Maximum number of bytes that can be outstanding per BookKeeperLog at any given time. This value is used for throttling
 # purposes. This value is not set on the BookKeeper Client Configuration, rather it is used internally by the Segment
 # Store throttler to manage the BookKeeper write backlog and reduce the chance of write timeouts.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -36,6 +36,7 @@ public class BookKeeperConfig {
     public static final Property<Integer> BK_WRITE_QUORUM_SIZE = Property.named("bkWriteQuorumSize", 3);
     public static final Property<Integer> BK_WRITE_TIMEOUT = Property.named("bkWriteTimeoutMillis", 60000);
     public static final Property<Integer> BK_READ_TIMEOUT = Property.named("readTimeoutMillis", 30000);
+    public static final Property<Integer> BK_READ_BATCH_SIZE = Property.named("readBatchSize", 64);
     public static final Property<Integer> MAX_OUTSTANDING_BYTES = Property.named("maxOutstandingBytes", 256 * 1024 * 1024);
     public static final Property<Integer> BK_LEDGER_MAX_SIZE = Property.named("bkLedgerMaxSize", 1024 * 1024 * 1024);
     public static final Property<String> BK_PASSWORD = Property.named("bkPass", "");
@@ -128,6 +129,12 @@ public class BookKeeperConfig {
     private final int bkReadTimeoutMillis;
 
     /**
+     * The number of Ledger Entries to read at once from BookKeeper.
+     */
+    @Getter
+    private final int bkReadBatchSize;
+
+    /**
      * The maximum number of bytes that can be outstanding per BookKeeperLog at any given time. This value should be used
      * for throttling purposes.
      */
@@ -184,6 +191,12 @@ public class BookKeeperConfig {
 
         this.bkWriteTimeoutMillis = properties.getInt(BK_WRITE_TIMEOUT);
         this.bkReadTimeoutMillis = properties.getInt(BK_READ_TIMEOUT);
+        this.bkReadBatchSize = properties.getInt(BK_READ_BATCH_SIZE);
+        if (this.bkReadBatchSize < 1) {
+            throw new InvalidPropertyValueException(String.format("Property %s (%d) must be a positive integer.",
+                    BK_READ_BATCH_SIZE, this.bkReadBatchSize));
+        }
+
         this.maxOutstandingBytes = properties.getInt(MAX_OUTSTANDING_BYTES);
         this.bkLedgerMaxSize = properties.getInt(BK_LEDGER_MAX_SIZE);
         this.bkPassword = properties.get(BK_PASSWORD).getBytes(StandardCharsets.UTF_8);

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -35,6 +35,7 @@ public class BookKeeperConfigTest {
         Assert.assertEquals(3, cfg.getBkWriteQuorumSize());
         Assert.assertEquals(60000, cfg.getBkWriteTimeoutMillis());
         Assert.assertEquals(30000, cfg.getBkReadTimeoutMillis());
+        Assert.assertEquals(64, cfg.getBkReadBatchSize());
         Assert.assertEquals(256 * 1024 * 1024, cfg.getMaxOutstandingBytes());
         Assert.assertEquals(1024 * 1024 * 1024, cfg.getBkLedgerMaxSize());
         Assert.assertEquals(0, cfg.getBKPassword().length);

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -46,6 +46,25 @@ public class BookKeeperConfigTest {
     }
 
     @Test
+    public void testBadValues() {
+        AssertExtensions.assertThrows(
+                BookKeeperConfig.ZK_HIERARCHY_DEPTH.toString(),
+                () -> BookKeeperConfig.builder().with(BookKeeperConfig.ZK_HIERARCHY_DEPTH, -1).build(),
+                ex -> ex instanceof InvalidPropertyValueException);
+
+        AssertExtensions.assertThrows(
+                BookKeeperConfig.BK_WRITE_QUORUM_SIZE.toString(),
+                () -> BookKeeperConfig.builder().with(BookKeeperConfig.BK_WRITE_QUORUM_SIZE, 2)
+                        .with(BookKeeperConfig.BK_ACK_QUORUM_SIZE, 3).build(),
+                ex -> ex instanceof InvalidPropertyValueException);
+
+        AssertExtensions.assertThrows(
+                BookKeeperConfig.BK_READ_BATCH_SIZE.toString(),
+                () -> BookKeeperConfig.builder().with(BookKeeperConfig.BK_READ_BATCH_SIZE, -1).build(),
+                ex -> ex instanceof InvalidPropertyValueException);
+    }
+
+    @Test
     public void testZkServers() {
         // When multiple servers are specified and separated by comma, it should replace it by semicolon
         BookKeeperConfig cfg1 = BookKeeperConfig.builder()


### PR DESCRIPTION
**Change log description**  
- When performing a Ledger Read (Segment Container Recovery) the Ledger is now read in batches, as opposed from all at once.

**Purpose of the change**  
Fixes #4454.

**What the code does**  
- `LedgerHandle.readEntries` loads all the entries in the Java Heap before returning them as an `Enumeration`. This can cause Java Heap OOM if there is significant memory pressure and we need to load a full ledger (1GB).
- `LogReader` has been changed to read the ledger in batches (configurable via setting `bookkeeper.readBatchSize`, defaulted to 64 (entries at once)) instead of the whole thing at once. Nothing is changed from the POV of the upstream code.
- Introduced a `BufferedIterator` in `common` that enables this behavior (for purposes of reuse and proper testing).

**How to verify it**  
All tests must pass.
