### PR TITLE
Issue 3961: Prune Idle connections

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/ConnectionPoolImpl.java
@@ -77,7 +77,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
     static {
         // The default caching policy for name lookup cache is -1 which is forever.
         // Change this configuration to 60 seconds.
-        java.security.Security.setProperty("networkaddress.cache.ttl" , "60");
+        java.security.Security.setProperty("networkaddress.cache.ttl", "60");
     }
     private static final Comparator<Connection> COMPARATOR = new Comparator<Connection>() {
         @Override
@@ -328,7 +328,6 @@ public class ConnectionPoolImpl implements ConnectionPool {
             // Shut down the event loop to terminate all threads.
             group.shutdownGracefully();
             metricNotifier.close();
-
         }
     }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/PravegaNodeUri.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/PravegaNodeUri.java
@@ -13,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.InetAddress;
@@ -35,19 +34,18 @@ public class PravegaNodeUri {
         this.ipAddress = getInetAddress(endpoint);
     }
 
-    @SneakyThrows(UnknownHostException.class)
     private InetAddress getInetAddress(String endpoint) {
         try {
             return InetAddress.getByName(endpoint);
         } catch (UnknownHostException e) {
             log.error("Unable to to fetch IP address for endpoint {}", endpoint, e);
-            throw e;
+            return null;
         }
     }
 
     public boolean isModified() {
         InetAddress currentIPAddress = getInetAddress(this.endpoint);
-        if (currentIPAddress.equals(this.ipAddress)) {
+        if (currentIPAddress != null && currentIPAddress.equals(this.ipAddress)) {
             return false;
         } else {
             log.warn("IP address of node : {} has changed to {}", this, currentIPAddress);


### PR DESCRIPTION
**Change log description**  
- Prune connections which now point to an invalid IP address.
- Prune connections that are idle.

**Purpose of the change**  
Fixes #3961 

**What the code does**  
This PR periodically prunes connections from the connection pool that satisfy the following conditions

1. Connections that are idle.
2. If connections pointing to a docker container does not terminate even after the docker container has been assigned a newer IP the requests will be sent to the older IP address. This is possible in scenarios where the client is behind a proxy or load balancing layer. 
The current code attempts to do a DNS lookup and verify if the IP Address of the container has changed. If there is a change then such connections are also closed.

**How to verify it**  
All the existing and newly added tests should pass.
