### PR TITLE
Issue 4471: Fix controller client channel termination logic.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -1096,7 +1096,11 @@ public class ControllerImpl implements Controller {
     @Override
     public void close() {
         if (!closed.getAndSet(true)) {
-            this.channel.shutdownNow(); // Initiates a shutdown of channel.
+            this.channel.shutdownNow(); // Initiates a shutdown of channel, although forceful the shutdown is not instantaneous.
+            Exceptions.handleInterrupted(() -> {
+                boolean shutdownStatus = channel.awaitTermination(10, TimeUnit.SECONDS);
+                log.debug("Controller client shutdown has been initiated. Channel status: channel.isTerminated():{}", shutdownStatus);
+            });
         }
     }
 

--- a/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+mock-maker-inline


### PR DESCRIPTION
**Change log description**  
* Ensure the client waits before the termination is completed.
* Ensure exceptions related to the credential plugin are handled and the channel is closed.

**Purpose of the change**  
Fixes #4471

**What the code does**  
`io.grpc.ManagedChannel#shutdownNow` only triggers a forceful shutdown. Although forceful, the shutdown process is still not instantaneous. The fix ensures `io.grpc.ManagedChannel#awaitTermination` is used to handle this. 

**How to verify it**  
All the existing and newly added tests should continue to pass.
