### PR TITLE
Issue 4459: [r0.6] Upgrading bookkeeper version to 4.8.2

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -7,31 +7,35 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-FROM apache/bookkeeper:4.7.3
+FROM apache/bookkeeper:4.8.2
 
-ARG BK_VERSION=4.7.3
+ARG BK_VERSION=4.8.2
 ARG DISTRO_NAME=bookkeeper-all-${BK_VERSION}-bin
-ARG GPG_KEY=FD74402C
 
 RUN set -x \
-    && yum install -y iproute \
+    && yum install -y iproute wget \
     && cd /opt \
-    && curl -O "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz" \
-    && curl -O "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.asc" \
-    && curl -O "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.sha512" \
+    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz" \
+    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.asc" \
+    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.sha512" \
     && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
-    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" || \
-       gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$GPG_KEY" || \
-       gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$GPG_KEY" \
+    && wget https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
+    && gpg --import KEYS \
     && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && cp -r bookkeeper-all-${BK_VERSION}/* /opt/bookkeeper/ \
     && rm -rf "bookkeeper-all-${BK_VERSION}" "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
+    # install zookeeper shell
+    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && python get-pip.py \
+    && pip install zk-shell \
+    && rm -rf get-pip.py \
     && yum clean all
 
 WORKDIR /opt/bookkeeper
 
 COPY entrypoint.sh /opt/bookkeeper/scripts/pravega_entrypoint.sh
+
 # For backwards compatibility with older operator versions
 COPY entrypoint.sh /opt/bookkeeper/entrypoint.sh
 
@@ -40,7 +44,4 @@ RUN chmod +x -R /opt/bookkeeper/scripts/
 ENTRYPOINT [ "/bin/bash", "/opt/bookkeeper/scripts/pravega_entrypoint.sh" ]
 CMD ["bookie"]
 
-# BookKeeper healthcheck was broken in 4.7.3 and was not fixed until 4.9.0
-# This overrides the healthcheck to the default BK healthcheck method
-# https://github.com/apache/bookkeeper/issues/1687
-HEALTHCHECK --interval=10s --timeout=60s CMD /opt/bookkeeper/bin/bookkeeper shell bookiesanity
+HEALTHCHECK --interval=10s --timeout=60s CMD /bin/bash /opt/bookkeeper/scripts/healthcheck.sh

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -10,20 +10,9 @@
 #
 set -e
 
-# To create directories for multiple ledgers and journals if specified
-create_dir() {
-  IFS=',' read -ra directories <<< $1
-  for i in "${directories[@]}"
-  do
-      mkdir -p $i
-      if [ "$(id -u)" = '0' ]; then
-          chown -R "${BK_USER}:${BK_USER}" $i
-      fi
-  done
-}
-
 BOOKIE_PORT=${bookiePort:-${BOOKIE_PORT}}
 BOOKIE_PORT=${BOOKIE_PORT:-3181}
+BOOKIE_HTTP_PORT=${BOOKIE_HTTP_PORT:-9090}
 BK_zkServers=$(echo "${ZK_URL:-127.0.0.1:2181}" | sed -r 's/;/,/g')
 ZK_URL=$(echo "${ZK_URL:-127.0.0.1:2181}" | sed -r 's/,/;/g')
 PRAVEGA_PATH=${PRAVEGA_PATH:-"pravega"}
@@ -31,8 +20,18 @@ PRAVEGA_CLUSTER_NAME=${PRAVEGA_CLUSTER_NAME:-"pravega-cluster"}
 BK_CLUSTER_NAME=${BK_CLUSTER_NAME:-"bookkeeper"}
 BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}/ledgers"
 BK_DIR="/bk"
+BK_zkLedgersRootPath=${BK_LEDGERS_PATH}
+BK_HOME=/opt/bookkeeper
+BINDIR=${BK_HOME}/bin
+BOOKKEEPER=${BINDIR}/bookkeeper
+SCRIPTS_DIR=${BK_HOME}/scripts
 
+export PATH=$PATH:/opt/bookkeeper/bin
+export JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+export BK_zkLedgersRootPath=${BK_LEDGERS_PATH}
 export BOOKIE_PORT=${BOOKIE_PORT}
+export SERVICE_PORT=${BOOKIE_PORT}
+export BK_bookiePort=${BK_bookiePort:-${BOOKIE_PORT}}
 export BK_zkServers=${BK_zkServers}
 export BK_metadataServiceUri=zk://${ZK_URL}${BK_LEDGERS_PATH}
 export BK_journalDirectories=${BK_journalDirectories:-${BK_DIR}/journal}
@@ -48,31 +47,143 @@ export BK_tlsTrustStoreType=JKS
 export BK_tlsTrustStore=/var/private/tls/bookie.truststore.jks
 export BK_tlsTrustStorePasswordPath=/var/private/tls/bookie.truststore.passwd
 
-echo "creating directories for ledger and journal"
-create_dir "${BK_journalDirectories}"
-create_dir "${BK_ledgerDirectories}"
+# Create directories for multiple ledgers and journals if specified.
+create_bookie_dirs() {
+  IFS=',' read -ra directories <<< $1
+  for i in "${directories[@]}"
+  do
+      mkdir -p $i
+      if [ "$(id -u)" = '0' ]; then
+          chown -R "${BK_USER}:${BK_USER}" $i
+      fi
+  done
+}
 
-echo "wait for zookeeper"
-until zk-shell --run-once "ls /" ${BK_zkServers}; do sleep 5; done
+wait_for_zookeeper() {
+    echo "Waiting for zookeeper"
+    until zk-shell --run-once "ls /" ${BK_zkServers}; do sleep 5; done
+}
 
-# We need to update the metadata endpoint and Bookie ID before attempting to delete the cookie
-sed -i "s|.*metadataServiceUri=.*\$|metadataServiceUri=${BK_metadataServiceUri}|" /opt/bookkeeper/conf/bk_server.conf
-if [ ! -z "$BK_useHostNameAsBookieID" ]; then
-  sed -i "s|.*useHostNameAsBookieID=.*\$|useHostNameAsBookieID=${BK_useHostNameAsBookieID}|" ${BK_HOME}/conf/bk_server.conf
-fi
 
-if [ `find $BK_journalDirectory $BK_ledgerDirectories $BK_indexDirectories -type f 2> /dev/null | wc -l` -gt 0 ]; then
-  # The container already contains data in BK directories. This is probably because
-  # the container has been restarted; or, if running on Kubernetes, it has probably been
-  # updated or evacuated without losing its persistent volumes.
-  echo "data available in bookkeeper directories; not formatting the bookie"
-else
-  # The container does not contain any BK data, it is probably a new
-  # bookie. We will format any pre-existent data and metadata before starting
-  # the bookie to avoid potential conflicts.
-  echo "format bookie data and metadata"
-  /opt/bookkeeper/bin/bookkeeper shell bookieformat -nonInteractive -force -deleteCookie
-fi
+create_zk_root() {
+    if [ "x${BK_CLUSTER_ROOT_PATH}" != "x" ]; then
+        echo "Creating the zk root dir '${BK_CLUSTER_ROOT_PATH}' at '${BK_zkServers}'"
+        zk-shell --run-once "create ${BK_CLUSTER_ROOT_PATH} '' false false true" ${BK_zkServers}
+    fi
+}
 
-echo "start bookie"
-/opt/bookkeeper/scripts/entrypoint.sh bookie
+configure_bk() {
+    # We need to update the metadata endpoint and Bookie ID before attempting to delete the cookie
+    sed -i "s|.*metadataServiceUri=.*\$|metadataServiceUri=${BK_metadataServiceUri}|" /opt/bookkeeper/conf/bk_server.conf
+    if [ ! -z "$BK_useHostNameAsBookieID" ]; then
+      sed -i "s|.*useHostNameAsBookieID=.*\$|useHostNameAsBookieID=${BK_useHostNameAsBookieID}|" ${BK_HOME}/conf/bk_server.conf
+    fi
+}
+
+fix_bk_ipv6_check() {
+
+   # `${SCRIPTS_DIR}/common.sh` - a shell script in Bookeeper, runs this command: `/sbin/sysctl -n net.ipv6.bindv6only`.
+   # This command can return an error exit code `255` and error message:
+   #    `sysctl: cannot stat /proc/sys/net/ipv6/bindv6only: No such file or directory`
+   #
+   # If the `common.sh` file is sourced in a script that sets "exit on error" as true (set -e), the script shall return
+   # an error code `255`. Since, the `bookkeeper/bin/bookeeper` shell script sources the `common.sh` file, and it sets
+   # "exit on error" as true, we encounter this error when it is invoked. To avoid that error, here we modify the
+   # `common.sh` file to execute `/sbin/sysctl -n net.ipv6.bindv6only` only if file `/proc/sys/net/ipv6/bindv6only`
+   # is available.
+
+   # Replace the 22nd line with "if [ -f /sbin/sysctl ] && [ -f /proc/sys/net/ipv6/bindv6only ]; then".
+   sed -i "22s|.*|if [ -f /sbin/sysctl ] \&\& [ -f /proc/sys/net/ipv6/bindv6only ]; then|" ${BK_HOME}/bin/common.sh
+}
+
+initialize_cluster() {
+    set +e
+
+    zk-shell --run-once "ls ${BK_zkLedgersRootPath}/available/readonly" ${BK_zkServers}
+    if [ $? -eq 0 ]; then
+        echo "Cluster metadata already exists"
+    else
+        # Create an ephemeral zk node `bkInitLock` for use as a lock.
+        lock=`zk-shell --run-once "create ${BK_CLUSTER_ROOT_PATH}/bkInitLock '' true false false" ${BK_zkServers}`
+        if [ -z "$lock" ]; then
+            echo "Bookkeeper znodes do not exist in Zookeeper. Initializing a new Bookeekeper cluster."
+
+            # Note that this `bookkeeper` shell script sets "exit on error" (`set -e`) and sources from
+            # ${SCRIPTS_DIR}/common.sh. Make sure to invoke `fix_bk_ipv6_check()` before the control reaches here.
+            /opt/bookkeeper/bin/bookkeeper shell initnewcluster
+            if [ $? -eq 0 ]; then
+                echo "initnewcluster operation succeeded"
+            else
+                echo "initnewcluster operation failed. Please check the reason."
+                echo "Exit status of initnewcluster"
+                echo $?
+                exit
+            fi
+        else
+            echo "Others may be initializing the cluster at the same time."
+            tenSeconds=1
+            while [ ${tenSeconds} -lt 100 ]
+            do
+                sleep 10
+                zk-shell --run-once "ls ${BK_zkLedgersRootPath}/available/readonly" ${BK_zkServers}
+                if [ $? -eq 0 ]; then
+                    echo "Waited $tenSeconds * 10 seconds. Successfully listed ''${BK_zkLedgersRootPath}/available/readonly'"
+                    break
+                else
+                    echo "Waited $tenSeconds * 10 seconds. Continue waiting."
+                    (( tenSeconds++ ))
+                    continue
+                fi
+            done
+
+            if [ ${tenSeconds} -eq 1000 ]; then
+                echo "Waited 1000 seconds for bookkeeper cluster to initialize, but to no . Something is wrong, please check"
+                exit
+            fi
+        fi
+    fi
+    set -e
+}
+
+format_bookie_data_and_metadata() {
+    if [ `find $BK_journalDirectory $BK_ledgerDirectories $BK_indexDirectories -type f 2> /dev/null | wc -l` -gt 0 ]; then
+      # The container already contains data in BK directories. This is probably because
+      # the container has been restarted; or, if running on Kubernetes, it has probably been
+      # updated or evacuated without losing its persistent volumes.
+      echo "Data available in bookkeeper directories; not formatting the bookie"
+    else
+      # The container does not contain any BK data, it is probably a new
+      # bookie. We will format any pre-existent data and metadata before starting
+      # the bookie to avoid potential conflicts.
+      echo "Formatting bookie data and metadata"
+      /opt/bookkeeper/bin/bookkeeper shell bookieformat -nonInteractive -force -deleteCookie || true
+    fi
+}
+
+echo "Creating directories for Bookkeeper journal and ledgers"
+create_bookie_dirs "${BK_journalDirectories}"
+create_bookie_dirs "${BK_ledgerDirectories}"
+
+echo "Updating Bookkeeper common.sh file to fix IPV6 check"
+fix_bk_ipv6_check
+
+echo "Sourcing ${SCRIPTS_DIR}/common.sh"
+source ${SCRIPTS_DIR}/common.sh
+
+echo "Waiting for Zookeeper to come up"
+wait_for_zookeeper
+
+echo "Creating Zookeeper root"
+create_zk_root
+
+echo "Configuring Bookkeeper"
+configure_bk
+
+echo "Formatting Bookie data and metadata, if needed"
+format_bookie_data_and_metadata
+
+echo "Initializing Cluster"
+initialize_cluster
+
+echo "Starting the bookie"
+/opt/bookkeeper/bin/bookkeeper bookie


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

**Change log description**  
Upgrade the Bookeeper server from `4.7.3` to `4.8.2`.

**Purpose of the change**  
Resolves #4459 

**What the code does**  
Modifies the Dockerfile and entrypoint to work with Bookeeper `4.8.2`. It does the following:

1. The default 4.8.2 bookkeeper start up scripts uses `ZooKeeperMain` to create/modify nodes in ZK. This throws
```
/opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 3
```
Due to this, we ended up in using `zk-shell` on similar lines as Apache Bookeeper PR https://github.com/apache/bookkeeper/pull/1666.

2. The `4.8.2` script exits if `BK_STREAM_STORAGE_ROOT_PATH` is not set. Also, a zk node in this path is expected to be present if a bookie is up and running. (This is not the case with the default bk 4.8.2 image)

3. `/opt/bookkeeper/bin/bkctl --service-uri` this option used if Bookkeeper image did not work. `java.lang.IllegalArgumentException: No service URI` is observed. It is similar to issues observed in apache/bookkeeper#2112.

4. It has a workaround for creating ephmeral node using `zk-shell`. The exit status returned by the `/opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain` used in the base image is always 0, even in the case the node exists, causing unnecessary bookie restart.

**How to verify it**  
* A successful system test run
* A successful longevity test run
* Manual testing of at least the following scenarios:
  * Upgrade
  * Failure of Bookkeeper instances in a cluster
