### PR TITLE
Issue 4318: Replace `ByteArraySegment.subSegment()` with `ByteArraySegment.slice()`.

### DIFF
--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -249,7 +249,6 @@ public class ByteArraySegment implements ArrayView {
      * @throws ArrayIndexOutOfBoundsException If offset or length are invalid.
      */
     public ByteArraySegment subSegment(int offset, int length) {
-        // TODO: drop this in favor of slice(). https://github.com/pravega/pravega/issues/4318
         return subSegment(offset, length, this.readOnly);
     }
 

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -127,7 +127,7 @@ public class ByteArraySegment implements ArrayView {
 
     @Override
     public ByteArraySegment slice(int offset, int length) {
-        return subSegment(offset, length);
+        return subSegment(offset, length, this.readOnly);
     }
 
     @Override
@@ -237,19 +237,6 @@ public class ByteArraySegment implements ArrayView {
     public OutputStream getWriter() {
         Preconditions.checkState(!this.readOnly, "Cannot modify a read-only ByteArraySegment.");
         return new FixedByteArrayOutputStream(this.array, this.startOffset, this.length);
-    }
-
-    /**
-     * Returns a new ByteArraySegment that is a sub-segment of this ByteArraySegment. The new ByteArraySegment wraps
-     * the same underlying byte array that this ByteArraySegment does.
-     *
-     * @param offset The offset within this ByteArraySegment where the new ByteArraySegment starts.
-     * @param length The length of the new ByteArraySegment.
-     * @return The new ByteArraySegment.
-     * @throws ArrayIndexOutOfBoundsException If offset or length are invalid.
-     */
-    public ByteArraySegment subSegment(int offset, int length) {
-        return subSegment(offset, length, this.readOnly);
     }
 
     /**

--- a/common/src/main/java/io/pravega/common/util/btree/BTreePage.java
+++ b/common/src/main/java/io/pravega/common/util/btree/BTreePage.java
@@ -178,9 +178,9 @@ class BTreePage {
         Preconditions.checkArgument(!contents.isReadOnly(), "Cannot wrap a read-only ByteArraySegment.");
         this.config = config;
         this.contents = contents;
-        this.header = contents.subSegment(0, DATA_OFFSET);
-        this.data = contents.subSegment(DATA_OFFSET, contents.getLength() - DATA_OFFSET - FOOTER_LENGTH);
-        this.footer = contents.subSegment(contents.getLength() - FOOTER_LENGTH, FOOTER_LENGTH);
+        this.header = contents.slice(0, DATA_OFFSET);
+        this.data = contents.slice(DATA_OFFSET, contents.getLength() - DATA_OFFSET - FOOTER_LENGTH);
+        this.footer = contents.slice(contents.getLength() - FOOTER_LENGTH, FOOTER_LENGTH);
         if (validate) {
             int headerId = getHeaderId();
             int footerId = getFooterId();
@@ -252,7 +252,7 @@ class BTreePage {
      */
     ByteArraySegment getValueAt(int pos) {
         Preconditions.checkElementIndex(pos, getCount(), "pos must be non-negative and smaller than the number of items.");
-        return this.data.subSegment(pos * this.config.entryLength + this.config.keyLength, this.config.valueLength);
+        return this.data.slice(pos * this.config.entryLength + this.config.keyLength, this.config.valueLength);
     }
 
     /**
@@ -265,7 +265,7 @@ class BTreePage {
      */
     ByteArraySegment getKeyAt(int pos) {
         Preconditions.checkElementIndex(pos, getCount(), "pos must be non-negative and smaller than the number of items.");
-        return this.data.subSegment(pos * this.config.entryLength, this.config.keyLength);
+        return this.data.slice(pos * this.config.entryLength, this.config.keyLength);
     }
 
     /**
@@ -294,8 +294,8 @@ class BTreePage {
     PageEntry getEntryAt(int pos) {
         Preconditions.checkElementIndex(pos, getCount(), "pos must be non-negative and smaller than the number of items.");
         return new PageEntry(
-                this.data.subSegment(pos * this.config.entryLength, this.config.keyLength),
-                this.data.subSegment(pos * this.config.entryLength + this.config.keyLength, this.config.valueLength));
+                this.data.slice(pos * this.config.entryLength, this.config.keyLength),
+                this.data.slice(pos * this.config.entryLength + this.config.keyLength, this.config.valueLength));
     }
 
     /**
@@ -349,7 +349,7 @@ class BTreePage {
             int itemsPerPage = remainingItems / remainingPageCount;
 
             // Copy data over to the new page.
-            ByteArraySegment splitPageData = this.data.subSegment(readIndex, itemsPerPage * this.config.entryLength);
+            ByteArraySegment splitPageData = this.data.slice(readIndex, itemsPerPage * this.config.entryLength);
             result.add(new BTreePage(this.config, itemsPerPage, splitPageData));
 
             // Update pointers.

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -252,7 +252,7 @@ public class ByteArraySegmentTests {
         }
 
         // Check that a sub-segment is also read-only.
-        Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment.", segment.subSegment(0, 1).isReadOnly());
+        Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment.", segment.slice(0, 1).isReadOnly());
         Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment from non-read-only segment (when attempting to create a non-read-only segment).", segment.subSegment(0, 1, false).isReadOnly());
         Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment from non-read-only segment.", new ByteArraySegment(buffer).subSegment(0, 1, true).isReadOnly());
     }

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -251,7 +251,7 @@ public class ByteArraySegmentTests {
             Assert.assertEquals("One of the 'mutator' methods modified the buffer at index " + i, i, buffer[i]);
         }
 
-        // Check that a subsegment is also read-only.
+        // Check that a sub-segment is also read-only.
         Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment.", segment.subSegment(0, 1).isReadOnly());
         Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment from non-read-only segment (when attempting to create a non-read-only segment).", segment.subSegment(0, 1, false).isReadOnly());
         Assert.assertTrue("Unexpected value for isReadOnly() for read-only sub-segment from non-read-only segment.", new ByteArraySegment(buffer).subSegment(0, 1, true).isReadOnly());

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -201,7 +201,7 @@ public class ByteArraySegmentTests {
      * Tests the ability for the ByteArraySegment to create sub-segments.
      */
     @Test
-    public void testSubSegment() {
+    public void testSlice() {
         final byte[] buffer = createFormattedBuffer();
         ByteArraySegment segment = new ByteArraySegment(buffer);
 
@@ -214,17 +214,17 @@ public class ByteArraySegmentTests {
 
             // Check correctness.
             for (int i = 0; i < segment.getLength(); i++) {
-                Assert.assertEquals(String.format("Unexpected value at offset %d for subsegment (O=%d, L=%d), iteration %d.", i, startOffset, segment.getLength(), iteration), buffer[i + startOffset], segment.get(i));
+                Assert.assertEquals(String.format("Unexpected value at offset %d for slice (O=%d, L=%d), iteration %d.", i, startOffset, segment.getLength(), iteration), buffer[i + startOffset], segment.get(i));
             }
 
-            // Pick a new size and create a new subsegment.
+            // Pick a new size and create a new slice.
             if (iteration % 2 == 0) {
                 // Upper half for even iterations.
                 startOffset = startOffset + segment.getLength() / 2;
-                segment = segment.subSegment(segment.getLength() / 2, segment.getLength() - segment.getLength() / 2);
+                segment = segment.slice(segment.getLength() / 2, segment.getLength() - segment.getLength() / 2);
             } else {
                 // Lower half for odd iterations.
-                segment = segment.subSegment(0, segment.getLength() / 2);
+                segment = segment.slice(0, segment.getLength() / 2);
             }
         }
     }

--- a/common/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
+++ b/common/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
@@ -539,7 +539,7 @@ public class BTreeIndexTests extends ThreadPooledTestSuite {
                                 "Offset not registered or already obsolete: " + offset);
                     }
 
-                    return new ByteArraySegment(this.data.getData().subSegment((int) offset, length).getCopy());
+                    return new ByteArraySegment(this.data.getData().slice((int) offset, length).getCopy());
 
                 }
             }, executorService());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
@@ -77,8 +77,8 @@ public class DataFrame {
         Exceptions.checkArgument(sourceLength > FrameHeader.SERIALIZATION_LENGTH, "data",
                 "Insufficient array length. Byte array must have a length of at least %d.", FrameHeader.SERIALIZATION_LENGTH + 1);
 
-        this.header = new WriteFrameHeader(CURRENT_VERSION, this.data.subSegment(0, FrameHeader.SERIALIZATION_LENGTH));
-        this.contents = this.data.subSegment(FrameHeader.SERIALIZATION_LENGTH, sourceLength - FrameHeader.SERIALIZATION_LENGTH);
+        this.header = new WriteFrameHeader(CURRENT_VERSION, this.data.slice(0, FrameHeader.SERIALIZATION_LENGTH));
+        this.contents = this.data.slice(FrameHeader.SERIALIZATION_LENGTH, sourceLength - FrameHeader.SERIALIZATION_LENGTH);
     }
 
     /**
@@ -117,7 +117,7 @@ public class DataFrame {
             return this.data;
         } else {
             // We have just created this frame. Only return the segment of the buffer that contains data.
-            return this.data.subSegment(0, getLength());
+            return this.data.slice(0, getLength());
         }
     }
 
@@ -159,7 +159,7 @@ public class DataFrame {
         }
 
         this.writeEntryStartIndex = this.writePosition;
-        this.writeEntryHeader = new WriteEntryHeader(this.contents.subSegment(this.writePosition, WriteEntryHeader.HEADER_SIZE));
+        this.writeEntryHeader = new WriteEntryHeader(this.contents.slice(this.writePosition, WriteEntryHeader.HEADER_SIZE));
         this.writeEntryHeader.setFirstRecordEntry(firstRecordEntry);
         this.writePosition += WriteEntryHeader.HEADER_SIZE;
         return true;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
@@ -369,7 +369,7 @@ public class StorageReadManager implements AutoCloseable {
                 // Get the source Request's result, slice it and return the sub-segment that this request maps to.
                 Result sourceResult = source.resultFuture.join();
                 int offset = (int) (this.getOffset() - source.getOffset());
-                this.resultFuture.complete(new Result(sourceResult.getData().subSegment(offset, getLength()), true));
+                this.resultFuture.complete(new Result(sourceResult.getData().slice(offset, getLength()), true));
             } catch (Throwable ex) {
                 if (Exceptions.mustRethrow(ex)) {
                     throw ex;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -232,7 +232,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
 
             if (readData.getLength() >= EntrySerializer.HEADER_LENGTH + header.getKeyLength()) {
                 // We read enough information.
-                ArrayView keyData = readData.subSegment(header.getKeyOffset(), header.getKeyLength());
+                ArrayView keyData = readData.slice(header.getKeyOffset(), header.getKeyLength());
                 if (header.isDeletion()) {
                     complete(TableKey.notExists(keyData));
                 } else {
@@ -283,7 +283,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
 
             if (!this.keyValidated) {
                 // Compare the sought key and the data we read, byte-by-byte.
-                ByteArraySegment keyData = readData.subSegment(header.getKeyOffset(), header.getKeyLength());
+                ByteArraySegment keyData = readData.slice(header.getKeyOffset(), header.getKeyLength());
                 for (int i = 0; i < this.soughtKey.getLength(); i++) {
                     if (this.soughtKey.get(i) != keyData.get(i)) {
                         // Key mismatch; no point in continuing.
@@ -311,7 +311,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
             if (header.getValueLength() == 0) {
                 valueData = new ByteArraySegment(new byte[0]);
             } else {
-                valueData = readData.subSegment(header.getValueOffset(), header.getValueLength());
+                valueData = readData.slice(header.getValueOffset(), header.getValueLength());
             }
 
             complete(TableEntry.versioned(getKeyData(this.soughtKey, readData, header), valueData, getKeyVersion()));
@@ -320,7 +320,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
 
         private ArrayView getKeyData(ArrayView soughtKey, ByteArraySegment readData, EntrySerializer.Header header) {
             if (soughtKey == null) {
-                soughtKey = readData.subSegment(header.getKeyOffset(), header.getKeyLength());
+                soughtKey = readData.slice(header.getKeyOffset(), header.getKeyLength());
             }
 
             return soughtKey;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
@@ -154,7 +154,7 @@ public class DataFrameTests {
             // Append the first half of the record as one DataFrame Entry.
             dataFrame.startNewEntry(true); // true - this is the first entry for the record.
             int firstHalfLength = record.getLength() / 2;
-            int bytesAppended = dataFrame.append(record.subSegment(0, firstHalfLength));
+            int bytesAppended = dataFrame.append(record.slice(0, firstHalfLength));
             dataFrame.endEntry(false); // false - we did not finish the record.
             if (bytesAppended < firstHalfLength) {
                 // We filled out the frame.
@@ -165,7 +165,7 @@ public class DataFrameTests {
             // Append the second half of the record as one DataFrame Entry.
             dataFrame.startNewEntry(false); // false - this is not the first entry for the record.
             int secondHalfLength = record.getLength() - firstHalfLength;
-            bytesAppended = dataFrame.append(record.subSegment(firstHalfLength, secondHalfLength));
+            bytesAppended = dataFrame.append(record.slice(firstHalfLength, secondHalfLength));
             fullRecordsAppended += bytesAppended;
             if (bytesAppended < secondHalfLength) {
                 // We filled out the frame.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
@@ -116,7 +116,7 @@ class SegmentMock implements DirectSegmentAccess {
         }
 
         // We get a slice of the data view, and return a ReadResultMock with entry lengths of 3.
-        return new TruncateableReadResultMock(offset, dataView.subSegment((int) offset, dataView.getLength() - (int) offset), maxLength, 3);
+        return new TruncateableReadResultMock(offset, dataView.slice((int) offset, dataView.getLength() - (int) offset), maxLength, 3);
     }
 
     @Override

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/cache/BenchmarkTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/cache/BenchmarkTests.java
@@ -133,7 +133,7 @@ public class BenchmarkTests {
                     }
 
                     if (insert) {
-                        int insertedId = s.insert(writeBuffer.subSegment(0, length));
+                        int insertedId = s.insert(writeBuffer.slice(0, length));
                         synchronized (ids) {
                             ids.add(insertedId);
                         }


### PR DESCRIPTION
Signed-off-by: co-jo <Colin.Hryniowski@emc.com>

**Change log description**  

* Search and replace instances of `ByteArraySegment.subSegment` with its `.slice` method.
* Rename some test methods to reflect this replacement.

**Purpose of the change**  
* Closes #4318 

**What the code does**  
* No logic changes; a straightforward search and replace operation.
