### PR TITLE
Issue 4576: (SegmentStore) Fixed Cache Manager bugs

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -512,19 +512,21 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
          * {@link #isEmpty()} set to true.
          */
         public static CacheStatus combine(Iterator<CacheStatus> cacheStates) {
-            if (!cacheStates.hasNext()) {
-                return new CacheStatus(EMPTY_VALUE, EMPTY_VALUE);
-            }
-
             int minGen = EMPTY_VALUE;
             int maxGen = 0;
+            int nonEmptyCount = 0;
             while (cacheStates.hasNext()) {
                 CacheStatus cs = cacheStates.next();
-                minGen = Math.min(minGen, cs.getOldestGeneration());
-                maxGen = Math.max(maxGen, cs.getNewestGeneration());
+                if (!cs.isEmpty()) {
+                    minGen = Math.min(minGen, cs.getOldestGeneration());
+                    maxGen = Math.max(maxGen, cs.getNewestGeneration());
+                    nonEmptyCount++;
+                }
             }
 
-            return new CacheManager.CacheStatus(minGen, maxGen);
+            return nonEmptyCount == 0
+                    ? new CacheStatus(EMPTY_VALUE, EMPTY_VALUE)
+                    : new CacheStatus(minGen, maxGen);
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
@@ -113,7 +112,7 @@ class SegmentKeyCache {
      */
     synchronized List<CacheEntry> evictAll() {
         // Remove those entries that have a generation below the oldest permissible one.
-        val entries = this.cacheEntries.values().stream().collect(Collectors.toList());
+        val entries = new ArrayList<>(this.cacheEntries.values());
         this.cacheEntries.clear();
         return entries;
     }
@@ -371,13 +370,6 @@ class SegmentKeyCache {
          */
         synchronized long getHighestOffset() {
             return this.highestOffset;
-        }
-
-        /**
-         * Gets a value representing the {@link CacheStorage} address for this Cache Entry's data.
-         */
-        synchronized int getCacheAddress() {
-            return this.cacheAddress;
         }
 
         /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -13,10 +13,10 @@ import com.google.common.collect.Iterators;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.segmentstore.storage.cache.CacheState;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
 import io.pravega.segmentstore.storage.cache.NoOpCache;
-import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
@@ -82,10 +82,20 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                 new CacheManager.CacheStatus(1, 10),
                 new CacheManager.CacheStatus(2, 11),
                 new CacheManager.CacheStatus(3, 9),
-                new CacheManager.CacheStatus(5, 5)));
+                new CacheManager.CacheStatus(5, 5),
+                new CacheManager.CacheStatus(CacheManager.CacheStatus.EMPTY_VALUE, CacheManager.CacheStatus.EMPTY_VALUE)));
         Assert.assertFalse("Unexpected isEmpty() when provided non-empty iterator.", nonEmpty.isEmpty());
         Assert.assertEquals("Unexpected OG when provided non-empty iterator.", 1, nonEmpty.getOldestGeneration());
         Assert.assertEquals("Unexpected NG when provided non-empty iterator.", 11, nonEmpty.getNewestGeneration());
+
+        val nonEmptyOfEmpties = CacheManager.CacheStatus.combine(Iterators.forArray(
+                new CacheManager.CacheStatus(CacheManager.CacheStatus.EMPTY_VALUE, CacheManager.CacheStatus.EMPTY_VALUE),
+                new CacheManager.CacheStatus(CacheManager.CacheStatus.EMPTY_VALUE, CacheManager.CacheStatus.EMPTY_VALUE)));
+        Assert.assertTrue("Unexpected isEmpty() when provided non-empty iterator of empty values.", nonEmptyOfEmpties.isEmpty());
+        Assert.assertEquals("Unexpected OG when provided non-empty iterator of empty values.",
+                CacheManager.CacheStatus.EMPTY_VALUE, nonEmptyOfEmpties.getOldestGeneration());
+        Assert.assertEquals("Unexpected NG when provided non-empty iterator of empty values.",
+                CacheManager.CacheStatus.EMPTY_VALUE, nonEmptyOfEmpties.getNewestGeneration());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -45,7 +45,7 @@ import org.junit.rules.Timeout;
 public class CacheManagerTests extends ThreadPooledTestSuite {
     private static final int CLEANUP_TIMEOUT_MILLIS = 2000;
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(100000);
+    public Timeout globalTimeout = Timeout.seconds(10);
 
     @Override
     protected int getThreadPoolSize() {


### PR DESCRIPTION
**Change log description**  
- Fixed a bug in CacheManager where it would incorrectly calculate the Newest Generation of a CacheStatus collection if at least one of them has no meaningful data.
- Fixed a bug in CacheManager where it would not refresh the client status after an eviction which could lead to over-increasing the Oldest Generation, leading to excessive cache eviction.

**Purpose of the change**  
Fixes #4576.

**What the code does**  
The Cache Manager relies on all of its clients to accurately report their state (Oldest & Newest generations). It uses that to determine if the Oldest Generation should be increased which should force an eviction.

1. There was a bug in how some of these were aggregated into a single state. If a collection of `CacheStatus` instances contained at least one of them which reported that it had no data (empty), then the resulting `CacheStatus` would incorrectly have its Newest Generation set to Int32.MAX (due to the way values are calculated). This would end up being reported as a `WARN` by the `CacheManager` since that value was always out of bounds (Old Gen - New Gen).
2. There was another bug in the Cache Manager by which it would fail to refresh the `CacheStatus` after a successful eviction. This would lead it to run in a (tight) loop and continue to evict data because it was relying from the obsolete `CacheStatus` it originally fetched. This bug was introduced with #4074 .

**How to verify it**  
Updated unit test to cover this case.
