### PR TITLE
Issue 4601: (RollingStorage/ExtendedS3) S3 client consumes whole InputStream and causes java.lang.IllegalArgumentException

### DIFF
--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
@@ -29,13 +29,15 @@ import com.emc.object.s3.request.PutObjectRequest;
 import com.emc.object.s3.request.SetObjectAclRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Properties;
 import lombok.Synchronized;
+import lombok.val;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.gaul.s3proxy.AuthenticationType;
 import org.gaul.s3proxy.S3Proxy;
 import org.jclouds.ContextBuilder;
@@ -108,22 +110,22 @@ public class S3ProxyImpl extends S3ImplBase {
     @Synchronized
     @Override
     public void putObject(String bucketName, String key, Range range, Object content) {
-        byte[] totalByes = new byte[Math.toIntExact(range.getLast() + 1)];
+        byte[] existingBytes = new byte[Math.toIntExact(range.getFirst())];
         try {
             if (range.getFirst() != 0) {
-                int bytesRead = client.getObject(bucketName, key).getObject().read(totalByes, 0,
+                int bytesRead = client.getObject(bucketName, key).getObject().read(existingBytes, 0,
                         Math.toIntExact(range.getFirst()));
                 if (bytesRead != range.getFirst()) {
-                    throw new IllegalStateException("Unable to read from the object " + key);
+                    throw new S3Exception("InvalidRange", HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE, "InvalidRange", key);
                 }
             }
-            int bytesRead = ((InputStream) content).read(totalByes, Math.toIntExact(range.getFirst()),
-                    Math.toIntExact(range.getLast() + 1 - range.getFirst()));
-
-            if (bytesRead != range.getLast() + 1 - range.getFirst()) {
-                throw new IllegalStateException("Not able to read from input stream.");
+            val contentBytes  = IOUtils.toByteArray((InputStream) content);
+            if (contentBytes.length != Math.toIntExact(range.getLast()  - range.getFirst() + 1)) {
+                throw new S3Exception("InvalidRange", HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE, "InvalidRange", key);
             }
-            client.putObject(new PutObjectRequest(bucketName, key, (Object) new ByteArrayInputStream(totalByes)));
+
+            val objectAfterPut = ArrayUtils.addAll(existingBytes, contentBytes);
+            client.putObject(new PutObjectRequest(bucketName, key, (Object) objectAfterPut));
             aclMap.put(key, aclMap.get(key).withSize(range.getLast() - 1));
         } catch (IOException e) {
             throw new S3Exception("NoObject", HttpStatus.SC_NOT_FOUND, "NoSuchKey", key);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.storage.rolling;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
+import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.CollectionHelpers;
 import io.pravega.segmentstore.contracts.BadOffsetException;
@@ -29,6 +30,7 @@ import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.SyncStorage;
 import io.pravega.shared.NameUtils;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -301,6 +303,7 @@ public class RollingStorage implements SyncStorage {
     }
 
     @Override
+    @SneakyThrows(IOException.class)
     public void write(SegmentHandle handle, long offset, InputStream data, int length) throws StreamSegmentException {
         val h = getHandle(handle);
         ensureNotDeleted(h);
@@ -321,7 +324,13 @@ public class RollingStorage implements SyncStorage {
             int writeLength = (int) Math.min(length - bytesWritten, h.getRollingPolicy().getMaxLength() - last.getLength());
             assert writeLength > 0 : "non-positive write length";
             long chunkOffset = offset + bytesWritten - last.getStartOffset();
-            this.baseStorage.write(h.getActiveChunkHandle(), chunkOffset, data, writeLength);
+
+            // Use a BoundedInputStream to ensure that the underlying storage does not try to read more (or less) data
+            // than we instructed it to. Invoking BoundedInputStream.close() will throw an IOException if baseStorage.write()
+            // has not read all the bytes it was supposed to.
+            try (BoundedInputStream bis = new BoundedInputStream(data, writeLength)) {
+                this.baseStorage.write(h.getActiveChunkHandle(), chunkOffset, bis, writeLength);
+            }
             last.increaseLength(writeLength);
             bytesWritten += writeLength;
         }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -406,8 +406,7 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
             for (int j = 0; j < APPENDS_PER_SEGMENT; j++) {
                 byte[] writeData = String.format(APPEND_FORMAT, segmentName, j).getBytes();
 
-                // Append some garbage at the end to make sure we only write as much as instructed, and not the whole InputStream.
-                val dataStream = new SequenceInputStream(new ByteArrayInputStream(writeData), new ByteArrayInputStream(extraData));
+                val dataStream = new ByteArrayInputStream(writeData);
                 s.write(writeHandle, offset, dataStream, writeData.length, TIMEOUT).join();
                 writeStream.write(writeData);
                 offset += writeData.length;


### PR DESCRIPTION
**Change log description**  
S3 client consumes whole InputStream and causes java.lang.IllegalArgumentException.
With this change, RollingStorage.write sends in BoundedInputStream to storage adapters to prevent reading more data.
Also, S3 client mocks simulate this InvalidRange behavior to match how real ECS bahaves.

**Purpose of the change**  
Fixes #4601 

**What the code does**  
RollingStorage.write sends in BoundedInputStream to storage adapters to prevent reading more data.
S3 client mocks simulate this range behavior to match how real ECS bahaves.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
