### PR TITLE
Issue 4561 - bugfix of docker script inside common.sh

### DIFF
--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -26,9 +26,10 @@ add_system_property_ecs_config_uri() {
     local identity=$3
     local secret=$4
 
-    if [ ${configUri} != *"identity="* ]; then
+    if ! echo ${configUri} | grep -q "identity"; then
         configUri=${configUri}"%26identity="${identity}"%26secretKey="${secret}
     fi
 
+    echo "${name}" "${configUri}"
     add_system_property "${name}" "${configUri}"
 }


### PR DESCRIPTION
**Change log description**  
This is a bugfix of issue 4561
The approach used before in the script was only able to test substring successfully in some cases.
Changed the approach to use "grep" to test substring, which works in all cases.

**Purpose of the change**  
Fixes #4561 

**What the code does**  
Use "grep" to test substring in the function add_system_property_ecs_config_uri() inside common.sh, which is used by init_tier2.sh

**How to verify it**  
In case of ECS used as tier-2, if the ECS configUri contains "identity", which means the credential is provided, then the configUri is passed to Pravega Java process directly; 
Otherwise, it append ECS credentials (from env vars) onto the configUri
