### PR TITLE
Issue 4552: Reduce Javadoc errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -445,6 +445,13 @@ project('segmentstore:server:host') {
     applicationDistribution.into("bin") {
         from(createAppWithGCLogging)
     }
+
+    javadoc {
+        dependsOn delombok
+        source = delombok.outputDir
+        failOnError = false
+        options.addBooleanOption("Xdoclint:all,-reference,-missing", true)
+    }
 }
 
 project('test:integration') {

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -49,7 +49,7 @@ public interface ReaderGroupManager extends AutoCloseable {
      * Creates a new ReaderGroup.
      *
      * Readers will be able to join the group by calling
-     * {@link ClientFactory#createReader(String, String, Serializer, ReaderConfig)}
+     * {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}
      * . Once this is done they will start receiving events from the point defined in the config
      * passed here.
      * <p>

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -138,13 +138,11 @@ public class StreamManagerImpl implements StreamManager {
 
     /**
      * Fetch the {@link StreamInfo} for a given stream.
-     * Note: The access level of this method can be reduced once the deprecated method
-     * {@link io.pravega.client.batch.BatchClient#getStreamInfo(Stream)} is removed.
      *
      * @param stream The Stream.
      * @return A future representing {@link StreamInfo}.
      */
-    public CompletableFuture<StreamInfo> getStreamInfo(final Stream stream) {
+    private CompletableFuture<StreamInfo> getStreamInfo(final Stream stream) {
         //Fetch the stream cut representing the current TAIL and current HEAD of the stream.
         CompletableFuture<StreamCut> currentTailStreamCut = streamCutHelper.fetchTailStreamCut(stream);
         CompletableFuture<StreamCut> currentHeadStreamCut = streamCutHelper.fetchHeadStreamCut(stream);

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * to only one reader.
  *
  * The readers in the group may change over time. Readers are added to the group by calling
- * {@link ClientFactory#createReader(String, String, Serializer, ReaderConfig)} and are removed by
+ * {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)} and are removed by
  * calling {@link #readerOffline(String, Position)}
  */
 public interface ReaderGroup extends ReaderGroupNotificationListener, AutoCloseable {
@@ -83,7 +83,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
      * <p>- To reset a reader group to a given StreamCut use
      * {@link ReaderGroupConfig.ReaderGroupConfigBuilder#startFromStreamCuts(Map)}.</p>
      *
-     * All existing readers will have to call {@link ClientFactory#createReader(String, String, Serializer, ReaderConfig)}.
+     * All existing readers will have to call {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}.
      * If they continue to read events they will eventually encounter an {@link ReinitializationRequiredException} .
      *
      * @param config The new configuration for the ReaderGroup.
@@ -106,7 +106,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
 
     /**
      * Returns a set of readerIds for the readers that are considered to be online by the group.
-     * i.e. {@link ClientFactory#createReader(String, String, Serializer, ReaderConfig)} was called but
+     * i.e. {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)} was called but
      * {@link #readerOffline(String, Position)} was not called subsequently.
      *
      * @return Set of active reader IDs of the group

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -22,8 +22,8 @@ import java.util.concurrent.ScheduledExecutorService;
  * to only one reader.
  *
  * The readers in the group may change over time. Readers are added to the group by calling
- * {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)} and are removed by
- * calling {@link #readerOffline(String, Position)}
+ * {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}
+ * and are removed by calling {@link #readerOffline(String, Position)}
  */
 public interface ReaderGroup extends ReaderGroupNotificationListener, AutoCloseable {
 
@@ -83,7 +83,8 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
      * <p>- To reset a reader group to a given StreamCut use
      * {@link ReaderGroupConfig.ReaderGroupConfigBuilder#startFromStreamCuts(Map)}.</p>
      *
-     * All existing readers will have to call {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}.
+     * All existing readers will have to call
+     * {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}.
      * If they continue to read events they will eventually encounter an {@link ReinitializationRequiredException} .
      *
      * @param config The new configuration for the ReaderGroup.
@@ -106,8 +107,8 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
 
     /**
      * Returns a set of readerIds for the readers that are considered to be online by the group.
-     * i.e. {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)} was called but
-     * {@link #readerOffline(String, Position)} was not called subsequently.
+     * i.e. {@link io.pravega.client.EventStreamClientFactory#createReader(String, String, Serializer, ReaderConfig)}
+     * was called but {@link #readerOffline(String, Position)} was not called subsequently.
      *
      * @return Set of active reader IDs of the group
      */

--- a/client/src/main/java/io/pravega/client/stream/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Controller.java
@@ -300,7 +300,7 @@ public interface Controller extends AutoCloseable {
      * This is called by writers via {@link EventStreamWriter#noteTime(long)} or
      * {@link Transaction#commit(long)}. The controller should aggrigate this information and write
      * it to the stream's marks segment so that it read by readers who will in turn ultimately
-     * surface this information through the {@link EventStreamReader#getCurrentTimeWindow()} API.
+     * surface this information through the {@link EventStreamReader#getCurrentTimeWindow(Stream)} API.
      * 
      * @param writer The name of the writer. (User defined)
      * @param stream The stream the timestamp is associated with.

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -53,14 +53,14 @@ import static io.pravega.common.concurrent.Futures.getAndHandleExceptions;
  * method is called no other methods should be called on this class.
  * 
  * This class updates makes transitions using the {@link ReaderGroupState} object. If there are available
- * segments a reader can acquire them by calling {@link #acquireNewSegmentsIfNeeded(long)}.
+ * segments a reader can acquire them by calling {@link #acquireNewSegmentsIfNeeded(long, Position)}.
  * 
  * To balance load across multiple readers a reader can release segments so that other readers can acquire
- * them by calling {@link #releaseSegment(Segment, long, long)}. A reader can tell if calling this method is
+ * them by calling {@link #releaseSegment(Segment, long, long, Position)}. A reader can tell if calling this method is
  * needed by calling {@link #findSegmentToReleaseIfRequired()}
  * 
  * Finally when a segment is sealed it may have one or more successors. So when a reader comes to the end of a
- * segment it should call {@link #handleEndOfSegment(Segment)} so that it can continue reading from the
+ * segment it should call {@link #handleEndOfSegment(SegmentWithRange)} so that it can continue reading from the
  * successor to that segment.
  */
 @Slf4j
@@ -279,8 +279,8 @@ public class ReaderGroupStateManager {
 
     /**
      * If there are unassigned segments and this host has not acquired one in a while, acquires them.
-     * @param lagTime the time between the reader's current location and the end of the stream
-     * @param Position the last position read by the reader.
+     * @param timeLag the time between the reader's current location and the end of the stream
+     * @param position the last position read by the reader.
      * @return A map from the new segment that was acquired to the offset to begin reading from within the segment.
      */
     Map<SegmentWithRange, Long> acquireNewSegmentsIfNeeded(long timeLag, Position position) throws ReaderNotInReaderGroupException {

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -37,9 +37,9 @@ public interface TableSegment<KeyT, ValueT> extends AutoCloseable {
 
     /**
      * Inserts or updates an existing Table Entry into this Table Segment.
-     * @param entry The Entry to insert or update. If {@link TableEntry#getKey()}#getVersion() is null, this will perform
-     *              an Unconditional Update, otherwise it will perform a Conditional Update based on the information
-     *              provided. See {@link TableSegment} doc for more details on Types of Updates.
+     * @param entry The Entry to insert or update. If {@link TableEntry#getKey()}{@link TableKey#getVersion()} is null,
+     *              this will perform an Unconditional Update, otherwise it will perform a Conditional Update
+     *              based on the information provided. See {@link TableSegment} doc for more details on Types of Updates.
      * @return A CompletableFuture that, when completed, will contain the {@link KeyVersion} associated with the newly
      * inserted or updated entry. Notable exceptions:
      * <ul>
@@ -52,9 +52,10 @@ public interface TableSegment<KeyT, ValueT> extends AutoCloseable {
      * Inserts new or updates existing Table Entries into this Table Segment.
      *
      * @param entries A Collection of entries to insert or update. If for at least one such entry,
-     *                {@link TableEntry#getKey()}#getVersion() returns a non-null value, this will perform an atomic
-     *                Conditional Update where all the entries either get applied or none will; otherwise a Unconditional
-     *                Update will be performed. See {@link TableSegment} doc for more details on Types of Updates.
+     *                {@link TableEntry#getKey()}{@link TableKey#getVersion()} returns a non-null value,
+     *                this will perform an atomic Conditional Update where all the entries either get applied or
+     *                none will; otherwise a Unconditional Update will be performed.
+     *                See {@link TableSegment} doc for more details on Types of Updates.
      * @return A CompletableFuture that, when completed, will contain a map of {@link KeyT} to {@link KeyVersion} which
      * represents the versions for the inserted/updated keys. Notable exceptions:
      * <ul>

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -37,7 +37,7 @@ public interface TableSegment<KeyT, ValueT> extends AutoCloseable {
 
     /**
      * Inserts or updates an existing Table Entry into this Table Segment.
-     * @param entry The Entry to insert or update. If {@link TableEntry#getKey()#getVersion()} is null, this will perform
+     * @param entry The Entry to insert or update. If {@link TableEntry#getKey()}#getVersion() is null, this will perform
      *              an Unconditional Update, otherwise it will perform a Conditional Update based on the information
      *              provided. See {@link TableSegment} doc for more details on Types of Updates.
      * @return A CompletableFuture that, when completed, will contain the {@link KeyVersion} associated with the newly
@@ -52,7 +52,7 @@ public interface TableSegment<KeyT, ValueT> extends AutoCloseable {
      * Inserts new or updates existing Table Entries into this Table Segment.
      *
      * @param entries A Collection of entries to insert or update. If for at least one such entry,
-     *                {@link TableEntry#getKey()#getVersion()} returns a non-null value, this will perform an atomic
+     *                {@link TableEntry#getKey()}#getVersion() returns a non-null value, this will perform an atomic
      *                Conditional Update where all the entries either get applied or none will; otherwise a Unconditional
      *                Update will be performed. See {@link TableSegment} doc for more details on Types of Updates.
      * @return A CompletableFuture that, when completed, will contain a map of {@link KeyT} to {@link KeyVersion} which

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -63,8 +63,8 @@ public interface RevisionDataOutput extends DataOutput {
     int UUID_BYTES = 2 * Long.BYTES;
 
     /**
-     * Gets a value indicating whether this instance of a RevisionDataOutput requires {@link #length} to be called prior to writing
-     * anything to it.
+     * Gets a value indicating whether this instance of a RevisionDataOutput requires {@link #length} to be called
+     * prior to writing anything to it.
      *
      * @return True if Length must be declared beforehand (by invoking length()) or not.
      */

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -28,7 +28,7 @@ import java.util.function.ToIntFunction;
  */
 public interface RevisionDataOutput extends DataOutput {
     /**
-     * Maximum value that can be encoded using {@link #writeCompactLong).
+     * Maximum value that can be encoded using {@link #writeCompactLong}.
      */
     long COMPACT_LONG_MAX = 0x3FFF_FFFF_FFFF_FFFFL - 1;
 
@@ -63,7 +63,7 @@ public interface RevisionDataOutput extends DataOutput {
     int UUID_BYTES = 2 * Long.BYTES;
 
     /**
-     * Gets a value indicating whether this instance of a RevisionDataOutput requires {@link #length) to be called prior to writing
+     * Gets a value indicating whether this instance of a RevisionDataOutput requires {@link #length} to be called prior to writing
      * anything to it.
      *
      * @return True if Length must be declared beforehand (by invoking length()) or not.

--- a/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
@@ -52,8 +52,8 @@ import java.util.Map;
  * * Are incremental on top of the previous ones, can be added on the fly, and can be used to make format changes
  * without breaking backward or forward compatibility.
  * * Older code will read as many revisions as it knows about, so even if newer code encodes B revisions, older code that
- * only knows about A < B revisions will only read the first A revisions, ignoring the rest. Similarly, newer code that
- * knows about B revisions will be able to handle A < B revisions by reading as much as is available.
+ * only knows about {@literal A < B} revisions will only read the first A revisions, ignoring the rest. Similarly, newer code that
+ * knows about B revisions will be able to handle {@literal A < B} revisions by reading as much as is available.
  * ** It is the responsibility of the calling code to fill-in-the-blanks for newly added fields in revisions &gt; A.
  * * Once published, the format for a Version-Revision should never change, otherwise existing (older) code will not be
  * able to process that serialization.
@@ -420,7 +420,7 @@ public abstract class VersionedSerializer<T> {
      * <code>
      * class Segment { ... }
      *
-     * class SegmentSerializer extends VersionedSerializer.Direct<Segment> {
+     * class SegmentSerializer extends VersionedSerializer.Direct{@literal <Segment>} {
      *    // This is the version we'll be serializing now. We have already introduced read support for Version 1, but
      *    // we cannot write into Version 1 until we know that all deployed code knows how to read it. In order to guarantee
      *    // a successful upgrade when changing Versions, all existing code needs to know how to read the new version.
@@ -481,10 +481,10 @@ public abstract class VersionedSerializer<T> {
      *    private final Long lastUsed;
      *
      *    // Attribute class is immutable; it has a builder that helps create new instances (this can be generated with Lombok).
-     *    static class AttributeBuilder implements ObjectBuilder<Attribute> { ... }
+     *    static class AttributeBuilder implements ObjectBuilder{@literal <Attribute>} { ... }
      * }
      *
-     * class AttributeSerializer extends VersionedSerializer.WithBuilder<Attribute, Attribute.AttributeBuilder> {
+     * class AttributeSerializer extends VersionedSerializer.WithBuilder{@literal <Attribute, Attribute.AttributeBuilder>} {
      *    {@literal @}Override
      *    protected byte getWriteVersion() { return 0; } // Version we're serializing at.
      *
@@ -596,21 +596,21 @@ public abstract class VersionedSerializer<T> {
      * class BaseType { ... }
      *
      * class SubType1 extends BaseType {
-     *     static class SubType1Builder implements ObjectBuilder<SubType1> { ... }
-     *     static class SubType1Serializer extends VersionedSerializer.WithBuilder<SubType1, SubType1Builder> { ... }
+     *     static class SubType1Builder implements ObjectBuilder{@literal <SubType1>} { ... }
+     *     static class SubType1Serializer extends VersionedSerializer.WithBuilder{@literal <SubType1, SubType1Builder>} { ... }
      * }
      *
      * class SubType11 extends SubType1 {
-     *     static class SubType11Builder implements ObjectBuilder<SubType11> { ... }
-     *     static class SubType11Serializer extends VersionedSerializer.WithBuilder<SubType11, SubType11Builder> { ... }
+     *     static class SubType11Builder implements ObjectBuilder{@literal <SubType11>} { ... }
+     *     static class SubType11Serializer extends VersionedSerializer.WithBuilder{@literal <SubType11, SubType11Builder>} { ... }
      * }
      *
      * class SubType2 extends BaseType {
-     *     static class SubType2Builder implements ObjectBuilder<SubType2> { ... }
-     *     static class SubType2Serializer extends VersionedSerializer.WithBuilder<SubType2, SubType2Builder> { ... }
+     *     static class SubType2Builder implements ObjectBuilder{@literal <SubType2>} { ... }
+     *     static class SubType2Serializer extends VersionedSerializer.WithBuilder{@literal <SubType2, SubType2Builder>} { ... }
      * }
      *
-     * class BaseTypeSerializer extends VersionedSerializer.MultiType<BaseType> {
+     * class BaseTypeSerializer extends VersionedSerializer.MultiType{@literal <BaseType>} {
      *    {@literal @}Override
      *    protected void declareSerializers(Builder b) {
      *        // Declare sub-serializers here. IDs must be unique, non-changeable (during refactoring) and not necessarily

--- a/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/VersionedSerializer.java
@@ -52,8 +52,9 @@ import java.util.Map;
  * * Are incremental on top of the previous ones, can be added on the fly, and can be used to make format changes
  * without breaking backward or forward compatibility.
  * * Older code will read as many revisions as it knows about, so even if newer code encodes B revisions, older code that
- * only knows about {@literal A < B} revisions will only read the first A revisions, ignoring the rest. Similarly, newer code that
- * knows about B revisions will be able to handle {@literal A < B} revisions by reading as much as is available.
+ * only knows about {@literal A < B} revisions will only read the first A revisions, ignoring the rest. Similarly,
+ * newer code that knows about B revisions will be able to handle {@literal A < B} revisions by reading
+ * as much as is available.
  * ** It is the responsibility of the calling code to fill-in-the-blanks for newly added fields in revisions &gt; A.
  * * Once published, the format for a Version-Revision should never change, otherwise existing (older) code will not be
  * able to process that serialization.
@@ -420,7 +421,7 @@ public abstract class VersionedSerializer<T> {
      * <code>
      * class Segment { ... }
      *
-     * class SegmentSerializer extends VersionedSerializer.Direct{@literal <Segment>} {
+     * class SegmentSerializer extends VersionedSerializer.Direct{@code <Segment>} {
      *    // This is the version we'll be serializing now. We have already introduced read support for Version 1, but
      *    // we cannot write into Version 1 until we know that all deployed code knows how to read it. In order to guarantee
      *    // a successful upgrade when changing Versions, all existing code needs to know how to read the new version.
@@ -481,10 +482,10 @@ public abstract class VersionedSerializer<T> {
      *    private final Long lastUsed;
      *
      *    // Attribute class is immutable; it has a builder that helps create new instances (this can be generated with Lombok).
-     *    static class AttributeBuilder implements ObjectBuilder{@literal <Attribute>} { ... }
+     *    static class AttributeBuilder implements ObjectBuilder{@code <Attribute>} { ... }
      * }
      *
-     * class AttributeSerializer extends VersionedSerializer.WithBuilder{@literal <Attribute, Attribute.AttributeBuilder>} {
+     * class AttributeSerializer extends VersionedSerializer.WithBuilder{@code <Attribute, Attribute.AttributeBuilder>} {
      *    {@literal @}Override
      *    protected byte getWriteVersion() { return 0; } // Version we're serializing at.
      *
@@ -596,21 +597,21 @@ public abstract class VersionedSerializer<T> {
      * class BaseType { ... }
      *
      * class SubType1 extends BaseType {
-     *     static class SubType1Builder implements ObjectBuilder{@literal <SubType1>} { ... }
-     *     static class SubType1Serializer extends VersionedSerializer.WithBuilder{@literal <SubType1, SubType1Builder>} { ... }
+     *     static class SubType1Builder implements ObjectBuilder{@code <SubType1>} { ... }
+     *     static class SubType1Serializer extends VersionedSerializer.WithBuilder{@code <SubType1, SubType1Builder>} { ... }
      * }
      *
      * class SubType11 extends SubType1 {
-     *     static class SubType11Builder implements ObjectBuilder{@literal <SubType11>} { ... }
-     *     static class SubType11Serializer extends VersionedSerializer.WithBuilder{@literal <SubType11, SubType11Builder>} { ... }
+     *     static class SubType11Builder implements ObjectBuilder{@code <SubType11>} { ... }
+     *     static class SubType11Serializer extends VersionedSerializer.WithBuilder{@code <SubType11, SubType11Builder>} { ... }
      * }
      *
      * class SubType2 extends BaseType {
-     *     static class SubType2Builder implements ObjectBuilder{@literal <SubType2>} { ... }
-     *     static class SubType2Serializer extends VersionedSerializer.WithBuilder{@literal <SubType2, SubType2Builder>} { ... }
+     *     static class SubType2Builder implements ObjectBuilder{@code <SubType2>} { ... }
+     *     static class SubType2Serializer extends VersionedSerializer.WithBuilder{@code <SubType2, SubType2Builder>} { ... }
      * }
      *
-     * class BaseTypeSerializer extends VersionedSerializer.MultiType{@literal <BaseType>} {
+     * class BaseTypeSerializer extends VersionedSerializer.MultiType{@code <BaseType>} {
      *    {@literal @}Override
      *    protected void declareSerializers(Builder b) {
      *        // Declare sub-serializers here. IDs must be unique, non-changeable (during refactoring) and not necessarily

--- a/common/src/main/java/io/pravega/common/util/BufferedIterator.java
+++ b/common/src/main/java/io/pravega/common/util/BufferedIterator.java
@@ -43,7 +43,7 @@ public class BufferedIterator<T> implements Iterator<T> {
      * @param getItemRange A {@link BiFunction} that returns a range of items that will be buffered next. The first
      *                     argument is the first index to fetch (inclusive) and the second argument is the last index to
      *                     fetch (inclusive). This method will always be invoked in sequence with non-overlapping ranges.
-     *                     This method will never be passed invalid args (Arg1 > Arg 2) and it should never return an empty
+     *                     This method will never be passed invalid args {@literal (Arg1 > Arg2)} and it should never return an empty
      *                     iterator.
      * @param firstIndex   The index of the first item to return (inclusive).
      * @param lastIndex    The index of the last item to return (inclusive).

--- a/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
+++ b/common/src/main/java/io/pravega/common/util/btree/ByteArrayComparator.java
@@ -30,7 +30,7 @@ import java.util.Comparator;
  *
  * For example:
  * - Consider any two Longs L1 and L2.
- * - Let S1 be the result of {@link BitConverter#writeUnsignedLong) when applied to L1, and S2 the result when applied to L2.
+ * - Let S1 be the result of {@link BitConverter#writeUnsignedLong} when applied to L1, and S2 the result when applied to L2.
  * - Then {@link Long#compare} applied to (L1, L2) is equal to {@link ByteArrayComparator#compare} applied to (S1, S2).
  * - This equality would not hold should L1 and L2 be serialized using {@link BitConverter#writeLong} or if we used plain
  * (signed) byte comparison internall.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -207,8 +207,8 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
      * Same as {@link #applyCachePolicyInternal()}, but this is safe for concurrent invocation and handles all exceptions by
      * logging them.
      *
-     * We must ensure that no two invocations of the {@link #applyCachePolicyInternal()) execute at the same time. It performs
-     * a good amount of state checking and updating, and concurrent calls would corrupt the internal state of the {@link CacheManager).
+     * We must ensure that no two invocations of the {@link #applyCachePolicyInternal()} execute at the same time. It performs
+     * a good amount of state checking and updating, and concurrent calls would corrupt the internal state of the {@link CacheManager}.
      *
      * Under normal operating conditions, the only method invoking this is {@link #runOneIteration()} which is guaranteed
      * to execute only once at a time. Concurrent invocations come from {@link #cacheFullCallback()} which are triggered

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DirectSegmentAccess.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DirectSegmentAccess.java
@@ -36,7 +36,7 @@ public interface DirectSegmentAccess {
      * Appends a range of bytes at the end of the Segment and atomically updates the given attributes. The byte range
      * will be appended as a contiguous block, however there is no guarantee of ordering between different calls to this
      * method.
-     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#append(String, byte[], Collection, Duration)
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#append(String, BufferView, Collection, Duration)
      *
      * @param data             The data to add.
      * @param attributeUpdates A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
@@ -54,7 +54,7 @@ public interface DirectSegmentAccess {
     /**
      * Performs an attribute update operation on the Segment.
      *
-     *  @see StreamSegmentStore#append(String, byte[], Collection, Duration).
+     *  @see io.pravega.segmentstore.contracts.StreamSegmentStore#append(String, BufferView, Collection, Duration)
      *
      * @param attributeUpdates A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
      *                         See Notes about AttributeUpdates in the interface Javadoc.
@@ -69,7 +69,7 @@ public interface DirectSegmentAccess {
 
     /**
      * Gets the values of the given Attributes (Core or Extended).
-     * @see StreamSegmentStore#getAttributes(String, Collection, boolean, Duration).
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#getAttributes(String, Collection, boolean, Duration)
      *
      * @param attributeIds A Collection of Attribute Ids to fetch. These may be Core or Extended Attributes.
      * @param cache        If set, then any Extended Attribute values that are not already in the in-memory Segment
@@ -87,7 +87,7 @@ public interface DirectSegmentAccess {
 
     /**
      * Initiates a Read operation on the Segment and returns a ReadResult which can be used to consume the read data.
-     * @see StreamSegmentStore#read(String, long, int, Duration).
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#read(String, long, int, Duration)
      *
      * @param offset    The offset within the Segment to start reading at.
      * @param maxLength The maximum number of bytes to read.
@@ -100,7 +100,7 @@ public interface DirectSegmentAccess {
 
     /**
      * Gets information about the Segment.
-     * @see StreamSegmentStore#getStreamSegmentInfo(String, boolean, Duration).
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#getStreamSegmentInfo(String, Duration)
      *
      * @return The requested Segment Info. Note that this result will only contain those attributes that
      * are loaded in memory (if any) or Core Attributes. To ensure that Extended Attributes are also included, you must use
@@ -111,7 +111,7 @@ public interface DirectSegmentAccess {
 
     /**
      * Seals the Segment.
-     * @see StreamSegmentStore#sealStreamSegment(String, Duration).
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#sealStreamSegment(String, Duration)
      *
      * @param timeout Timeout for the operation
      * @return A CompletableFuture that, when completed normally, will contain the final length of the Segment.
@@ -122,7 +122,7 @@ public interface DirectSegmentAccess {
 
     /**
      * Truncates the Segment at a given offset.
-     * @see StreamSegmentStore#truncateStreamSegment(String, long, Duration).
+     * @see io.pravega.segmentstore.contracts.StreamSegmentStore#truncateStreamSegment(String, long, Duration)
      *
      * @param offset  The offset at which to truncate. This must be at least equal to the existing truncation
      *                offset and no larger than the Segment's length. After the operation is complete,

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -100,7 +100,7 @@ public interface SegmentMetadata extends SegmentProperties {
      *
      * Notes on concurrency:
      * - All retrieval methods are thread-safe and can be invoked from any context.
-     * - Iterating over this Map's elements ({@link Map#keySet(), {@link Map#values()}, {@link Map#entrySet()}) is not
+     * - Iterating over this Map's elements ({@link Map#keySet()}, {@link Map#values()}, {@link Map#entrySet()}) is not
      * thread safe and should only be done in an (external) synchronized context (while holding the same lock that is
      * used to update this {@link SegmentMetadata} instance).
      * - Consider using {@link #getSnapshot()} if you need a thread-safe way of iterating over the current set of Attributes.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilderConfig.java
@@ -111,7 +111,7 @@ public class ServiceBuilderConfig {
 
     /**
      * Represents a Builder for the ServiceBuilderConfig.
-     * @return The new instance of a Configuration.
+     * Returns the new instance of a Configuration.
      */
     public static class Builder {
         private final Properties properties;

--- a/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
+++ b/shared/authplugin/src/main/java/io/pravega/auth/AuthHandler.java
@@ -14,7 +14,7 @@ import java.security.Principal;
 /**
  * Custom authorization/authentication handlers implement this interface.
  * The implementations are loaded from the classpath using `ServiceLoader` (https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html)
- * Pravega controller also implements this interface through {@link io.pravega.controller.server.rpc.auth.PasswordAuthHandler}.
+ * Pravega controller also implements this interface through {@code io.pravega.controller.server.rpc.auth.PasswordAuthHandler}.
  *
  * Each custom auth handler is registered with a unique name identifying a supported authentication scheme.
  *

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -341,7 +341,7 @@ public final class NameUtils {
 
     /**
      * Method to generate Fully Qualified table name using scope, and other tokens to be used to compose the table name.
-     * The composed name has following format \<scope\>/_tables/\<tokens[0]\>/\<tokens[1]\>...
+     * The composed name has following format {@literal <scope>/_tables/<tokens[0]>/<tokens[1]>...}
      * 
      * @param scope scope in which table segment to create
      * @param tokens tokens used for composing table segment name

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -341,7 +341,7 @@ public final class NameUtils {
 
     /**
      * Method to generate Fully Qualified table name using scope, and other tokens to be used to compose the table name.
-     * The composed name has following format {@literal <scope>/_tables/<tokens[0]>/<tokens[1]>...}
+     * The composed name has following format: {@literal <scope>/_tables/<tokens[0]>/<tokens[1]>...}
      * 
      * @param scope scope in which table segment to create
      * @param tokens tokens used for composing table segment name

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -318,7 +318,7 @@ public class AssertExtensions {
     }
 
     /**
-     * Asserts that actual < expected.
+     * Asserts that actual {@literal <} expected.
      *
      * @param message  The message to include in the Assert calls.
      * @param expected The larger value.
@@ -329,7 +329,7 @@ public class AssertExtensions {
     }
 
     /**
-     * Asserts that actual <= expected.
+     * Asserts that actual {@literal <=} expected.
      *
      * @param message  The message to include in the Assert calls.
      * @param expected The larger value.
@@ -340,7 +340,7 @@ public class AssertExtensions {
     }
 
     /**
-     * Asserts that actual > expected.
+     * Asserts that actual {@literal >} expected.
      *
      * @param message  The message to include in the Assert calls.
      * @param expected The smaller value.
@@ -351,7 +351,7 @@ public class AssertExtensions {
     }
 
     /**
-     * Asserts that actual >= expected.
+     * Asserts that actual {@literal >=} expected.
      *
      * @param message  The message to include in the Assert calls.
      * @param expected The smaller value.


### PR DESCRIPTION
Signed-off-by: Bibin Sebastian <bibinvamattathil@gmail.com>

**Change log description**  
Fixing Javadoc errors

**Purpose of the change**  
Fixes #4552 

**What the code does**  
No code changes. 
- Multiple method syntax fixes in javadocs comments
- Multiple javadoc tag syntax fixes
- Multiple changes to format code snippets

**How to verify it**  
run `./gradlew clean build -x test` or `./gradlew clean javadoc` 
you shouldn't see any error in javadoc generation step.