### PR TITLE
Issue 4478: Remove cached watermarking client for deleted stream

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
@@ -367,6 +367,11 @@ public class PeriodicWatermarking {
         return missingRanges;
     }
 
+    @VisibleForTesting
+    boolean checkExistsInCache(Stream stream) {
+        return watermarkClientCache.asMap().containsKey(stream);
+    }
+        
     static class WatermarkClient {
         private final RevisionedStreamClient<Watermark> client;
         


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Revisioned stream clients for watermark stream are cached on controller instance. When a stream is deleted and recreated, the cached client could get no such segment exception. 

**Purpose of the change**  
Fixes #4478 

**What the code does**  
If noSuchSegmentException is thrown when trying to reinitialize the cached client, invalidate the cache for the stream. 

**How to verify it**  
integration test added for deleting and recreating the stream.