### PR TITLE
Issue 4594: Changed `pravegaVersion` to 0.8.0-SNAPSHOT in master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.7.0-SNAPSHOT
+pravegaVersion=0.8.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**  
Changed `pravegaVersion` to 0.8.0-SNAPSHOT.

**Purpose of the change**  
Fixes #4594.

**What the code does**  
No code changes.

**How to verify it**  
Look at the file.
