### PR TITLE
Issue-4642: Added certificates into Java truststore for ECS TLS connections.

### DIFF
--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -33,3 +33,12 @@ add_system_property_ecs_config_uri() {
     echo "${name}" "${configUri}"
     add_system_property "${name}" "${configUri}"
 }
+
+# Add ECS certificates into Java truststore
+add_certs_into_truststore() {
+    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    for cert in $CERTS
+    do
+      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+    done
+}

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -69,6 +69,7 @@ init_tier2() {
     add_system_property_ecs_config_uri "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}" "${EXTENDEDS3_ACCESS_KEY_ID}" "${EXTENDEDS3_SECRET_KEY}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
     add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
+    add_certs_into_truststore
     ;;
     esac
 }


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

**Change log description**  
In the initialization of segmentstore container, certificates mounted under /etc/ssl/certs/java/ecs-certs are added into the default Java truststore for TLS enabled connection. 

**Purpose of the change**  
Closes #4642 

**What the code does**  
The init scripts scans /etc/ssl/certs/java/ecs-certs, and add each certificates found into Java truststore which is located at $JAVA_HOME/jre/lib/security/cacerts.

**How to verify it**  
The certificates should be added into the truststore, and the TLS connection based on ECS self-signed certificate could be established.
