### PR TITLE
Issue 4590: (SegmentStore) Fixed Read Index concurrent Tier 2 read bug

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
@@ -90,7 +90,7 @@ public class CachePolicy {
     public CachePolicy(long maxSize, double targetUtilization, double maxUtilization, Duration maxTime, Duration generationDuration) {
         Preconditions.checkArgument(maxSize > 0, "maxSize must be a positive integer");
         Preconditions.checkArgument(targetUtilization > 0 && targetUtilization <= 1.0,
-                "maxUtilization must be a number in the range (0.0, 1.0].");
+                "targetUtilization must be a number in the range (0.0, 1.0].");
         Preconditions.checkArgument(maxUtilization >= targetUtilization && maxUtilization <= 1.0,
                 "maxUtilization must be a number in the range (0.0, 1.0], at least equal to targetUtilization(%s).", targetUtilization);
         this.maxSize = maxSize;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -563,11 +563,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     private CacheIndexEntry addSingleEntryToCacheAndIndex(BufferView data, long offset, String operationName) {
         int dataAddress = this.cacheStorage.insert(data);
         CacheIndexEntry newEntry;
-        ReadIndexEntry oldEntry;
+        ReadIndexEntry rejectedEntry;
         try {
             newEntry = new CacheIndexEntry(offset, data.getLength(), dataAddress);
             synchronized (this.lock) {
-                oldEntry = addToIndex(newEntry);
+                rejectedEntry = addToIndex(newEntry);
             }
         } catch (Throwable ex) {
             if (!Exceptions.mustRethrow(ex)) {
@@ -577,21 +577,41 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             throw ex;
         }
 
-        if (oldEntry != null) {
-            deleteData(oldEntry);
-            log.warn("{}: {} overrode existing entry (Offset = {}, OldLength = {}, NewLength = {}).",
-                    this.traceObjectId, operationName, newEntry.getStreamSegmentOffset(), newEntry.getLength(), oldEntry.getLength());
+        if (rejectedEntry != null) {
+            deleteData(rejectedEntry);
+            if (rejectedEntry != newEntry) {
+                log.warn("{}: {} overrode existing entry (Offset = {}, OldLength = {}, NewLength = {}).",
+                        this.traceObjectId, operationName, newEntry.getStreamSegmentOffset(), rejectedEntry.getLength(), newEntry.getLength());
+            }
         }
         return newEntry;
     }
 
+    /**
+     * Attempts to add the given {@link ReadIndexEntry} to the index. No cache operations are performed.
+     *
+     * @param entry The {@link ReadIndexEntry} to add.
+     * @return A rejected {@link ReadIndexEntry}. If the given entry has overridden another that already existed in the
+     * index, the overridden one will be returned. If the given entry could not be added to the index due to another,
+     * more up-to-date one existing already, the given entry will be returned as rejected (and no modifications will
+     * be made to the index). A null value will be returned if there was no conflict.
+     */
     @GuardedBy("lock")
-    private ReadIndexEntry addToIndex(ReadIndexEntry entry) {
+    private ReadIndexEntry addToIndex(final ReadIndexEntry entry) {
         Exceptions.checkNotClosed(this.closed, this);
-        // Insert the new entry and figure out if an old entry was overwritten.
-        ReadIndexEntry oldEntry = this.indexEntries.put(entry);
+
+        // Insert the new entry and figure out if an old entry was overwritten. The vast majority of times there will
+        // be nothing to override, so we use an optimistic concurrency strategy to execute this. If we end up replacing
+        // an entry, we'll verify it and undo the insertion if appropriate.
+        ReadIndexEntry rejectedEntry = this.indexEntries.put(entry);
         if (entry.isDataEntry()) {
-            if (entry instanceof MergedIndexEntry) {
+            if (rejectedEntry != null && rejectedEntry.getLength() > entry.getLength()) {
+                // We have replaced an entry which had more up-to-date information. If we allow the existing entry to be
+                // overridden, we have potential (in-memory) data loss, so this cannot happen. Undo this.
+                this.indexEntries.put(rejectedEntry);
+                rejectedEntry.setGeneration(entry.getGeneration());
+                rejectedEntry = entry;
+            } else if (entry instanceof MergedIndexEntry) {
                 // This entry has already existed in the cache for a while; do not change its generation.
                 this.summary.addOne(entry.getGeneration());
             } else {
@@ -601,12 +621,12 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             }
         }
 
-        if (oldEntry != null && oldEntry.isDataEntry()) {
+        if (rejectedEntry != null && rejectedEntry != entry && rejectedEntry.isDataEntry()) {
             // Need to eject the old entry's data from the Cache Stats.
-            this.summary.removeOne(oldEntry.getGeneration());
+            this.summary.removeOne(rejectedEntry.getGeneration());
         }
 
-        return oldEntry;
+        return rejectedEntry;
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -784,8 +784,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                             .join();
 
                     Assert.assertArrayEquals("Unexpected appended data read back.", storageData, segmentData);
-                    Assert.assertEquals("Unexpected number of bytes in Cache.",
-                            storageData.length, context.cacheStorage.getState().getStoredBytes());
+
+                    // The cleanup is async, so we must keep trying to check until it is done.
+                    AssertExtensions.assertEventuallyEquals("Unexpected number of bytes in the cache.",
+                            (long) storageData.length,
+                            () -> context.cacheStorage.getState().getStoredBytes(),
+                            10, TIMEOUT.toMillis());
+
                 });
     }
 
@@ -811,8 +816,12 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                     val actualAppendedData = StreamHelpers.readAll(appendedDataStream, appendedData.get().getLength());
                     AssertExtensions.assertArrayEquals("Unexpected appended data read back.",
                             appendedData.get().array(), 0, actualAppendedData, 0, appendedData.get().getLength());
-                    Assert.assertEquals("Unexpected number of bytes in Cache.",
-                            metadata.getLength(), context.cacheStorage.getState().getStoredBytes());
+
+                    // The cleanup is async, so we must keep trying to check until it is done.
+                    AssertExtensions.assertEventuallyEquals("Unexpected number of bytes in the cache.",
+                            metadata.getLength(),
+                            () -> context.cacheStorage.getState().getStoredBytes(),
+                            10, TIMEOUT.toMillis());
                 });
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.io.StreamHelpers;
 import io.pravega.common.util.BufferView;
@@ -60,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -754,6 +756,153 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         // Now do the read again - if everything was cached properly in the previous call to 'checkReadIndex', no Storage
         // call should be executed.
         checkReadIndex("CacheReads", segmentContents, context);
+    }
+
+    /**
+     * Tests a scenario where two concurrent Storage reads for the same offset execute, and the second ends up overwriting
+     * the first one.
+     */
+    @Test
+    public void testStorageReadsConcurrentWithOverwrite() throws Exception {
+        testConcurrentStorageReads(
+                (context, metadata) -> {
+                    // Do nothing.
+                },
+                (context, metadata) -> {
+                    // Check all the appended data. It must not have been overridden.
+                    Assert.assertEquals("Not expecting any extra data in this test.", metadata.getLength(), metadata.getStorageLength());
+                    val readResult = context.readIndex.read(metadata.getId(), 0, (int) metadata.getStorageLength(), TIMEOUT);
+
+                    // Read from segment.
+                    byte[] segmentData = new byte[(int) metadata.getStorageLength()];
+                    readResult.readRemaining(segmentData, TIMEOUT);
+
+                    // Then from Storage.
+                    byte[] storageData = new byte[segmentData.length];
+                    context.storage.openRead(metadata.getName())
+                            .thenCompose(handle -> context.storage.read(handle, 0, storageData, 0, storageData.length, TIMEOUT))
+                            .join();
+
+                    Assert.assertArrayEquals("Unexpected appended data read back.", storageData, segmentData);
+                    Assert.assertEquals("Unexpected number of bytes in Cache.",
+                            storageData.length, context.cacheStorage.getState().getStoredBytes());
+                });
+    }
+
+    /**
+     * Tests a scenario where two concurrent Storage reads for the same offset execute, but the first one completes first,
+     * then a new append is added to the segment, and when the second read completes it should be discarded (as opposed
+     * from overwriting the Read Index Entry).
+     */
+    @Test
+    public void testStorageReadsConcurrentNoOverwrite() throws Exception {
+        val appendedData = new AtomicReference<ByteArraySegment>();
+        testConcurrentStorageReads(
+                (context, metadata) -> {
+                    // Now perform an append.
+                    appendedData.set(getAppendData(metadata.getName(), metadata.getId(), 1, 1));
+                    metadata.setLength(metadata.getLength() + appendedData.get().getLength());
+                    context.readIndex.append(metadata.getId(), metadata.getStorageLength(), appendedData.get());
+                },
+                (context, metadata) -> {
+                    // Check all the appended data. It must not have been overridden.
+                    val appendedDataStream = context.readIndex.readDirect(metadata.getId(), metadata.getStorageLength(), appendedData.get().getLength());
+                    Assert.assertNotNull("Unable to read appended data.", appendedDataStream);
+                    val actualAppendedData = StreamHelpers.readAll(appendedDataStream, appendedData.get().getLength());
+                    AssertExtensions.assertArrayEquals("Unexpected appended data read back.",
+                            appendedData.get().array(), 0, actualAppendedData, 0, appendedData.get().getLength());
+                    Assert.assertEquals("Unexpected number of bytes in Cache.",
+                            metadata.getLength(), context.cacheStorage.getState().getStoredBytes());
+                });
+    }
+
+    private void testConcurrentStorageReads(BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
+                                            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
+        val cachePolicy = new CachePolicy(100, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
+        @Cleanup
+        TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
+
+        // Create the segment
+        val segmentId = createSegment(0, context);
+        val metadata = context.metadata.getStreamSegmentMetadata(segmentId);
+        context.storage.create(metadata.getName(), TIMEOUT).join();
+
+        // Append some data to the Read Index.
+        val dataInStorage = getAppendData(metadata.getName(), segmentId, 0, 0);
+        metadata.setLength(dataInStorage.getLength());
+        context.readIndex.append(segmentId, 0, dataInStorage);
+
+        // Then write to Storage.
+        context.storage.openWrite(metadata.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, dataInStorage.getReader(), dataInStorage.getLength(), TIMEOUT))
+                .join();
+        metadata.setStorageLength(dataInStorage.getLength());
+
+        // Then evict it from the cache.
+        boolean evicted = context.cacheManager.applyCachePolicy();
+        Assert.assertTrue("Expected an eviction.", evicted);
+
+        @Cleanup("release")
+        val firstInsertBlocker = new ReusableLatch();
+        @Cleanup("release")
+        val firstInsertInCache = new ReusableLatch();
+        @Cleanup("release")
+        val secondInsertBlocker = new ReusableLatch();
+        @Cleanup("release")
+        val secondInsertInCache = new ReusableLatch();
+        val insertCount = new AtomicInteger();
+        context.cacheStorage.insertCallback = address -> {
+            int insertId = insertCount.incrementAndGet();
+            if (insertId == 1) {
+                firstInsertInCache.release();
+                Exceptions.handleInterrupted(firstInsertBlocker::await);
+            } else if (insertId == 2) {
+                secondInsertInCache.release();
+                Exceptions.handleInterrupted(secondInsertBlocker::await);
+            } else {
+                Assert.fail("Too many inserts.");
+            }
+        };
+
+        // Initiate the first Storage Read.
+        val read1Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
+        val read1Data = new byte[dataInStorage.getLength()];
+        val read1Future = CompletableFuture.runAsync(() -> read1Result.readRemaining(read1Data, TIMEOUT), executorService());
+
+        // Wait for it to process (the only time we can intercept it is when it's about to be entered into the cache).
+        firstInsertInCache.await();
+
+        // Initiate the second storage read.
+        val read2Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
+        val read2Data = new byte[dataInStorage.getLength()];
+        val read2Future = CompletableFuture.runAsync(() -> read2Result.readRemaining(read2Data, TIMEOUT), executorService());
+
+        // Wait for it to process.
+        secondInsertInCache.await();
+
+        // Unblock the first Storage Read and wait for it to complete.
+        firstInsertBlocker.release();
+        read1Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Wait for the data to be fully added to the cache. Without this the subsequent append will not write to this entry.
+        TestUtils.await(
+                () -> {
+                    try {
+                        return context.readIndex.read(0, 0, dataInStorage.getLength(), TIMEOUT).next().getType() == ReadResultEntryType.Cache;
+                    } catch (StreamSegmentNotExistsException ex) {
+                        throw new CompletionException(ex);
+                    }
+                }, 10, TIMEOUT.toMillis());
+
+        // If there's anything to do between the two reads, do it now.
+        executeBetweenReads.accept(context, metadata);
+
+        // Unblock second Storage Read.
+        secondInsertBlocker.release();
+        read2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Perform final check.
+        finalCheck.accept(context, metadata);
     }
 
     /**
@@ -1771,4 +1920,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     //endregion
 
+    @FunctionalInterface
+    private interface BiConsumerWithException<T, U> {
+        void accept(T var1, U var2) throws Exception;
+    }
 }


### PR DESCRIPTION
**Change log description**  
Fixed a bug in StreamSegmentReadIndex where it would have been possible for two concurrent Storage read requests to override one another, resulting in potential (in-memory) data loss should there be an append executed in between the two.

**Purpose of the change**  
Fixes #4590.

**What the code does**  
When the Read Index receives concurrent reads for the same range in a Segment that is not cached, it may issue only one Tier 2 read and serve all such reads from it. However sometimes it may happen that each such read will trigger its own Tier 2 read, which will be accompanied by its own callback, when the data is inserted into the Cache. If such a scenario happens, the callback that is invoked later will override the data (and entry) inserted by the callback that is invoked first. Under normal circumstances this is not a big deal.

However, considering the scenario outlined in #4590, it is possible that the cache entry inserted by the first callback may have been modified (appended to) before the second one, and removing it from the cache will result in missing data that is not in Tier 2 nor in memory. This would cause both cache reads to fail and Tier 2 syncs to fail as well.

This PR fixes this problem by checking the size of the cache entry that is about to be overridden. If greater than the one that it is about to be replaced with, it will not perform the operation. Since cache entries can only grow (due to append being the only modification allowed), such a check is sufficient to prevent in-memory data loss.

**How to verify it**  
New unit tests added to verify this specific scenario.
