### PR TITLE
Issue 4590: (SegmentStore) Fixed Read Index concurrent Tier 2 read bug (Part 2)

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -621,18 +621,13 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                     try {
                         newEntry = new CacheIndexEntry(segmentOffset, dataToInsert.getLength(), dataAddress);
                         ReadIndexEntry overriddenEntry = addToIndex(newEntry);
-                        if (overriddenEntry != null) {
-                            // We shouldn't get in here, ever ...
-                            throw new IllegalStateException(String.format("Insert overrode existing entry. Offset = %s, Length = %s.",
-                                    segmentOffset, dataToInsert.getLength()));
-                        }
+                        Preconditions.checkState(overriddenEntry == null,
+                                "Insert overrode existing entry. Offset = %s, Length = %s.", segmentOffset, dataToInsert.getLength());
 
                         lastInsertedEntry = newEntry;
                     } catch (Throwable ex) {
-                        if (!Exceptions.mustRethrow(ex)) {
-                            // Clean up the data we inserted if we were unable to add it to the index.
-                            this.cacheStorage.delete(dataAddress);
-                        }
+                        // Clean up the data we inserted if we were unable to add it to the index.
+                        this.cacheStorage.delete(dataAddress);
                         throw ex;
                     }
                 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -650,7 +650,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     private ReadIndexEntry addToIndex(ReadIndexEntry entry) {
         Exceptions.checkNotClosed(this.closed, this);
         // Insert the new entry and figure out if an old entry was overwritten.
-        ReadIndexEntry oldEntry = this.indexEntries.put(entry);
+        ReadIndexEntry rejectedEntry = this.indexEntries.put(entry);
         if (entry.isDataEntry()) {
             if (entry instanceof MergedIndexEntry) {
                 // This entry has already existed in the cache for a while; do not change its generation.
@@ -662,12 +662,12 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             }
         }
 
-        if (oldEntry != null && oldEntry.isDataEntry()) {
+        if (rejectedEntry != null && rejectedEntry.isDataEntry()) {
             // Need to eject the old entry's data from the Cache Stats.
-            this.summary.removeOne(oldEntry.getGeneration());
+            this.summary.removeOne(rejectedEntry.getGeneration());
         }
 
-        return oldEntry;
+        return rejectedEntry;
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -621,15 +621,14 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                     try {
                         newEntry = new CacheIndexEntry(segmentOffset, dataToInsert.getLength(), dataAddress);
                         ReadIndexEntry overriddenEntry = addToIndex(newEntry);
-                        Preconditions.checkState(overriddenEntry == null,
-                                "Insert overrode existing entry. Offset = %s, Length = %s.", segmentOffset, dataToInsert.getLength());
-
+                        assert overriddenEntry == null : "Insert overrode existing entry; " + segmentOffset + ":" + dataToInsert.getLength();
                         lastInsertedEntry = newEntry;
                     } catch (Throwable ex) {
                         // Clean up the data we inserted if we were unable to add it to the index.
                         this.cacheStorage.delete(dataAddress);
                         throw ex;
                     }
+
                 }
 
                 // Slice the remainder of the buffer, or set it to null if we processed everything.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -27,13 +27,13 @@ import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.TestCacheManager;
+import io.pravega.segmentstore.server.TestStorage;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
-import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.cache.CacheState;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
-import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
+import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
@@ -89,7 +89,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration TIMEOUT = Duration.ofSeconds(200000);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule
@@ -764,7 +764,12 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testStorageReadsConcurrentWithOverwrite() throws Exception {
-        testConcurrentStorageReads(
+        testStorageReadsConcurrentWithOverwrite(0);
+        testStorageReadsConcurrentWithOverwrite(1);
+    }
+
+    private void testStorageReadsConcurrentWithOverwrite(int offsetDeltaBetweenReads) throws Exception {
+        testConcurrentStorageReads(offsetDeltaBetweenReads, 1,
                 (context, metadata) -> {
                     // Do nothing.
                 },
@@ -801,8 +806,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testStorageReadsConcurrentNoOverwrite() throws Exception {
+        testStorageReadsConcurrentNoOverwrite(0);
+        testStorageReadsConcurrentNoOverwrite(1);
+    }
+
+    private void testStorageReadsConcurrentNoOverwrite(int offsetDeltaBetweenReads) throws Exception {
         val appendedData = new AtomicReference<ByteArraySegment>();
-        testConcurrentStorageReads(
+        testConcurrentStorageReads(offsetDeltaBetweenReads, 0,
                 (context, metadata) -> {
                     // Now perform an append.
                     appendedData.set(getAppendData(metadata.getName(), metadata.getId(), 1, 1));
@@ -825,8 +835,12 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 });
     }
 
-    private void testConcurrentStorageReads(BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
-                                            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
+    private void testConcurrentStorageReads(
+            int offsetDeltaBetweenReads,
+            int extraAllowedStorageReads,
+            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
+            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
+        val maxAllowedStorageReads = 2 + extraAllowedStorageReads;
         val cachePolicy = new CachePolicy(100, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
         @Cleanup
         TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
@@ -852,48 +866,55 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         Assert.assertTrue("Expected an eviction.", evicted);
 
         @Cleanup("release")
-        val firstInsertBlocker = new ReusableLatch();
+        val firstReadBlocker = new ReusableLatch();
         @Cleanup("release")
-        val firstInsertInCache = new ReusableLatch();
+        val firstRead = new ReusableLatch();
         @Cleanup("release")
-        val secondInsertBlocker = new ReusableLatch();
+        val secondReadBlocker = new ReusableLatch();
         @Cleanup("release")
-        val secondInsertInCache = new ReusableLatch();
-        val insertCount = new AtomicInteger();
+        val secondRead = new ReusableLatch();
+        val cacheInsertCount = new AtomicInteger();
         context.cacheStorage.insertCallback = address -> {
-            int insertId = insertCount.incrementAndGet();
-            if (insertId == 1) {
-                firstInsertInCache.release();
-                Exceptions.handleInterrupted(firstInsertBlocker::await);
-            } else if (insertId == 2) {
-                secondInsertInCache.release();
-                Exceptions.handleInterrupted(secondInsertBlocker::await);
-            } else {
-                Assert.fail("Too many inserts.");
+            if (cacheInsertCount.incrementAndGet() > 1) {
+                Assert.fail("Too many cache inserts.");
             }
         };
+
+        val storageReadCount = new AtomicInteger();
+        context.storage.setReadInterceptor((segment, wrappedStorage) -> {
+            int readCount = storageReadCount.incrementAndGet();
+            if (readCount == 1) {
+                firstRead.release();
+                Exceptions.handleInterrupted(firstReadBlocker::await);
+            } else if (readCount == 2) {
+                secondRead.release();
+                Exceptions.handleInterrupted(secondReadBlocker::await);
+            } else if (readCount > maxAllowedStorageReads) {
+                Assert.fail("Too many storage reads. Max allowed = " + maxAllowedStorageReads);
+            }
+        });
 
         // Initiate the first Storage Read.
         val read1Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
         val read1Data = new byte[dataInStorage.getLength()];
         val read1Future = CompletableFuture.runAsync(() -> read1Result.readRemaining(read1Data, TIMEOUT), executorService());
 
-        // Wait for it to process (the only time we can intercept it is when it's about to be entered into the cache).
-        firstInsertInCache.await();
+        // Wait for it to process.
+        firstRead.await();
 
         // Initiate the second storage read.
-        val read2Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
-        val read2Data = new byte[dataInStorage.getLength()];
+        val read2Length = dataInStorage.getLength() - offsetDeltaBetweenReads;
+        val read2Result = context.readIndex.read(segmentId, offsetDeltaBetweenReads, read2Length, TIMEOUT);
+        val read2Data = new byte[read2Length];
         val read2Future = CompletableFuture.runAsync(() -> read2Result.readRemaining(read2Data, TIMEOUT), executorService());
 
-        // Wait for it to process.
-        secondInsertInCache.await();
+        secondRead.await();
 
         // Unblock the first Storage Read and wait for it to complete.
-        firstInsertBlocker.release();
+        firstReadBlocker.release();
         read1Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
-        // Wait for the data to be fully added to the cache. Without this the subsequent append will not write to this entry.
+        // Wait for the data from the first read to be fully added to the cache. Without this the subsequent append will not write to this entry.
         TestUtils.await(
                 () -> {
                     try {
@@ -907,11 +928,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         executeBetweenReads.accept(context, metadata);
 
         // Unblock second Storage Read.
-        secondInsertBlocker.release();
+        secondReadBlocker.release();
         read2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
         // Perform final check.
         finalCheck.accept(context, metadata);
+        Assert.assertEquals("Unexpected number of storage reads.", maxAllowedStorageReads, storageReadCount.get());
+        Assert.assertEquals("Unexpected number of cache inserts.", 1, cacheInsertCount.get());
     }
 
     /**
@@ -1805,7 +1828,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         final ContainerReadIndex readIndex;
         final TestCacheManager cacheManager;
         final TestCacheStorage cacheStorage;
-        final Storage storage;
+        final TestStorage storage;
         final int maxExpectedStorageReadLength;
 
         TestContext() {
@@ -1815,7 +1838,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         TestContext(ReadIndexConfig readIndexConfig, CachePolicy cachePolicy) {
             this.cacheStorage = new TestCacheStorage(Integer.MAX_VALUE);
             this.metadata = new MetadataBuilder(CONTAINER_ID).build();
-            this.storage = InMemoryStorageFactory.newStorage(executorService());
+            this.storage = new TestStorage(new InMemoryStorage(), executorService());
             this.storage.initialize(1);
             this.cacheManager = new TestCacheManager(cachePolicy, this.cacheStorage, executorService());
             this.readIndex = new ContainerReadIndex(readIndexConfig, this.metadata, this.storage, this.cacheManager, executorService());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -89,7 +89,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(200000);
+    private static final Duration TIMEOUT = Duration.ofSeconds(20);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
@@ -19,6 +19,11 @@ import lombok.NonNull;
  */
 public interface CacheStorage extends AutoCloseable {
     /**
+     * Gets a value representing a "null" address.
+     */
+    int NO_ADDRESS = CacheLayout.NO_ADDRESS;
+
+    /**
      * Gets a value representing the size of one block. For efficiency purposes, it is highly recommended that all inserted
      * data align to this value (i.e., have a length that is a multiple of this value).
      *


### PR DESCRIPTION
**Change log description**  
Fixed a (second) bug in StreamSegmentReadIndex where it would have been possible for two concurrent Storage read requests to override one another, resulting in potential (in-memory) data loss should there be an append executed in between the two.

**Purpose of the change**  
Fixes #4590.

**What the code does**  
See #4592 for details on the first bug.
#4592 handled the case when the concurrent reads began at  exactly the same Segment offset. This PR covers an additional case when two or more concurrent Tier 2 reads (resulting from cache misses) do not necessarily start at the same offset, but have at least one overlapping byte.

This PR aims to completely eliminate duplicated data in the Read Index due to such situations. Having Read Index entries that overlap can cause inconsistent read behaviors depending on what offset your read originated; this can also cause recently appended data to vanish from the read index (see parent issue for how this can happen).

**How to verify it**  
New unit tests added to verify this specific scenario.
