### PR TITLE
Issue 4610: (CherryPick-0.7)(SegmentStore) Read Index data corruption during concurre…

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
@@ -11,11 +11,16 @@ package io.pravega.segmentstore.server;
 
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import lombok.Setter;
 
 /**
  * Exposes the applyCachePolicy method in the CacheManager.
  */
 public class TestCacheManager extends CacheManager {
+    @Setter
+    private Consumer<Client> unregisterInterceptor;
+
     public TestCacheManager(CachePolicy policy, CacheStorage cacheStorage, ScheduledExecutorService executorService) {
         super(policy, cacheStorage, executorService);
     }
@@ -23,5 +28,15 @@ public class TestCacheManager extends CacheManager {
     @Override
     public boolean applyCachePolicy() {
         return super.applyCachePolicy();
+    }
+
+    @Override
+    public void unregister(Client client) {
+        Consumer<Client> interceptor = this.unregisterInterceptor;
+        if (interceptor != null) {
+            interceptor.accept(client);
+        }
+
+        super.unregister(client);
     }
 }


### PR DESCRIPTION
**Change log description**  
Fixed a bug where a concurrent segment merge and cache eviction could corrupt the Read Index.
Cherrypicking PR #4611 into r0.7.

**Purpose of the change**  
Fixes #4610.

**What the code does**  
See #4611 

**How to verify it**  
See #4611.
