### PR TITLE
Issue 2183: Rebalance readers in event processors when new controllers are added

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
@@ -28,13 +28,13 @@ public class EventProcessorConfig<T extends ControllerEvent> {
     private final ExceptionHandler exceptionHandler;
     private final Serializer<T> serializer;
     private final Supplier<EventProcessor<T>> supplier;
-    private final long minRebalanceIntervalMillis;
+    private final long rebalancePeriodMillis;
 
     private EventProcessorConfig(final EventProcessorGroupConfig config,
                                  final ExceptionHandler exceptionHandler,
                                  final Serializer<T> serializer,
                                  final Supplier<EventProcessor<T>> supplier, 
-                                 final long minRebalanceIntervalMillis) {
+                                 final long rebalancePeriodMillis) {
         Preconditions.checkNotNull(config);
         Preconditions.checkNotNull(serializer);
         Preconditions.checkNotNull(supplier);
@@ -46,7 +46,7 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         }
         this.serializer = serializer;
         this.supplier = supplier;
-        this.minRebalanceIntervalMillis = minRebalanceIntervalMillis;
+        this.rebalancePeriodMillis = rebalancePeriodMillis;
     }
 
     public static <T extends ControllerEvent> EventProcessorConfigBuilder<T> builder() {
@@ -62,7 +62,7 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         private ExceptionHandler exceptionHandler;
         private Serializer<T> serializer;
         private Supplier<EventProcessor<T>> supplier;
-        private long minRebalanceIntervalMillis = Duration.ofMinutes(2).toMillis();
+        private long rebalancePeriodMillis = Duration.ofMinutes(2).toMillis();
 
         EventProcessorConfigBuilder() {
         }
@@ -87,13 +87,13 @@ public class EventProcessorConfig<T extends ControllerEvent> {
             return this;
         }
         
-        public EventProcessorConfigBuilder<T> minRebalanceIntervalMillis(long minRebalanceIntervalMillis) {
-            this.minRebalanceIntervalMillis = minRebalanceIntervalMillis;
+        public EventProcessorConfigBuilder<T> minRebalanceIntervalMillis(long rebalancePeriodMillis) {
+            this.rebalancePeriodMillis = rebalancePeriodMillis;
             return this;
         }
 
         public EventProcessorConfig<T> build() {
-            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier, minRebalanceIntervalMillis);
+            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier, rebalancePeriodMillis);
         }
 
         @Override

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
@@ -15,7 +15,6 @@ import io.pravega.client.stream.Serializer;
 import com.google.common.base.Preconditions;
 import lombok.Data;
 
-import java.time.Duration;
 import java.util.function.Supplier;
 
 /**
@@ -62,7 +61,7 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         private ExceptionHandler exceptionHandler;
         private Serializer<T> serializer;
         private Supplier<EventProcessor<T>> supplier;
-        private long rebalancePeriodMillis = Duration.ofMinutes(2).toMillis();
+        private long rebalancePeriodMillis = Long.MIN_VALUE; // default is rebalancing disabled
 
         EventProcessorConfigBuilder() {
         }
@@ -93,13 +92,13 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         }
 
         public EventProcessorConfig<T> build() {
-            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier, rebalancePeriodMillis);
+            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier, this.rebalancePeriodMillis);
         }
 
         @Override
         public String toString() {
             return "Props.PropsBuilder(config=" + this.config + ", exceptionHandler=" + this.exceptionHandler + ", serializer=" +
-                    this.serializer + ", supplier=" + this.supplier + ")";
+                    this.serializer + ", supplier=" + this.supplier + ", rebalancePeriodMillis=" + this.rebalancePeriodMillis + ")";
         }
     }
 }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorConfig.java
@@ -15,6 +15,7 @@ import io.pravega.client.stream.Serializer;
 import com.google.common.base.Preconditions;
 import lombok.Data;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 /**
@@ -27,12 +28,13 @@ public class EventProcessorConfig<T extends ControllerEvent> {
     private final ExceptionHandler exceptionHandler;
     private final Serializer<T> serializer;
     private final Supplier<EventProcessor<T>> supplier;
+    private final long minRebalanceIntervalMillis;
 
     private EventProcessorConfig(final EventProcessorGroupConfig config,
                                  final ExceptionHandler exceptionHandler,
                                  final Serializer<T> serializer,
-                                 final Supplier<EventProcessor<T>> supplier) {
-
+                                 final Supplier<EventProcessor<T>> supplier, 
+                                 final long minRebalanceIntervalMillis) {
         Preconditions.checkNotNull(config);
         Preconditions.checkNotNull(serializer);
         Preconditions.checkNotNull(supplier);
@@ -44,6 +46,7 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         }
         this.serializer = serializer;
         this.supplier = supplier;
+        this.minRebalanceIntervalMillis = minRebalanceIntervalMillis;
     }
 
     public static <T extends ControllerEvent> EventProcessorConfigBuilder<T> builder() {
@@ -59,6 +62,7 @@ public class EventProcessorConfig<T extends ControllerEvent> {
         private ExceptionHandler exceptionHandler;
         private Serializer<T> serializer;
         private Supplier<EventProcessor<T>> supplier;
+        private long minRebalanceIntervalMillis = Duration.ofMinutes(2).toMillis();
 
         EventProcessorConfigBuilder() {
         }
@@ -82,9 +86,14 @@ public class EventProcessorConfig<T extends ControllerEvent> {
             this.supplier = supplier;
             return this;
         }
+        
+        public EventProcessorConfigBuilder<T> minRebalanceIntervalMillis(long minRebalanceIntervalMillis) {
+            this.minRebalanceIntervalMillis = minRebalanceIntervalMillis;
+            return this;
+        }
 
         public EventProcessorConfig<T> build() {
-            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier);
+            return new EventProcessorConfig<>(this.config, this.exceptionHandler, this.serializer, this.supplier, minRebalanceIntervalMillis);
         }
 
         @Override

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
@@ -13,6 +13,7 @@ import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.controller.store.checkpoint.CheckpointStoreException;
 import io.pravega.shared.controller.event.ControllerEvent;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -47,12 +48,14 @@ public interface EventProcessorSystem {
      *              in the EventProcessorGroup.
      * @param checkpointStore Checkpoint store.
      * @param <T> Stream Event type parameter.
-     * @param rebalanceExecutor executor to run periodic checks for readergroup rebalance.
+     * @param rebalanceExecutor executor to run periodic checks for readergroup rebalance. 
+     *                          Pass null to disable rebalancing.
+     *                          
      * @return EventProcessorGroup reference.
      * @throws CheckpointStoreException on error accessing or updating checkpoint store.
      */
     <T extends ControllerEvent> EventProcessorGroup<T> createEventProcessorGroup(
             final EventProcessorConfig<T> eventProcessorConfig, final CheckpointStore checkpointStore,
-            final ScheduledExecutorService rebalanceExecutor)
+            @Nullable final ScheduledExecutorService rebalanceExecutor)
             throws CheckpointStoreException;
 }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/EventProcessorSystem.java
@@ -13,6 +13,8 @@ import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.controller.store.checkpoint.CheckpointStoreException;
 import io.pravega.shared.controller.event.ControllerEvent;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 /**
  * It acts as the manager and wrapper around EventProcessor groups
  * processing events from Pravega Streams belonging to a specific scope.
@@ -45,10 +47,12 @@ public interface EventProcessorSystem {
      *              in the EventProcessorGroup.
      * @param checkpointStore Checkpoint store.
      * @param <T> Stream Event type parameter.
+     * @param rebalanceExecutor executor to run periodic checks for readergroup rebalance.
      * @return EventProcessorGroup reference.
      * @throws CheckpointStoreException on error accessing or updating checkpoint store.
      */
     <T extends ControllerEvent> EventProcessorGroup<T> createEventProcessorGroup(
-            final EventProcessorConfig<T> eventProcessorConfig, final CheckpointStore checkpointStore)
+            final EventProcessorConfig<T> eventProcessorConfig, final CheckpointStore checkpointStore,
+            final ScheduledExecutorService rebalanceExecutor)
             throws CheckpointStoreException;
 }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/RequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/RequestHandler.java
@@ -12,6 +12,7 @@ package io.pravega.controller.eventProcessor;
 import io.pravega.shared.controller.event.ControllerEvent;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * Interface for request handlers.
@@ -20,5 +21,5 @@ import java.util.concurrent.CompletableFuture;
  */
 @FunctionalInterface
 public interface RequestHandler<Request extends ControllerEvent> {
-    CompletableFuture<Void> process(Request request);
+    CompletableFuture<Void> process(Request request, Supplier<Boolean> isCancelled);
 }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
@@ -232,7 +232,7 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
             log.warn("error while trying to store checkpoint in the store {}", e);
         }
     }
-    
+
     @AllArgsConstructor
     private static class PositionCounter {
         private final Position position;

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
@@ -183,6 +183,7 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
         // Invoke arriveAndAwaitAdvance and wait for phase to advance which will happen 
         // only when all ongoing processing is completed and all registered parties have arrived. 
         phaser.arriveAndAwaitAdvance();
+        phaser.arriveAndDeregister();
         periodicCheckpoint.cancel(true);
     }
 

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessor.java
@@ -13,6 +13,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.client.stream.Position;
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.controller.eventProcessor.RequestHandler;
 import io.pravega.controller.retryable.RetryableException;
@@ -23,8 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
@@ -61,6 +64,11 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
     private final ScheduledFuture<?> periodicCheckpoint;
     private final Checkpointer checkpointer;
     private final Writer<R> internalWriter;
+    /**
+     * The phaser is used to count number of ongoing requests and act as a 
+     * barrier to complete shutdown until all ongoing requests are completed. 
+     */
+    private final Phaser phaser;
 
     public ConcurrentEventProcessor(final H requestHandler,
                                     final ScheduledExecutorService executor) {
@@ -87,6 +95,11 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
         this.executor = executor;
         periodicCheckpoint = this.executor.scheduleAtFixedRate(this::periodicCheckpoint, 0, checkpointPeriod, timeUnit);
         semaphore = new Semaphore(maxConcurrent);
+        // It is initialized with 1 unarrived party for phase 0.
+        // Until all registered parties do not arrive, the phase is not advanced. 
+        // The final arriveAndAwaitAdvance is invoked from shutdown(afterstop) and blocks until all registered parties 
+        // have arrived. 
+        this.phaser = new Phaser(1);
     }
 
     @Override
@@ -95,13 +108,15 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
         // and it could lead to memory overload.
         if (!stop.get()) {
             semaphore.acquireUninterruptibly();
+            // Use phaser.register to register a new party to indicate starting of a new processing.
+            phaser.register();
 
             long next = counter.incrementAndGet();
             PositionCounter pc = new PositionCounter(position, next);
             running.add(pc);
 
             // In case of a retryable exception, retry few times before putting the event back into event stream.
-            withRetries(() -> requestHandler.process(request), executor)
+            withRetries(() -> requestHandler.process(request, stop::get), executor)
                     .whenCompleteAsync((r, e) -> {
                         CompletableFuture<Void> future;
                         if (e != null) {
@@ -112,8 +127,14 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
                             future = CompletableFuture.completedFuture(null);
                         }
 
-                        future.thenAcceptAsync(x -> {
-                            checkpoint(pc);
+                        future.whenCompleteAsync((res, ex) -> {
+                            // do not update checkpoint if stop has been initiated and request has been cancelled.
+                            if (!stop.get() || ex == null || !(Exceptions.unwrap(ex) instanceof CancellationException)) {
+                                checkpoint(pc);
+                            }
+                            
+                            // Report arrival and deregister a party to indicate completion of an ongoing processing.
+                            phaser.arriveAndDeregister();
                             semaphore.release();
                         }, executor);
                     }, executor);
@@ -147,8 +168,10 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
 
             future = indefiniteRetries(() -> writeBack(request, writer), executor);
         } else {
-            log.error("ConcurrentEventProcessor Processing failed, exiting {}", e);
-            future = CompletableFuture.completedFuture(null);
+            // Fail the future with actual failure. The failure will be handled by the caller. 
+            Throwable actual = Exceptions.unwrap(e);
+            log.warn("ConcurrentEventProcessor Processing failed, {} {}", actual.getClass(), actual.getMessage());
+            future = Futures.failedFuture(actual);
         }
 
         return future;
@@ -157,7 +180,15 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
     @Override
     protected void afterStop() {
         stop.set(true);
+        // Invoke arriveAndAwaitAdvance and wait for phase to advance which will happen 
+        // only when all ongoing processing is completed and all registered parties have arrived. 
+        phaser.arriveAndAwaitAdvance();
         periodicCheckpoint.cancel(true);
+    }
+
+    @VisibleForTesting
+    boolean isStopFlagSet() {
+        return stop.get();
     }
 
     /**
@@ -187,7 +218,8 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
         }
     }
 
-    private void periodicCheckpoint() {
+    @VisibleForTesting
+    void periodicCheckpoint() {
         try {
             if (checkpoint.get() != null && checkpoint.get().position != null) {
                 if (checkpointer != null) {
@@ -200,7 +232,7 @@ public class ConcurrentEventProcessor<R extends ControllerEvent, H extends Reque
             log.warn("error while trying to store checkpoint in the store {}", e);
         }
     }
-
+    
     @AllArgsConstructor
     private static class PositionCounter {
         private final Position position;

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -334,13 +334,13 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
 
         EventProcessorCell<T> cell = eventProcessorMap.get(readerId);
         log.info("Stopping event processor cell: {}", cell);
-        cell.stopAsync();
-        log.info("Awaiting termination of event processor cell: {}", cell);
         try {
+            cell.stopAsync();
+            log.info("Awaiting termination of event processor cell: {}", cell);
             cell.awaitTerminated();
             eventProcessorMap.remove(readerId);
         } catch (Exception e) {
-            log.warn("Failed terminating event processor cell {}.", cell, e);
+            log.error("Failed terminating event processor cell {}.", cell, e);
         }
     }
     

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -69,7 +69,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
     
     private ScheduledFuture<?> rebalanceFuture;
     
-    private final long minRebalancePeriodMillis;
+    private final long rebalancePeriod;
     /**
      * We use this lock for mutual exclusion between shutDown and changeEventProcessorCount methods.
      */
@@ -89,7 +89,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
                         eventProcessorConfig.getSerializer(),
                         EventWriterConfig.builder().build());
         this.checkpointStore = checkpointStore;
-        this.minRebalancePeriodMillis = eventProcessorConfig.getMinRebalanceIntervalMillis();
+        this.rebalancePeriod = eventProcessorConfig.getRebalancePeriodMillis();
     }
 
     void initialize() throws CheckpointStoreException {
@@ -159,9 +159,9 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
             eventProcessorMap.entrySet().forEach(entry -> entry.getValue().startAsync());
             log.info("Waiting for all all event processors in {} to start", this.toString());
             eventProcessorMap.entrySet().forEach(entry -> entry.getValue().awaitStartupComplete());
-            if (minRebalancePeriodMillis > 0) {
+            if (rebalancePeriod > 0) {
                 rebalanceFuture = executorService.scheduleWithFixedDelay(this::rebalance,
-                        minRebalancePeriodMillis, minRebalancePeriodMillis, TimeUnit.MILLISECONDS);
+                        rebalancePeriod, rebalancePeriod, TimeUnit.MILLISECONDS);
             } else {
                 rebalanceFuture = null;
             }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorSystemImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorSystemImpl.java
@@ -20,6 +20,8 @@ import io.pravega.controller.store.checkpoint.CheckpointStoreException;
 import io.pravega.shared.controller.event.ControllerEvent;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 @Slf4j
 public class EventProcessorSystemImpl implements EventProcessorSystem {
 
@@ -58,14 +60,14 @@ public class EventProcessorSystemImpl implements EventProcessorSystem {
     @Override
     public <T extends ControllerEvent> EventProcessorGroup<T> createEventProcessorGroup(
             final EventProcessorConfig<T> eventProcessorConfig,
-            final CheckpointStore checkpointStore) throws CheckpointStoreException {
+            final CheckpointStore checkpointStore, final ScheduledExecutorService rebalanceExecutor) throws CheckpointStoreException {
         Preconditions.checkNotNull(eventProcessorConfig, "eventProcessorConfig");
         Preconditions.checkNotNull(checkpointStore, "checkpointStore");
 
         EventProcessorGroupImpl<T> actorGroup;
 
         // Create event processor group.
-        actorGroup = new EventProcessorGroupImpl<>(this, eventProcessorConfig, checkpointStore);
+        actorGroup = new EventProcessorGroupImpl<>(this, eventProcessorConfig, checkpointStore, rebalanceExecutor);
 
         // Initialize it.
         actorGroup.initialize();

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandler.java
@@ -91,7 +91,7 @@ public abstract class SerializedRequestHandler<T extends ControllerEvent> implem
         CompletableFuture<Void> future;
         try {
             assert work != null;
-            if (!work.cancelledSupplier.get()) {
+            if (!work.getCancelledSupplier().get()) {
                 future = processEvent(work.getEvent());
             } else {
                 future = new CompletableFuture<>();

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorConfig.java
@@ -122,4 +122,11 @@ public interface ControllerEventProcessorConfig {
      * @return Checkpoint configuration for request stream event processors.
      */
     CheckpointConfig getRequestStreamCheckpointConfig();
+    
+    /**
+     * Fetches rebalance interval set for event processors.
+     *
+     * @return period in milliseconds.
+     */
+    long getRebalanceIntervalMillis();
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -91,6 +91,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
     private final StreamRequestHandler streamRequestHandler;
     private final CommitRequestHandler commitRequestHandler;
     private final AbortRequestHandler abortRequestHandler;
+    private final long rebalanceIntervalMillis;
     private ScheduledExecutorService rebalanceExecutor;
 
     public ControllerEventProcessors(final String host,
@@ -137,6 +138,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
         this.commitRequestHandler = new CommitRequestHandler(streamMetadataStore, streamMetadataTasks, streamTransactionMetadataTasks, bucketStore, executor);
         this.abortRequestHandler = new AbortRequestHandler(streamMetadataStore, streamMetadataTasks, executor);
         this.executor = executor;
+        this.rebalanceIntervalMillis = config.getRebalanceIntervalMillis();
     }
 
     @Override
@@ -335,6 +337,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                         .decider(ExceptionHandler.DEFAULT_EXCEPTION_HANDLER)
                         .serializer(COMMIT_EVENT_SERIALIZER)
                         .supplier(() -> new ConcurrentEventProcessor<>(commitRequestHandler, executor))
+                        .minRebalanceIntervalMillis(rebalanceIntervalMillis)
                         .build();
 
         log.info("Creating commit event processors");
@@ -363,6 +366,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                         .decider(ExceptionHandler.DEFAULT_EXCEPTION_HANDLER)
                         .serializer(ABORT_EVENT_SERIALIZER)
                         .supplier(() -> new ConcurrentEventProcessor<>(abortRequestHandler, executor))
+                        .minRebalanceIntervalMillis(rebalanceIntervalMillis)
                         .build();
 
         log.info("Creating abort event processors");
@@ -391,6 +395,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                         .decider(ExceptionHandler.DEFAULT_EXCEPTION_HANDLER)
                         .serializer(CONTROLLER_EVENT_SERIALIZER)
                         .supplier(() -> new ConcurrentEventProcessor<>(streamRequestHandler, executor))
+                        .minRebalanceIntervalMillis(rebalanceIntervalMillis)
                         .build();
 
         log.info("Creating request event processors");

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/impl/ControllerEventProcessorConfigImpl.java
@@ -20,6 +20,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.Duration;
+
 /**
  * Configuration of controller event processors.
  */
@@ -45,6 +47,8 @@ public class ControllerEventProcessorConfigImpl implements ControllerEventProces
     private final CheckpointConfig commitCheckpointConfig;
     private final CheckpointConfig abortCheckpointConfig;
     private final CheckpointConfig scaleCheckpointConfig;
+    
+    private final long rebalanceIntervalMillis;
 
     @Builder
     ControllerEventProcessorConfigImpl(final String scopeName,
@@ -58,7 +62,8 @@ public class ControllerEventProcessorConfigImpl implements ControllerEventProces
                                        final int abortReaderGroupSize,
                                        final CheckpointConfig commitCheckpointConfig,
                                        final CheckpointConfig abortCheckpointConfig,
-                                       final ScalingPolicy scaleStreamScalingPolicy) {
+                                       final ScalingPolicy scaleStreamScalingPolicy,
+                                       final long rebalanceIntervalMillis) {
 
         Exceptions.checkNotNullOrEmpty(scopeName, "scopeName");
         Exceptions.checkNotNullOrEmpty(commitStreamName, "commitStreamName");
@@ -89,6 +94,7 @@ public class ControllerEventProcessorConfigImpl implements ControllerEventProces
         this.scaleReaderGroupName = Config.SCALE_READER_GROUP;
         this.scaleReaderGroupSize = 1;
         this.scaleCheckpointConfig = CheckpointConfig.none();
+        this.rebalanceIntervalMillis = rebalanceIntervalMillis;
     }
 
     public static ControllerEventProcessorConfig withDefault() {
@@ -105,6 +111,7 @@ public class ControllerEventProcessorConfigImpl implements ControllerEventProces
                 .abortReaderGroupSize(1)
                 .commitCheckpointConfig(CheckpointConfig.periodic(10, 10))
                 .abortCheckpointConfig(CheckpointConfig.periodic(10, 10))
+                .rebalanceIntervalMillis(Duration.ofMinutes(2).toMillis())
                 .build();
     }
 

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
@@ -11,23 +11,32 @@ package io.pravega.controller.eventProcessor.impl;
 
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.impl.PositionInternal;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.eventProcessor.RequestHandler;
 import io.pravega.controller.retryable.RetryableException;
 import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.shared.controller.event.RequestProcessor;
+import io.pravega.test.common.AssertExtensions;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ConcurrentEventProcessorTest {
@@ -73,14 +82,14 @@ public class ConcurrentEventProcessorTest {
         private final Exception exception;
 
         @Override
-        public CompletableFuture<Void> process(TestEvent testEvent) {
+        public CompletableFuture<Void> process(TestEvent testEvent, Supplier<Boolean> isCancelled) {
             return Futures.failedFuture(exception);
         }
     }
 
     private class TestRequestHandler implements RequestHandler<TestEvent> {
         @Override
-        public CompletableFuture<Void> process(TestEvent testEvent) {
+        public CompletableFuture<Void> process(TestEvent testEvent, Supplier<Boolean> isCancelled) {
             if (runningcount.getAndIncrement() > 2) {
                 result.completeExceptionally(new RuntimeException("max concurrent not honoured"));
             }
@@ -108,6 +117,7 @@ public class ConcurrentEventProcessorTest {
     private CompletableFuture<Void> result;
 
     private AtomicInteger runningcount;
+    private ScheduledExecutorService executor;
 
     @Before
     public void setup() {
@@ -116,8 +126,14 @@ public class ConcurrentEventProcessorTest {
         latch = new CompletableFuture<>();
         result = new CompletableFuture<>();
         runningcount = new AtomicInteger(0);
+        executor = Executors.newScheduledThreadPool(2);
     }
 
+    @After
+    public void tearDown() {
+        executor.shutdownNow();    
+    }
+    
     @Test(timeout = 10000)
     public void testConcurrentEventProcessor() throws InterruptedException, ExecutionException {
         EventProcessor.Writer<TestEvent> writer = event -> CompletableFuture.completedFuture(null);
@@ -143,7 +159,7 @@ public class ConcurrentEventProcessorTest {
                 }
             }
         };
-        ConcurrentEventProcessor<TestEvent, TestRequestHandler> processor = new ConcurrentEventProcessor<>(new TestRequestHandler(), 2, Executors.newScheduledThreadPool(2),
+        ConcurrentEventProcessor<TestEvent, TestRequestHandler> processor = new ConcurrentEventProcessor<>(new TestRequestHandler(), 2, executor,
                 checkpointer, writer, 1, TimeUnit.SECONDS);
 
         CompletableFuture.runAsync(() -> {
@@ -182,7 +198,7 @@ public class ConcurrentEventProcessorTest {
 
         // process throwing retryable exception. Verify that event is written back and checkpoint has moved forward
         ConcurrentEventProcessor<TestEvent, TestFailureRequestHandler> processor = new ConcurrentEventProcessor<>(new TestFailureRequestHandler(new RetryableTestException()),
-                2, Executors.newScheduledThreadPool(2),
+                2, executor,
                 checkpointer, writer, 1, TimeUnit.SECONDS);
 
         processor.process(request, new TestPosition(0));
@@ -214,7 +230,7 @@ public class ConcurrentEventProcessorTest {
         // process throwing non retryable exception. Verify that no event is written back while the checkpoint has moved forward
         ConcurrentEventProcessor<TestEvent, TestFailureRequestHandler> processor = new ConcurrentEventProcessor<>(
                 new TestFailureRequestHandler(new RuntimeException()),
-                2, Executors.newScheduledThreadPool(2),
+                2, executor,
                 checkpointer, writer, 1, TimeUnit.SECONDS);
 
         processor.process(request, new TestPosition(0));
@@ -242,7 +258,7 @@ public class ConcurrentEventProcessorTest {
         // process throwing non retryable exception. Verify that no event is written back while the checkpoint has moved forward
         ConcurrentEventProcessor<TestEvent, TestFailureRequestHandler> processor = new ConcurrentEventProcessor<>(
                 new TestFailureRequestHandler(new RetryableTestException()),
-                2, Executors.newScheduledThreadPool(2),
+                2, executor,
                 checkpointer, writer, 1, TimeUnit.SECONDS);
 
         processor.process(request, new TestPosition(0));
@@ -252,4 +268,74 @@ public class ConcurrentEventProcessorTest {
         processor.afterStop();
     }
 
+    @Test(timeout = 10000)
+    public void testShutdown() {
+        // Submit 3 requests to be processed.
+        // Processing of second request should wait on completion of first request. 
+        // Issue a shutdown and then complete first and third requests while cancelling second request. 
+        CompletableFuture<TestPosition> checkpoint = new CompletableFuture<>();
+        TestEvent request0 = new TestEvent(0);
+        TestEvent request1 = new TestEvent(1);
+        TestEvent request2 = new TestEvent(2);
+        EventProcessor.Checkpointer checkpointer = pos -> checkpoint.complete((TestPosition) pos);
+        EventProcessor.Writer<TestEvent> writer = event -> CompletableFuture.completedFuture(null);
+
+        CompletableFuture<CompletableFuture<Void>> processing0 = new CompletableFuture<>();
+        CompletableFuture<CompletableFuture<Void>> processing1 = new CompletableFuture<>();
+        CompletableFuture<CompletableFuture<Void>> processing2 = new CompletableFuture<>();
+        
+        // process throwing non retryable exception. Verify that no event is written back while the checkpoint has moved forward
+        RequestHandler<TestEvent> requestHandler = (event, isCancelled) -> {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            switch (event.number) {
+                case 0:
+                    processing0.complete(future);
+                    return future;                    
+                case 1:
+                    processing1.complete(future);
+                    // wait until processing 1 completes before beginning processing 2. by that time stop 
+                    // should have been invoked as well. 
+                    processing0.join().join();
+                    if (isCancelled.get()) {
+                        future.cancel(true);
+                    }
+                    return future;
+                case 2:
+                    processing2.complete(future);
+                    return future;
+                default:
+                    throw new RuntimeException("Unexpected");
+            }
+        };
+
+        ConcurrentEventProcessor<TestEvent, RequestHandler<TestEvent>> processor = new ConcurrentEventProcessor<>(
+                requestHandler, 100, executor,
+                checkpointer, writer, 10, TimeUnit.MILLISECONDS);
+
+        processor.process(request0, new TestPosition(0));
+        processor.process(request1, new TestPosition(1));
+        processor.process(request2, new TestPosition(2));
+        
+        // send stop asynchronously
+        CompletableFuture<Void> stopFuture = CompletableFuture.runAsync(processor::afterStop);
+        
+        Futures.loop(() -> !processor.isStopFlagSet(), () -> Futures.delayedFuture(Duration.ofMillis(10), executor), executor).join();
+
+        // complete processing of event 1
+        processing0.join().complete(null);
+        // processing of event 2 should have been cancelled
+        AssertExtensions.assertFutureThrows("This should have been cancelled", processing1.join(),
+                e -> Exceptions.unwrap(e) instanceof CancellationException);
+        // verify that event processor's afterStop has not completed yet.
+        assertFalse(stopFuture.isDone());
+        // complete processing of event 3 
+        processing2.join().complete(null);
+
+        // stop should complete after we have completed all ongoing processing
+        stopFuture.join();
+
+        // assert that checkpoint points to event `0`. 
+        processor.periodicCheckpoint();
+        assertEquals(0, checkpoint.join().number);
+    }
 }

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -19,7 +19,9 @@ import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderSegmentDistribution;
 import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.impl.EventReadImpl;
 import io.pravega.client.stream.impl.PositionImpl;
 import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.controller.eventProcessor.CheckpointConfig;
@@ -36,21 +38,29 @@ import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.shared.controller.event.RequestProcessor;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -207,6 +217,18 @@ public class EventProcessorTest {
         }
     }
 
+    private ScheduledExecutorService executor;
+    
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();    
+    }
+    
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+    
     @Test(timeout = 10000)
     @SuppressWarnings("unchecked")
     public void testEventProcessorCell() throws CheckpointStoreException, ReinitializationRequiredException {
@@ -362,7 +384,7 @@ public class EventProcessorTest {
 
         // Create EventProcessorGroup.
         EventProcessorGroupImpl<TestEvent> group = (EventProcessorGroupImpl<TestEvent>)
-                system.createEventProcessorGroup(eventProcessorConfig, checkpointStore);
+                system.createEventProcessorGroup(eventProcessorConfig, checkpointStore, executor);
 
         // Await until it is ready.
         group.awaitRunning();
@@ -408,7 +430,7 @@ public class EventProcessorTest {
 
         // Create EventProcessorGroup.
         EventProcessorGroupImpl<TestEvent> group = (EventProcessorGroupImpl<TestEvent>)
-                system.createEventProcessorGroup(eventProcessorConfig, checkpointStore);
+                system.createEventProcessorGroup(eventProcessorConfig, checkpointStore, executor);
 
         // test idempotent initialize
         group.initialize();
@@ -443,7 +465,7 @@ public class EventProcessorTest {
 
         // Create EventProcessorGroup.
         EventProcessorGroupImpl<TestEvent> group = (EventProcessorGroupImpl<TestEvent>) system
-                .createEventProcessorGroup(eventProcessorConfig, checkpointStore);
+                .createEventProcessorGroup(eventProcessorConfig, checkpointStore, executor);
 
         // awaitRunning should succeed.
         group.awaitRunning();
@@ -475,7 +497,7 @@ public class EventProcessorTest {
 
         // Create EventProcessorGroup.
         EventProcessorGroupImpl<TestEvent> group = (EventProcessorGroupImpl<TestEvent>) system.createEventProcessorGroup(eventProcessorConfig,
-                    checkpointStore);
+                    checkpointStore, executor);
         group.awaitRunning();
 
         // Add a few event processors to the group.
@@ -489,6 +511,149 @@ public class EventProcessorTest {
         }
         assertEquals(count * expectedSum, actualSum);
 
+        // Stop the group, and await its termmination.
+        group.stopAsync();
+        group.awaitTerminated();
+    }
+
+    @Test(timeout = 10000)
+    @SuppressWarnings("unchecked")
+    public void testEventProcessorGroupRebalance() throws CheckpointStoreException, ReinitializationRequiredException {
+        String systemName = "rebalance";
+        String readerGroupName = "rebalance";
+
+        CheckpointStore checkpointStore = CheckpointStoreFactory.createInMemoryStore();
+
+        EventProcessorGroupConfig config = createEventProcessorGroupConfig(2);
+        
+        EventStreamClientFactory clientFactory = Mockito.mock(EventStreamClientFactory.class);
+
+        EventStreamReader<TestEvent> reader = Mockito.mock(EventStreamReader.class);
+        Mockito.when(reader.readNextEvent(anyLong())).thenReturn(Mockito.mock(EventReadImpl.class));
+
+        Mockito.when(clientFactory.createReader(anyString(), anyString(), any(), any()))
+               .thenAnswer(x -> reader);
+
+        Mockito.when(clientFactory.<String>createEventWriter(anyString(), any(), any())).thenReturn(new EventStreamWriterMock<>());
+
+        ReaderGroup readerGroup = Mockito.mock(ReaderGroup.class);
+        Mockito.when(readerGroup.getGroupName()).thenReturn(readerGroupName);
+
+        ReaderGroupManager readerGroupManager = Mockito.mock(ReaderGroupManager.class);
+        Mockito.when(readerGroupManager.getReaderGroup(anyString())).then(invocation -> readerGroup);
+
+        EventProcessorSystemImpl system = new EventProcessorSystemImpl(systemName, PROCESS, SCOPE, clientFactory, readerGroupManager);
+
+        EventProcessorConfig<TestEvent> eventProcessorConfig = EventProcessorConfig.<TestEvent>builder()
+                .supplier(() -> new TestEventProcessor(false))
+                .serializer(new EventSerializer<>())
+                .decider((Throwable e) -> ExceptionHandler.Directive.Stop)
+                .config(config)
+                .minRebalanceIntervalMillis(0L)
+                .build();
+
+        // Create EventProcessorGroup.
+        EventProcessorGroupImpl<TestEvent> group = (EventProcessorGroupImpl<TestEvent>) system.createEventProcessorGroup(eventProcessorConfig,
+                    checkpointStore, executor);
+        group.awaitRunning();
+
+        ConcurrentHashMap<String, EventProcessorCell<TestEvent>> eventProcessorMap = group.getEventProcessorMap();
+        assertEquals(2, eventProcessorMap.size());
+
+        List<String> readerIds = eventProcessorMap.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
+
+        // region case 1: even distribution - 2 readers with 2 segments each
+        HashMap<String, Integer> distribution = new HashMap<>();
+        distribution.put(readerIds.get(0), 2);
+        distribution.put(readerIds.get(1), 2);
+        
+        ReaderSegmentDistribution readerSegmentDistribution = ReaderSegmentDistribution
+                .builder().readerSegmentDistribution(distribution).unassignedSegments(0).build();
+        Mockito.when(readerGroup.getReaderSegmentDistribution()).thenReturn(readerSegmentDistribution);
+
+        // call rebalance. no new readers should be added or existing reader removed.
+        group.rebalance();
+
+        eventProcessorMap = group.getEventProcessorMap();
+        assertEquals(2, eventProcessorMap.size());
+        // the original readers should not have been replaced
+        assertTrue(eventProcessorMap.containsKey(readerIds.get(0)));
+        assertTrue(eventProcessorMap.containsKey(readerIds.get(1)));
+
+        // endregion
+        
+        // region case 2: two external readers with 0 segment assignment and 2 overloaded readers in the 
+        // readergroup. unassigned = 0
+        String reader2 = "reader2";
+        String reader3 = "reader3";
+
+        distribution = new HashMap<>();
+        distribution.put(readerIds.get(0), 2);
+        distribution.put(readerIds.get(1), 2);
+        distribution.put(reader2, 0);
+        distribution.put(reader3, 0);
+        
+        readerSegmentDistribution = ReaderSegmentDistribution
+                .builder().readerSegmentDistribution(distribution).unassignedSegments(0).build();
+        Mockito.when(readerGroup.getReaderSegmentDistribution()).thenReturn(readerSegmentDistribution);
+
+        // call rebalance. this should replace existing overloaded readers
+        group.rebalance();
+        
+        eventProcessorMap = group.getEventProcessorMap();
+        assertEquals(2, eventProcessorMap.size());
+        assertFalse(eventProcessorMap.containsKey(readerIds.get(0)));
+        assertFalse(eventProcessorMap.containsKey(readerIds.get(1)));
+
+        // update the readers in the readergroup
+        readerIds = eventProcessorMap.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
+
+        // endregion
+        
+        // region case 3: even distribution among 4 readers
+        distribution = new HashMap<>();
+        distribution.put(readerIds.get(0), 1);
+        distribution.put(readerIds.get(1), 1);
+        distribution.put(reader2, 1);
+        distribution.put(reader3, 1);
+
+        readerSegmentDistribution = ReaderSegmentDistribution
+                .builder().readerSegmentDistribution(distribution).unassignedSegments(0).build();
+        Mockito.when(readerGroup.getReaderSegmentDistribution()).thenReturn(readerSegmentDistribution);
+
+        // call rebalance. nothing should happen
+        group.rebalance();
+        
+        // no change to the group
+        eventProcessorMap = group.getEventProcessorMap();
+        assertEquals(2, eventProcessorMap.size());
+        assertTrue(eventProcessorMap.containsKey(readerIds.get(0)));
+        assertTrue(eventProcessorMap.containsKey(readerIds.get(1)));
+
+        // endregion
+        
+        // region case 4: with 1 overloaded reader and 2 unassigned segments
+        distribution = new HashMap<>();
+        distribution.put(readerIds.get(0), 2);
+        distribution.put(readerIds.get(1), 0);
+        distribution.put(reader2, 0);
+        distribution.put(reader3, 0);
+
+        readerSegmentDistribution = ReaderSegmentDistribution
+                .builder().readerSegmentDistribution(distribution).unassignedSegments(2).build();
+        Mockito.when(readerGroup.getReaderSegmentDistribution()).thenReturn(readerSegmentDistribution);
+
+        // call rebalance. overloaded reader should be replaced
+        group.rebalance();
+
+        // no change to the group
+        eventProcessorMap = group.getEventProcessorMap();
+        assertEquals(2, eventProcessorMap.size());
+        assertFalse(eventProcessorMap.containsKey(readerIds.get(0)));
+        assertTrue(eventProcessorMap.containsKey(readerIds.get(1)));
+
+        // endregion
+        
         // Stop the group, and await its termmination.
         group.stopAsync();
         group.awaitTerminated();

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -646,7 +646,7 @@ public class EventProcessorTest {
         // call rebalance. overloaded reader should be replaced
         group.rebalance();
 
-        // no change to the group
+        // reader0 should have been replaced. 
         eventProcessorMap = group.getEventProcessorMap();
         assertEquals(2, eventProcessorMap.size());
         assertFalse(eventProcessorMap.containsKey(readerIds.get(0)));

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -61,11 +63,11 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         assertNull(stream1Queue);
         // post 3 work for stream1
         TestEvent s1e1 = new TestEvent("scope", "stream1", 1);
-        CompletableFuture<Void> s1p1 = requestHandler.process(s1e1);
+        CompletableFuture<Void> s1p1 = requestHandler.process(s1e1, () -> false);
         TestEvent s1e2 = new TestEvent("scope", "stream1", 2);
-        CompletableFuture<Void> s1p2 = requestHandler.process(s1e2);
+        CompletableFuture<Void> s1p2 = requestHandler.process(s1e2, () -> false);
         TestEvent s1e3 = new TestEvent("scope", "stream1", 3);
-        CompletableFuture<Void> s1p3 = requestHandler.process(s1e3);
+        CompletableFuture<Void> s1p3 = requestHandler.process(s1e3, () -> false);
 
         stream1Queue = requestHandler.getEventQueueForKey(getKeyForStream("scope", "stream1"));
         assertTrue(stream1Queue.size() >= 2);
@@ -85,11 +87,11 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
 
         // post 3 work for stream2
         TestEvent s2e1 = new TestEvent("scope", "stream2", 1);
-        CompletableFuture<Void> s2p1 = requestHandler.process(s2e1);
+        CompletableFuture<Void> s2p1 = requestHandler.process(s2e1, () -> false);
         TestEvent s2e2 = new TestEvent("scope", "stream2", 2);
-        CompletableFuture<Void> s2p2 = requestHandler.process(s2e2);
+        CompletableFuture<Void> s2p2 = requestHandler.process(s2e2, () -> false);
         TestEvent s2e3 = new TestEvent("scope", "stream2", 3);
-        CompletableFuture<Void> s2p3 = requestHandler.process(s2e3);
+        CompletableFuture<Void> s2p3 = requestHandler.process(s2e3, () -> false);
 
         List<Pair<TestEvent, CompletableFuture<Void>>> stream2Queue = requestHandler.getEventQueueForKey(getKeyForStream("scope", "stream1"));
         assertTrue(stream2Queue.size() >= 2);
@@ -143,7 +145,7 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         // now that we have drained all the work from the processor.
         // let's post new work for stream 1
         TestEvent s1e4 = new TestEvent("scope", "stream1", 4);
-        CompletableFuture<Void> s1p4 = requestHandler.process(s1e4);
+        CompletableFuture<Void> s1p4 = requestHandler.process(s1e4, () -> false);
 
         stream1Queue = requestHandler.getEventQueueForKey(getKeyForStream("scope", "stream1"));
         assertNotNull(stream1Queue);
@@ -195,11 +197,11 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         assertNull(stream1Queue);
         // post 3 work for stream1
         TestEvent s1e1 = new TestEvent("scope", "stream1", 1);
-        CompletableFuture<Void> s1p1 = requestHandler.process(s1e1);
+        CompletableFuture<Void> s1p1 = requestHandler.process(s1e1, () -> false);
         TestEvent s1e2 = new TestEvent("scope", "stream1", 2);
-        CompletableFuture<Void> s1p2 = requestHandler.process(s1e2);
+        CompletableFuture<Void> s1p2 = requestHandler.process(s1e2, () -> false);
         TestEvent s1e3 = new TestEvent("scope", "stream1", 3);
-        CompletableFuture<Void> s1p3 = requestHandler.process(s1e3);
+        CompletableFuture<Void> s1p3 = requestHandler.process(s1e3, () -> false);
 
         // post events for some more arbitrary streams in background
         AtomicBoolean stop = new AtomicBoolean(false);
@@ -248,7 +250,7 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         signalQueue.add(new ImmutablePair<>(new CompletableFuture<>(), CompletableFuture.completedFuture(null)));
         // we should have first event processing throw a synchronous exception
         AssertExtensions.assertFutureThrows("Processing should have failed in procesEvent method with synchronous exception", 
-                throwingRequestHandler.process(event), 
+                throwingRequestHandler.process(event, () -> false), 
                 e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("1"));
 
         // verify that the processing is complete and the event is removed from the queue for the stream. 
@@ -261,8 +263,8 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         CompletableFuture<Void> signal3 = new CompletableFuture<>();
         signalQueue.add(new ImmutablePair<>(wait2, signal2));
         signalQueue.add(new ImmutablePair<>(wait3, signal3));
-        CompletableFuture<Void> future2 = throwingRequestHandler.process(event2);
-        CompletableFuture<Void> future3 = throwingRequestHandler.process(event3);
+        CompletableFuture<Void> future2 = throwingRequestHandler.process(event2, () -> false);
+        CompletableFuture<Void> future3 = throwingRequestHandler.process(event3, () -> false);
         
         // processing for 2nd event is called. 
         wait2.join();
@@ -285,12 +287,73 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
                 future3, e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("3"));
     }
 
+    @Test(timeout = 10000)
+    public void testCancellation() {
+        final ConcurrentHashMap<String, List<Integer>> orderOfProcessing = new ConcurrentHashMap<>();
+
+        SerializedRequestHandler<TestEvent> requestHandler = new SerializedRequestHandler<TestEvent>(executorService()) {
+            @Override
+            public CompletableFuture<Void> processEvent(TestEvent event) {
+                orderOfProcessing.compute(event.getKey(), (x, y) -> {
+                    if (y == null) {
+                        y = new ArrayList<>();
+                    }
+                    y.add(event.getNumber());
+                    return y;
+                });
+                return event.getFuture();
+            }
+        };
+
+        String scope = "scope";
+        String stream = "stream";
+        List<Pair<TestEvent, CompletableFuture<Void>>> queue = requestHandler.getEventQueueForKey(getKeyForStream(scope, stream));
+        assertNull(queue);
+        AtomicBoolean stop = new AtomicBoolean(false);
+        // post 3 work for stream
+        TestEvent e1 = new TestEvent(scope, stream, 1);
+        CompletableFuture<Void> p1 = requestHandler.process(e1, stop::get);
+        TestEvent e2 = new TestEvent(scope, stream, 2);
+        CompletableFuture<Void> p2 = requestHandler.process(e2, stop::get);
+        TestEvent e3 = new TestEvent(scope, stream, 3);
+        CompletableFuture<Void> p3 = requestHandler.process(e3, stop::get);
+
+        queue = requestHandler.getEventQueueForKey(getKeyForStream(scope, stream));
+        assertTrue(queue.size() >= 2);
+        assertTrue(queue.stream().noneMatch(x -> x.getRight().isDone()));
+        List<Integer> collect = queue.stream().map(x -> x.getLeft().getNumber()).collect(Collectors.toList());
+        assertTrue(collect.indexOf(2) < collect.indexOf(3));
+        
+        // now set stop = true
+        stop.set(true);
+        
+        // verify that until p1 completes nothing else will be processed. 
+        queue = requestHandler.getEventQueueForKey(getKeyForStream(scope, stream));
+        assertTrue(queue.size() >= 2);
+        assertTrue(queue.stream().noneMatch(x -> x.getRight().isDone()));
+        
+        // now complete processing for event 1. All subsequent events for the stream will be cancelled.
+        e1.complete();
+        CompletableFuture.allOf(p1, p2, p3)
+                         .exceptionally(e -> {
+                             if (Exceptions.unwrap(e) instanceof CancellationException) {
+                                 return null;
+                             } else {
+                                 throw new CompletionException(e);
+                             }
+                         })
+                         .join();
+        assertTrue(p1.isDone());
+        assertTrue(p2.isCancelled());
+        assertTrue(p3.isCancelled());
+    }
+
     private void runBackgroundStreamProcessing(String streamName, SerializedRequestHandler<TestEvent> requestHandler, AtomicBoolean stop) {
         CompletableFuture.runAsync(() -> {
             while (!stop.get()) {
                 TestEvent event = new TestEvent("scope", streamName, 0);
                 event.complete();
-                Futures.await(requestHandler.process(event));
+                Futures.await(requestHandler.process(event, () -> false));
             }
         });
     }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -160,7 +160,7 @@ public class ControllerEventProcessorsTest {
         };
 
         try {
-            when(system.createEventProcessorGroup(any(), any())).thenReturn(processor);
+            when(system.createEventProcessorGroup(any(), any(), any())).thenReturn(processor);
         } catch (CheckpointStoreException e) {
             e.printStackTrace();
         }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -629,7 +629,7 @@ public abstract class RequestHandlersTest {
         ScaleOpEvent scaleEvent = new ScaleOpEvent(fairness, fairness, Collections.singletonList(0L), 
                 Collections.singletonList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), 
                 false, System.currentTimeMillis(), 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
         // verify that scale was started
         assertEquals(State.SCALING, streamStore.getState(fairness, fairness, true, null, executor).join());
@@ -642,7 +642,7 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).sealSegment(anyString(), anyString(), anyLong(), anyString(), anyLong());
         
         // 5. process again. it should succeed while ignoring waiting processor
-        streamRequestHandler.process(scaleEvent).join();
+        streamRequestHandler.process(scaleEvent, () -> false).join();
         EpochRecord activeEpoch = streamStore.getActiveEpoch(fairness, fairness, null, true, executor).join();
         assertEquals(1, activeEpoch.getEpoch());
         assertEquals(State.ACTIVE, streamStore.getState(fairness, fairness, true, null, executor).join());
@@ -651,7 +651,7 @@ public abstract class RequestHandlersTest {
         ScaleOpEvent scaleEvent2 = new ScaleOpEvent(fairness, fairness, Collections.singletonList(StreamSegmentNameUtils.computeSegmentId(1, 1)),
                 Collections.singletonList(new AbstractMap.SimpleEntry<>(0.0, 1.0)),
                 false, System.currentTimeMillis(), 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent2),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
@@ -682,7 +682,7 @@ public abstract class RequestHandlersTest {
         assertEquals(State.UPDATING, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         UpdateStreamEvent event = new UpdateStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).updatePolicy(anyString(), anyString(), any(), anyLong(), anyString(), anyLong());
@@ -695,12 +695,12 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).updatePolicy(anyString(), anyString(), any(), anyLong(), anyString(), anyLong());
         
         // 5. process again. it should succeed while ignoring waiting processor
-        streamRequestHandler.process(event).join();
+        streamRequestHandler.process(event, () -> false).join();
         assertEquals(State.ACTIVE, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         // 6. run a new update. it should fail because of waiting processor and our state does not allow us to ignore waiting processor
         UpdateStreamEvent event2 = new UpdateStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
@@ -730,7 +730,7 @@ public abstract class RequestHandlersTest {
         assertEquals(State.TRUNCATING, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         TruncateStreamEvent event = new TruncateStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).truncateSegment(anyString(), anyString(), anyLong(), anyLong(), anyString(), anyLong());
@@ -743,12 +743,12 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).truncateSegment(anyString(), anyString(), anyLong(), anyLong(), anyString(), anyLong());
         
         // 5. process again. it should succeed while ignoring waiting processor
-        streamRequestHandler.process(event).join();
+        streamRequestHandler.process(event, () -> false).join();
         assertEquals(State.ACTIVE, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         // 6. run a new update. it should fail because of waiting processor.
         TruncateStreamEvent event2 = new TruncateStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
@@ -776,7 +776,7 @@ public abstract class RequestHandlersTest {
         assertEquals(State.COMMITTING_TXN, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         CommitEvent event = new CommitEvent(fairness, fairness, 0);
-        AssertExtensions.assertFutureThrows("", requestHandler.process(event),
+        AssertExtensions.assertFutureThrows("", requestHandler.process(event, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).commitTransaction(anyString(), anyString(), anyLong(), anyLong(), any(), anyString());
@@ -789,12 +789,12 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).commitTransaction(anyString(), anyString(), anyLong(), anyLong(), any(), anyString());
         
         // 5. process again. it should succeed while ignoring waiting processor
-        requestHandler.process(event).join();
+        requestHandler.process(event, () -> false).join();
         assertEquals(State.ACTIVE, streamStore.getState(fairness, fairness, true, null, executor).join());
         
         // 6. run a new update. it should fail because of waiting processor.
         CommitEvent event2 = new CommitEvent(fairness, fairness, 0);
-        AssertExtensions.assertFutureThrows("", requestHandler.process(event2),
+        AssertExtensions.assertFutureThrows("", requestHandler.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
@@ -823,7 +823,7 @@ public abstract class RequestHandlersTest {
         assertEquals(State.SEALING, streamStore.getState(fairness, fairness, true, null, executor).join());
 
         SealStreamEvent event = new SealStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce())
@@ -837,12 +837,12 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).sealSegment(anyString(), anyString(), anyLong(), anyString(), anyLong());
 
         // 5. process again. it should succeed while ignoring waiting processor
-        streamRequestHandler.process(event).join();
+        streamRequestHandler.process(event, () -> false).join();
         assertEquals(State.SEALED, streamStore.getState(fairness, fairness, true, null, executor).join());
 
         // 6. run a new update. it should fail because of waiting processor.
         SealStreamEvent event2 = new SealStreamEvent(fairness, fairness, 0L);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
@@ -872,7 +872,7 @@ public abstract class RequestHandlersTest {
         assertEquals(State.SEALED, streamStore.getState(fairness, fairness, true, null, executor).join());
 
         DeleteStreamEvent event = new DeleteStreamEvent(fairness, fairness, 0L, createTimestamp);
-        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event),
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce())
@@ -886,7 +886,7 @@ public abstract class RequestHandlersTest {
                 .when(segmentHelper).deleteSegment(anyString(), anyString(), anyLong(), anyString(), anyLong());
 
         // 5. process again. it should succeed while ignoring waiting processor
-        streamRequestHandler.process(event).join();
+        streamRequestHandler.process(event, () -> false).join();
         AssertExtensions.assertFutureThrows("", streamStore.getState(fairness, fairness, true, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
     }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -196,7 +196,7 @@ public abstract class ScaleRequestHandlerTest {
 
         AutoScaleEvent scaleUpEvent = new AutoScaleEvent(scope, stream, 2, AutoScaleEvent.UP, System.currentTimeMillis(),
                 1, false, System.currentTimeMillis());
-        assertTrue(Futures.await(multiplexer.process(scaleUpEvent)));
+        assertTrue(Futures.await(multiplexer.process(scaleUpEvent, () -> false)));
 
         // verify that one scaleOp event is written into the stream
         assertEquals(1, writer.queue.size());
@@ -215,7 +215,7 @@ public abstract class ScaleRequestHandlerTest {
         assertEquals(1, scaleOpEvent.getSegmentsToSeal().size());
         assertTrue(scaleOpEvent.getSegmentsToSeal().contains(2L));
 
-        assertTrue(Futures.await(multiplexer.process(scaleOpEvent)));
+        assertTrue(Futures.await(multiplexer.process(scaleOpEvent, () -> false)));
 
         // verify that the event is processed successfully
         List<StreamSegmentRecord> activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
@@ -231,7 +231,7 @@ public abstract class ScaleRequestHandlerTest {
         // process first scale down event. it should only mark the segment as cold
         AutoScaleEvent scaleDownEvent = new AutoScaleEvent(scope, stream, four, AutoScaleEvent.DOWN, System.currentTimeMillis(),
                 0, false, System.currentTimeMillis());
-        assertTrue(Futures.await(multiplexer.process(scaleDownEvent)));
+        assertTrue(Futures.await(multiplexer.process(scaleDownEvent, () -> false)));
         assertTrue(writer.queue.isEmpty());
 
         activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
@@ -241,7 +241,7 @@ public abstract class ScaleRequestHandlerTest {
 
         AutoScaleEvent scaleDownEvent2 = new AutoScaleEvent(scope, stream, three, AutoScaleEvent.DOWN, System.currentTimeMillis(),
                 0, false, System.currentTimeMillis());
-        assertTrue(Futures.await(multiplexer.process(scaleDownEvent2)));
+        assertTrue(Futures.await(multiplexer.process(scaleDownEvent2, () -> false)));
         assertTrue(streamStore.isCold(scope, stream, three, null, executor).join());
 
         // verify that a new event has been posted
@@ -257,7 +257,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(scaleOpEvent.getSegmentsToSeal().contains(four));
 
         // process scale down event
-        assertTrue(Futures.await(multiplexer.process(scaleOpEvent)));
+        assertTrue(Futures.await(multiplexer.process(scaleOpEvent, () -> false)));
         long five = computeSegmentId(5, 2);
 
         activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
@@ -272,14 +272,14 @@ public abstract class ScaleRequestHandlerTest {
         // And if someone changes retry durations and number of attempts in retry helper, it will impact this test's running time.
         // hence sending incorrect segmentsToSeal list which will result in a non retryable failure and this will fail immediately
         assertFalse(Futures.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(five),
-                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()))));
+                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false)));
         activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
         assertTrue(activeSegments.stream().noneMatch(z -> z.segmentId() == three));
         assertTrue(activeSegments.stream().noneMatch(z -> z.segmentId() == four));
         assertTrue(activeSegments.stream().anyMatch(z -> z.segmentId() == five));
         assertTrue(activeSegments.size() == 3);
 
-        assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID()))));
+        assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID()), () -> false)));
     }
 
     @Test(timeout = 30000)
@@ -306,21 +306,21 @@ public abstract class ScaleRequestHandlerTest {
         
         // process first auto scale down event. it should only mark the segment as cold
         multiplexer.process(new AutoScaleEvent(scope, stream, 1L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
-                0, false, System.currentTimeMillis())).join();
+                0, false, System.currentTimeMillis()), () -> false).join();
         assertTrue(writer.queue.isEmpty());
 
         assertTrue(streamStore.isCold(scope, stream, 1L, null, executor).join());
 
         // process second auto scale down event. since its not for an immediate neighbour so it should only mark the segment as cold
         multiplexer.process(new AutoScaleEvent(scope, stream, 3L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
-                0, false, System.currentTimeMillis())).join();
+                0, false, System.currentTimeMillis()), () -> false).join();
         assertTrue(streamStore.isCold(scope, stream, 3L, null, executor).join());
         // no scale event should be posted
         assertTrue(writer.queue.isEmpty());
 
         // process third auto scale down event. This should result in a scale op event being posted to merge segments 0, 1 
         multiplexer.process(new AutoScaleEvent(scope, stream, 0L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
-                0, false, System.currentTimeMillis())).join();
+                0, false, System.currentTimeMillis()), () -> false).join();
         assertTrue(streamStore.isCold(scope, stream, 0L, null, executor).join());
         
         // verify that a new event has been posted
@@ -335,7 +335,7 @@ public abstract class ScaleRequestHandlerTest {
 
         // process fourth auto scale down event. This should result in a scale op event being posted to merge segments 3, 4 
         multiplexer.process(new AutoScaleEvent(scope, stream, 4L, AutoScaleEvent.DOWN, System.currentTimeMillis(),
-                0, false, System.currentTimeMillis())).join();
+                0, false, System.currentTimeMillis()), () -> false).join();
         assertTrue(streamStore.isCold(scope, stream, 4L, null, executor).join());
         // verify that a new event has been posted
         assertEquals(1, writer.queue.size());
@@ -348,7 +348,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(scaleDownEvent2.getSegmentsToSeal().contains(4L));
 
         // process first scale down event, this should submit scale and scale the stream down to 4 segments
-        multiplexer.process(scaleDownEvent1).join();
+        multiplexer.process(scaleDownEvent1, () -> false).join();
         EpochRecord activeEpoch = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
         List<StreamSegmentRecord> segments = activeEpoch.getSegments();
         assertEquals(1, activeEpoch.getEpoch());
@@ -359,7 +359,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(segments.stream().anyMatch(x -> x.getSegmentNumber() == 5));
 
         // process second scale down event, this should submit scale and scale the stream down to 4 segments
-        multiplexer.process(scaleDownEvent2).join();
+        multiplexer.process(scaleDownEvent2, () -> false).join();
         // verify that no scale has happened
         activeEpoch = streamStore.getActiveEpoch(scope, stream, null, true, executor).join();
         // verify that no scale has happened. 
@@ -392,7 +392,7 @@ public abstract class ScaleRequestHandlerTest {
 
         // 2. start scale
         requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(0L, 1L, 2L),
-                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis())).join();
+                Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false).join();
 
         // 3. verify that scale is complete
         State state = streamStore.getState(scope, stream, true, null, executor).join();
@@ -469,7 +469,7 @@ public abstract class ScaleRequestHandlerTest {
         // 2. start scale
         requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(0L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 0.25), new AbstractMap.SimpleEntry<>(0.25, 0.5)),
-                false, System.currentTimeMillis(), System.currentTimeMillis())).join();
+                false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false).join();
 
         // 3. verify that scale is complete
         State state = streamStore.getState(scope, stream, true, null, executor).join();
@@ -487,7 +487,7 @@ public abstract class ScaleRequestHandlerTest {
         // 6. run scale. this should fail in scaleCreateNewEpochs with IllegalArgumentException with epochTransitionConsistent
         AssertExtensions.assertFutureThrows("epoch transition should be inconsistent", requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(1L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 0.75), new AbstractMap.SimpleEntry<>(0.75, 1.0)),
-                false, System.currentTimeMillis(), System.currentTimeMillis())), e -> Exceptions.unwrap(e) instanceof IllegalStateException);
+                false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false), e -> Exceptions.unwrap(e) instanceof IllegalStateException);
 
         state = streamStore.getState(scope, stream, true, null, executor).join();
         assertEquals(State.ACTIVE, state);
@@ -527,7 +527,7 @@ public abstract class ScaleRequestHandlerTest {
         // 2. start scale
         requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(0L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.0, 0.25), new AbstractMap.SimpleEntry<>(0.25, 0.5)),
-                false, System.currentTimeMillis(), System.currentTimeMillis())).join();
+                false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false).join();
 
         // 3. verify that scale is complete
         State state = streamStore.getState(scope, stream, true, null, executor).join();
@@ -545,7 +545,7 @@ public abstract class ScaleRequestHandlerTest {
         // 6. run scale against old record but with manual scale flag set to true. This should be migrated to new epoch and processed.
         requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(1L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 0.75), new AbstractMap.SimpleEntry<>(0.75, 1.0)),
-                true, System.currentTimeMillis(), System.currentTimeMillis())).join();
+                true, System.currentTimeMillis(), System.currentTimeMillis()), () -> false).join();
 
         state = streamStore.getState(scope, stream, true, null, executor).join();
         assertEquals(State.ACTIVE, state);
@@ -931,7 +931,7 @@ public abstract class ScaleRequestHandlerTest {
 
         AutoScaleEvent scaleUpEvent = new AutoScaleEvent(scope, stream, StreamSegmentNameUtils.computeSegmentId(2, 1),
                 AutoScaleEvent.UP, System.currentTimeMillis(), 1, false, System.currentTimeMillis());
-        assertTrue(Futures.await(multiplexer.process(scaleUpEvent)));
+        assertTrue(Futures.await(multiplexer.process(scaleUpEvent, () -> false)));
 
         reset(streamStore);
         // verify that one scaleOp event is written into the stream

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/RequestProcessorTest.java
@@ -208,12 +208,12 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         });
 
         // 1. start test event1 processing on processor 1. Don't let this complete.
-        CompletableFuture<Void> processing11 = requestProcessor1.process(event11);
+        CompletableFuture<Void> processing11 = requestProcessor1.process(event11, () -> false);
         // wait to ensure it is started.
         started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
-        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21),
+        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // also verify that store has set the processor name of processor 2.
         String waitingProcessor = getStore().getWaitingRequestProcessor(scope, stream, null, executorService()).join();
@@ -228,17 +228,17 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         processing11.join();
 
         // 4. submit another processing for processor1. this should get postponed too but processor name should not change.
-        AssertExtensions.assertFutureThrows("This should fail and event should be reposted", requestProcessor1.process(event12),
+        AssertExtensions.assertFutureThrows("This should fail and event should be reposted", requestProcessor1.process(event12, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         TestEvent1 taken1 = requestProcessor1.queue.take();
         assertEquals(taken1, event12);
 
         // 5. now try processing event on processor 2. this should start successfully.
-        CompletableFuture<Void> processing22 = requestProcessor2.process(event22);
+        CompletableFuture<Void> processing22 = requestProcessor2.process(event22, () -> false);
         started2.join();
         // 6. try to start a new processing on processor 1 while processing on `2` is ongoing. This should fail but should not be able
         // to change the processor name.
-        AssertExtensions.assertFutureThrows("This should fail without even starting", requestProcessor1.process(event12),
+        AssertExtensions.assertFutureThrows("This should fail without even starting", requestProcessor1.process(event12, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
 
         waitingProcessor = getStore().getWaitingRequestProcessor(scope, stream, null, executorService()).join();
@@ -276,12 +276,12 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         TestEvent2 event2 = new TestEvent2(scope, stream, () -> Futures.failedFuture(StoreException.create(StoreException.Type.OPERATION_NOT_ALLOWED, "Failing processing")));
 
         // 1. start test event1 processing on processor 1. Don't let this complete.
-        CompletableFuture<Void> processing11 = requestProcessor1.process(event1);
+        CompletableFuture<Void> processing11 = requestProcessor1.process(event1, () -> false);
         // wait to ensure it is started.
         started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
-        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event2),
+        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // also verify that store has set the processor name of processor 2.
         String waitingProcessor = getStore().getWaitingRequestProcessor(scope, stream, null, executorService()).join();
@@ -300,7 +300,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         // 4. re submit processing for processor1. this should get be picked while we ignore started.
         event1 = new TestEvent1(scope, stream, () -> CompletableFuture.completedFuture(null));
 
-        requestProcessor1.process(event1).join();
+        requestProcessor1.process(event1, () -> false).join();
         assertTrue(requestProcessor1.queue.isEmpty());
 
         // 5. verify that wait processor name is still set to processor 2
@@ -310,7 +310,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         // 6. now set ignore started to false. The processing of event 1 should be disallowed because of started
         requestProcessor1.ignoreStarted = false;
         // we should get operation not allowed exception
-        AssertExtensions.assertFutureThrows("", requestProcessor1.process(event1), 
+        AssertExtensions.assertFutureThrows("", requestProcessor1.process(event1, () -> false), 
                 e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // event should be posted back
         assertEquals(requestProcessor1.queue.take(), event1);
@@ -326,7 +326,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         FailingEvent event1 = new FailingEvent("scope", "stream", 
                 Futures.failedFuture(new RuntimeException("hasStarted")), CompletableFuture.completedFuture(null));
 
-        AssertExtensions.assertFutureThrows("exception should be thrown after has started", processor.process(event1),
+        AssertExtensions.assertFutureThrows("exception should be thrown after has started", processor.process(event1, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("hasStarted"));
 
         verify(processor, times(1)).hasTaskStarted(event1);
@@ -336,7 +336,7 @@ public abstract class RequestProcessorTest extends ThreadPooledTestSuite {
         FailingEvent event2 = new FailingEvent("scope", "stream", 
                 CompletableFuture.completedFuture(true), Futures.failedFuture(new RuntimeException("execute")));
 
-        AssertExtensions.assertFutureThrows("exception should be thrown after execute", processor.process(event2),
+        AssertExtensions.assertFutureThrows("exception should be thrown after execute", processor.process(event2, () -> false),
                 e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("execute"));
         verify(processor, times(1)).writeBack(event2);
         verify(processor, times(1)).hasTaskStarted(event2);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -812,7 +812,7 @@ public class StreamTransactionMetadataTasksTest {
                 .supplier(factory)
                 .build();
 
-        system.createEventProcessorGroup(config, CheckpointStoreFactory.createInMemoryStore());
+        system.createEventProcessorGroup(config, CheckpointStoreFactory.createInMemoryStore(), executor);
     }
 
     public static class RegularBookKeeperLogTests extends StreamTransactionMetadataTasksTest {

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
@@ -11,15 +11,19 @@ package io.pravega.test.integration.controller.server;
 
 import com.google.common.base.Preconditions;
 import io.pravega.client.ClientConfig;
+import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Position;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderSegmentDistribution;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectBuilder;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.io.serialization.RevisionDataInput;
@@ -49,8 +53,16 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,6 +70,7 @@ import lombok.Cleanup;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
+import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -81,6 +94,7 @@ public class EventProcessorTest {
     private ServiceBuilder serviceBuilder;
     private StreamSegmentStore store;
     private TableStore tableStore;
+    private ScheduledExecutorService executor;
     
     public static class TestEventProcessor extends EventProcessor<TestEvent> {
         long sum;
@@ -185,13 +199,15 @@ public class EventProcessorTest {
                 4);
         controllerWrapper.awaitRunning();
         controller = controllerWrapper.getController();
+        executor = Executors.newSingleThreadScheduledExecutor();
     }
 
     @After
     public void tearDown() throws Exception {
         controllerWrapper.close();
         server.close();
-        zkTestServer.stop();   
+        zkTestServer.stop();
+        executor.shutdownNow();
     }
     
     @Test(timeout = 60000)
@@ -262,8 +278,8 @@ public class EventProcessorTest {
                 .build();
         @Cleanup
         EventProcessorGroup<TestEvent> eventProcessorGroup =
-                system.createEventProcessorGroup(eventProcessorConfig, CheckpointStoreFactory.createInMemoryStore());
-
+                system.createEventProcessorGroup(eventProcessorConfig, CheckpointStoreFactory.createInMemoryStore(), executor);
+        
         Long value = result.join();
         Assert.assertEquals(expectedSum, value.longValue());
         log.info("SUCCESS: received expected sum = " + expectedSum);
@@ -334,7 +350,7 @@ public class EventProcessorTest {
                 .build();
         @Cleanup
         EventProcessorGroup<TestEvent> eventProcessorGroup =
-                system.createEventProcessorGroup(eventProcessorConfig, CheckpointStoreFactory.createInMemoryStore());
+                system.createEventProcessorGroup(eventProcessorConfig, CheckpointStoreFactory.createInMemoryStore(), executor);
 
         eventProcessorGroup.awaitRunning();
         // wait until both events are read
@@ -377,7 +393,7 @@ public class EventProcessorTest {
 
         @Cleanup
         EventProcessorGroup<TestEvent> eventProcessorGroup2 =
-                system.createEventProcessorGroup(eventProcessorConfig2, CheckpointStoreFactory.createInMemoryStore());
+                system.createEventProcessorGroup(eventProcessorConfig2, CheckpointStoreFactory.createInMemoryStore(), executor);
         eventProcessorGroup2.awaitRunning();
 
         // verify that both events are read again
@@ -389,11 +405,187 @@ public class EventProcessorTest {
         eventProcessorGroup2.awaitTerminated();
     }
 
+    @Test(timeout = 60000)
+    public void testEventProcessorRebalance() throws Exception {
+        final String scope = "scope";
+        final String streamName = "stream";
+        final String readerGroupName = "readerGroup";
+
+        controller.createScope(scope).join();
+
+        final StreamConfiguration config = StreamConfiguration.builder()
+                                                              .scalingPolicy(ScalingPolicy.fixed(4))
+                                                              .build();
+
+        controller.createStream(scope, streamName, config).join();
+
+        eventSerializer = new EventSerializer<>(new TestSerializer());
+
+        @Cleanup
+        ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(ClientConfig.builder().build());
+
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory);
+        
+        CheckpointConfig.CheckpointPeriod period =
+                CheckpointConfig.CheckpointPeriod.builder()
+                                                 .numEvents(1)
+                                                 .numSeconds(1)
+                                                 .build();
+
+        CheckpointConfig checkpointConfig =
+                CheckpointConfig.builder()
+                                .type(CheckpointConfig.Type.Periodic)
+                                .checkpointPeriod(period)
+                                .build();
+
+        EventProcessorGroupConfig eventProcessorGroupConfig =
+                EventProcessorGroupConfigImpl.builder()
+                                             .eventProcessorCount(1)
+                                             .readerGroupName(readerGroupName)
+                                             .streamName(streamName)
+                                             .checkpointConfig(checkpointConfig)
+                                             .build();
+
+        LinkedBlockingQueue<Integer> queue1 = new LinkedBlockingQueue<>();
+        
+        EventProcessorConfig<TestEvent> eventProcessorConfig1 = EventProcessorConfig.<TestEvent>builder()
+                .supplier(() -> new TestEventProcessor2(queue1))
+                .serializer(eventSerializer)
+                .decider((Throwable e) -> ExceptionHandler.Directive.Stop)
+                .config(eventProcessorGroupConfig)
+                .minRebalanceIntervalMillis(Duration.ofMillis(100).toMillis())
+                .build();
+        
+        // create a group and verify that all events can be written and read by readers in this group.
+        EventProcessorSystem system1 = new EventProcessorSystemImpl("Controller", "process1", scope,
+                new ClientFactoryImpl(scope, controller, connectionFactory),
+                new ReaderGroupManagerImpl(scope, controller, clientFactory, connectionFactory));
+
+        @Cleanup
+        EventProcessorGroup<TestEvent> eventProcessorGroup1 =
+                system1.createEventProcessorGroup(eventProcessorConfig1, CheckpointStoreFactory.createInMemoryStore(), executor);
+
+        eventProcessorGroup1.awaitRunning();
+
+        log.info("first event processor started");
+        
+        @Cleanup
+        EventStreamWriter<TestEvent> writer = clientFactory.createEventWriter(streamName,
+                eventSerializer, EventWriterConfig.builder().build());
+
+        // write 10 events and read them back from the queue passed to first event processor's
+        List<Integer> input = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        ConcurrentHashSet<Integer> output = new ConcurrentHashSet<>();
+
+        for (int val : input) {
+            writer.writeEvent(new TestEvent(val));
+        }
+        writer.flush();
+
+        // now wait until all the entries are read back. 
+        for(int i = 0; i < 10; i++) {
+            // read 10 events back
+            Integer entry = queue1.take();
+            output.add(entry);
+        }
+        assertEquals(10, output.size());
+
+        log.info("first event processor read all the messages");
+        
+        LinkedBlockingQueue<Integer> queue2 = new LinkedBlockingQueue<>();
+
+        EventProcessorConfig<TestEvent> eventProcessorConfig2 = EventProcessorConfig.<TestEvent>builder()
+                .supplier(() -> new TestEventProcessor2(queue2))
+                .serializer(eventSerializer)
+                .decider((Throwable e) -> ExceptionHandler.Directive.Stop)
+                .config(eventProcessorGroupConfig)
+                .minRebalanceIntervalMillis(Duration.ofMillis(100).toMillis())
+                .build();
+
+        // add another system and event processor group (effectively add a new set of readers to the readergroup) 
+        EventProcessorSystem system2 = new EventProcessorSystemImpl("Controller", "process2", scope,
+                new ClientFactoryImpl(scope, controller, connectionFactory),
+                new ReaderGroupManagerImpl(scope, controller, clientFactory, connectionFactory));
+
+        @Cleanup
+        EventProcessorGroup<TestEvent> eventProcessorGroup2 =
+                system2.createEventProcessorGroup(eventProcessorConfig2, CheckpointStoreFactory.createInMemoryStore(), executor);
+
+        eventProcessorGroup2.awaitRunning();
+
+        log.info("second event processor started");
+
+        AtomicInteger queue1EntriesFound = new AtomicInteger(0);
+        AtomicInteger queue2EntriesFound = new AtomicInteger(0);
+        ConcurrentHashSet<Integer> output2 = new ConcurrentHashSet<>();
+
+        // wait until rebalance may have happened. 
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl(scope, controller, clientFactory,
+                connectionFactory);
+
+        ReaderGroup readerGroup = groupManager.getReaderGroup(readerGroupName);
+
+        AtomicBoolean allAssigned = new AtomicBoolean(false);
+        Futures.loop(() -> !allAssigned.get(), () -> Futures.delayedFuture(Duration.ofMillis(100), executor).thenAccept(v -> {
+            ReaderSegmentDistribution distribution = readerGroup.getReaderSegmentDistribution();
+            int numberOfReaders = distribution.getReaderSegmentDistribution().size();
+            allAssigned.set(numberOfReaders == 2 && distribution.getReaderSegmentDistribution().values().stream().noneMatch(x -> x == 0));
+        }), executor).join(); 
+        
+        // write 10 new events
+        for (int val : input) {
+            writer.writeEvent(new TestEvent(val));
+        }
+        writer.flush();
+
+        // wait until at least one event is read from queue2 
+        CompletableFuture.allOf(CompletableFuture.runAsync(() -> {
+            while (queue1EntriesFound.get() + queue2EntriesFound.get() < 10) {
+                Integer entry = queue1.poll();
+                if (entry != null) {
+                    log.info("entry read from queue 1: {}", entry);
+                    queue1EntriesFound.incrementAndGet();
+                    output2.add(entry);
+                } else {
+                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
+                }
+            }
+        }), CompletableFuture.runAsync(() -> {
+            while (queue1EntriesFound.get() + queue2EntriesFound.get() < 10) {
+                Integer entry = queue2.poll();
+                if (entry != null) {
+                    log.info("entry read from queue 2: {}", entry);
+                    queue2EntriesFound.incrementAndGet();
+                    output2.add(entry);
+                } else {
+                    Exceptions.handleInterrupted(() -> Thread.sleep(100));
+                }
+            }
+        })).join();
+        
+        assertTrue(queue1EntriesFound.get() > 0);
+        assertTrue(queue2EntriesFound.get() > 0);
+        assertEquals(10, output2.size());
+    }
+
     private static class TestSerializer extends ControllerEventSerializer {
         @Override
         protected void declareSerializers(Builder builder) {
             super.declareSerializers(builder);
             builder.serializer(TestEvent.class, 127, new TestEvent.Serializer());
+        }
+    }
+
+    public static class TestEventProcessor2 extends EventProcessor<TestEvent> {
+        private final LinkedBlockingQueue<Integer> queue;
+        TestEventProcessor2(LinkedBlockingQueue<Integer> queue) {
+            this.queue = queue;
+        }
+
+        @Override
+        protected void process(TestEvent event, Position position) {
+            queue.add(event.number);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
1. Adds logic in EventProcessorGroup to identify idle and overloaded readers in readergroup and perform.
2. While shutting down an overloaded reader cancel any outstanding request on its event processor cell.
3. In Concurrent event processor, complete the shutdown only after all outstanding requests have been terminated. 

**Purpose of the change**  
Fixes #2183

**What the code does**  
When a readergroup has idle as well as overloaded readers, a rebalance is triggered. 
The EventProcessor group, which owns the readergroup for the eventprocessor, periodically checks if there are idle readers in the readergroup. If there are idle readers and this instance of EventProcessorGroup owns an overloaded reader (reader with more than fair share of segments in the distribution), then it is replaced. Replacement is two step process - first add a new reader, then shutdown the overloaded reader. Addition of new reader does not automatically trigger a rebalance. But when overloaded reader is shutdown, its segments become orphaned and are redistributed among all available readers. This results in redistribution, though not necessarily fair, of segments from overloaded reader to all other readers. 
As eventprocessor, whose reader is removed, is shutdown, it waits until all outstanding requests are either cancelled or completed before completing the shutdown. 

Changes by classes:
- `EventProcessorConfig.java`
Add a new configuration to eventprocessor config for minimum rebalance period. 
- `EventProcessorGroupImpl.java`
Event processorGroup will periodically check if there are idle readers in the reader group and if it owns any overloaded reader. 
If there is an overloaded reader, a replacement reader is added to the group and then eventprocessorcell containing the overloaded reader is then shutdown. This calls the `afterStop` method in the underlying eventprocessor implementation. 
- `ConcurrentEventProcessor.java`
The ConcurrentEventProcessor's `afterStop` sets the stop flag and sends a CANCEL signal to all existing "running jobs" and waits for all jobs to either complete or cancel. 
- `SerializedRequestHandler.java`
Each job, before starting, in SerializedRequestHandler, checks if the job has been canceled or cancels the future if the job has been cancelled. 

**How to verify it**  
Unit tests added to EventProcessorTest (unit and integration) to test rebalance logic. 
Unit test added to ConcurrentEventProcessorTest and SerializedRequestHandlerTest to verify that all 
