### PR TITLE
Issue 4618: (SegmentStore) Fixed a possible infinite loop in StorageWriter for empty appends.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1567,10 +1567,11 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         while (this.operations.size() > 0 && !reachedEnd) {
             StorageOperation first = this.operations.getFirst();
             long lastOffset = first.getLastStreamSegmentOffset();
-            boolean isAppendOperation = isAppendOperation(first);
-            reachedEnd = lastOffset >= newLength || !isAppendOperation;
-
-            if (lastOffset <= newLength && isAppendOperation) {
+            reachedEnd = lastOffset >= newLength;
+            if (!isAppendOperation(first)) {
+                // We can only remove Append Operations.
+                reachedEnd = true;
+            } else if (lastOffset <= newLength) {
                 // Fully flushed Append Operation.
                 this.operations.removeFirst();
             }


### PR DESCRIPTION
**Change log description**  
Fixed a bug in SegmentAggregator where it could enter an infinite async loop if it receives an empty append.

**Purpose of the change**  
Fixes #4618.

**What the code does**  
See #4618 for a scenario that can lead to a situation like this.

Currently, if a `SegmentAggregator` is sitting on an Append of length 0 **and** it receives a non-append operation (such as Merge, Truncate, Seal), it will try to flush that 0-length append and end up in an infinite loop, without any chance of exiting it (short of a container restart). This was due to some short-circuit in the `flushPendingAppends` method that was exiting early from the call if there was nothing to flush, without invoking the `updateStatePostFlush` callback which would have removed that empty append from the queue. Since the append was not removed, the subsequent invocation of this method would end up in the same place, thus triggering the infinite loop.

The change in this PR removes this short-circuit and leaves the code to deal with empty appends (which it already did). Minor adjustments had to be made in `updateStatePostFlush` to account for real situations where this was a legitimate empty-flush (covered by existing unit tests).

**How to verify it**  
New unit test to verify this scenario was added.
