### PR TITLE
Issue 4639: Table store helper to retry only on unknownhost and auth failure for update requests

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
@@ -50,6 +50,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static io.pravega.controller.server.WireCommandFailedException.Reason.ConnectionDropped;
+import static io.pravega.controller.server.WireCommandFailedException.Reason.ConnectionFailed;
 import static io.pravega.controller.store.stream.AbstractStreamMetadataStore.DATA_NOT_FOUND_PREDICATE;
 
 /**
@@ -176,7 +178,7 @@ public class PravegaTablesStoreHelper {
                 new TableEntryImpl<>(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), KeyVersion.NOT_EXISTS), value));
         Supplier<String> errorMessage = () -> String.format("addNewEntry: key: %s table: %s", key, tableName);
         return withRetries(() -> segmentHelper.updateTableEntries(tableName, entries, authToken.get(), RequestTag.NON_EXISTENT_ID),
-                errorMessage)
+                errorMessage, true)
                 .exceptionally(e -> {
                     Throwable unwrap = Exceptions.unwrap(e);
                     if (unwrap instanceof StoreException.WriteConflictException) {
@@ -257,7 +259,7 @@ public class PravegaTablesStoreHelper {
         List<TableEntry<byte[], byte[]>> entries = Collections.singletonList(
                 new TableEntryImpl<>(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), version), value));
         return withRetries(() -> segmentHelper.updateTableEntries(tableName, entries, authToken.get(), RequestTag.NON_EXISTENT_ID),
-                () -> String.format("updateEntry: key: %s table: %s", key, tableName))
+                () -> String.format("updateEntry: key: %s table: %s", key, tableName), true)
                 .thenApplyAsync(x -> {
                     KeyVersion first = x.get(0);
                     log.trace("entry for key {} updated to table {} with new version {}", key, tableName, first.getSegmentVersion());
@@ -529,8 +531,10 @@ public class PravegaTablesStoreHelper {
     <T> CompletableFuture<T> expectingDataExists(CompletableFuture<T> future, T toReturn) {
         return Futures.exceptionallyExpecting(future, e -> Exceptions.unwrap(e) instanceof StoreException.DataExistsException, toReturn);
     }
-
-    private <T> Supplier<CompletableFuture<T>> exceptionalCallback(Supplier<CompletableFuture<T>> future, Supplier<String> errorMessageSupplier) {
+    
+    private <T> Supplier<CompletableFuture<T>> exceptionalCallback(Supplier<CompletableFuture<T>> future, 
+                                                                   Supplier<String> errorMessageSupplier, 
+                                                                   boolean throwOriginalOnCFE) {
         return () -> CompletableFuture.completedFuture(null).thenComposeAsync(v -> future.get(), executor).exceptionally(t -> {
             String errorMessage = errorMessageSupplier.get();
             Throwable cause = Exceptions.unwrap(t);
@@ -540,6 +544,9 @@ public class PravegaTablesStoreHelper {
                 switch (wcfe.getReason()) {
                     case ConnectionDropped:
                     case ConnectionFailed:
+                        toThrow = throwOriginalOnCFE ? wcfe : 
+                                StoreException.create(StoreException.Type.CONNECTION_ERROR, wcfe, errorMessage);        
+                        break;
                     case UnknownHost:
                         toThrow = StoreException.create(StoreException.Type.CONNECTION_ERROR, wcfe, errorMessage);
                         break;
@@ -586,17 +593,27 @@ public class PravegaTablesStoreHelper {
      * are thrown back
      */
     private <T> CompletableFuture<T> withRetries(Supplier<CompletableFuture<T>> futureSupplier, Supplier<String> errorMessage) {
-        return RetryHelper.withRetriesAsync(exceptionalCallback(futureSupplier, errorMessage),
-                e -> {
-                    Throwable unwrap = Exceptions.unwrap(e);
-                    return unwrap instanceof StoreException.StoreConnectionException;
-                }, numOfRetries, executor)
+        return withRetries(futureSupplier, errorMessage, false);
+    }
+
+    private <T> CompletableFuture<T> withRetries(Supplier<CompletableFuture<T>> futureSupplier, Supplier<String> errorMessage, 
+                                         boolean throwOriginalOnCfe) {
+        return RetryHelper.withRetriesAsync(exceptionalCallback(futureSupplier, errorMessage, throwOriginalOnCfe),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException, numOfRetries, executor)
                 .exceptionally(e -> {
                     Throwable t = Exceptions.unwrap(e);
                     if (t instanceof RetriesExhaustedException) {
                         throw new CompletionException(t.getCause());
                     } else {
-                        throw new CompletionException(t);
+                        Throwable unwrap = Exceptions.unwrap(e);
+                        if (unwrap instanceof WireCommandFailedException &&
+                                (((WireCommandFailedException) unwrap).getReason().equals(ConnectionDropped) ||
+                                        ((WireCommandFailedException) unwrap).getReason().equals(ConnectionFailed))) {
+                            throw new CompletionException(StoreException.create(StoreException.Type.CONNECTION_ERROR, 
+                                    errorMessage.get()));
+                        } else {
+                            throw new CompletionException(unwrap);
+                        }
                     }
                 });
     }

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStoreHelperTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
 public class PravegaTablesStoreHelperTest {
     private ScheduledExecutorService executor;
@@ -196,5 +196,58 @@ public class PravegaTablesStoreHelperTest {
         doAnswer(x -> connectionFailed).when(segmentHelper).createTableSegment(anyString(), anyString(), anyLong());
         AssertExtensions.assertFutureThrows("AuthFailed", storeHelper.createTable("table"),
                 e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+    }
+    
+    @Test
+    public void testNoRetriesOnUpdate() {
+        SegmentHelper segmentHelper = SegmentHelperMock.getSegmentHelperMockForTables(executor);
+        GrpcAuthHelper authHelper = GrpcAuthHelper.getDisabledAuthHelper();
+        PravegaTablesStoreHelper storeHelper = spy(new PravegaTablesStoreHelper(segmentHelper, authHelper, executor, 2));
+
+        // region connection dropped
+        CompletableFuture<Void> connectionDropped = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.ConnectionDropped));
+        doAnswer(x -> connectionDropped).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(1)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(2)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        // endregion
+        
+        // region connectionfailed
+        CompletableFuture<Void> connectionFailed = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.ConnectionFailed));
+        doAnswer(x -> connectionFailed).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(3)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(4)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        // endregion
+        
+        CompletableFuture<Void> unknownHost = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.UnknownHost));
+        doAnswer(x -> unknownHost).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        // this should be retried. we have configured 2 retries, so 2 retries should happen hence jump from 4 to 6. 
+        verify(segmentHelper, times(6)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(8)).updateTableEntries(anyString(), any(), anyString(), anyLong());
     }
 }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
For table update calls, retry should be done only for WrongHost and auth failed but not for other store connection failure exceptions.

**Purpose of the change**  
Fixes #4639 

**What the code does**  
 While interacting with segment store for table queries, we retry on store exceptions for all requests.
This can have undesired effect for conditional updates because they can now fail with write conflict exception.

**How to verify it**  
Unit test added. 
