### PR TITLE
Issue 4609: (CherryPick-0.7) ExtendedS3Storage.concat using appends when source segment is small (#4617)

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Metrics.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Metrics.java
@@ -33,4 +33,5 @@ final class ExtendedS3Metrics {
     static final Counter CREATE_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_CREATE_COUNT);
     static final Counter DELETE_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_DELETE_COUNT);
     static final Counter CONCAT_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_CONCAT_COUNT);
+    static final Counter LARGE_CONCAT_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);
 }

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -39,6 +39,8 @@ import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SyncStorage;
+
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.SortedSet;
@@ -386,23 +388,57 @@ public class ExtendedS3Storage implements SyncStorage {
      * completeMultiPartUpload call. Specifically, to concatenate, we are copying the target segment T and the
      * source segment S to T, so essentially we are doing T <- T + S.
      */
-    private Void doConcat(SegmentHandle targetHandle, long offset, String sourceSegment) throws StreamSegmentNotExistsException {
+    private Void doConcat(SegmentHandle targetHandle, long offset, String sourceSegment) throws Exception {
         Preconditions.checkArgument(!targetHandle.isReadOnly(), "target handle must not be read-only.");
         long traceId = LoggerHelpers.traceEnter(log, "concat", targetHandle.getSegmentName(), offset, sourceSegment);
         Timer timer = new Timer();
-        SortedSet<MultipartPartETag> partEtags = new TreeSet<>();
-        String targetPath = config.getPrefix() + targetHandle.getSegmentName();
-        String uploadId = client.initiateMultipartUpload(config.getBucket(), targetPath);
 
+        String targetPath = config.getPrefix() + targetHandle.getSegmentName();
         // check whether the target exists
         if (!doExists(targetHandle.getSegmentName())) {
             throw new StreamSegmentNotExistsException(targetHandle.getSegmentName());
         }
         // check whether the source is sealed
         SegmentProperties si = doGetStreamSegmentInfo(sourceSegment);
+        String sourcePath = config.getPrefix() + sourceSegment;
         Preconditions.checkState(si.isSealed(), "Cannot concat segment '%s' into '%s' because it is not sealed.",
                 sourceSegment, targetHandle.getSegmentName());
 
+        if (config.getSmallObjectSizeLimitForConcat() < si.getLength()) {
+            doConcatWithMultipartUpload(targetPath, sourceSegment, offset);
+            ExtendedS3Metrics.LARGE_CONCAT_COUNT.inc();
+        } else {
+            doConcatWithAppend(targetPath, sourcePath, offset, si.getLength());
+        }
+        // Now delete the source object.
+        client.deleteObject(config.getBucket(), sourcePath);
+
+        Duration elapsed = timer.getElapsed();
+        log.debug("Concat target={} source={} offset={} bytesWritten={} latency={}.", targetHandle.getSegmentName(), sourceSegment, offset, si.getLength(), elapsed.toMillis());
+
+        ExtendedS3Metrics.CONCAT_LATENCY.reportSuccessEvent(elapsed);
+        ExtendedS3Metrics.CONCAT_BYTES.add(si.getLength());
+        ExtendedS3Metrics.CONCAT_COUNT.inc();
+
+        LoggerHelpers.traceLeave(log, "concat", traceId);
+
+        return null;
+    }
+
+    private void doConcatWithAppend(String targetPath, String sourcePath, long offset, long length) throws Exception {
+        try (InputStream reader = client.readObjectStream(config.getBucket(),
+                sourcePath, Range.fromOffsetLength(0, length))) {
+            client.putObject(this.config.getBucket(),
+                    targetPath,
+                    Range.fromOffsetLength(offset, length),
+                    new BufferedInputStream(reader, Math.toIntExact(length)));
+        }
+    }
+
+    private void doConcatWithMultipartUpload(String targetPath, String sourceSegment, long offset) {
+        String uploadId = client.initiateMultipartUpload(config.getBucket(), targetPath);
+
+        SortedSet<MultipartPartETag> partEtags = new TreeSet<>();
         //Copy the first part
         CopyPartRequest copyRequest = new CopyPartRequest(config.getBucket(),
                 targetPath,
@@ -432,19 +468,6 @@ public class ExtendedS3Storage implements SyncStorage {
         //Close the upload
         client.completeMultipartUpload(new CompleteMultipartUploadRequest(config.getBucket(),
                 targetPath, uploadId).withParts(partEtags));
-
-        client.deleteObject(config.getBucket(), config.getPrefix() + sourceSegment);
-        Duration elapsed = timer.getElapsed();
-
-        log.debug("Concat target={} source={} offset={} bytesWritten={} latency={}.", targetHandle.getSegmentName(), sourceSegment, offset, si.getLength(), elapsed.toMillis());
-
-        ExtendedS3Metrics.CONCAT_LATENCY.reportSuccessEvent(elapsed);
-        ExtendedS3Metrics.CONCAT_BYTES.add(si.getLength());
-        ExtendedS3Metrics.CONCAT_COUNT.inc();
-
-        LoggerHelpers.traceLeave(log, "concat", traceId);
-
-        return null;
     }
 
     private Void doDelete(SegmentHandle handle) {

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -30,6 +30,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> PREFIX = Property.named("prefix", "/");
     public static final Property<Boolean> USENONEMATCH = Property.named("useNoneMatch", false);
+    public static final Property<Integer> SMALL_OBJECT_THRESHOLD = Property.named("smallObjectSizeLimitForConcat", 1024 * 1024);
 
     private static final String COMPONENT_CODE = "extendeds3";
     private static final String PATH_SEPARATOR = "/";
@@ -75,6 +76,14 @@ public class ExtendedS3StorageConfig {
     @Getter
     private final boolean useNoneMatch;
 
+    /**
+     * Size of ECS objects in bytes above which it is no longer considered a small object.
+     * For small source objects, to implement concat ExtendedS3Storage reads complete objects and appends it to target
+     * instead of using multi part upload.
+     */
+    @Getter
+    private final int smallObjectSizeLimitForConcat;
+
     //endregion
 
     //region Constructor
@@ -93,6 +102,7 @@ public class ExtendedS3StorageConfig {
         String givenPrefix = Preconditions.checkNotNull(properties.get(PREFIX), "prefix");
         this.prefix = givenPrefix.endsWith(PATH_SEPARATOR) ? givenPrefix : givenPrefix + PATH_SEPARATOR;
         this.useNoneMatch = properties.getBoolean(USENONEMATCH);
+        this.smallObjectSizeLimitForConcat = properties.getInt(SMALL_OBJECT_THRESHOLD);
     }
 
     /**

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -185,10 +185,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
             assertEquals(2, ExtendedS3Metrics.DELETE_LATENCY.toOpStatsData().getNumSuccessfulEvents());
             assertTrue(0 < ExtendedS3Metrics.DELETE_LATENCY.toOpStatsData().getAvgLatencyMillis());
 
-        } finally {
-
         }
-
     }
 
     /**
@@ -224,6 +221,29 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
             // Verify with prefix
             assertFalse(s.exists(segmentName1, null).get());
             assertFalse(s.exists(segmentName1 + "$header", null).get());
+        }
+    }
+
+    /**
+     * Tests the concat() method forcing to use multipart upload.
+     *
+     * @throws Exception if an unexpected error occurred.
+     */
+    @Test
+    public void testConcatWithMultipartUpload() throws Exception {
+        val adapterConfig = ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, setup.configUri)
+                .with(ExtendedS3StorageConfig.BUCKET, setup.adapterConfig.getBucket())
+                .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
+                .with(ExtendedS3StorageConfig.USENONEMATCH, true)
+                .with(ExtendedS3StorageConfig.SMALL_OBJECT_THRESHOLD, 1)
+                .build();
+        final String context = createSegmentName("Concat");
+        assertEquals(0, ExtendedS3Metrics.LARGE_CONCAT_COUNT.get());
+        try (Storage s = createStorage(setup.client, adapterConfig, executorService())) {
+            testConcat(context, s);
+            assertTrue(ExtendedS3Metrics.LARGE_CONCAT_COUNT.get() > 0);
+            assertEquals(ExtendedS3Metrics.CONCAT_COUNT.get(), ExtendedS3Metrics.LARGE_CONCAT_COUNT.get());
         }
     }
 

--- a/config/config.properties
+++ b/config/config.properties
@@ -448,6 +448,16 @@ extendeds3.configUri=http://localhost:9020?identity=user&secretKey=password
 # Prefix is optional.
 # extendeds3.prefix=
 
+# Size of ECS objects in bytes above which it is no longer considered a small object.
+# This value is used to optimize transactions performance when size of transaction segments is small.
+# For small transaction segments, to implement concat ExtendedS3Storage reads complete source segment and appends it to target
+# instead of using multipart upload.
+# smallObjectSizeLimitForConcat is optional.
+# Valid values: Positive integer.
+# Default value: 1048576 (1MB).
+# Recommended values: 1 MB.
+# extendeds3.smallObjectSizeLimitForConcat=1048576
+
 ##endregion
 
 ##region filesystem settings

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -308,75 +308,79 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     public void testConcat() throws Exception {
         final String context = createSegmentName("Concat");
         try (Storage s = createStorage()) {
-            s.initialize(DEFAULT_EPOCH);
-            HashMap<String, ByteArrayOutputStream> appendData = populate(s, context);
-
-            // Check invalid segment name.
-            val firstSegmentName = getSegmentName(0, context);
-            val firstSegmentHandle = s.openWrite(firstSegmentName).join();
-            val sealedSegmentName = createSegmentName("SealedSegment");
-            createSegment(sealedSegmentName, s);
-            val sealedSegmentHandle = s.openWrite(sealedSegmentName).join();
-            s.write(sealedSegmentHandle, 0, new ByteArrayInputStream(new byte[1]), 1, TIMEOUT).join();
-            s.seal(sealedSegmentHandle, TIMEOUT).join();
-            AtomicLong firstSegmentLength = new AtomicLong(s.getStreamSegmentInfo(firstSegmentName,
-                    TIMEOUT).join().getLength());
-            assertSuppliedFutureThrows("concat() did not throw for non-existent target segment name.",
-                    () -> s.concat(createInexistentSegmentHandle(s, false), 0, sealedSegmentName, TIMEOUT),
-                    ex -> ex instanceof StreamSegmentNotExistsException);
-
-            assertSuppliedFutureThrows("concat() did not throw for invalid source StreamSegment name.",
-                    () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), "foo2", TIMEOUT),
-                    ex -> ex instanceof StreamSegmentNotExistsException);
-
-            ArrayList<String> concatOrder = new ArrayList<>();
-            concatOrder.add(firstSegmentName);
-            for (String sourceSegment : appendData.keySet()) {
-                if (sourceSegment.equals(firstSegmentName)) {
-                    // FirstSegment is where we'll be concatenating to.
-                    continue;
-                }
-
-                assertSuppliedFutureThrows("Concat allowed when source segment is not sealed.",
-                        () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT),
-                        ex -> ex instanceof IllegalStateException);
-
-                // Seal the source segment and then re-try the concat
-                val sourceWriteHandle = s.openWrite(sourceSegment).join();
-                s.seal(sourceWriteHandle, TIMEOUT).join();
-                SegmentProperties preConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-                SegmentProperties sourceProps = s.getStreamSegmentInfo(sourceSegment, TIMEOUT).join();
-
-                s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT).join();
-                concatOrder.add(sourceSegment);
-                SegmentProperties postConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-                Assert.assertFalse("concat() did not delete source segment", s.exists(sourceSegment, TIMEOUT).join());
-
-                // Only check lengths here; we'll check the contents at the end.
-                Assert.assertEquals("Unexpected target StreamSegment.length after concatenation.",
-                        preConcatTargetProps.getLength() + sourceProps.getLength(), postConcatTargetProps.getLength());
-                firstSegmentLength.set(postConcatTargetProps.getLength());
-            }
-
-            // Check the contents of the first StreamSegment. We already validated that the length is correct.
-            SegmentProperties segmentProperties = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-            byte[] readBuffer = new byte[(int) segmentProperties.getLength()];
-
-            // Read the entire StreamSegment.
-            int bytesRead = s.read(firstSegmentHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
-            Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
-
-            // Check, concat-by-concat, that the final data is correct.
-            int offset = 0;
-            for (String segmentName : concatOrder) {
-                byte[] concatData = appendData.get(segmentName).toByteArray();
-                AssertExtensions.assertArrayEquals("Unexpected concat data.", concatData, 0, readBuffer, offset,
-                        concatData.length);
-                offset += concatData.length;
-            }
-
-            Assert.assertEquals("Concat included more bytes than expected.", offset, readBuffer.length);
+            testConcat(context, s);
         }
+    }
+
+    protected void testConcat(String context, Storage s) throws Exception {
+        s.initialize(DEFAULT_EPOCH);
+        HashMap<String, ByteArrayOutputStream> appendData = populate(s, context);
+
+        // Check invalid segment name.
+        val firstSegmentName = getSegmentName(0, context);
+        val firstSegmentHandle = s.openWrite(firstSegmentName).join();
+        val sealedSegmentName = createSegmentName("SealedSegment");
+        createSegment(sealedSegmentName, s);
+        val sealedSegmentHandle = s.openWrite(sealedSegmentName).join();
+        s.write(sealedSegmentHandle, 0, new ByteArrayInputStream(new byte[1]), 1, TIMEOUT).join();
+        s.seal(sealedSegmentHandle, TIMEOUT).join();
+        AtomicLong firstSegmentLength = new AtomicLong(s.getStreamSegmentInfo(firstSegmentName,
+                TIMEOUT).join().getLength());
+        assertSuppliedFutureThrows("concat() did not throw for non-existent target segment name.",
+                () -> s.concat(createInexistentSegmentHandle(s, false), 0, sealedSegmentName, TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        assertSuppliedFutureThrows("concat() did not throw for invalid source StreamSegment name.",
+                () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), "foo2", TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        ArrayList<String> concatOrder = new ArrayList<>();
+        concatOrder.add(firstSegmentName);
+        for (String sourceSegment : appendData.keySet()) {
+            if (sourceSegment.equals(firstSegmentName)) {
+                // FirstSegment is where we'll be concatenating to.
+                continue;
+            }
+
+            assertSuppliedFutureThrows("Concat allowed when source segment is not sealed.",
+                    () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT),
+                    ex -> ex instanceof IllegalStateException);
+
+            // Seal the source segment and then re-try the concat
+            val sourceWriteHandle = s.openWrite(sourceSegment).join();
+            s.seal(sourceWriteHandle, TIMEOUT).join();
+            SegmentProperties preConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+            SegmentProperties sourceProps = s.getStreamSegmentInfo(sourceSegment, TIMEOUT).join();
+
+            s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT).join();
+            concatOrder.add(sourceSegment);
+            SegmentProperties postConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+            Assert.assertFalse("concat() did not delete source segment", s.exists(sourceSegment, TIMEOUT).join());
+
+            // Only check lengths here; we'll check the contents at the end.
+            Assert.assertEquals("Unexpected target StreamSegment.length after concatenation.",
+                    preConcatTargetProps.getLength() + sourceProps.getLength(), postConcatTargetProps.getLength());
+            firstSegmentLength.set(postConcatTargetProps.getLength());
+        }
+
+        // Check the contents of the first StreamSegment. We already validated that the length is correct.
+        SegmentProperties segmentProperties = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+        byte[] readBuffer = new byte[(int) segmentProperties.getLength()];
+
+        // Read the entire StreamSegment.
+        int bytesRead = s.read(firstSegmentHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
+        Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
+
+        // Check, concat-by-concat, that the final data is correct.
+        int offset = 0;
+        for (String segmentName : concatOrder) {
+            byte[] concatData = appendData.get(segmentName).toByteArray();
+            AssertExtensions.assertArrayEquals("Unexpected concat data.", concatData, 0, readBuffer, offset,
+                    concatData.length);
+            offset += concatData.length;
+        }
+
+        Assert.assertEquals("Concat included more bytes than expected.", offset, readBuffer.length);
     }
 
     /**

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -108,6 +108,7 @@ public final class MetricsNames {
     public static final String STORAGE_CREATE_COUNT = PREFIX + "segmentstore.storage.create_count";      // Counter
     public static final String STORAGE_DELETE_COUNT = PREFIX + "segmentstore.storage.delete_count";      // Counter
     public static final String STORAGE_CONCAT_COUNT = PREFIX + "segmentstore.storage.concat_count";      // Counter
+    public static final String STORAGE_LARGE_CONCAT_COUNT = PREFIX + "segmentstore.storage.large_concat_count"; // Counter
 
 
     // Cache stats


### PR DESCRIPTION
**Change log description** 
 With this change , for smaller source segments, concat should read complete source segment and append it to target instead of using multi-part upload.
For larger source segments continue using multi part upload method.

Cherry picks  #4617 

**Purpose of the change**  
Fixes #4609.

**What the code does**  
See  #4617.

**How to verify it**  
See  #4617.
**How to verify it**  
See  #4617.
