### PR TITLE
Issue 4529: From Seal Stream workflow, call abort Txn even for transactions that are in Aborting state

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/SealStreamTask.java
@@ -114,7 +114,8 @@ public class SealStreamTask implements StreamTask<SealStreamEvent> {
                         // abort transactions
                         return Futures.allOf(activeTxns.entrySet().stream().map(txIdPair -> {
                             CompletableFuture<Void> voidCompletableFuture;
-                            if (txIdPair.getValue().getTxnStatus().equals(TxnStatus.OPEN)) {
+                            TxnStatus txnStatus = txIdPair.getValue().getTxnStatus();
+                            if (txnStatus.equals(TxnStatus.OPEN) || txnStatus.equals(TxnStatus.ABORTING)) {
                                 voidCompletableFuture = Futures.toVoid(streamTransactionMetadataTasks
                                         .abortTxn(scope, stream, txIdPair.getKey(), null, context)
                                         .exceptionally(e -> {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
SealStreamTask now calls `abortTransaction` for transactions that are marked as aborting, such that an abort event is submitted for them. 

**Purpose of the change**  
Partial fix for #4529

**What the code does**  
When seal stream task is executed, it used to attempt to abort transactions that were open. Due to an unidentified bug, we have observed that in flink longevity there was a transaction for which the txn was marked for abort but corresponding event was not posted in the abort stream.
This prevented seal stream to complete as the transaction was never aborted. 

Now we call abort transaction for transactions that are Open as well as those that are already aborting. 
 
**How to verify it**  
Unit test added. 