### PR TITLE
Issue 4368: Sporadic failure in Watermark workflow test

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
@@ -236,7 +236,7 @@ public class WatermarkWorkflowTest {
         assertTrue(client.isWriterParticipating(5L));
 
         // verify that writer is active if we specify a higher timeout
-        assertTrue(client.isWriterActive(entry1, 1L));
+        assertTrue(client.isWriterActive(entry1, 1000L));
         assertTrue(client.isWriterTracked(entry1.getKey()));
         // now that the writer is being tracked
         assertFalse(Futures.delayedTask(() -> client.isWriterActive(entry1, 1L), Duration.ofSeconds(1), executor).join());


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes the test issue where active writer is checked with a very small timeout which makes it flaky.

**Purpose of the change**  
Fixes #4368 

**What the code does**  
The test wants to check that a writer has not timed out, however, it checks with a very small timeout value of 1 ms which makes the test flaky.  
Changed the timeout value to 1000 ms. 

**How to verify it**  
Test should pass consistently