### PR TITLE
Added new healthcheck for zookeeper

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -223,7 +223,7 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
 
     // Default Health Check which uses netstat command to ensure the service is  up and running.
     List<String> defaultHealthCheck(int port) {
-        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep \"imok\" || exit 1");
+        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + "  || echo ruok | nc 127.0.0.1 " + port  + " 2> /dev/null | grep imok || exit 1");
     }
 
     //Custom Health check with the command provided by the service.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -223,7 +223,7 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
 
     // Default Health Check which uses netstat command to ensure the service is  up and running.
     List<String> defaultHealthCheck(int port) {
-        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep \"iamok\" || exit 1");
+        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep \"imok\" || exit 1");
     }
 
     //Custom Health check with the command provided by the service.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -223,7 +223,7 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
 
     // Default Health Check which uses netstat command to ensure the service is  up and running.
     List<String> defaultHealthCheck(int port) {
-        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || exit 1");
+        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep "iamok" || exit 1");
     }
 
     //Custom Health check with the command provided by the service.

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/docker/DockerBasedService.java
@@ -223,7 +223,7 @@ public abstract class DockerBasedService implements io.pravega.test.system.frame
 
     // Default Health Check which uses netstat command to ensure the service is  up and running.
     List<String> defaultHealthCheck(int port) {
-        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep "iamok" || exit 1");
+        return  customHealthCheck("netstat -ltn 2> /dev/null | grep " + port + " || ss -ltn 2> /dev/null | grep " +  port + " || echo ruok | nc 127.0.0.1 + port 2> /dev/null | grep \"iamok\" || exit 1");
     }
 
     //Custom Health check with the command provided by the service.


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@emc.com>

**Change log description**  
Added a new health check for zookeeper service

**Purpose of the change**  
Fixes #4338 

**What the code does**  
Added new health check `ruok` for zookeeper service. `netstat` got removed from `zookeeper:3.5.5` onwards.

**How to verify it**  
System tests should pass.
