### PR TITLE
Issue 4653: Control rate of parallel Segment Container recoveries

### DIFF
--- a/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
+++ b/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
@@ -70,6 +70,8 @@ public class OrderedItemProcessor<ItemType, ResultType> implements AutoCloseable
      * @param capacity  The maximum number of concurrent executions.
      * @param processor A Function that, given an Item, returns a CompletableFuture that indicates when the item has been
      *                  processed (successfully or not).
+     * @param closeOnException Whether or not the OrderedItemProcessor should shut down when it throws an exception
+     *                         processing an item. The default behavior is to close the processor on exception.
      * @param executor  An Executor for async invocations.
      */
     public OrderedItemProcessor(int capacity, Function<ItemType, CompletableFuture<ResultType>> processor,

--- a/common/src/test/java/io/pravega/common/util/OrderedItemProcessorTests.java
+++ b/common/src/test/java/io/pravega/common/util/OrderedItemProcessorTests.java
@@ -243,12 +243,14 @@ public class OrderedItemProcessorTests extends ThreadPooledTestSuite {
             try {
                 p.process(i);
             } catch (IntentionalException ex) {
+                // Ensure that the only IntentionalException happens at the given failedIndex.
                 Assert.assertEquals(i, failedIndex);
             }
         }
 
+        // The rest of futures (i.e. CAPACITY - 1) before and after the failure should have been completed.
         for (int i = 0; i < CAPACITY - 1; i++) {
-            Assert.assertTrue("Already-processing future was completed as well.", processFutures.get(i).isDone());
+            Assert.assertTrue("A future was expected to be completed, but it was not.", processFutures.get(i).isDone());
         }
     }
 

--- a/config/config.properties
+++ b/config/config.properties
@@ -54,6 +54,11 @@ pravegaservice.containerCount=4
 # Valid values: Positive integer in the valid TCP port ranges.
 pravegaservice.listeningPort=12345
 
+# Number of Segment Containers that a Segment Store will start (and recover) in parallel. The main objective of this
+# parameter is to prevent multiple Segment Container recoveries in parallel to overload the cache. A higher value may
+# speed up recoveries, but sufficient cache size should be configured for safety.
+#pravegaservice.parallelContainerStarts=1
+
 # Full URL (host:port) where to find a ZooKeeper that can be used for coordinating this Pravega Cluster.
 # Required.
 pravegaservice.zkURL=localhost:2181

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -183,6 +183,7 @@ public final class ServiceStarter {
                         this.zkClient,
                         new Host(this.serviceConfig.getPublishedIPAddress(),
                                 this.serviceConfig.getPublishedPort(), null),
+                        this.serviceConfig.getParallelContainerStarts(),
                         setup.getCoreExecutor()));
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
@@ -37,18 +37,20 @@ class ZKSegmentContainerManager implements SegmentContainerManager {
     /**
      * Creates a new instance of the ZKSegmentContainerManager class.
      *
-     * @param containerRegistry      The SegmentContainerRegistry to manage.
-     * @param zkClient               ZooKeeper client.
-     * @param pravegaServiceEndpoint Pravega service endpoint details.
-     * @param executor               Executor service for running async operations.
+     * @param containerRegistry       The SegmentContainerRegistry to manage.
+     * @param zkClient                ZooKeeper client.
+     * @param pravegaServiceEndpoint  Pravega service endpoint details.
+     * @param parallelContainerStarts Defines the number of containers to start in parallel.
+     * @param executor                Executor service for running async operations.
      */
     ZKSegmentContainerManager(SegmentContainerRegistry containerRegistry, CuratorFramework zkClient,
-                              Host pravegaServiceEndpoint, ScheduledExecutorService executor) {
+                              Host pravegaServiceEndpoint, int parallelContainerStarts, ScheduledExecutorService executor) {
         Preconditions.checkNotNull(containerRegistry, "containerRegistry");
         Preconditions.checkNotNull(zkClient, "zkClient");
         this.host = Preconditions.checkNotNull(pravegaServiceEndpoint, "pravegaServiceEndpoint");
         this.cluster = new ClusterZKImpl(zkClient, ClusterType.HOST);
-        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint, executor);
+        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint,
+                parallelContainerStarts, executor);
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import lombok.Synchronized;

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -102,7 +102,9 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
         this.hostContainerMapNode = new NodeCache(zkClient, clusterPath);
         this.assigmentTask = new AtomicReference<>();
         this.lastReportTime = new AtomicLong(CURRENT_TIME_MILLIS.get());
-        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(1, this::startContainer, this.executor);
+        // Allow OrderedItemProcessor to throw exceptions, as they may happen while starting containers. But we want to
+        // continue processing subsequent container starts irrespective of such failures.
+        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(1, this::startContainer, false, this.executor);
     }
 
     /**

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -90,7 +90,7 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
      * @param pravegaServiceEndpoint The pravega endpoint for which we need to fetch the container assignment.
      */
     ZKSegmentContainerMonitor(SegmentContainerRegistry containerRegistry, CuratorFramework zkClient,
-                              Host pravegaServiceEndpoint, ScheduledExecutorService executor) {
+                              Host pravegaServiceEndpoint, int parallelContainerStarts, ScheduledExecutorService executor) {
         Preconditions.checkNotNull(zkClient, "zkClient");
 
         this.registry = Preconditions.checkNotNull(containerRegistry, "containerRegistry");
@@ -104,7 +104,7 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
         this.lastReportTime = new AtomicLong(CURRENT_TIME_MILLIS.get());
         // Allow OrderedItemProcessor to throw exceptions, as they may happen while starting containers. But we want to
         // continue processing subsequent container starts irrespective of such failures.
-        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(1, this::startContainer, false, this.executor);
+        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(parallelContainerStarts, this::startContainer, false, this.executor);
     }
 
     /**

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -17,6 +17,7 @@ import io.pravega.common.cluster.Host;
 import io.pravega.common.cluster.HostContainerMap;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.CollectionHelpers;
+import io.pravega.common.util.OrderedItemProcessor;
 import io.pravega.segmentstore.server.ContainerHandle;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import lombok.Synchronized;
@@ -77,6 +79,9 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
     private final ScheduledExecutorService executor;
     private AtomicReference<ScheduledFuture<?>> assigmentTask;
     private final AtomicLong lastReportTime;
+    // We start Segment Containers sequentially, given that starting them in parallel may lead to the cache being full
+    // if there is too much data to recover.
+    private final OrderedItemProcessor<Integer, ContainerHandle> startContainerOrderedProcessor;
 
     /**
      * Creates an instance of ZKSegmentContainerMonitor.
@@ -98,6 +103,7 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
         this.hostContainerMapNode = new NodeCache(zkClient, clusterPath);
         this.assigmentTask = new AtomicReference<>();
         this.lastReportTime = new AtomicLong(CURRENT_TIME_MILLIS.get());
+        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(1, this::startContainer, this.executor);
     }
 
     /**
@@ -148,6 +154,7 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
 
         // Wait for all the containers to be closed.
         Futures.await(Futures.allOf(results), CLOSE_TIMEOUT_PER_CONTAINER.toMillis());
+        this.startContainerOrderedProcessor.close();
     }
 
     @VisibleForTesting
@@ -189,8 +196,10 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
                     this.lastReportTime.set(CURRENT_TIME_MILLIS.get());
                 }
 
+                // We start segment containers sequentially to ensure that we do not overload the cache with parallel
+                // container recoveries.
+                containersToBeStarted.forEach(startContainerOrderedProcessor::process);
                 // Initiate the start and stop tasks asynchronously.
-                containersToBeStarted.forEach(this::startContainer);
                 containersToBeStopped.forEach(this::stopContainer);
             } else {
                 log.warn("No segment container assignments found");

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
@@ -51,6 +51,7 @@ public class ZKSegmentContainerManagerTest extends ThreadPooledTestSuite {
     private final static int TEST_TIMEOUT = 60000;
     private final static int RETRY_SLEEP_MS = 100;
     private final static int MAX_RETRY = 5;
+    private final static int MAX_PARALLEL_CONTAINER_STARTS = 1;
     private static final int PORT = TestUtils.getAvailableListenPort();
     private final static Host PRAVEGA_SERVICE_ENDPOINT = new Host(getHostAddress(), PORT, null);
     private final static String PATH = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
@@ -158,7 +159,7 @@ public class ZKSegmentContainerManagerTest extends ThreadPooledTestSuite {
     }
 
     private ZKSegmentContainerManager createContainerManager(SegmentContainerRegistry registry, CuratorFramework zkClient) {
-        return new ZKSegmentContainerManager(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, executorService());
+        return new ZKSegmentContainerManager(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, MAX_PARALLEL_CONTAINER_STARTS, executorService());
     }
 
     private void initializeHostContainerMapping(CuratorFramework zkClient) throws Exception {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
@@ -56,6 +56,7 @@ public class ZKSegmentContainerMonitorTest extends ThreadPooledTestSuite {
     private final static int TEST_TIMEOUT = 60000;
     private final static int RETRY_SLEEP_MS = 100;
     private final static int MAX_RETRY = 5;
+    private final static int MAX_PARALLEL_CONTAINER_STARTS = 1;
     private static final int PORT = TestUtils.getAvailableListenPort();
     private final static Host PRAVEGA_SERVICE_ENDPOINT = new Host(getHostAddress(), PORT, null);
     private final static String PATH = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
@@ -315,7 +316,7 @@ public class ZKSegmentContainerMonitorTest extends ThreadPooledTestSuite {
 
     private ZKSegmentContainerMonitor createContainerMonitor(
             SegmentContainerRegistry registry, CuratorFramework zkClient) {
-        return new ZKSegmentContainerMonitor(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, executorService());
+        return new ZKSegmentContainerMonitor(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, MAX_PARALLEL_CONTAINER_STARTS, executorService());
     }
 
     private void initializeHostContainerMapping(CuratorFramework zkClient) throws Exception {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -34,6 +34,7 @@ public class ServiceConfig {
     public static final Property<Integer> PUBLISHED_PORT = Property.named("publishedPort");
     public static final Property<String> LISTENING_IP_ADDRESS = Property.named("listeningIPAddress", "");
     public static final Property<String> PUBLISHED_IP_ADDRESS = Property.named("publishedIPAddress", "");
+    public static final Property<Integer> PARALLEL_CONTAINER_STARTS = Property.named("parallelContainerStarts", 1);
     public static final Property<String> ZK_URL = Property.named("zkURL", "localhost:2181");
     public static final Property<Integer> ZK_RETRY_SLEEP_MS = Property.named("zkRetrySleepMs", 5000);
     public static final Property<Integer> ZK_RETRY_COUNT = Property.named("zkRetryCount", 5);
@@ -152,6 +153,12 @@ public class ServiceConfig {
      */
     @Getter
     private final String publishedIPAddress;
+
+    /**
+     * Number of segment containers that a Segment Store will start (and recover) in parallel.
+     */
+    @Getter
+    private final int parallelContainerStarts;
 
     /**
      * The Zookeeper URL.
@@ -302,6 +309,7 @@ public class ServiceConfig {
         } else {
             this.publishedIPAddress = publishedIPAddress;
         }
+        this.parallelContainerStarts = properties.getInt(PARALLEL_CONTAINER_STARTS);
         this.zkURL = properties.get(ZK_URL);
         this.zkRetrySleepMs = properties.getInt(ZK_RETRY_SLEEP_MS);
         this.zkRetryCount = properties.getInt(ZK_RETRY_COUNT);
@@ -352,6 +360,7 @@ public class ServiceConfig {
                 .append(String.format("listeningIPAddress: %s, ", listeningIPAddress))
                 .append(String.format("publishedPort: %d, ", publishedPort))
                 .append(String.format("publishedIPAddress: %s, ", publishedIPAddress))
+                .append(String.format("parallelContainerStarts: %d, ", parallelContainerStarts))
                 .append(String.format("zkURL: %s, ", zkURL))
                 .append(String.format("zkRetrySleepMs: %d, ", zkRetrySleepMs))
                 .append(String.format("zkSessionTimeoutMs: %d, ", zkSessionTimeoutMs))


### PR DESCRIPTION
**Change log description**  
Enforces sequential start of containers to prevent multiple concurrent container recoveries from overloading the cache.

**Purpose of the change**  
Fixes #4653.

**What the code does**  
Until now, a Segment Store could start Segment Containers in parallel, which also includes the process of recovery in the case that the Segment Container to start is not new. However, if we think about a Segment Store recovering in parallel multiple Segment Containers, it may be the case that the data to process for each container is larger than the size of the cache (not to mention that the cache can still be used by other containers). This PR mainly serializes the execution of Segment Container starts with the main objective of preventing overloading the cache.

To this end, this PR includes the following changes:
-  In `ZKSegmentContainerMonitor`, we use the existing class `OrderedItemProcessor` to serialize the executions of `startContainer` method.
- The behavior of `OrderedItemProcessor` was by default to shut down the processor in case of an exception being thrown by any of the items being processed. While the default behavior remains the same, we added to this class a flag (`closeOnException`) to tolerate exceptions while processing items to continue processing the remaining ones. In our case, we want to start all the containers possible, even in the case that one/few of the containers have problems (i.e., `startContainer` throws an exception), which could be retried.

**How to verify it**  
Added a new test to `OrderedItemProcessor` to verify the behavior of `closeOnException`. The rest of tests for are passing, including system tests (build 2730).