### PR TITLE
Issue:  Prevent readers from waiting indefinitely if there is a partial/no response from the Segment Store.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
@@ -29,7 +29,17 @@ public interface EventSegmentReader extends AutoCloseable {
      *
      * @param offset The offset to set.
      */
-    public abstract void setOffset(long offset);
+    default void setOffset(long offset) {
+        setOffset(offset, false);
+    }
+
+    /**
+     * Sets the offset for reading from the segment.
+     *
+     * @param offset The offset to set.
+     * @param resendRequest Resend the read request incase there is an already pending read request for the offset.
+     */
+    void setOffset(long offset, boolean resendRequest);
 
     /**
      * Gets the current offset. (Passing this to setOffset in the future will reset reads to the

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
@@ -72,13 +72,13 @@ public interface EventSegmentReader extends AutoCloseable {
      * an event. If this timeout elapses, then null is returned. Once an event has been partially read, it will be
      * fully read without regard to the timeout.
      *
-     * @param firstByteTimeout The maximum length of time to block to get the first byte of the event.
+     * @param firstByteTimeoutMillis The maximum length of time to block to get the first byte of the event.
      * @return A ByteBuffer containing the serialized data that was written via
      *         {@link EventStreamWriter#writeEvent(String, Object)}
      * @throws EndOfSegmentException If no event could be read because the end of the segment was reached.
      * @throws SegmentTruncatedException If the segment has been truncated beyond the current offset and the data cannot be read.
      */
-    public abstract ByteBuffer read(long firstByteTimeout) throws EndOfSegmentException, SegmentTruncatedException;
+    public abstract ByteBuffer read(long firstByteTimeoutMillis) throws EndOfSegmentException, SegmentTruncatedException;
     
     /**
      * Issues a request to asynchronously fill up the buffer. The goal is to prevent future {@link #read()} calls from blocking.

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -29,7 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 @ToString
 class EventSegmentReaderImpl implements EventSegmentReader {
 
-    // Flaky network
+    /* Partial data timeout. This timeout is the maximum amount of time the reader will wait in the case of
+     * partial data being received by the client. After this timeout the client will resend the request. */
     private static final long READ_TIMEOUT_MS = 500;
 
     @GuardedBy("$lock")
@@ -92,7 +93,7 @@ class EventSegmentReaderImpl implements EventSegmentReader {
         }
         while (headerReadingBuffer.hasRemaining()) {
             if (in.read(headerReadingBuffer, READ_TIMEOUT_MS) == 0) {
-                log.warn("Timeout out while trying to read WireCommand headers during read of segment {} at offset {}",
+                log.warn("Timeout out while trying to read WireCommand header during read of segment {} at offset {}",
                         in.getSegmentId(), in.getOffset());
                 throw new TimeoutException("Timeout while trying to read WireCommand headers");
             }

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -39,8 +39,8 @@ class EventSegmentReaderImpl implements EventSegmentReader {
 
     @Override
     @Synchronized
-    public void setOffset(long offset) {
-        in.setOffset(offset);
+    public void setOffset(long offset, boolean resendRequest) {
+        in.setOffset(offset, resendRequest);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -31,7 +31,7 @@ class EventSegmentReaderImpl implements EventSegmentReader {
 
     /* Partial data timeout. This timeout is the maximum amount of time the reader will wait in the case of
      * partial data being received by the client. After this timeout the client will resend the request. */
-    private static final long READ_TIMEOUT_MS = 500;
+    static final long READ_TIMEOUT_MS = 500;
 
     @GuardedBy("$lock")
     private final ByteBuffer headerReadingBuffer = ByteBuffer.allocate(WireCommands.TYPE_PLUS_LENGTH_SIZE);

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStream.java
@@ -28,7 +28,16 @@ public interface SegmentInputStream extends AutoCloseable {
      *
      * @param offset The offset to set.
      */
-    public abstract void setOffset(long offset);
+    default void setOffset( long offset) {
+        setOffset(offset, false);
+    }
+
+    /**
+     * Sets the offset for reading from the segment.
+     * @param offset The offset to set.
+     * @param resendRequest Resend the read request in-case there is an already pending read request for the offset.
+     */
+    public abstract void setOffset(long offset, boolean resendRequest);
 
     /**
      * Gets the current offset. (Passing this to setOffset in the future will reset reads to the

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -82,13 +82,15 @@ class SegmentInputStreamImpl implements SegmentInputStream {
             receivedTruncated = false;
         }
         if (offset != this.offset || resendRequest) {
-            log.debug("Cancelling the read request for segment {} at offset {}. The new read offset is {} ", this.offset, asyncInput.getSegmentId(), offset);
+            if (outstandingRequest != null) {
+                log.debug("Cancelling the read request for segment {} at offset {}. The new read offset is {}", asyncInput.getSegmentId(), this.offset, offset);
+                outstandingRequest.cancel(true);
+                log.debug("Completed cancelling the read request for segment {}", asyncInput.getSegmentId());
+                outstandingRequest = null;
+            }
             this.offset = offset;
             buffer.clear();
             receivedEndOfSegment = false;
-            outstandingRequest.cancel(true);
-            log.debug("Completed cancelling the read request for segment {}", asyncInput.getSegmentId());
-            outstandingRequest = null;        
         }
     }
 

--- a/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
@@ -41,7 +41,7 @@ public class EventSegmentReaderImplTest {
         //return a value less than WireCommands.TYPE_PLUS_LENGTH_SIZE = 8 bytes.
         when(segmentInputStream.read(any(ByteBuffer.class), eq(1000L))).thenReturn(5);
         // simulate a timeout while reading the remaining part of the headers.
-        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS))).thenReturn(0);
+        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT))).thenReturn(0);
 
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);
@@ -63,7 +63,7 @@ public class EventSegmentReaderImplTest {
             return 8;
         }).when(segmentInputStream).read(any(ByteBuffer.class), eq(1000L));
         // simulate a timeout while reading the remaining data.
-        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS))).thenReturn(0);
+        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT))).thenReturn(0);
 
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);
@@ -96,7 +96,7 @@ public class EventSegmentReaderImplTest {
             headerReadingBuffer.put((byte) 0x01);
             return 5;
         }).doReturn(0) // the second invocation should cause a timeout.
-          .when(segmentInputStream).read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS));
+          .when(segmentInputStream).read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT));
 
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);

--- a/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
@@ -42,7 +42,7 @@ public class EventSegmentReaderImplTest {
         when(segmentInputStream.read(any(ByteBuffer.class), eq(1000L))).thenReturn(5);
         // simulate a timeout while reading the remaining part of the headers.
         when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT))).thenReturn(0);
-
+        when(segmentInputStream.getSegmentId()).thenReturn(new Segment("scope", "stream", 0L));
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);
         assertNull(readData);
@@ -51,7 +51,6 @@ public class EventSegmentReaderImplTest {
 
     @Test
     public void testEventDataTimeout() throws SegmentTruncatedException, EndOfSegmentException {
-        //Setup Mocks.
         // Setup Mocks
         SegmentInputStream segmentInputStream = mock(SegmentInputStream.class);
         EventSegmentReaderImpl segmentReader = new EventSegmentReaderImpl(segmentInputStream);
@@ -64,6 +63,7 @@ public class EventSegmentReaderImplTest {
         }).when(segmentInputStream).read(any(ByteBuffer.class), eq(1000L));
         // simulate a timeout while reading the remaining data.
         when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT))).thenReturn(0);
+        when(segmentInputStream.getSegmentId()).thenReturn(new Segment("scope", "stream", 0L));
 
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);
@@ -74,7 +74,6 @@ public class EventSegmentReaderImplTest {
 
     @Test
     public void testEventDataPartialTimeout() throws SegmentTruncatedException, EndOfSegmentException {
-        //Setup Mocks.
         // Setup Mocks
         SegmentInputStream segmentInputStream = mock(SegmentInputStream.class);
         EventSegmentReaderImpl segmentReader = new EventSegmentReaderImpl(segmentInputStream);
@@ -97,6 +96,7 @@ public class EventSegmentReaderImplTest {
             return 5;
         }).doReturn(0) // the second invocation should cause a timeout.
           .when(segmentInputStream).read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.PARTIAL_DATA_TIMEOUT));
+        when(segmentInputStream.getSegmentId()).thenReturn(new Segment("scope", "stream", 0L));
 
         // Invoke read.
         ByteBuffer readData = segmentReader.read(1000);

--- a/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/EventSegmentReaderImplTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.client.segment.impl;
+
+
+import io.pravega.shared.protocol.netty.WireCommandType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventSegmentReaderImplTest {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
+
+    @Test
+    public void testHeaderTimeout() throws SegmentTruncatedException, EndOfSegmentException {
+        // Setup Mocks
+        SegmentInputStream segmentInputStream = mock(SegmentInputStream.class);
+        EventSegmentReaderImpl segmentReader = new EventSegmentReaderImpl(segmentInputStream);
+        //return a value less than WireCommands.TYPE_PLUS_LENGTH_SIZE = 8 bytes.
+        when(segmentInputStream.read(any(ByteBuffer.class), eq(1000L))).thenReturn(5);
+        // simulate a timeout while reading the remaining part of the headers.
+        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS))).thenReturn(0);
+
+        // Invoke read.
+        ByteBuffer readData = segmentReader.read(1000);
+        assertNull(readData);
+        verify(segmentInputStream, times(1)).setOffset(0L, true);
+    }
+
+    @Test
+    public void testEventDataTimeout() throws SegmentTruncatedException, EndOfSegmentException {
+        //Setup Mocks.
+        // Setup Mocks
+        SegmentInputStream segmentInputStream = mock(SegmentInputStream.class);
+        EventSegmentReaderImpl segmentReader = new EventSegmentReaderImpl(segmentInputStream);
+        //return a value less than WireCommands.TYPE_PLUS_LENGTH_SIZE = 8 bytes.
+        doAnswer(i -> {
+            ByteBuffer headerReadingBuffer = i.getArgument(0);
+            headerReadingBuffer.putInt(WireCommandType.EVENT.getCode());
+            headerReadingBuffer.putInt(10);
+            return 8;
+        }).when(segmentInputStream).read(any(ByteBuffer.class), eq(1000L));
+        // simulate a timeout while reading the remaining data.
+        when(segmentInputStream.read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS))).thenReturn(0);
+
+        // Invoke read.
+        ByteBuffer readData = segmentReader.read(1000);
+        assertNull(readData);
+        verify(segmentInputStream, times(1)).setOffset(0L, true);
+        verify(segmentInputStream, times(0)).setOffset(0);
+    }
+
+    @Test
+    public void testEventDataPartialTimeout() throws SegmentTruncatedException, EndOfSegmentException {
+        //Setup Mocks.
+        // Setup Mocks
+        SegmentInputStream segmentInputStream = mock(SegmentInputStream.class);
+        EventSegmentReaderImpl segmentReader = new EventSegmentReaderImpl(segmentInputStream);
+        //return a value less than WireCommands.TYPE_PLUS_LENGTH_SIZE = 8 bytes.
+        doAnswer(i -> {
+            ByteBuffer headerReadingBuffer = i.getArgument(0);
+            headerReadingBuffer.putInt(WireCommandType.EVENT.getCode());
+            headerReadingBuffer.putInt(10);
+            return 8;
+        }).when(segmentInputStream).read(any(ByteBuffer.class), eq(1000L));
+        // simulate a partial read followed by timeout.
+        doAnswer(i -> {
+            ByteBuffer headerReadingBuffer = i.getArgument(0);
+            // append 5 bytes. 5 Bytes are remaining.
+            headerReadingBuffer.put((byte) 0x01);
+            headerReadingBuffer.put((byte) 0x01);
+            headerReadingBuffer.put((byte) 0x01);
+            headerReadingBuffer.put((byte) 0x01);
+            headerReadingBuffer.put((byte) 0x01);
+            return 5;
+        }).doReturn(0) // the second invocation should cause a timeout.
+          .when(segmentInputStream).read(any(ByteBuffer.class), eq(EventSegmentReaderImpl.READ_TIMEOUT_MS));
+
+        // Invoke read.
+        ByteBuffer readData = segmentReader.read(1000);
+        assertNull(readData);
+        verify(segmentInputStream, times(1)).setOffset(0L, true);
+        verify(segmentInputStream, times(0)).setOffset(0);
+    }
+}

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -9,12 +9,17 @@
  */
 package io.pravega.client.state.impl;
 
+import io.netty.buffer.Unpooled;
 import io.pravega.client.SynchronizerClientFactory;
+import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.security.auth.DelegationTokenProvider;
+import io.pravega.client.segment.impl.ConditionalOutputStreamFactory;
+import io.pravega.client.segment.impl.ConditionalOutputStreamFactoryImpl;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentInfo;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
+import io.pravega.client.segment.impl.SegmentInputStreamFactoryImpl;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
 import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
 import io.pravega.client.segment.impl.SegmentOutputStream;
@@ -37,12 +42,19 @@ import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.common.util.ByteBufferUtils;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+
+import io.pravega.shared.protocol.netty.ReplyProcessor;
+import io.pravega.shared.protocol.netty.WireCommands;
 import lombok.Cleanup;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -53,8 +65,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -350,6 +368,78 @@ public class RevisionedStreamClientTest {
         assertTrue("True is expected since offset is less than end offset", iterator.hasNext());
         assertNotNull("Verify the entry is not null", iterator.next());
         verify(in, times(2)).read(anyLong());
+    }
+
+    @Test
+    public void testRetryOnTimeout() {
+        String scope = "scope";
+        String stream = "stream";
+        Segment segment = new Segment(scope, stream, 0L);
+        // Setup Environment
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+
+        // Setup Mocks
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint
+                .getPort(), connectionFactory, false);
+
+        // Setup client connection.
+        ClientConnection c = mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, c);
+
+        // Create Scope and Stream.
+        createScopeAndStream(scope, stream, controller);
+
+        // Create mock ClientFactory.
+        SegmentInputStreamFactory segInputFactory = new SegmentInputStreamFactoryImpl(controller, connectionFactory);
+        SegmentOutputStreamFactory segOutputFactory = mock(SegmentOutputStreamFactory.class);
+        ConditionalOutputStreamFactory condOutputFactory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
+        SegmentMetadataClientFactory segMetaFactory = mock(SegmentMetadataClientFactory.class);
+        SegmentMetadataClient segMetaClient = mock(SegmentMetadataClient.class);
+        when(segMetaFactory.createSegmentMetadataClient(eq(segment), any(DelegationTokenProvider.class)))
+                .thenReturn(segMetaClient);
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, segInputFactory,
+                segOutputFactory, condOutputFactory, segMetaFactory);
+
+        RevisionedStreamClientImpl<String> client = spy((RevisionedStreamClientImpl<String>) clientFactory
+                .createRevisionedStreamClient(stream, serializer,
+                        SynchronizerConfig.builder().build()));
+        // Override the readTimeout value for RevisionedClient to 1 second.
+        doReturn(1000L).when(client).getReadTimeout();
+
+        // Setup the SegmentMetadataClient mock.
+        doReturn(new SegmentInfo(segment, 0L, 30L, false, 1L))
+                .when(segMetaClient).getSegmentInfo();
+
+        // Get the iterator from Revisioned Stream Client.
+        Iterator<Entry<Revision, String>> iterator = client.readFrom(new RevisionImpl(segment, 15, 1));
+        // since we are trying to read @ offset 15 and the writeOffset is 30L a true is returned for hasNext().
+        assertTrue(iterator.hasNext());
+
+        // Setup mock to validate a retry.
+        doNothing().doAnswer(i -> {
+            WireCommands.ReadSegment request = i.getArgument(0);
+            ReplyProcessor rp = connectionFactory.getProcessor(endpoint);
+            WireCommands.Event event = new WireCommands.Event(Unpooled.wrappedBuffer(serializer.serialize("A")));
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            event.writeFields(new DataOutputStream(bout));
+            ByteBuffer eventData = ByteBuffer.wrap(bout.toByteArray());
+            // Invoke Reply processor to simulate a successful read.
+            rp.process(new WireCommands.SegmentRead(request.getSegment(), 15L, true, true, eventData, request
+                    .getRequestId()));
+            ClientConnection.CompletedCallback callback = i.getArgument(1);
+            callback.complete(null);
+            return null;
+        }).when(c)
+                   .sendAsync(any(WireCommands.ReadSegment.class), any(ClientConnection.CompletedCallback.class));
+        Entry<Revision, String> r = iterator.next();
+        assertEquals("A", r.getValue());
+        // Verify retries have been performed.
+        verify(c, times(3))
+                .sendAsync(any(WireCommands.ReadSegment.class), any(ClientConnection.CompletedCallback.class));
     }
 
     private void createScopeAndStream(String scope, String stream, MockController controller) {

--- a/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/OrdererTest.java
@@ -37,6 +37,10 @@ public class OrdererTest {
         }
 
         @Override
+        public void setOffset(long offset, boolean resendRequest) {
+        }
+
+        @Override
         public ByteBuffer read(long firstByteTimeout) throws EndOfSegmentException {
             return null;
         }

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -66,6 +66,11 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     }
 
     @Override
+    public void setOffset(long offset) {
+        setOffset(offset, false);
+    }
+
+    @Override
     @Synchronized
     public long getOffset() {
         return readOffset;
@@ -176,11 +181,6 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     @Override
     public Segment getSegmentId() {
         return segment;
-    }
-
-    @Override
-    public void setOffset(long offset) {
-        setOffset(offset, false);
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentIoStreams.java
@@ -55,7 +55,7 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     
     @Override
     @Synchronized
-    public void setOffset(long offset) {
+    public void setOffset(long offset, boolean resend) {
         if (offset < 0) {
             throw new IllegalArgumentException("Invalid offset " + offset);
         }
@@ -176,6 +176,11 @@ public class MockSegmentIoStreams implements SegmentOutputStream, SegmentInputSt
     @Override
     public Segment getSegmentId() {
         return segment;
+    }
+
+    @Override
+    public void setOffset(long offset) {
+        setOffset(offset, false);
     }
 
     @Override


### PR DESCRIPTION
(Under discussion)

**Change log description**  
- Ensure Revisioned Stream resends the read request if the Segment store does not respond within 30 seconds after confirmation that the write-offset is greater than the current read-offset.
- Ensure the Event Stream Reader resends the read request if the complete WireCommand frame is not received within 30 seconds.

**Purpose of the change**  
Fixes #

**What the code does**  
This PR is in continuation of PR #4430. During the longevity testing of Pravega, we have observed scenarios where part of the WireCommand is never received by the client. This is observed post a network glitch on a Pravega cluster deployment that uses SDN with load balancers. The underlying network connection was never dropped nor did the packet arrive at the client. This PR addresses this issue which can potentially cause the readers to be stuck waiting for the last part of the data.

This change ensures the following:

- RevisionedStreamClient now resends the read request if there is no response from SSS. This resend logic is invoked only after the SegmentMetaClient confirms that the write-offset > the current read-offset i.e. the SSS has the data.
- Event StreamReader now resends the read request in the case of partial WireCommand frames being received by the client. Here too we are sure that the SSS has the data.


Note: A warning message indicating the partial response will be logged by the client along with the missing bytes.

**How to verify it**  
All the existing and newly added tests should continue to work. 


