### PR TITLE
Issue 4467: Observed NPE in StreamMetricsTest on travis

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -218,7 +218,7 @@ public class StreamMetricsTest {
         transaction.commit();
 
         AssertExtensions.assertEventuallyEquals(true, () -> transaction.checkStatus().equals(Transaction.Status.COMMITTED), 10000);
-
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getCounter(MetricsNames.COMMIT_TRANSACTION, streamTags(txScopeName, txStreamName)) != null, 10000);
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.COMMIT_TRANSACTION, streamTags(txScopeName, txStreamName)).count());
 
         Transaction<String> transaction2 = writer.beginTxn();
@@ -226,7 +226,7 @@ public class StreamMetricsTest {
         transaction2.abort();
 
         AssertExtensions.assertEventuallyEquals(true, () -> transaction2.checkStatus().equals(Transaction.Status.ABORTED), 10000);
-
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getCounter(MetricsNames.ABORT_TRANSACTION, streamTags(txScopeName, txStreamName)) != null, 10000);
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.ABORT_TRANSACTION, streamTags(txScopeName, txStreamName)).count());
     }
 }


### PR DESCRIPTION
**Change log description**  
Ensure that metrics are available in StreamMetricsTest.testTransactionMetrics before performing assertions.

**Purpose of the change**  
Fixes #4467.

**What the code does**  
In `StreamMetricsTest`, the new `testTransactionMetrics` adds assertions about whether Transaction metrics are being correctly published or not. However, the assertions on Transactions metrics are immediately performed after transaction operations. This induces a race condition that, especially on Travis, metrics are not yet published when we execute the assertions on them, thus leading to a NPE. This PR makes the test to wait for the metrics to exist prior asserting their values. 

**How to verify it**  
Executed multiple Travis builds (+10) and we have not observed this test to fail yet.