### PR TITLE
Issue 4543: Change pravega version to 0.6.3-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.6.2
+pravegaVersion=0.6.3-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Change pravega version to 0.6.3-SNAPSHOT in gradle.properties

**Purpose of the change**  
Fixes #4543 

**What the code does**  
Changes pravega version to 0.6.3-SNAPSHOT in gradle.properties

**How to verify it**  
new artifacts should be produced with 0.6.3-SNAPSHOT