### PR TITLE
Issue 4561: Using S3 Rest Style Config URI for Extended S3 client construction

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -9,11 +9,13 @@
  */
 package io.pravega.storage.extendeds3;
 
+import com.emc.object.s3.S3Config;
+import com.emc.object.util.ConfigUri;
+import com.google.common.base.Preconditions;
 import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
-import java.net.URI;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,12 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 public class ExtendedS3StorageConfig {
     //region Config Names
 
-    public static final Property<String> PREFIX = Property.named("prefix", "/");
-    public static final Property<String> ACCESS_KEY_ID = Property.named("accessKey", "");
-    public static final Property<String> SECRET_KEY = Property.named("secretKey", "");
-    public static final Property<String> URI = Property.named("url", "");
+    public static final Property<String> CONFIGURI = Property.named("configUri", "");
     public static final Property<String> BUCKET = Property.named("bucket", "");
-    public static final Property<String> NAMESPACE = Property.named("namespace", ""); // use default namespace
+    public static final Property<String> PREFIX = Property.named("prefix", "/");
     public static final Property<Boolean> USENONEMATCH = Property.named("useNoneMatch", false);
 
     private static final String COMPONENT_CODE = "extendeds3";
@@ -40,11 +39,10 @@ public class ExtendedS3StorageConfig {
     //region Members
 
     /**
-     * Prefix of the Pravega owned EXTENDEDS3 path under the assigned buckets. All the objects under this path will be
-     * exclusively owned by Pravega.
+     *  The S3 complete client config of the EXTENDEDS3 REST interface
      */
     @Getter
-    private final String prefix;
+    private final S3Config s3Config;
 
     /**
      *  The EXTENDEDS3 access key id - this is equivalent to the user
@@ -53,16 +51,10 @@ public class ExtendedS3StorageConfig {
     private final String accessKey;
 
     /**
-     *  The EXTENDEDS3 secret key associated with the ACCESS_KEY_ID
+     *  The EXTENDEDS3 secret key associated with the accessKey
      */
     @Getter
     private final String secretKey;
-
-    /**
-     *  The end point of the EXTENDEDS3 REST interface
-     */
-    @Getter
-    private final URI url;
 
     /**
      *  A unique bucket name to store objects
@@ -71,10 +63,11 @@ public class ExtendedS3StorageConfig {
     private final String bucket;
 
     /**
-     *  The optional namespace within EXTENDEDS3 - leave blank to use the default namespace
+     * Prefix of the Pravega owned EXTENDEDS3 path under the assigned buckets. All the objects under this path will be
+     * exclusively owned by Pravega.
      */
     @Getter
-    private final String namespace;
+    private final String prefix;
 
     /**
      *
@@ -92,13 +85,13 @@ public class ExtendedS3StorageConfig {
      * @param properties The TypedProperties object to read Properties from.
      */
     private ExtendedS3StorageConfig(TypedProperties properties) throws ConfigurationException {
-        String givenPrefix = properties.get(PREFIX);
+        ConfigUri<S3Config> s3ConfigUri = new ConfigUri<S3Config>(S3Config.class);
+        this.s3Config = Preconditions.checkNotNull(s3ConfigUri.parseUri(properties.get(CONFIGURI)), "configUri");
+        this.accessKey = Preconditions.checkNotNull(s3Config.getIdentity(), "identity");
+        this.secretKey = Preconditions.checkNotNull(s3Config.getSecretKey(), "secretKey");
+        this.bucket = Preconditions.checkNotNull(properties.get(BUCKET), "bucket");
+        String givenPrefix = Preconditions.checkNotNull(properties.get(PREFIX), "prefix");
         this.prefix = givenPrefix.endsWith(PATH_SEPARATOR) ? givenPrefix : givenPrefix + PATH_SEPARATOR;
-        this.accessKey = properties.get(ACCESS_KEY_ID);
-        this.secretKey = properties.get(SECRET_KEY);
-        this.url = java.net.URI.create(properties.get(URI));
-        this.bucket = properties.get(BUCKET);
-        this.namespace = properties.get(NAMESPACE);
         this.useNoneMatch = properties.getBoolean(USENONEMATCH);
     }
 

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.storage.extendeds3;
 
-import com.emc.object.s3.S3Config;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
@@ -50,12 +49,7 @@ public class ExtendedS3StorageFactory implements StorageFactory {
     }
 
     private ExtendedS3Storage createS3Storage() {
-        S3Config s3Config = new S3Config(config.getUrl())
-                .withIdentity(config.getAccessKey())
-                .withSecretKey(config.getSecretKey())
-                .withNamespace(config.getNamespace());
-
-        S3JerseyClient client = new S3JerseyClient(s3Config);
+        S3JerseyClient client = new S3JerseyClient(config.getS3Config());
         return new ExtendedS3Storage(client, this.config);
     }
 }

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfigTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfigTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import io.pravega.common.util.ConfigBuilder;
+import io.pravega.common.util.Property;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExtendedS3StorageConfigTest {
+
+    @Test
+    public void testConstructS3Config() {
+        ConfigBuilder<ExtendedS3StorageConfig> builder = ExtendedS3StorageConfig.builder();
+        builder.with(Property.named("configUri"), "http://127.0.0.1:9020?namespace=sampleNamespace&identity=user&secretKey=password")
+                .with(Property.named("bucket"), "testBucket")
+                .with(Property.named("prefix"), "testPrefix");
+        ExtendedS3StorageConfig config = builder.build();
+        assertEquals("user", config.getAccessKey());
+        assertEquals("password", config.getSecretKey());
+        assertEquals("testBucket", config.getBucket());
+        assertEquals("testPrefix/", config.getPrefix());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testInvalidFormat() {
+        ConfigBuilder<ExtendedS3StorageConfig> builder = ExtendedS3StorageConfig.builder();
+        builder.with(Property.named("configUri"), "http://localhost:9020?namespace=sampleNamespace&identity=&secretKey=password")
+                .with(Property.named("bucket"), "testBucket")
+                .with(Property.named("prefix"), "testPrefix");
+        ExtendedS3StorageConfig config = builder.build();
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testMissingSecretKey() {
+        ConfigBuilder<ExtendedS3StorageConfig> builder = ExtendedS3StorageConfig.builder();
+        builder.with(Property.named("configUri"), "http://localhost:9020?namespace=sampleNamespace&identity=user")
+                .with(Property.named("bucket"), "testBucket")
+                .with(Property.named("prefix"), "testPrefix");
+        ExtendedS3StorageConfig config = builder.build();
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -14,6 +14,7 @@ import com.emc.object.s3.S3Config;
 import com.emc.object.s3.bean.ObjectKey;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.emc.object.s3.request.DeleteObjectsRequest;
+import com.emc.object.util.ConfigUri;
 import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.Property;
 import io.pravega.segmentstore.contracts.SegmentProperties;
@@ -29,7 +30,6 @@ import io.pravega.storage.IdempotentStorageTestBase;
 import io.pravega.test.common.TestUtils;
 
 import java.io.ByteArrayInputStream;
-import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -77,13 +77,12 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
     @Test
     public void testCreateIfNoneMatch() {
         val adapterConfig = ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, setup.configUri)
                 .with(ExtendedS3StorageConfig.BUCKET, setup.adapterConfig.getBucket())
-                                               .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
-                                               .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
-                                               .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
-                .with(ExtendedS3StorageConfig.URI, setup.endpoint)
-                                               .with(ExtendedS3StorageConfig.USENONEMATCH, true)
-                                               .build();
+                .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
+                .with(ExtendedS3StorageConfig.USENONEMATCH, true)
+                .build();
+
         String segmentName = "foo_open";
         try (Storage s = createStorage(setup.client, adapterConfig, executorService())) {
             s.initialize(DEFAULT_EPOCH);
@@ -99,14 +98,16 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
     public void testConfigForTrailingCharInPrefix() {
         // Missing trailing '/'
         ConfigBuilder<ExtendedS3StorageConfig> builder1 = ExtendedS3StorageConfig.builder();
-        builder1.with(Property.named("prefix"), "samplePrefix");
+        builder1.with(Property.named("configUri"), "http://127.0.0.1:9020?identity=x&secretKey=x")
+                .with(Property.named("prefix"), "samplePrefix");
         ExtendedS3StorageConfig config1 = builder1.build();
         assertTrue(config1.getPrefix().endsWith("/"));
         assertEquals("samplePrefix/", config1.getPrefix());
 
         // Not missing '/'
         ConfigBuilder<ExtendedS3StorageConfig> builder2 = ExtendedS3StorageConfig.builder();
-        builder2.with(Property.named("prefix"), "samplePrefix/");
+        builder2.with(Property.named("configUri"), "http://127.0.0.1:9020?identity=x&secretKey=x")
+                .with(Property.named("prefix"), "samplePrefix/");
         ExtendedS3StorageConfig config2 = builder2.build();
         assertTrue(config2.getPrefix().endsWith("/"));
         assertEquals("samplePrefix/", config2.getPrefix());
@@ -232,22 +233,18 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
         private final S3JerseyClient client;
         private final S3ImplBase s3Proxy;
         private final int port = TestUtils.getAvailableListenPort();
-        private final String endpoint = "http://127.0.0.1:" + port;
+        private final String configUri = "http://127.0.0.1:" + port + "?identity=x&secretKey=x";
         private final S3Config s3Config;
 
         TestContext() throws Exception {
             String bucketName = BUCKET_NAME_PREFIX + UUID.randomUUID().toString();
             this.adapterConfig = ExtendedS3StorageConfig.builder()
+                    .with(ExtendedS3StorageConfig.CONFIGURI, configUri)
                     .with(ExtendedS3StorageConfig.BUCKET, bucketName)
-                    .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
-                    .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
                     .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
-                    .with(ExtendedS3StorageConfig.URI, endpoint)
                     .build();
-            URI uri = URI.create(endpoint);
-            s3Config = new S3Config(uri)
-                    .withIdentity(adapterConfig.getAccessKey()).withSecretKey(adapterConfig.getSecretKey());
-            s3Proxy = new S3ProxyImpl(endpoint, s3Config);
+            s3Config = new ConfigUri<>(S3Config.class).parseUri(configUri);
+            s3Proxy = new S3ProxyImpl(configUri, s3Config);
             s3Proxy.start();
             client = new S3JerseyClientWrapper(s3Config, s3Proxy);
             client.createBucket(bucketName);

--- a/config/config.properties
+++ b/config/config.properties
@@ -429,7 +429,7 @@ hdfs.hdfsUrl=localhost:9000
 
 # URI to specify the complete extended S3 client configurations (excludes bucket and prefix), in the format of
 # <protocol>://<host>[:<port>][/path][?<param-key>=<param-value>][&<param-key>=<param-value>][...]
-# Refer https://github.com/EMCECS/ecs-object-client-java/wiki/Config-URI-format for more details.
+# Refer to https://github.com/EMCECS/ecs-object-client-java/wiki/Config-URI-format for more details.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
 #
 # Supported parameters include but are not limited to:
@@ -442,8 +442,10 @@ extendeds3.configUri=http://localhost:9020?identity=user&secretKey=password
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
 # extendeds3.bucket=
 
-# Prefix in extended S3 cluster where all Pravega-related data for this cluster is following.
+# Prefix of extended S3 is a prefix that will be added to every object created in the bucket by all the
+# Pravega SegmentStore in this cluster.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
+# Prefix is optional.
 # extendeds3.prefix=
 
 ##endregion

--- a/config/config.properties
+++ b/config/config.properties
@@ -427,23 +427,24 @@ hdfs.hdfsUrl=localhost:9000
 
 ##region Extended S3 settings
 
-# URL where the extended S3 cluster is accessible at.
+# URI to specify the complete extended S3 client configurations (excludes bucket and prefix), in the format of
+# <protocol>://<host>[:<port>][/path][?<param-key>=<param-value>][&<param-key>=<param-value>][...]
+# Refer https://github.com/EMCECS/ecs-object-client-java/wiki/Config-URI-format for more details.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
-extendeds3.url=localhost:9020
-
-# Prefix in extended S3 cluster where all Pravega-related data for this cluster is following.
-# This value must be the same for all Pravega SegmentStore instances in this cluster.
-# extendeds3.prefix=
-
-# ACCESS_KEY_ID to access the extended S3 cluster
-# extendeds3.accessKey=
-
-# SECRET_KEY to access the extended S3 cluster
-# extendeds3.secretKey=
+#
+# Supported parameters include but are not limited to:
+#   url: where the extended S3 cluster is accessible at, e.g. http://localhost:9020
+#   identity: the access key to access the extended S3 cluster, e.g. identity=user
+#   secretKey: the secret key to access the extended S3 cluster, e.g. secretKey=password
+extendeds3.configUri=http://localhost:9020?identity=user&secretKey=password
 
 # Shared extended S3 bucket where the data is stored.
 # This value must be the same for all Pravega SegmentStore instances in this cluster.
 # extendeds3.bucket=
+
+# Prefix in extended S3 cluster where all Pravega-related data for this cluster is following.
+# This value must be the same for all Pravega SegmentStore instances in this cluster.
+# extendeds3.prefix=
 
 ##endregion
 

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -18,3 +18,17 @@ add_system_property() {
         export JAVA_OPTS="${JAVA_OPTS} -D${name}=${value}"
     fi
 }
+
+# Add system property for ECS configUri with ECS credentials
+add_system_property_ecs_config_uri() {
+    local name=$1
+    local configUri=$2
+    local identity=$3
+    local secret=$4
+
+    if [ ${configUri} != *"identity="* ]; then
+        configUri=${configUri}"%26identity="${identity}"%26secretKey="${secret}
+    fi
+
+    add_system_property "${name}" "${configUri}"
+}

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -61,13 +61,12 @@ init_tier2() {
 
     # Loop until all variables are set
     while [ -z ${EXTENDEDS3_CONFIGURI} ] ||
-          [ -z ${EXTENDEDS3_BUCKET} ] ||
-          [ -z ${EXTENDEDS3_PREFIX} ]
+          [ -z ${EXTENDEDS3_BUCKET} ]
     do
         echo "Looping till the container is restarted with all these variables set."
         sleep 60
     done
-    add_system_property "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}"
+    add_system_property_ecs_config_uri "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}" "${EXTENDEDS3_ACCESS_KEY_ID}" "${EXTENDEDS3_SECRET_KEY}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
     add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
     ;;

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -44,19 +44,9 @@ init_tier2() {
     EXTENDEDS3_PREFIX=${EXTENDEDS3_PREFIX:-"/"}
 
     # Determine whether there is any variable missing
-    if [ -z ${EXTENDEDS3_ACCESS_KEY_ID} ]
+    if [ -z ${EXTENDEDS3_CONFIGURI} ]
     then
-        echo "EXTENDEDS3_ACCESS_KEY_ID is missing."
-    fi
-
-    if [ -z ${EXTENDEDS3_SECRET_KEY} ]
-    then
-        echo "EXTENDEDS3_SECRET_KEY is missing."
-    fi
-
-    if [ -z ${EXTENDEDS3_URI} ]
-    then
-        echo "EXTENDEDS3_URI is missing."
+        echo "EXTENDEDS3_CONFIGURI is missing."
     fi
 
     if [ -z ${EXTENDEDS3_BUCKET} ]
@@ -64,21 +54,22 @@ init_tier2() {
         echo "EXTENDEDS3_BUCKET is missing."
     fi
 
+    if [ -z ${EXTENDEDS3_PREFIX} ]
+    then
+        echo "EXTENDEDS3_PREFIX is missing."
+    fi
+
     # Loop until all variables are set
-    while [ -z ${EXTENDEDS3_ACCESS_KEY_ID} ] ||
-          [ -z ${EXTENDEDS3_SECRET_KEY} ] ||
-          [ -z ${EXTENDEDS3_URI} ] ||
-          [ -z ${EXTENDEDS3_BUCKET} ]
+    while [ -z ${EXTENDEDS3_CONFIGURI} ] ||
+          [ -z ${EXTENDEDS3_BUCKET} ] ||
+          [ -z ${EXTENDEDS3_PREFIX} ]
     do
         echo "Looping till the container is restarted with all these variables set."
         sleep 60
     done
-    add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
-    add_system_property "extendeds3.accessKey" "${EXTENDEDS3_ACCESS_KEY_ID}"
-    add_system_property "extendeds3.secretKey" "${EXTENDEDS3_SECRET_KEY}"
-    add_system_property "extendeds3.url" "${EXTENDEDS3_URI}"
+    add_system_property "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
-    add_system_property "extendeds3.namespace" "${EXTENDEDS3_NAMESPACE}"
+    add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
     ;;
     esac
 }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -37,7 +37,7 @@ import org.junit.Before;
 public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
     //region Test Configuration and Setup
 
-    private String endpoint;
+    private String s3ConfigUri;
     private S3FileSystemImpl filesystemS3;
 
     /**
@@ -47,14 +47,11 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        endpoint = "http://127.0.0.1:" + TestUtils.getAvailableListenPort();
-        URI uri = URI.create(endpoint);
+        s3ConfigUri = "http://127.0.0.1:" + TestUtils.getAvailableListenPort() + "?identity=x&secretKey=x";
         filesystemS3 = new S3FileSystemImpl(getBaseDir().toString());
         this.configBuilder.include(ExtendedS3StorageConfig.builder()
-                                                          .with(ExtendedS3StorageConfig.BUCKET, "kanpravegatest")
-                                                          .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
-                                                          .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
-                .with(ExtendedS3StorageConfig.URI, endpoint));
+                .with(ExtendedS3StorageConfig.CONFIGURI, s3ConfigUri)
+                .with(ExtendedS3StorageConfig.BUCKET, "kanpravegatest"));
     }
 
     @Override
@@ -108,10 +105,10 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
 
         @Override
         public Storage createStorageAdapter() {
-            URI uri = URI.create(endpoint);
+            URI uri = URI.create(s3ConfigUri);
             S3Config s3Config = new S3Config(uri);
 
-            s3Config = s3Config.withIdentity(config.getAccessKey()).withSecretKey(config.getSecretKey())
+            s3Config = s3Config
                     .withRetryEnabled(false)
                     .withInitialRetryDelay(1)
                     .withProperty("com.sun.jersey.client.property.connectTimeout", 100);


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
Started using s3 rest style configUri for majority of extendeds3 storage client config.

**Purpose of the change**  
Closes #4561 

**What the code does**  
(Detailed description of the code changes)
config.properties now contains configUri, bucket and prefix for extendedS3 storage.
ExtendedS3StorageConfig takes configUri and construct s3Config from it.
ExtendedS3StorageFactory handles configUri now.
ExtendedS3StorageConfigTest is added.
ExtendedS3StorageTest is updated to work with the new configUri
ExtendedS3IntegrationTest is updated to work with the new configUri

**How to verify it**  
(Optional: steps to verify that the changes are effective)
No functional changes. All tests (unit, integration, system and longevity) should pass.
The new configUri should start taking effect.