### PR TITLE
Issue 4610: (SegmentStore) Read Index data corruption during concurrent segment merge and cache eviction.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -482,7 +482,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         StreamSegmentReadIndex sourceIndex = redirectEntry.getRedirectReadIndex();
 
         // Get all the entries from the source index and append them here.
-        List<MergedIndexEntry> sourceEntries = sourceIndex.removeAllEntries(redirectEntry.getStreamSegmentOffset());
+        List<MergedIndexEntry> sourceEntries = sourceIndex.removeAllDataEntries(redirectEntry.getStreamSegmentOffset());
 
         synchronized (this.lock) {
             // Remove redirect entry (again, no need to update the Cache Stats, as this is a RedirectIndexEntry).
@@ -1200,7 +1200,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      * live data in the {@link CacheManager}; as such it is the responsibility of the caller to manage their lifecycle
      * from now on.
      */
-    private List<MergedIndexEntry> removeAllEntries(long offsetAdjustment) {
+    private List<MergedIndexEntry> removeAllDataEntries(long offsetAdjustment) {
         Preconditions.checkState(this.metadata.isDeleted(), "Cannot fetch entries for a Segment that has not been deleted yet.");
         Exceptions.checkArgument(offsetAdjustment >= 0, "offsetAdjustment", "offsetAdjustment must be a non-negative number.");
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -482,7 +482,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         StreamSegmentReadIndex sourceIndex = redirectEntry.getRedirectReadIndex();
 
         // Get all the entries from the source index and append them here.
-        List<MergedIndexEntry> sourceEntries = sourceIndex.fetchAllEntries(redirectEntry.getStreamSegmentOffset());
+        List<MergedIndexEntry> sourceEntries = sourceIndex.removeAllEntries(redirectEntry.getStreamSegmentOffset());
 
         synchronized (this.lock) {
             // Remove redirect entry (again, no need to update the Cache Stats, as this is a RedirectIndexEntry).
@@ -1192,15 +1192,15 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     }
 
     /**
-     * Gets a copy of all the ReadIndexEntries in this Index that are not RedirectReadIndices and removes them from this
-     * index. All returned entries have their offsets adjusted by the given amount.
+     * Extracts all the ReadIndexEntries from this Index that are not RedirectReadIndices and clears the Index.
+     * All returned entries have their offsets adjusted by the given amount.
      *
      * @param offsetAdjustment The amount to adjust the offset by.
      * @return A List of {@link MergedIndexEntry} that represents the contents of this index. All these entries point to
      * live data in the {@link CacheManager}; as such it is the responsibility of the caller to manage their lifecycle
      * from now on.
      */
-    private List<MergedIndexEntry> fetchAllEntries(long offsetAdjustment) {
+    private List<MergedIndexEntry> removeAllEntries(long offsetAdjustment) {
         Preconditions.checkState(this.metadata.isDeleted(), "Cannot fetch entries for a Segment that has not been deleted yet.");
         Exceptions.checkArgument(offsetAdjustment >= 0, "offsetAdjustment", "offsetAdjustment must be a non-negative number.");
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -482,7 +482,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         StreamSegmentReadIndex sourceIndex = redirectEntry.getRedirectReadIndex();
 
         // Get all the entries from the source index and append them here.
-        List<MergedIndexEntry> sourceEntries = sourceIndex.getAllEntries(redirectEntry.getStreamSegmentOffset());
+        List<MergedIndexEntry> sourceEntries = sourceIndex.fetchAllEntries(redirectEntry.getStreamSegmentOffset());
 
         synchronized (this.lock) {
             // Remove redirect entry (again, no need to update the Cache Stats, as this is a RedirectIndexEntry).
@@ -1192,24 +1192,33 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     }
 
     /**
-     * Gets a copy of all the ReadIndexEntries in this Index that are not RedirectReadIndices. All returned
-     * entries have their offsets adjusted by the given amount.
+     * Gets a copy of all the ReadIndexEntries in this Index that are not RedirectReadIndices and removes them from this
+     * index. All returned entries have their offsets adjusted by the given amount.
      *
      * @param offsetAdjustment The amount to adjust the offset by.
+     * @return A List of {@link MergedIndexEntry} that represents the contents of this index. All these entries point to
+     * live data in the {@link CacheManager}; as such it is the responsibility of the caller to manage their lifecycle
+     * from now on.
      */
-    private List<MergedIndexEntry> getAllEntries(long offsetAdjustment) {
+    private List<MergedIndexEntry> fetchAllEntries(long offsetAdjustment) {
+        Preconditions.checkState(this.metadata.isDeleted(), "Cannot fetch entries for a Segment that has not been deleted yet.");
         Exceptions.checkArgument(offsetAdjustment >= 0, "offsetAdjustment", "offsetAdjustment must be a non-negative number.");
 
+        List<MergedIndexEntry> result;
         synchronized (this.lock) {
-            List<MergedIndexEntry> result = new ArrayList<>(this.indexEntries.size());
+            result = new ArrayList<>(this.indexEntries.size());
             this.indexEntries.forEach(entry -> {
                 if (entry.isDataEntry()) {
                     result.add(new MergedIndexEntry(entry.getStreamSegmentOffset() + offsetAdjustment, this.metadata.getId(), (CacheIndexEntry) entry));
                 }
             });
 
-            return result;
+            // The Index entries are no longer ours and this segment has been deleted. Clear the index to prevent the
+            // Cache Manager from messing around with the Cache Data that is now referenced by another Index.
+            this.indexEntries.clear();
         }
+
+        return result;
     }
 
     private void deleteData(ReadIndexEntry entry) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
@@ -11,11 +11,16 @@ package io.pravega.segmentstore.server;
 
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import lombok.Setter;
 
 /**
  * Exposes the applyCachePolicy method in the CacheManager.
  */
 public class TestCacheManager extends CacheManager {
+    @Setter
+    private Consumer<Client> unregisterInterceptor;
+
     public TestCacheManager(CachePolicy policy, CacheStorage cacheStorage, ScheduledExecutorService executorService) {
         super(policy, cacheStorage, executorService);
     }
@@ -23,5 +28,15 @@ public class TestCacheManager extends CacheManager {
     @Override
     public boolean applyCachePolicy() {
         return super.applyCachePolicy();
+    }
+
+    @Override
+    public void unregister(Client client) {
+        Consumer<Client> interceptor = this.unregisterInterceptor;
+        if (interceptor != null) {
+            interceptor.accept(client);
+        }
+
+        super.unregister(client);
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -91,7 +91,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration TIMEOUT = Duration.ofSeconds(2000000);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule
@@ -1416,6 +1416,93 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         StreamHelpers.readAll(contents.getData(), readData, 0, readData.length);
 
         Assert.assertArrayEquals("Unexpected data read from parent segment.", writeData.getCopy(), readData);
+    }
+
+    /**
+     * Tests a scenario where a call to {@link StreamSegmentReadIndex#completeMerge} executes concurrently with a
+     * CacheManager eviction. The Cache Manager must not evict the data for recently transferred entries, even if they
+     * would otherwise be eligible for eviction in the source segment.
+     */
+    @Test
+    public void testConcurrentEvictionTransactionStorageMerge() throws Exception {
+        val mergeOffset = 1;
+        val appendLength = 1;
+        CachePolicy cachePolicy = new CachePolicy(1, Duration.ZERO, Duration.ofMillis(1));
+        @Cleanup
+        TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
+
+        // Create parent segment and one transaction
+        long targetId = createSegment(0, context);
+        long sourceId = createTransaction(1, context);
+        val targetMetadata = context.metadata.getStreamSegmentMetadata(targetId);
+        val sourceMetadata = context.metadata.getStreamSegmentMetadata(sourceId);
+        createSegmentsInStorage(context);
+
+        // Write something to the parent segment.
+        appendSingleWrite(targetId, new ByteArraySegment(new byte[mergeOffset]), context);
+        context.storage.openWrite(targetMetadata.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, new ByteArrayInputStream(new byte[mergeOffset]), mergeOffset, TIMEOUT)).join();
+
+        // Write something to the transaction, but do not write anything in Storage - we want to verify we don't even
+        // try to reach in there.
+        val sourceContents = getAppendData(context.metadata.getStreamSegmentMetadata(sourceId).getName(), sourceId, 0, 0);
+        appendSingleWrite(sourceId, sourceContents, context);
+        sourceMetadata.setStorageLength(sourceMetadata.getLength());
+
+        // Seal & Begin-merge the transaction (do not seal in storage).
+        sourceMetadata.markSealed();
+        targetMetadata.setLength(sourceMetadata.getLength() + mergeOffset);
+        context.readIndex.beginMerge(targetId, mergeOffset, sourceId);
+        sourceMetadata.markMerged();
+        sourceMetadata.markDeleted();
+
+        // Trigger a Complete Merge. We want to intercept and pause it immediately before it is unregistered from the
+        // Cache Manager.
+        @Cleanup("release")
+        val unregisterCalled = new ReusableLatch();
+        @Cleanup("release")
+        val unregisterBlocker = new ReusableLatch();
+        context.cacheManager.setUnregisterInterceptor(c -> {
+            unregisterCalled.release();
+            Exceptions.handleInterrupted(unregisterBlocker::await);
+        });
+
+        val completeMerge = CompletableFuture.runAsync(() -> {
+            try {
+                context.readIndex.completeMerge(targetId, sourceId);
+            } catch (Exception ex) {
+                throw new CompletionException(ex);
+            }
+        }, executorService());
+
+        // Clear the cache. The source Read index is still registered in the Cache Manager - we want to ensure that any
+        // eviction happening at this point will not delete anything from the Cache that we don't want deleted.
+        unregisterCalled.await();
+        context.cacheManager.applyCachePolicy();
+
+        // Wait for the operation to complete.
+        unregisterBlocker.release();
+        completeMerge.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Verify that we can append (appending will modify the last cache entry; if it had been modified this would not
+        // work anymore).
+        val appendOffset = (int) targetMetadata.getLength();
+        val appendData = new byte[appendLength];
+        appendData[0] = (byte) 23;
+        targetMetadata.setLength(appendOffset + appendLength);
+        context.readIndex.append(targetId, appendOffset, new ByteArraySegment(appendData));
+
+        // Issue a read and verify we can read everything that we wrote. If it had been evicted or erroneously deleted
+        // from the cache this would result in an error.
+        byte[] expectedData = new byte[appendOffset + appendLength];
+        sourceContents.copyTo(expectedData, mergeOffset, sourceContents.getLength());
+        System.arraycopy(appendData, 0, expectedData, appendOffset, appendLength);
+
+        ReadResult rr = context.readIndex.read(targetId, 0, expectedData.length, TIMEOUT);
+        Assert.assertTrue("Parent Segment read indicates no data available.", rr.hasNext());
+        byte[] actualData = new byte[expectedData.length];
+        rr.readRemaining(actualData, TIMEOUT);
+        Assert.assertArrayEquals("Unexpected data read back.", expectedData, actualData);
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -91,7 +91,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(2000000);
+    private static final Duration TIMEOUT = Duration.ofSeconds(20);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule


### PR DESCRIPTION
**Change log description**  
Fixed a bug where a concurrent segment merge and cache eviction could corrupt the Read Index.

**Purpose of the change**  
Fixes #4610.

**What the code does**  
In the Read Index, Segments are merged into each other in a two-step process. Step 1 (BeginMerge) is performed when the request is received externally and involves adding a Redirect placeholder in the index for the merged byte range. Step 2 (CompleteMerge) is performed when the merge is performed in Tier 2 and involves atomically removing the Redirect placeholder and copying over the entire Read Index of the source segment.

With the current implementation, Step 2 has a short period of time where, if a Cache Manager eviction executes, it can effectively delete the data from the cache. That is because the source index entries were copied over but they still remained in the source index. If the Cache Manager decided it's time to evict data, those old entries were eligible for eviction since the segment has just been merged. If this does go through, the newly copied entries will now point to invalid Cache addresses, which can have a number of bad side effects:
- A subsequent append will fail because it tries to append to a non-allocated block
- A subsequent read will fail because there's no data to read from the cache.
- The cache blocks could have been reallocated to other entries, so:
    - A subsequent append will fail because the append condition (last block length) doesn't match what's in the cache.
    - A subsequent read will read data belonging to completely unrelated segments and/or events
    - A subsequent cache eviction could deallocate blocks that are used by other entries.    

To resolve this, we need to change the "copy" to a "move". We atomically replace the Redirect Index entry with copies of the source entries and remove the source entries from the source index. This way, they will be out of reach of the Cache Manager. Since the source segment ceased to exist (it was merged), this operation should have no side effects.

**How to verify it**  
Unit tests added to verify scenario.
