### PR TITLE
Issue 4648: System tests are failing with zookeeper-operator 0.2.6-rc1

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -239,7 +239,7 @@ public class ZookeeperK8sService extends AbstractService {
                 .put("kind", CUSTOM_RESOURCE_KIND)
                 .put("metadata", ImmutableMap.of("name", deploymentName))
                 .put("spec", ImmutableMap.builder().put("image",  getImageSpec(DOCKER_REGISTRY + PREFIX + "/" + ZOOKEEPER_IMAGE_NAME, PRAVEGA_ZOOKEEPER_IMAGE_VERSION))
-                                         .put("size", clusterSize)
+                                         .put("replicas", clusterSize)
                                          .build())
                 .build();
     }


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

**Change log description**  
Since `replicas` field is not set, system tests were deploying `3` instances of `zk` instead of `1`. Set the replicas correctly to fix the issue

**Purpose of the change**  
Fixes  #4648

**What the code does**  
Changed the deprecated size field to replicas

**How to verify it**  
System tests should pass
