### PR TITLE
Issue 4473:  Bump snapshot version in 0.6.1 to 0.6.2-SNAPSHOT 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.6.1
+pravegaVersion=0.6.2-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
 Change pravega version in r0.6 branch from 0.6.1 to 0.6.2-snapshot

**Purpose of the change**  
Fixes #4473 

**What the code does**  
Changes version to 0.6.2-SNAPSHOT in gradle.properties file

**How to verify it**  
Subsequent builds should be generated with 0.6.2-SNAPSHOT as pravega version
