### PR TITLE
Issue 4347: Enable auto-reload of modified logging configuration at runtime

### DIFF
--- a/client/src/test/resources/logback-test.xml
+++ b/client/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/client/src/test/resources/logback.xml
+++ b/client/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <logger name="org.apache.zookeeper" level="WARN"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/controller/src/test/resources/logback.xml
+++ b/controller/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/segmentstore/server/host/src/config/logback.xml
+++ b/segmentstore/server/host/src/config/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/segmentstore/storage/impl/src/test/resources/logback.xml
+++ b/segmentstore/storage/impl/src/test/resources/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/segmentstore/storage/src/test/resources/logback.xml
+++ b/segmentstore/storage/src/test/resources/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/test/integration/src/main/resources/logback-test.xml
+++ b/test/integration/src/main/resources/logback-test.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/test/integration/src/test/resources/logback.xml
+++ b/test/integration/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/test/system/src/test/resources/logback-test.xml
+++ b/test/system/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>


### PR DESCRIPTION
**Change log description**  

Enable logging configuration re-load upon configuration file modification. 

**Purpose of the change**  
Resolves #4347. 

**What the code does**  

Adds `scanPeriod` attribute to Logback configuration element `configuration` with `scan` enabled, so that logging configuration changes are reloaded. 

Currently,  the logging configuration specifies `<configuration scan="true">`, which in theory should automatically reload logging configuration changes at runtime with a default scan period of 1 minute ([source](http://logback.qos.ch/manual/configuration.html)). However, the version of logback we use (`1.2.3`) has a bug, which deactivates `scan` if `scanPeriod` is left unspecified: https://jira.qos.ch/browse/LOGBACK-1194. 

Alternatively, we could upgrade the Logback library, but arguably it makes sense to update the `scanPeriod` attribute anyway to make it explicit/visible. 

**How to verify it**  
Run Pravega standalone. Modify log level and/ other configuration, and wait for about 30 seconds to take effect. 
