### PR TITLE
Issue 4549: Removed the default git-clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
+git:
+  depth: false
 language: java
 install: true
 jdk:

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,6 @@ allprojects {
         }
     }
     version = getProjectVersion()
-    println "version is:" + version
     group = "io.pravega"
 
     configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ allprojects {
         }
     }
     version = getProjectVersion()
+    println "version is:" + version
     group = "io.pravega"
 
     configurations.all {


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@emc.com>

**Change log description**  
On Travis CI the default behaviour is to use a clone-depth of 50. Due to that pravega build version is coming as `0.6.0-50.23b7340-SNAPSHOT` instead of `0.6.0-2386.23b7340-SNAPSHOT`
**Purpose of the change**  
 Fixes #4549 

**What the code does**  
Remove the default git clone depth

**How to verify it**  
Build version is coming fine
