### PR TITLE
Issue 4495: Recording WARN and ERROR log entries as metrics.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ project ('shared:metrics') {
         compile group: 'io.micrometer', name: 'micrometer-registry-influx', version: micrometerVersion
         // https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-influx/<micrometerVersion>
         compile project(':common')
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
     }
 
     javadoc {

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -36,8 +36,11 @@ You may obtain a copy of the License at
         </encoder>
     </appender>
 
+    <appender name="Metrics" class="io.pravega.shared.metrics.MetricsLogAppender"/>
+
     <root level="${log.level:-INFO}">
         <appender-ref ref="consoleAppender"/>
         <appender-ref ref="FILE"/>
+        <appender-ref ref="Metrics"/>
     </root>
 </configuration>

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -64,6 +64,10 @@ public final class MetricsNames {
     // PREFIX can be loaded from config when config becomes dependency.
     public static final String PREFIX = "pravega" + ".";
 
+    // Metrics for all services
+    public static final String LOG_ERRORS = PREFIX + "logged_errors";     // Counter
+    public static final String LOG_WARNINGS = PREFIX + "logged_warnings"; // Counter
+
     // Metrics in Segment Store Service
     // Segment-related stats
     public static final String SEGMENT_CREATE_LATENCY = PREFIX + "segmentstore.segment.create_latency_ms";              // Histogram

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -28,6 +28,7 @@ public final class MetricsTags {
     public static final String TAG_SEGMENT = "segment";
     public static final String TAG_TRANSACTION = "transaction";
     public static final String TAG_EPOCH = "epoch";
+    public static final String TAG_CLASS = "class";
 
     private static final String TRANSACTION_DELIMITER = "#transaction.";
     private static final String EPOCH_DELIMITER = ".#epoch.";
@@ -164,5 +165,24 @@ public final class MetricsTags {
             hostTag[1] = "unknown";
         }
         return hostTag;
+    }
+
+    /**
+     * Generate a Class Name tag (string array) on the input class name.
+     *
+     * @param className The name of the class to create a tag for.
+     * @return string array as the class name tag of metric.
+     */
+    public static String[] classNameTag(String className) {
+        return new String[]{TAG_CLASS, getSimpleClassName(className)};
+    }
+
+    private static String getSimpleClassName(String name) {
+        int lastSeparator = name.lastIndexOf(".");
+        if (lastSeparator < 0 || lastSeparator >= name.length() - 1) {
+            return name;
+        } else {
+            return name.substring(lastSeparator + 1);
+        }
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -11,7 +11,6 @@ package io.pravega.shared;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -29,6 +28,7 @@ public final class MetricsTags {
     public static final String TAG_TRANSACTION = "transaction";
     public static final String TAG_EPOCH = "epoch";
     public static final String TAG_CLASS = "class";
+    public static final String TAG_EXCEPTION = "exception";
 
     private static final String TRANSACTION_DELIMITER = "#transaction.";
     private static final String EPOCH_DELIMITER = ".#epoch.";
@@ -168,13 +168,17 @@ public final class MetricsTags {
     }
 
     /**
-     * Generate a Class Name tag (string array) on the input class name.
+     * Generate an Exception tag (string array) on the input class name.
      *
-     * @param className The name of the class to create a tag for.
-     * @return string array as the class name tag of metric.
+     * @param loggingClassName   The name of the class that recorded the exception.
+     * @param exceptionClassName The name of the exception class that was recorded. May be null.
+     * @return A String array containing the necessary tags. If exceptionClassName is null, the result will have two
+     * elements, otherwise it will have four.
      */
-    public static String[] classNameTag(String className) {
-        return new String[]{TAG_CLASS, getSimpleClassName(className)};
+    public static String[] exceptionTag(String loggingClassName, String exceptionClassName) {
+        return exceptionClassName == null
+                ? new String[]{TAG_CLASS, getSimpleClassName(loggingClassName)}
+                : new String[]{TAG_CLASS, getSimpleClassName(loggingClassName), TAG_EXCEPTION, getSimpleClassName(exceptionClassName)};
     }
 
     private static String getSimpleClassName(String name) {

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -172,13 +172,14 @@ public final class MetricsTags {
      *
      * @param loggingClassName   The name of the class that recorded the exception.
      * @param exceptionClassName The name of the exception class that was recorded. May be null.
-     * @return A String array containing the necessary tags. If exceptionClassName is null, the result will have two
-     * elements, otherwise it will have four.
+     * @return A String array containing the necessary tags.
      */
     public static String[] exceptionTag(String loggingClassName, String exceptionClassName) {
-        return exceptionClassName == null
-                ? new String[]{TAG_CLASS, getSimpleClassName(loggingClassName)}
-                : new String[]{TAG_CLASS, getSimpleClassName(loggingClassName), TAG_EXCEPTION, getSimpleClassName(exceptionClassName)};
+        String[] result = new String[]{TAG_CLASS, getSimpleClassName(loggingClassName), TAG_EXCEPTION, "none"};
+        if (exceptionClassName != null) {
+            result[3] = getSimpleClassName(exceptionClassName);
+        }
+        return result;
     }
 
     private static String getSimpleClassName(String name) {

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsLogAppender.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsLogAppender.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.shared.metrics;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import ch.qos.logback.core.status.Status;
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.MetricsTags;
+import java.util.List;
+
+/**
+ * Log Appender that intercepts all events with {@link Level#ERROR} or {@link Level#WARN} and records a metric for them.
+ */
+public class MetricsLogAppender implements Appender<ILoggingEvent> {
+    private static final DynamicLogger DYNAMIC_LOGGER = MetricsProvider.getDynamicLogger();
+
+    //region Appender Implementation
+
+    @Override
+    public String getName() {
+        return "Metrics Appender";
+    }
+
+    @Override
+    public void doAppend(ILoggingEvent event) throws LogbackException {
+        if (event.getLevel() == Level.ERROR) {
+            DYNAMIC_LOGGER.incCounterValue(MetricsNames.LOG_ERRORS, 1, MetricsTags.classNameTag(event.getLoggerName()));
+        } else if (event.getLevel() == Level.WARN) {
+            DYNAMIC_LOGGER.incCounterValue(MetricsNames.LOG_WARNINGS, 1, MetricsTags.classNameTag(event.getLoggerName()));
+        }
+    }
+
+    //endregion
+
+    //region Unimplemented Methods
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public boolean isStarted() {
+        return true;
+    }
+
+    @Override
+    public void setName(String name) {
+    }
+
+    @Override
+    public void setContext(Context context) {
+    }
+
+    @Override
+    public Context getContext() {
+        return null;
+    }
+
+    @Override
+    public void addStatus(Status status) {
+    }
+
+    @Override
+    public void addInfo(String msg) {
+    }
+
+    @Override
+    public void addInfo(String msg, Throwable ex) {
+    }
+
+    @Override
+    public void addWarn(String msg) {
+    }
+
+    @Override
+    public void addWarn(String msg, Throwable ex) {
+    }
+
+    @Override
+    public void addError(String msg) {
+    }
+
+    @Override
+    public void addError(String msg, Throwable ex) {
+    }
+
+    @Override
+    public void addFilter(Filter<ILoggingEvent> newFilter) {
+    }
+
+    @Override
+    public void clearAllFilters() {
+    }
+
+    @Override
+    public List<Filter<ILoggingEvent>> getCopyOfAttachedFiltersList() {
+        return null;
+    }
+
+    @Override
+    public FilterReply getFilterChainDecision(ILoggingEvent event) {
+        return null;
+    }
+
+    //endregion
+}

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsLogAppender.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsLogAppender.java
@@ -11,6 +11,7 @@ package io.pravega.shared.metrics;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.LogbackException;
@@ -37,10 +38,15 @@ public class MetricsLogAppender implements Appender<ILoggingEvent> {
     @Override
     public void doAppend(ILoggingEvent event) throws LogbackException {
         if (event.getLevel() == Level.ERROR) {
-            DYNAMIC_LOGGER.incCounterValue(MetricsNames.LOG_ERRORS, 1, MetricsTags.classNameTag(event.getLoggerName()));
+            recordEvent(MetricsNames.LOG_ERRORS, event);
         } else if (event.getLevel() == Level.WARN) {
-            DYNAMIC_LOGGER.incCounterValue(MetricsNames.LOG_WARNINGS, 1, MetricsTags.classNameTag(event.getLoggerName()));
+            recordEvent(MetricsNames.LOG_WARNINGS, event);
         }
+    }
+
+    private void recordEvent(String metricName, ILoggingEvent event) {
+        IThrowableProxy p = event.getThrowableProxy();
+        DYNAMIC_LOGGER.recordMeterEvents(metricName, 1, MetricsTags.exceptionTag(event.getLoggerName(), p == null ? null : p.getClassName()));
     }
 
     //endregion

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -18,9 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
-import static io.pravega.shared.MetricsTags.classNameTag;
 import static io.pravega.shared.MetricsTags.containerTag;
 import static io.pravega.shared.MetricsTags.createHostTag;
+import static io.pravega.shared.MetricsTags.exceptionTag;
 import static io.pravega.shared.MetricsTags.hostTag;
 import static io.pravega.shared.MetricsTags.segmentTags;
 import static io.pravega.shared.MetricsTags.streamTags;
@@ -160,7 +160,7 @@ public class MetricsTagsTest {
     }
 
     @Test
-    public void testCreateNameTags() {
+    public void testExceptionTags() {
         val classNames = ImmutableMap
                 .<String, String>builder()
                 .put("A", "A")
@@ -168,10 +168,22 @@ public class MetricsTagsTest {
                 .put(".C", "C")
                 .put("D.E.F", "F")
                 .build();
-        for (val e : classNames.entrySet()) {
-            val tags = classNameTag(e.getKey());
+        for (val logClassName : classNames.entrySet()) {
+            // Check without exception.
+            String[] tags = exceptionTag(logClassName.getKey(), null);
+            Assert.assertEquals(2, tags.length);
             Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
-            Assert.assertEquals(e.getValue(), tags[1]);
+            Assert.assertEquals(logClassName.getValue(), tags[1]);
+
+            // Check with exceptions.
+            for (val exceptionClassName : classNames.entrySet()) {
+                tags = exceptionTag(logClassName.getKey(), exceptionClassName.getKey());
+                Assert.assertEquals(4, tags.length);
+                Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
+                Assert.assertEquals(logClassName.getValue(), tags[1]);
+                Assert.assertEquals(MetricsTags.TAG_EXCEPTION, tags[2]);
+                Assert.assertEquals(exceptionClassName.getValue(), tags[3]);
+            }
         }
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -171,19 +171,21 @@ public class MetricsTagsTest {
         for (val logClassName : classNames.entrySet()) {
             // Check without exception.
             String[] tags = exceptionTag(logClassName.getKey(), null);
-            Assert.assertEquals(2, tags.length);
-            Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
-            Assert.assertEquals(logClassName.getValue(), tags[1]);
+            checkExceptionTags(tags, logClassName.getValue(), "none");
 
             // Check with exceptions.
             for (val exceptionClassName : classNames.entrySet()) {
                 tags = exceptionTag(logClassName.getKey(), exceptionClassName.getKey());
-                Assert.assertEquals(4, tags.length);
-                Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
-                Assert.assertEquals(logClassName.getValue(), tags[1]);
-                Assert.assertEquals(MetricsTags.TAG_EXCEPTION, tags[2]);
-                Assert.assertEquals(exceptionClassName.getValue(), tags[3]);
+                checkExceptionTags(tags, logClassName.getValue(), exceptionClassName.getValue());
             }
         }
+    }
+
+    private void checkExceptionTags(String[] tags, String expectedClassTag, String expectedExceptionTag) {
+        Assert.assertEquals(4, tags.length);
+        Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
+        Assert.assertEquals(expectedClassTag, tags[1]);
+        Assert.assertEquals(MetricsTags.TAG_EXCEPTION, tags[2]);
+        Assert.assertEquals(expectedExceptionTag, tags[3]);
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsTagsTest.java
@@ -10,12 +10,15 @@
 package io.pravega.shared;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.net.InetAddress;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Assert;
 import org.junit.Test;
 
-import java.net.InetAddress;
-
 import static io.pravega.shared.MetricsTags.DEFAULT_HOSTNAME_KEY;
+import static io.pravega.shared.MetricsTags.classNameTag;
 import static io.pravega.shared.MetricsTags.containerTag;
 import static io.pravega.shared.MetricsTags.createHostTag;
 import static io.pravega.shared.MetricsTags.hostTag;
@@ -154,5 +157,21 @@ public class MetricsTagsTest {
         assertEquals("scope/stream/tablesInStream", tags[5]);
         assertEquals(MetricsTags.TAG_EPOCH, tags[6]);
         assertEquals("0", tags[7]);
+    }
+
+    @Test
+    public void testCreateNameTags() {
+        val classNames = ImmutableMap
+                .<String, String>builder()
+                .put("A", "A")
+                .put("B.", "B.")
+                .put(".C", "C")
+                .put("D.E.F", "F")
+                .build();
+        for (val e : classNames.entrySet()) {
+            val tags = classNameTag(e.getKey());
+            Assert.assertEquals(MetricsTags.TAG_CLASS, tags[0]);
+            Assert.assertEquals(e.getValue(), tags[1]);
+        }
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsLogAppenderTests.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsLogAppenderTests.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.shared.metrics;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import com.google.common.collect.ImmutableMap;
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.MetricsTags;
+import java.util.Arrays;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Marker;
+
+/**
+ * Unit tests for the {@link MetricsLogAppender} class.
+ */
+@Slf4j
+public class MetricsLogAppenderTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10);
+
+    @Before
+    public void setUp() {
+        MetricsProvider.initialize(MetricsConfig.builder()
+                                                .with(MetricsConfig.ENABLE_STATISTICS, true)
+                                                .build());
+        MetricsProvider.getMetricsProvider().startWithoutExporting();
+    }
+
+    /**
+     * Tests the {@link MetricsNames#LOG_WARNINGS} metric.
+     */
+    @Test
+    public void testWarn() {
+        testLog(Level.WARN, MetricsNames.LOG_WARNINGS, true);
+    }
+
+    /**
+     * Tests the {@link MetricsNames#LOG_ERRORS} metric.
+     */
+    @Test
+    public void testLogError() {
+        testLog(Level.ERROR, MetricsNames.LOG_ERRORS, true);
+    }
+
+    /**
+     * Tests that no other log levels result in any activity.
+     */
+    @Test
+    public void testOtherLevels() {
+        val metricsToCheck = Arrays.asList(MetricsNames.LOG_WARNINGS, MetricsNames.LOG_ERRORS);
+        for (val m : metricsToCheck) {
+            testLog(Level.TRACE, m, false);
+            testLog(Level.DEBUG, m, false);
+            testLog(Level.INFO, m, false);
+        }
+    }
+
+    private void testLog(Level level, String metricName, boolean expectValues) {
+        val classNames = ImmutableMap
+                .<String, String>builder()
+                .put("A", "A")
+                .put("B.", "B.")
+                .put(".C", "C")
+                .put("D.E.F", "F")
+                .build();
+        val appender = new MetricsLogAppender();
+        for (val e : classNames.entrySet()) {
+            appender.doAppend(new TestEvent(level, e.getKey()));
+        }
+
+        for (val e : classNames.entrySet()) {
+            val c = MetricRegistryUtils.getCounter(metricName, MetricsTags.classNameTag(e.getValue()));
+            int expectedValue = expectValues ? 1 : 0;
+            Assert.assertEquals("Unexpected counter value for " + e, expectedValue, (int) c.count());
+        }
+    }
+
+    @Builder
+    @Getter
+    private static class TestEvent implements ILoggingEvent {
+        private final Level level;
+        private final String loggerName;
+
+        @Override
+        public String getThreadName() {
+            return "Test Thread Name";
+        }
+
+        @Override
+        public String getMessage() {
+            return "Test Message";
+        }
+
+        @Override
+        public Object[] getArgumentArray() {
+            return new Object[0];
+        }
+
+        @Override
+        public String getFormattedMessage() {
+            return getMessage();
+        }
+
+        @Override
+        public LoggerContextVO getLoggerContextVO() {
+            return null;
+        }
+
+        @Override
+        public IThrowableProxy getThrowableProxy() {
+            return null;
+        }
+
+        @Override
+        public StackTraceElement[] getCallerData() {
+            return new StackTraceElement[0];
+        }
+
+        @Override
+        public boolean hasCallerData() {
+            return false;
+        }
+
+        @Override
+        public Marker getMarker() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getMDCPropertyMap() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getMdc() {
+            return null;
+        }
+
+        @Override
+        public long getTimeStamp() {
+            return 0;
+        }
+
+        @Override
+        public void prepareForDeferredProcessing() {
+        }
+    }
+}


### PR DESCRIPTION
**Change log description**  
- Recording all WARNs and ERRORs as metrics with logging class name and exception name as tags.

**Purpose of the change**  
Fixes #4495.

**What the code does**  
- Created a new Log Appender to intercept all log entries that have severity set to WARN or ERROR. 
- All these are reported into metrics via 2 distinct counters (one for WARN, one for ERROR), and using the source class/log name as a tag, and exception name (if any) as another tag.

**How to verify it**  
Unit tests updated. A longevity with metrics should also be run to verify this.
