### PR TITLE
Issue 4443: Use DelegationTokenProvider for BatchClient.

### DIFF
--- a/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/JwtTokenProviderImpl.java
@@ -53,7 +53,7 @@ public class JwtTokenProviderImpl implements DelegationTokenProvider {
     private static final Pattern JWT_EXPIRATION_PATTERN = Pattern.compile("\"exp\":\\s?(\\d+)");
 
     /**
-     * Represents the hreshold (in seconds) for triggering delegation token refresh.
+     * Represents the threshold (in seconds) for triggering delegation token refresh.
      */
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)

--- a/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
@@ -102,7 +102,7 @@ public class DelegationTokenTest {
      * This test verifies that a event stream reader continues to read events as a result of automatic delegation token
      * renewal, after the initial delegation token it uses expires.
      *
-     * We use an extraordinarily high test timeout and read time outs to account for any inordinate delays that may be
+     * We use an extraordinarily high test timeout and read timeouts to account for any inordinate delays that may be
      * encountered in testing environments.
      */
     @Test(timeout = 50000)
@@ -189,7 +189,7 @@ public class DelegationTokenTest {
      * This test verifies that a batch client continues to read events as a result of automatic delegation token
      * renewal, after the initial delegation token it uses expires.
      * <p>
-     * We use an extraordinarily high test timeout and read time outs to account for any inordinate delays that may be
+     * We use an extraordinarily high test timeout and read timeouts to account for any inordinate delays that may be
      * encountered in testing environments.
      */
     @Test(timeout = 50000)

--- a/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/DelegationTokenTest.java
@@ -9,10 +9,14 @@
  */
 package io.pravega.test.integration;
 
+import com.google.common.collect.Lists;
+import io.pravega.client.BatchClientFactory;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
+import io.pravega.client.batch.SegmentIterator;
+import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
@@ -22,10 +26,13 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.test.integration.demo.ClusterWrapper;
+
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import lombok.Cleanup;
@@ -33,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -71,19 +79,7 @@ public class DelegationTokenTest {
                     .build();
             log.debug("Done creating client config.");
 
-            @Cleanup
-            StreamManager streamManager = StreamManager.create(clientConfig);
-            assertNotNull(streamManager);
-            log.debug("Done creating stream manager.");
-
-            boolean isScopeCreated = streamManager.createScope(scope);
-            assertTrue("Failed to create scope", isScopeCreated);
-            log.debug("Done creating stream manager.");
-
-            boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                    .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                    .build());
-            Assert.assertTrue("Failed to create the stream ", isStreamCreated);
+            createScopeStream(scope, streamName, numSegments, clientConfig);
 
             @Cleanup
             EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
@@ -127,19 +123,7 @@ public class DelegationTokenTest {
                     .build();
             log.debug("Done creating client config.");
 
-            @Cleanup
-            final StreamManager streamManager = StreamManager.create(clientConfig);
-            assertNotNull(streamManager);
-            log.debug("Done creating stream manager.");
-
-            boolean isScopeCreated = streamManager.createScope(scope);
-            assertTrue("Failed to create scope", isScopeCreated);
-            log.debug("Done creating stream manager.");
-
-            boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                    .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                    .build());
-            Assert.assertTrue("Failed to create the stream ", isStreamCreated);
+            createScopeStream(scope, streamName, numSegments, clientConfig);
 
             @Cleanup
             final EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
@@ -199,5 +183,97 @@ public class DelegationTokenTest {
         } finally {
             pravegaCluster.close();
         }
+    }
+
+    /**
+     * This test verifies that a batch client continues to read events as a result of automatic delegation token
+     * renewal, after the initial delegation token it uses expires.
+     * <p>
+     * We use an extraordinarily high test timeout and read time outs to account for any inordinate delays that may be
+     * encountered in testing environments.
+     */
+    @Test(timeout = 50000)
+    public void testBatchClientDelegationTokenRenewal() throws InterruptedException {
+        // Delegation token renewal threshold is 5 seconds, so we are using 6 seconds as Token TTL so that token doesn't
+        // get renewed before each use.
+        @Cleanup
+        ClusterWrapper pravegaCluster = new ClusterWrapper(true, 6);
+        pravegaCluster.initialize();
+
+        final String scope = "testscope";
+        final String streamName = "teststream";
+        final int numSegments = 1;
+
+        final ClientConfig clientConfig = ClientConfig.builder()
+                                                      .controllerURI(URI.create(pravegaCluster.controllerUri()))
+                                                      .credentials(new DefaultCredentials("1111_aaaa", "admin"))
+                                                      .build();
+        log.debug("Done creating client config.");
+
+        // Create Scope and Stream.
+        createScopeStream(scope, streamName, 1, clientConfig);
+        // write ten Events.
+        writeTenEvents(scope, streamName, clientConfig);
+
+        // Now, read the events from the stream using Batch client.
+        @Cleanup
+        BatchClientFactory batchClientFactory = BatchClientFactory.withScope(scope, clientConfig);
+
+        List<SegmentRange> segmentRanges = Lists.newArrayList(batchClientFactory
+                .getSegments(Stream.of(scope, streamName), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());
+
+        assertEquals("The number of segments in the stream is 1", 1, segmentRanges.size());
+        SegmentIterator<String> segmentIterator = batchClientFactory
+                .readSegment(segmentRanges.get(0), new JavaSerializer<>());
+
+        int eventReadCount = 0;
+
+        while (segmentIterator.hasNext()) {
+            // We are keeping sleep time relatively large, just to make sure that the delegation token expires
+            // midway.
+            Thread.sleep(500);
+            String event = segmentIterator.next();
+            log.debug("Done reading event {}", event);
+            eventReadCount++;
+        }
+        // Assert that we end up reading 10 events even though delegation token must have expired midway.
+        //
+        // To look for evidence of delegation token renewal check the logs for the following message:
+        // - "Token is nearing expiry, so refreshing it"
+        assertEquals(10, eventReadCount);
+    }
+
+    private void writeTenEvents(String scope, String streamName, ClientConfig clientConfig) {
+        @Cleanup
+        final EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
+
+        // Perform writes on a separate thread.
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
+                new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+
+        for (int i = 0; i < 10; i++) {
+            String msg = "message: " + i;
+            writer.writeEvent(msg);
+            log.debug("Done writing message '{}' to stream '{} / {}'", msg, scope, streamName);
+        }
+        writer.flush();
+    }
+
+    private void createScopeStream(String scope, String streamName, int numSegments, ClientConfig clientConfig) {
+        @Cleanup final StreamManager streamManager = StreamManager.create(clientConfig);
+        assertNotNull(streamManager);
+        log.debug("Done creating stream manager.");
+
+        boolean isScopeCreated = streamManager.createScope(scope);
+        assertTrue("Failed to create scope", isScopeCreated);
+        log.debug("Done creating stream manager.");
+
+        boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                                                                                                   .scalingPolicy(ScalingPolicy
+                                                                                                           .fixed(numSegments))
+                                                                                                   .build());
+        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
     }
 }


### PR DESCRIPTION
**Change log description**  
Use DelegationTokenProvider for BatchClient.

**Purpose of the change**  
Fixes #4443 

**What the code does**  
Leverage DelegationTokenProvider to retrieve the delegation token on BatchClient.

**How to verify it**  
All the existing and newly added tests should continue to pass.
