### PR TITLE
Issue 4597: Optimization of String splits for Metrics

### DIFF
--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -256,8 +256,11 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
             final AppendBatchSizeTracker batchSizeTracker = getAppendBatchSizeTracker(dataAppended.getRequestId());
             if (batchSizeTracker != null) {
                 long pendingAckCount = batchSizeTracker.recordAck(dataAppended.getEventNumber());
-                metricNotifier.updateSuccessMetric(CLIENT_OUTSTANDING_APPEND_COUNT, writerTags(dataAppended.getWriterId().toString()),
-                                                   pendingAckCount);
+                // Only publish client side metrics when there is some metrics notifier configured for efficiency.
+                if (!metricNotifier.equals(MetricNotifier.NO_OP_METRIC_NOTIFIER)) {
+                    metricNotifier.updateSuccessMetric(CLIENT_OUTSTANDING_APPEND_COUNT, writerTags(dataAppended.getWriterId().toString()),
+                            pendingAckCount);
+                }
             }
         }
         // Obtain ReplyProcessor and process the reply.

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -361,7 +361,7 @@ public class FlowHandlerTest {
     /**
      * Added a mock MetricNotifier different from the default one to exercise reporting metrics from client side.
      */
-    class TestMetricNotifier implements MetricNotifier {
+    static class TestMetricNotifier implements MetricNotifier {
         @Override
         public void updateSuccessMetric(ClientMetricKeys metricKey, String[] metricTags, long value) {
             assertNotNull(metricKey);

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -364,16 +364,19 @@ public class FlowHandlerTest {
     static class TestMetricNotifier implements MetricNotifier {
         @Override
         public void updateSuccessMetric(ClientMetricKeys metricKey, String[] metricTags, long value) {
+            NO_OP_METRIC_NOTIFIER.updateSuccessMetric(metricKey, metricTags, value);
             assertNotNull(metricKey);
         }
 
         @Override
         public void updateFailureMetric(ClientMetricKeys metricKey, String[] metricTags, long value) {
+            NO_OP_METRIC_NOTIFIER.updateFailureMetric(metricKey, metricTags, value);
             assertNotNull(metricKey);
         }
 
         @Override
         public void close() {
+            NO_OP_METRIC_NOTIFIER.close();
         }
     }
 }

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -375,5 +375,5 @@ public class FlowHandlerTest {
         @Override
         public void close() {
         }
-    };
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -102,7 +102,7 @@ public final class MetricsTags {
         }
 
         String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
-        String[] tokens = segmentBaseName.split("[/]");
+        String[] tokens = segmentBaseName.split("/");
         int segmentIdIndex = tokens.length == 2 ? 1 : 2;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {
             String[] segmentIdTokens = tokens[segmentIdIndex].split(EPOCH_DELIMITER);

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -308,7 +308,7 @@ public final class NameUtils {
         String originalSegmentName = isTransactionSegment(qualifiedName) ? getParentStreamSegmentName(qualifiedName) : qualifiedName;
 
         List<String> retVal = new LinkedList<>();
-        String[] tokens = originalSegmentName.split("[/]");
+        String[] tokens = originalSegmentName.split("/");
         int segmentIdIndex = tokens.length == 2 ? 1 : 2;
         long segmentId;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {
@@ -369,7 +369,7 @@ public final class NameUtils {
     public static List<String> extractTableSegmentTokens(String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName);
         List<String> retVal = new LinkedList<>();
-        String[] tokens = qualifiedName.split("[/]");
+        String[] tokens = qualifiedName.split("/");
         Preconditions.checkArgument(tokens.length > 2);
         Preconditions.checkArgument(tokens[1].equals(TABLES));
         // add scope
@@ -388,7 +388,7 @@ public final class NameUtils {
      */
     public static boolean isTableSegment(String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName);
-        String[] tokens = qualifiedName.split("[/]");
+        String[] tokens = qualifiedName.split("/");
         Preconditions.checkArgument(tokens.length > 2);
 
         return tokens[1].equals(TABLES);
@@ -427,7 +427,7 @@ public final class NameUtils {
 
     private static String[] updateSegmentTags(String qualifiedSegmentName, String[] tags) {
         String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
-        String[] tokens = segmentBaseName.split("[/]");
+        String[] tokens = segmentBaseName.split("/");
 
         int segmentIdIndex = (tokens.length == 1) ? 0 : (tokens.length) == 2 ? 1 : 2;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -318,8 +318,11 @@ public class CommandEncoder extends FlushingMessageToByteEncoder<Object> {
         int blockSize = 0;
         if (blockSizeSupplier != null) {
             blockSize = blockSizeSupplier.getAppendBlockSize();
-            metricNotifier.updateSuccessMetric(CLIENT_APPEND_BLOCK_SIZE, segmentTags(append.getSegment(), append.getWriterId().toString()),
-                                               blockSize);
+            // Only publish client side metrics when there is some metrics notifier configured for efficiency.
+            if (!metricNotifier.equals(MetricNotifier.NO_OP_METRIC_NOTIFIER)) {
+                metricNotifier.updateSuccessMetric(CLIENT_APPEND_BLOCK_SIZE, segmentTags(append.getSegment(), append.getWriterId().toString()),
+                        blockSize);
+            }
         }
         segmentBeingAppendedTo = append.segment;
         writerIdPerformingAppends = append.writerId;


### PR DESCRIPTION
**Change log description**  
Uses single-character input in String.split() for efficiency reasons.

**Purpose of the change**  
Fixes #4597.

**What the code does**  
This PR attempts to use a variant of the `String.split()` method implementation, which is optimized for single-character split patterns. There are several occurrences in `NameUtils` class that can exploit this approach, but by some reason a reggex expression is used. This PR just replaces these occurrences, as some of them are on the hot write path.

**How to verify it**  
We have executed a micro benchmark to compare both approaches. Improvement in performance of `String.split()` is consistently between 2x and 4x:
```
    public static void main(String[] args) {
        String toSplit = "this/is/a/segment";
        long iterations = 1000000;
        long iniTime = System.nanoTime();
        for (long i = 0; i < iterations; i++) {
            toSplit.split("[/]");
        }
        double timeReggex = System.nanoTime() - iniTime;
        System.out.println("Time Reggex: " + timeReggex/1000000.0 + "ms");

        iniTime = System.nanoTime();
        for (long i = 0; i < iterations; i++) {
            toSplit.split("/");
        }
        double timeNoReggex = System.nanoTime() - iniTime;
        System.out.println("Time No Reggex: " + timeNoReggex/1000000.0 + "ms");
        System.out.println("Improvement: " + timeReggex/timeNoReggex);
    }
```
These are results from multiple executions:
```
Time Reggex: 747.486985ms
Time No Reggex: 208.371695ms
Improvement: 3.587276981165796
```
```
Time Reggex: 775.19952ms
Time No Reggex: 272.466208ms
Improvement: 2.845121696705964
```
```
Time Reggex: 795.027535ms
Time No Reggex: 399.01521ms
Improvement: 1.9924742593145761
```
Even with larger number of iterations (100M), the improvement is still consistent:
```
Time Reggex: 47721.324557ms
Time No Reggex: 17042.942773ms
Improvement: 2.80006365054524
```