### PR TITLE
Issue 4558: Low single segment write performance

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -388,6 +388,11 @@ metrics.enableStatistics=false
 # please refer to: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
 #bookkeeper.networkTopologyScriptFileName=/opt/pravega/scripts/sample-bookkeeper-topology.sh
 
+# Configure the digest type for messages sent to Bookkeeper. Note that there is a relevant computational cost associated
+# to this option, which impacts on write throughput. Current options are: CRC32C (default), MAC, CRC32, DUMMY (no digest).
+# Please, see https://bookkeeper.apache.org/docs/latest/api/ledger-api/
+#bookkeeper.digestType=CRC32C
+
 ##endregion
 
 ##region HDFS Settings

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -49,7 +49,7 @@ public class BookKeeperConfig {
     public static final Property<Integer> BK_MIN_NUM_RACKS_PER_WRITE_QUORUM = Property.named("minNumRacksPerWriteQuorum", 2);
     public static final Property<String> BK_NETWORK_TOPOLOGY_SCRIPT_FILE_NAME = Property.named("networkTopologyScriptFileName",
             "/opt/pravega/scripts/sample-bookkeeper-topology.sh");
-    public static final Property<String> BK_DIGEST_TYPE = Property.named("digestType", "CRC32C");
+    public static final Property<String> BK_DIGEST_TYPE = Property.named("digestType", BookKeeper.DigestType.CRC32C.name());
 
     public static final String COMPONENT_CODE = "bookkeeper";
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfig.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import lombok.Getter;
+import org.apache.bookkeeper.client.BookKeeper;
 
 /**
  * General configuration for BookKeeper Client.
@@ -48,6 +49,7 @@ public class BookKeeperConfig {
     public static final Property<Integer> BK_MIN_NUM_RACKS_PER_WRITE_QUORUM = Property.named("minNumRacksPerWriteQuorum", 2);
     public static final Property<String> BK_NETWORK_TOPOLOGY_SCRIPT_FILE_NAME = Property.named("networkTopologyScriptFileName",
             "/opt/pravega/scripts/sample-bookkeeper-topology.sh");
+    public static final Property<String> BK_DIGEST_TYPE = Property.named("digestType", "CRC32C");
 
     public static final String COMPONENT_CODE = "bookkeeper";
     /**
@@ -172,6 +174,9 @@ public class BookKeeperConfig {
     @Getter
     private final String networkTopologyFileName;
 
+    @Getter
+    private final BookKeeper.DigestType digestType;
+
     //endregion
 
     //region Constructor
@@ -220,6 +225,8 @@ public class BookKeeperConfig {
         this.enforceMinNumRacksPerWriteQuorum = properties.getBoolean(BK_ENFORCE_MIN_NUM_RACKS_PER_WRITE);
         this.minNumRacksPerWriteQuorum = properties.getInt(BK_MIN_NUM_RACKS_PER_WRITE_QUORUM);
         this.networkTopologyFileName = properties.get(BK_NETWORK_TOPOLOGY_SCRIPT_FILE_NAME);
+
+        this.digestType = getDigestType(properties.get(BK_DIGEST_TYPE));
     }
 
     /**
@@ -236,6 +243,19 @@ public class BookKeeperConfig {
      */
     public static ConfigBuilder<BookKeeperConfig> builder() {
         return new ConfigBuilder<>(COMPONENT_CODE, BookKeeperConfig::new);
+    }
+
+    private BookKeeper.DigestType getDigestType(String digestType) {
+        if (digestType.equals(BookKeeper.DigestType.MAC.name())) {
+            return BookKeeper.DigestType.MAC;
+        } else if (digestType.equals(BookKeeper.DigestType.CRC32.name())) {
+            return BookKeeper.DigestType.CRC32;
+        } else if (digestType.equals(BookKeeper.DigestType.DUMMY.name())) {
+            return BookKeeper.DigestType.DUMMY;
+        } else {
+            // Default digest for performance reasons.
+            return BookKeeper.DigestType.CRC32C;
+        }
     }
 
     //endregion

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
@@ -31,7 +31,6 @@ final class Ledgers {
      * How many ledgers to fence out (from the end of the list) when acquiring lock.
      */
     static final int MIN_FENCE_LEDGER_COUNT = 2;
-    private static final BookKeeper.DigestType LEDGER_DIGEST_TYPE = BookKeeper.DigestType.MAC;
 
     /**
      * Creates a new Ledger in BookKeeper.
@@ -44,12 +43,13 @@ final class Ledgers {
      */
     static LedgerHandle create(BookKeeper bookKeeper, BookKeeperConfig config) throws DurableDataLogException {
         try {
+
             return Exceptions.handleInterruptedCall(() ->
                     bookKeeper.createLedger(
                             config.getBkEnsembleSize(),
                             config.getBkWriteQuorumSize(),
                             config.getBkAckQuorumSize(),
-                            LEDGER_DIGEST_TYPE,
+                            config.getDigestType(),
                             config.getBKPassword()));
         } catch (BKException.BKNotEnoughBookiesException bkEx) {
             throw new DataLogNotAvailableException("Unable to create new BookKeeper Ledger.", bkEx);
@@ -70,7 +70,7 @@ final class Ledgers {
     static LedgerHandle openFence(long ledgerId, BookKeeper bookKeeper, BookKeeperConfig config) throws DurableDataLogException {
         try {
             return Exceptions.handleInterruptedCall(
-                    () -> bookKeeper.openLedger(ledgerId, LEDGER_DIGEST_TYPE, config.getBKPassword()));
+                    () -> bookKeeper.openLedger(ledgerId, config.getDigestType(), config.getBKPassword()));
         } catch (BKException bkEx) {
             throw new DurableDataLogException(String.format("Unable to open-fence ledger %d.", ledgerId), bkEx);
         }
@@ -88,7 +88,7 @@ final class Ledgers {
     static LedgerHandle openRead(long ledgerId, BookKeeper bookKeeper, BookKeeperConfig config) throws DurableDataLogException {
         try {
             return Exceptions.handleInterruptedCall(
-                    () -> bookKeeper.openLedgerNoRecovery(ledgerId, LEDGER_DIGEST_TYPE, config.getBKPassword()));
+                    () -> bookKeeper.openLedgerNoRecovery(ledgerId, config.getDigestType(), config.getBKPassword()));
         } catch (BKException bkEx) {
             throw new DurableDataLogException(String.format("Unable to open-read ledger %d.", ledgerId), bkEx);
         }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperConfigTest.java
@@ -12,6 +12,8 @@ package io.pravega.segmentstore.storage.impl.bookkeeper;
 import io.pravega.common.util.InvalidPropertyValueException;
 import io.pravega.test.common.AssertExtensions;
 import java.time.Duration;
+
+import org.apache.bookkeeper.client.BookKeeper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -46,6 +48,7 @@ public class BookKeeperConfigTest {
         Assert.assertEquals(false, cfg.isEnforceMinNumRacksPerWriteQuorum());
         Assert.assertEquals(2, cfg.getMinNumRacksPerWriteQuorum());
         Assert.assertEquals("/opt/pravega/scripts/sample-bookkeeper-topology.sh", cfg.getNetworkTopologyFileName());
+        Assert.assertEquals(BookKeeper.DigestType.CRC32C, cfg.getDigestType());
     }
 
     @Test

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/BookKeeperAdapter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/BookKeeperAdapter.java
@@ -147,7 +147,7 @@ class BookKeeperAdapter extends StoreAdapter {
             boolean success = false;
             try {
                 ledger = getBookKeeper().createLedger(this.bkConfig.getBkEnsembleSize(), this.bkConfig.getBkWriteQuorumSize(), this.bkConfig.getBkAckQuorumSize(),
-                        BookKeeper.DigestType.MAC, new byte[0]);
+                        BookKeeper.DigestType.CRC32C, new byte[0]);
                 this.ledgers.put(logName, ledger);
                 success = true;
             } catch (Exception ex) {


### PR DESCRIPTION
**Change log description**  
Add configuration option for Bookkeeper digest type.

**Purpose of the change**  
Fixes #4558.

**What the code does**  
This PR enables us to configure the digest type used in Bookkeeper. The type of digest has an important impact on performance, so we have also changed the default one to `CRC32C` (formerly, it was `MAC`). Note that this change is reasonable, given that the `MAC` digest may protect from "byzantine Bookies", which may not be an expected adversarial model in many environments.

**How to verify it**  
We have observed a 2x throughput increase writing to a single ledger via the `SelfTester` tool on AWS just changing the digest type:

_MAC_
```
sudo ./gradlew clean selftest -Dtarget=BookKeeper -Dbkc=3 -Dc=1 -Ds=1 -Dp=10 -Dpp=10 -Dws=1000000 -Do=10000 -Dselftest.zkIp=10.0.0.193
0:00:47.073 [Reporter]: 10100/10000; Ops = 227/243; Data (P/T/C/S): 9632.1/0.0/0.0/0.0 MB; TPut: 217.4/232.0 MB/s; TPools (Q/T/S): S = ?/?/?, T = 0/1/80, FJ = 0/0/0.
0:00:47.074 [Reporter]: Operation Summary
0:00:47.074 [Reporter]:     Operation Type |   Count |  LAvg |   L50 |   L75 |   L90 |   L99 |  L999
0:00:47.074 [Reporter]:             Append |   10100 |   369 |   376 |   392 |   404 |   427 |   502
0:00:47.074 [SelfTest]: Finished successfully.
```
_CRC32C_
```
sudo ./gradlew clean selftest -Dtarget=BookKeeper -Dbkc=3 -Dc=1 -Ds=1 -Dp=10 -Dpp=10 -Dws=1000000 -Do=10000 -Dselftest.zkIp=10.0.0.193
0:00:28.489 [Reporter]: 10093/10000; Ops = 451/408; Data (P/T/C/S): 9625.4/0.0/0.0/0.0 MB; TPut: 430.5/389.6 MB/s; TPools (Q/T/S): S = ?/?/?, T = 0/1/80, FJ = 0/0/0.
0:00:28.489 [Reporter]: Operation Summary
0:00:28.489 [Reporter]:     Operation Type |   Count |  LAvg |   L50 |   L75 |   L90 |   L99 |  L999
0:00:28.490 [Reporter]:             Append |   10093 |   211 |   210 |   218 |   231 |   271 |   289
0:00:28.490 [SelfTest]: Finished successfully.
```
The rest of test should be working as before.