### PR TITLE
Issue 4532: Typo in Javadoc for io.pravega.client.stream.StreamConfiguration

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -39,7 +39,7 @@ public class StreamConfiguration implements Serializable {
      * The duration after the last call to {@link EventStreamWriter#noteTime(long)} which the
      * timestamp should be considered valid before it is forgotten. Meaning that after this long of
      * not calling {@link EventStreamWriter#noteTime(long)} the writer will be forgotten.
-     * If there are no known writers, readers that call {@link EventStreamReader#getCurrentTimeWindow()}
+     * If there are no known writers, readers that call {@link EventStreamReader#getCurrentTimeWindow(Stream)}
      * will receive a `null` when they are at the corresponding position in the stream.
      */
     private final long timestampAggregationTimeout;


### PR DESCRIPTION
Signed-off-by: Bibin Sebastian <bibinvamattathil@gmail.com>

**Change log description**  
Fixing method syntax of EventStreamReader#getCurrentTimeWindow(Stream) method in javadoc

**Purpose of the change**  
Fixes #4532 

**What the code does**  
No code changes, only javadoc is updated

**How to verify it**  
Run './gradlew clean javadocs' command to verify that the javadoc warning for io.pravega.client.stream.StreamConfiguration doesn't appear anymore.
