### PR TITLE
Issue 4458: Fixed docker swarm system test failure

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/LargeEventTest.java
@@ -74,12 +74,12 @@ public class LargeEventTest extends AbstractReadWriteTest {
     }
 
     /**
-     * Invoke the simpleTest, ensure we are able to produce  events.
+     * Invoke the largeEventSimpleTest, ensure we are able to produce  events.
      * The test fails incase of exceptions while writing to the stream.
      *
      */
     @Test
-    public void simpleTest() {
+    public void largeEventSimpleTest() {
         Service conService = Utils.createPravegaControllerService(null);
         List<URI> ctlURIs = conService.getServiceDetails();
         URI controllerUri = ctlURIs.get(0);


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@emc.com>

**Change log description**  
Two of the tests were using the same name, due to that docker swarm system tests were failing.
`io.pravega.test.system.LargeEventTest.simpleTest`
`io.pravega.test.system.LargeEventTest.simpleTest`

**Purpose of the change**  
#4458

**What the code does**  
Renamed the `simpleTest` to `largeEventSimpleTest`
**How to verify it**  
Docker swarm system tests are  passed
