### PR TITLE
Issue 4583: (SegmentStore) StorageWriter auto-close in case of Tier 2 write stall

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -570,7 +570,7 @@ extendeds3.url=localhost:9020
 
 # The maximum timeout (in milliseconds) to wait for new items to come into the DurableLog (in case we reached the tail).
 # Valid values: Positive integer.
-#writer.maxReadTimeoutMillis=1800000
+#writer.maxReadTimeoutMillis=180000
 
 # The amount of time to sleep (in milliseconds) if an exception was encountered during the execution of a Writer's iteration.
 # This can be used as a way to "back off" in cases a transient error occurred and not go into a very tight loop while
@@ -587,9 +587,9 @@ extendeds3.url=localhost:9020
 # time, the Storage Writer and its owning Segment Container will shut down (and eventually restart). This should resume
 # data moving to Tier 2.
 # Valid values: A value larger than 'writer.flushTimeoutMillis'.
-# Recommended values. 5x'writer.flushTimeoutMillis'. Setting to a very low value (close to 'writer.flushTimeoutMillis')
-# may inadvertently restart Segment Containers even if something is not stalled. To disable, set this to a very large
-# value (although this is not recommended).
+# Recommended values. 5x'writer.flushTimeoutMillis'. Setting to a very low value (close to 'writer.flushTimeoutMillis' or
+# 'writer.maxReadTimeoutMillis') may inadvertently restart Segment Containers even if something is not stalled. To
+# disable, set this to a very large value (although this is not recommended).
 #writer.idleTimeoutMillis=300000
 
 # The timeout (in milliseconds) for acknowledging data writes (and subsequently truncating Tier1 DurableDataLog).

--- a/config/config.properties
+++ b/config/config.properties
@@ -582,6 +582,16 @@ extendeds3.url=localhost:9020
 # Valid values: Positive integer.
 #writer.flushTimeoutMillis=60000
 
+# The maximum amount of time to wait for an idle Storage Writer iteration. An idle iteration can arise when a Tier2 Storage
+# operation hangs and/or does not respect the provided timeout. If an iteration hasn't made progress after this amount of
+# time, the Storage Writer and its owning Segment Container will shut down (and eventually restart). This should resume
+# data moving to Tier 2.
+# Valid values: A value larger than 'writer.flushTimeoutMillis'.
+# Recommended values. 5x'writer.flushTimeoutMillis'. Setting to a very low value (close to 'writer.flushTimeoutMillis')
+# may inadvertently restart Segment Containers even if something is not stalled. To disable, set this to a very large
+# value (although this is not recommended).
+#writer.idleTimeoutMillis=300000
+
 # The timeout (in milliseconds) for acknowledging data writes (and subsequently truncating Tier1 DurableDataLog).
 # Valid values: Positive integer.
 #writer.ackTimeoutMillis=15000

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/IterationIdleTimeoutException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/IterationIdleTimeoutException.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.writer;
+
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Exception that is thrown whenever a {@link StorageWriter} iteration has been idle (no activity) for more than
+ * the allowed time.
+ */
+public class IterationIdleTimeoutException extends TimeoutException {
+    IterationIdleTimeoutException(int containerId) {
+        super(String.format("StorageWriter[%s] Iteration was idle timeout exceeded.", containerId));
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/IterationMonitor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/IterationMonitor.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.writer;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+/**
+ * Helps monitor {@link StorageWriter} iterations.
+ */
+@Slf4j
+class IterationMonitor implements AutoCloseable {
+    private final TaskTracker tracker;
+    private final Duration maxIterationDuration;
+    private final Runnable onTimeout;
+    private final ScheduledExecutorService executor;
+    private final AtomicBoolean closed;
+    private final AtomicReference<ScheduledFuture<?>> monitor;
+
+    IterationMonitor(@NonNull TaskTracker tracker, @NonNull Duration maxAllowedElapsed, @NonNull Runnable onTimeout,
+                     @NonNull ScheduledExecutorService executor) {
+        Preconditions.checkArgument(!maxAllowedElapsed.isNegative() && !maxAllowedElapsed.isZero());
+        this.tracker = tracker;
+        this.maxIterationDuration = maxAllowedElapsed;
+        this.onTimeout = onTimeout;
+        this.executor = executor;
+        this.closed = new AtomicBoolean();
+        this.monitor = new AtomicReference<>();
+    }
+
+    @Override
+    public void close() {
+        this.closed.set(true);
+        val m = this.monitor.getAndSet(null);
+        m.cancel(true);
+    }
+
+    public void start() {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        Preconditions.checkState(this.monitor.get() == null, "Already started.");
+        runOnce();
+    }
+
+    private long getDelayMillis() {
+        return this.maxIterationDuration.minus(this.tracker.getLongestPendingDuration()).toMillis();
+    }
+
+    private void runOnce() {
+        if (this.closed.get()) {
+            // Nothing to do.
+            return;
+        }
+
+        long newDelay = getDelayMillis();
+        if (newDelay <= 0) {
+            // We are done. Invoke the callback and close.
+            log.info("Timeout expired. Invoking callback and closing.");
+            invokeCallback();
+            close();
+            return;
+        }
+
+        val f = this.executor.schedule(() -> {
+            try {
+                runOnce();
+            } catch (Throwable ex) {
+                log.error("Caught exception during execution.", ex);
+                close();
+            }
+        }, newDelay, TimeUnit.MILLISECONDS);
+
+        val previous = this.monitor.getAndSet(f);
+        if (previous != null) {
+            previous.cancel(true);
+        }
+    }
+
+    private void invokeCallback() {
+        try {
+            this.onTimeout.run();
+        } catch (Throwable ex) {
+            log.error("Unable to invoke on-timeout callback.", ex);
+        }
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/TaskTracker.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/TaskTracker.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.writer;
+
+import io.pravega.common.AbstractTimer;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+/**
+ * Keeps track of the duration of arbitrary async operations and provides methods to query the ones that are incomplete.
+ */
+@ThreadSafe
+class TaskTracker {
+    //region Members
+
+    private final AbstractTimer timer;
+    private final ConcurrentHashMap<Integer, TrackTarget> pending;
+    private final AtomicInteger trackId;
+    private final Duration createTime;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the {@link TaskTracker} class.
+     *
+     * @param timer A {@link AbstractTimer} that can be used to provide the current time.
+     */
+    TaskTracker(@NonNull AbstractTimer timer) {
+        this.timer = timer;
+        this.pending = new ConcurrentHashMap<>();
+        this.trackId = new AtomicInteger();
+        this.createTime = timer.getElapsed();
+    }
+
+    //endregion
+
+    //region Operations
+
+    /**
+     * Gets a {@link Duration} that expresses the amount of time elapsed since the creation of this tracker.
+     *
+     * @return a {@link Duration}.
+     */
+    public Duration getElapsedSinceCreation() {
+        return this.timer.getElapsed().minus(this.createTime);
+    }
+
+    /**
+     * Gets a {@link Duration} that expresses the highest amount of time elapsed for any pending task. If no tasks are
+     * pending, this will return {@link Duration#ZERO}.
+     *
+     * @return A {@link Duration}.
+     */
+    public Duration getLongestPendingDuration() {
+        long max = 0;
+        long currentTime = this.timer.getElapsedNanos();
+        for (val t : this.pending.values()) {
+            max = Math.max(currentTime - t.getStartTimeNanos(), max);
+        }
+
+        return Duration.ofNanos(max);
+    }
+
+    /**
+     * Gets an unordered collection of {@link PendingTask} instances representing all the tasks that haven't yet
+     * been completed.
+     *
+     * @return a Collection of {@link PendingTask} for all invocations of {@link #track} that have not yet completed.
+     */
+    public Collection<PendingTask> getAllPending() {
+        long currentTime = this.timer.getElapsedNanos();
+        return this.pending.values().stream()
+                .map(t -> new PendingTask(Duration.ofNanos(currentTime - t.getStartTimeNanos()), t.getArgs()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Tracks the async execution of a task.
+     *
+     * @param taskSupplier A {@link Supplier} that, when invoked, will return a {@link CompletableFuture} which can be
+     *                     used to track the outcome of a task. This task will be added to the list of pending tasks
+     *                     and will be removed when it completes, successfully or exceptionally.
+     * @param context      Any context relating to this task. These args will be part of the {@link PendingTask} that
+     *                     is associated with this task (when invoking {@link #getAllPending()}.
+     * @param <T>          Return type.
+     * @return The result of {@link Supplier}.
+     */
+    public <T> CompletableFuture<T> track(Supplier<CompletableFuture<T>> taskSupplier, Object... context) {
+        val target = new TrackTarget(this.trackId.getAndIncrement(), this.timer.getElapsedNanos(), context);
+        val previous = this.pending.put(target.getId(), target);
+        assert previous == null;
+        try {
+            CompletableFuture<T> result = taskSupplier.get();
+            result.whenComplete((r, ex) -> complete(target.getId()));
+            return result;
+        } catch (Throwable ex) {
+            complete(target.getId());
+            throw ex;
+        }
+    }
+
+    private void complete(int id) {
+        TrackTarget t = this.pending.remove(id);
+        assert t != null;
+    }
+
+    //endregion
+
+    //region Helper Classes
+
+    @Data
+    private static class TrackTarget {
+        private final int id;
+        private final long startTimeNanos;
+        private final Object[] args;
+    }
+
+    /**
+     * A Task that has begun executing but not yet completed.
+     */
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class PendingTask {
+        /**
+         * Elapsed time since execution began.
+         */
+        private final Duration elapsed;
+        /**
+         * Any context that was provided with the execution of this Task.
+         */
+        private final Object[] context;
+
+        @Override
+        public String toString() {
+            return String.format("Elapsed = %s ms, Context = [%s]", this.elapsed.toMillis(),
+                    Arrays.stream(this.context).map(Object::toString).collect(Collectors.joining(", ")));
+        }
+    }
+
+    //endregion
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
@@ -32,7 +32,7 @@ public class WriterConfig {
     public static final Property<Long> MAX_READ_TIMEOUT_MILLIS = Property.named("maxReadTimeoutMillis", 30 * 60 * 1000L);
     public static final Property<Long> ERROR_SLEEP_MILLIS = Property.named("errorSleepMillis", 1000L);
     public static final Property<Long> FLUSH_TIMEOUT_MILLIS = Property.named("flushTimeoutMillis", 60 * 1000L);
-    public static final Property<Long> IDLE_TIMEOUT_MILLIS = Property.named("IdleTimeoutMillis", FLUSH_TIMEOUT_MILLIS.getDefaultValue() * 5);
+    public static final Property<Long> IDLE_TIMEOUT_MILLIS = Property.named("idleTimeoutMillis", FLUSH_TIMEOUT_MILLIS.getDefaultValue() * 5);
     public static final Property<Long> ACK_TIMEOUT_MILLIS = Property.named("ackTimeoutMillis", 15 * 1000L);
     public static final Property<Long> SHUTDOWN_TIMEOUT_MILLIS = Property.named("shutdownTimeoutMillis", 10 * 1000L);
     public static final Property<Long> MAX_ROLLOVER_SIZE = Property.named("maxRolloverSizeBytes", SegmentRollingPolicy.NO_ROLLING.getMaxLength());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterState.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterState.java
@@ -78,6 +78,16 @@ class WriterState {
     }
 
     /**
+     * Gets a {@link Duration} representing the highest amount of time for any pending task. If no tasks are pending or
+     * there is no iteration active, this will return {@link Duration#ZERO}.
+     * @return A {@link Duration}.
+     */
+    Duration getIterationIdleDuration() {
+        TaskTracker t = getIterationTracker();
+        return t == null ? Duration.ZERO : t.getLongestPendingDuration();
+    }
+
+    /**
      * Gets a value indicating the id of the current iteration.
      */
     long getIterationId() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/IterationMonitorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/IterationMonitorTests.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.writer;
+
+import io.pravega.test.common.InlineExecutor;
+import io.pravega.test.common.IntentionalException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link IterationMonitor} class.
+ */
+public class IterationMonitorTests {
+    private static final Duration CHECK_INTERVAL = Duration.ofSeconds(10);
+    private static final Duration MAX_IDLE = Duration.ofSeconds(30);
+
+    /**
+     * Tests normal functionality.
+     */
+    @Test
+    public void testFunctionality() {
+        val iterationCount = 10;
+        val timeIncrement = MAX_IDLE.toMillis() / iterationCount;
+        val delayFuture = new AtomicReference<>(new CompletableFuture<Void>());
+        val idleDuration = new AtomicReference<Duration>(Duration.ZERO);
+        val callbackCount = new AtomicInteger();
+        @Cleanup("shutdown")
+        val executor = new MockExecutor(delayFuture::get);
+        @Cleanup
+        val monitor = new IterationMonitor(idleDuration::get, CHECK_INTERVAL, MAX_IDLE, callbackCount::incrementAndGet, executor);
+
+        int expectedInvocationCount = 0;
+        for (int iterationId = 0; iterationId < iterationCount; iterationId++) {
+            idleDuration.set(Duration.ofMillis(MAX_IDLE.toMillis() / 2 + timeIncrement * iterationId));
+            if (idleDuration.get().compareTo(MAX_IDLE) >= 0) {
+                expectedInvocationCount++;
+            }
+
+            delayFuture.getAndSet(new CompletableFuture<>()).complete(null); // Simulate timer elapsed.
+            Assert.assertEquals("Unexpected invocation count for iteration " + iterationId, expectedInvocationCount, callbackCount.get());
+        }
+
+        // Close the monitor and verify that nothing else gets invoked.
+        monitor.close();
+        delayFuture.getAndSet(null).complete(null); // Simulate timer elapsed.
+        Assert.assertEquals("Unexpected invocation count after closing.", expectedInvocationCount, callbackCount.get());
+    }
+
+    /**
+     * Tests the ability to handle errors thrown by the callback.
+     */
+    @Test
+    public void testCallbackErrorAsync() {
+        val delayFuture = new AtomicReference<>(new CompletableFuture<Void>());
+        val idleDuration = new AtomicReference<Duration>(MAX_IDLE);
+        val callbackCount = new AtomicInteger();
+        @Cleanup("shutdown")
+        val executor = new MockExecutor(delayFuture::get);
+        @Cleanup
+        val monitor = new IterationMonitor(idleDuration::get, CHECK_INTERVAL, MAX_IDLE,
+                () -> {
+                    callbackCount.incrementAndGet();
+                    throw new IntentionalException();
+                }, executor);
+
+        // Invoke first time.
+        delayFuture.getAndSet(new CompletableFuture<>()).complete(null); // Simulate timer elapsed.
+        Assert.assertEquals("Unexpected invocation count.", 1, callbackCount.get());
+
+        // Invoke the second time. This is to make sure that the exception thrown the first time does not stall the monitor.
+        delayFuture.getAndSet(new CompletableFuture<>()).complete(null); // Simulate timer elapsed.
+        Assert.assertEquals("Unexpected invocation count.", 2, callbackCount.get());
+    }
+
+    /**
+     * Tests the ability to cancel any ongoing monitoring if {@link IterationMonitor#close()} is invoked.
+     */
+    @Test
+    public void testClose() {
+        val delayFuture = new AtomicReference<>(new CompletableFuture<Void>());
+        val idleDuration = new AtomicReference<Duration>(MAX_IDLE);
+        val callbackCount = new AtomicInteger();
+        @Cleanup("shutdown")
+        val executor = new MockExecutor(delayFuture::get);
+        @Cleanup
+        val monitor = new IterationMonitor(idleDuration::get, CHECK_INTERVAL, MAX_IDLE, callbackCount::incrementAndGet, executor);
+
+        monitor.close();
+
+        // Invoke and verify that it doesn't get run.
+        delayFuture.getAndSet(new CompletableFuture<>()).complete(null); // Simulate timer elapsed.
+        Assert.assertEquals("Unexpected invocation count.", 0, callbackCount.get());
+    }
+
+    //region MockExecutor and MockFuture
+
+    @RequiredArgsConstructor
+    private static class MockExecutor implements ScheduledExecutorService {
+        private final Supplier<CompletableFuture<Void>> scheduleDelayProvider;
+        private final InlineExecutor inlineExecutor = new InlineExecutor();
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long initialDelayMillis, long delayMillis, TimeUnit timeUnit) {
+            Assert.assertEquals("MockExecutor can only support millis.", TimeUnit.MILLISECONDS, timeUnit);
+            val result = new MockFuture(delayMillis);
+            runScheduledTask(runnable, result::isCancelled);
+            return result;
+        }
+
+        private void runScheduledTask(Runnable runnable, Supplier<Boolean> isCancelled) {
+            this.scheduleDelayProvider.get().thenRunAsync(() -> {
+                if (isCancelled.get()) {
+                    return;
+                }
+
+                runnable.run();
+                runScheduledTask(runnable, isCancelled);
+            }, this.inlineExecutor);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable runnable, long delayMillis, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long l, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void shutdown() {
+            this.inlineExecutor.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return this.inlineExecutor.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return this.inlineExecutor.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return this.inlineExecutor.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long l, TimeUnit timeUnit) {
+            return false;
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> callable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable runnable, T t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<?> submit(Runnable runnable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> collection) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class MockFuture implements ScheduledFuture<Void> {
+        private final long delay;
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        @Override
+        public boolean cancel(boolean b) {
+            return this.cancelled.compareAndSet(false, true);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.cancelled.get();
+        }
+
+        @Override
+        public boolean isDone() {
+            return this.cancelled.get();
+        }
+
+        @Override
+        public long getDelay(TimeUnit timeUnit) {
+            Assert.assertEquals("MockExecutor can only support millis.", TimeUnit.MILLISECONDS, timeUnit);
+            return this.delay;
+        }
+
+        @Override
+        public int compareTo(Delayed delayed) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Void get() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Void get(long l, TimeUnit timeUnit) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    //endregion
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/IterationMonitorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/IterationMonitorTests.java
@@ -255,6 +255,16 @@ public class IterationMonitorTests {
         }
 
         @Override
+        public boolean equals(Object o) {
+            return super.equals(o);
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
+
+        @Override
         public Void get() {
             throw new UnsupportedOperationException();
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -625,6 +625,8 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
                 .with(WriterConfig.FLUSH_THRESHOLD_MILLIS, DEFAULT_CONFIG.getFlushThresholdTime().toMillis())
                 .with(WriterConfig.FLUSH_ATTRIBUTES_THRESHOLD, DEFAULT_CONFIG.getFlushAttributesThreshold())
                 .with(WriterConfig.FLUSH_TIMEOUT_MILLIS, 10L)
+                .with(WriterConfig.MIN_READ_TIMEOUT_MILLIS, 9L)
+                .with(WriterConfig.MAX_READ_TIMEOUT_MILLIS, 10L)
                 .with(WriterConfig.IDLE_TIMEOUT_MILLIS, 300L)
                 .with(WriterConfig.SHUTDOWN_TIMEOUT_MILLIS, 10L)
                 .build();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TaskTrackerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TaskTrackerTests.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.writer;
+
+import io.pravega.segmentstore.server.ManualTimer;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.IntentionalException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TaskTracker}.
+ */
+public class TaskTrackerTests {
+    private static final int SHORT_TIMEOUT = 200;
+
+    /**
+     * Tests the {@link TaskTracker#getElapsedSinceCreation()} method.
+     */
+    @Test
+    public void testGetElapsedSinceCreation() {
+        val timer = new ManualTimer();
+        timer.setElapsedMillis(1234);
+        val t = new TaskTracker(timer);
+        Assert.assertEquals(0, t.getElapsedSinceCreation().toMillis());
+        timer.setElapsedMillis(1239);
+        Assert.assertEquals(5, t.getElapsedSinceCreation().toMillis());
+    }
+
+    /**
+     * Tests the {@link TaskTracker#track} method.
+     */
+    @Test
+    public void testTrack() throws Exception {
+        val timer = new ManualTimer();
+        timer.setElapsedMillis(0);
+        val tracker = new TaskTracker(timer);
+
+        // Add one tracked item.
+        val f1 = new CompletableFuture<Long>();
+        val args1 = new Object[]{"a1", "a2"};
+        val f1Result = tracker.track(() -> f1, args1);
+        Assert.assertFalse("Not expecting result future to be complete yet.", f1.isDone());
+        timer.setElapsedMillis(10);
+        Assert.assertEquals(10, tracker.getLongestPendingDuration().toMillis());
+        val pending1 = getPending(tracker);
+        Assert.assertEquals(1, pending1.size());
+        checkPending(10, args1, pending1.get(0));
+
+        // Add a second one.
+        val f2 = new CompletableFuture<Long>();
+        val f2Result = tracker.track(() -> f2);
+        timer.setElapsedMillis(20);
+        Assert.assertEquals(20, tracker.getLongestPendingDuration().toMillis());
+        val pending2 = getPending(tracker);
+        Assert.assertEquals(2, pending2.size());
+        checkPending(20, args1, pending2.get(0));
+        checkPending(10, null, pending2.get(1));
+
+        // Add a third.
+        val f3 = new CompletableFuture<Long>();
+        val args3 = new Object[0];
+        val f3Result = tracker.track(() -> f3, args3);
+        timer.setElapsedMillis(30);
+
+        // The fourth one will fail synchronously.
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Exception did not bubble up.",
+                () -> tracker.track(() -> {
+                    throw new IntentionalException();
+                }), ex -> ex instanceof IntentionalException);
+        Assert.assertEquals(30, tracker.getLongestPendingDuration().toMillis());
+        val pending3 = getPending(tracker);
+        Assert.assertEquals(3, pending3.size());
+        checkPending(30, args1, pending3.get(0));
+        checkPending(20, null, pending3.get(1));
+        checkPending(10, args3, pending3.get(2));
+
+        // Complete the second one.
+        timer.setElapsedMillis(40);
+        f2.complete(1L);
+        Assert.assertEquals(1L, (long) f2Result.get(SHORT_TIMEOUT, TimeUnit.MILLISECONDS));
+        Assert.assertEquals(40, tracker.getLongestPendingDuration().toMillis()); // f1 hasn't completed yet.
+        val pending4 = getPending(tracker);
+        Assert.assertEquals(2, pending4.size());
+        checkPending(40, args1, pending4.get(0));
+        checkPending(20, args3, pending4.get(1));
+
+        // Fail the first one.
+        timer.setElapsedMillis(50);
+        f1.completeExceptionally(new IntentionalException());
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Async exception did not propagate.",
+                () -> f1Result,
+                ex -> ex instanceof IntentionalException);
+        Assert.assertEquals(30, tracker.getLongestPendingDuration().toMillis()); // f3 is the only one remaining.
+        val pending5 = getPending(tracker);
+        Assert.assertEquals(1, pending5.size());
+        checkPending(30, args3, pending5.get(0));
+
+        // Complete the third one.
+        f3.complete(123456L);
+        Assert.assertEquals(123456L, (long) f3Result.get(SHORT_TIMEOUT, TimeUnit.MILLISECONDS));
+        Assert.assertEquals(0, tracker.getLongestPendingDuration().toMillis()); // Nothing pending.
+        Assert.assertEquals(0, tracker.getAllPending().size());
+    }
+
+    private void checkPending(long millis, Object[] args, TaskTracker.PendingTask actual) {
+        Assert.assertEquals("Unexpected elapsed time for " + actual, millis, actual.getElapsed().toMillis());
+        if (args == null || args.length == 0) {
+            Assert.assertEquals("Not expecting any args for " + actual, 0, actual.getContext().length);
+        } else {
+            Assert.assertSame("Unexpected args for " + actual, args, actual.getContext());
+        }
+    }
+
+    private List<TaskTracker.PendingTask> getPending(TaskTracker tracker) {
+        return tracker.getAllPending().stream()
+                .sorted((p1, p2) -> Long.compare(p2.getElapsed().toMillis(), p1.getElapsed().toMillis()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
**Change log description**  
The Storage Writer now tracks all operations it performs during an iteration and shuts down if it doesn't observe any progress after a specified amount of time.

**Purpose of the change**  
Fixes #4583.

**What the code does**  
See #4583 for a scenario that triggered this.

The StorageWriter now tracks the execution of all async Tier 2 flushes it performs. This is done for each Segment and for each of that Segment's processors (AttributeAggregator, SegmentAggregator, WriterTableProcessor).  Once a flush is initiated, it is tracked until it completes, either normally or with an exception. The `TaskTracker` can calculate the amount of time each pending task has been "idle" for, and returns the maximum of that value.

Added a config value `writer.idleTimeoutMillis` which is used by the StorageWriter in the following way:
- If a pending task (tracked by `TaskTracker`) has been idle for an amount of time longer than this value, then the `StorageWriter` will auto-close. It will attempt to abort any ongoing operations.
    - It will dump the list of pending tasks (with sufficient information to determine which is which) into the logs.
- The owning Segment Container will also auto-close, and will be restarted quickly.
    - After a restart, the new `StorageWriter` instance will resume operations.
    - If whatever operation from the old `StorageWriter` instance does eventually get unstuck, it should not have any negative effect (such as corrupting data) in Tier 2 since the new Segment Container will have a higher epoch than the old one, so the fencing logic within the Tier 2 adapter will prevent it from executing.

**How to verify it**  
New unit tests added to cover new functionality.
