### PR TITLE
Issue 4654: DataLogWriterNotPrimaryException thrown indefinitely

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -31,6 +31,7 @@ import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperatio
 import io.pravega.segmentstore.server.logs.operations.MetadataOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
+import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import java.time.Duration;
@@ -440,7 +441,8 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
         ex = Exceptions.unwrap(ex);
         return Exceptions.mustRethrow(ex)
                 || ex instanceof DataCorruptionException     // Data corruption - stop processing to prevent more damage.
-                || ex instanceof StorageNotPrimaryException; // Fenced out - another instance took over.
+                || ex instanceof StorageNotPrimaryException  // Fenced out - another instance took over.
+                || ex instanceof DataLogWriterNotPrimaryException;  // Fenced out at the DurableLog level.
     }
 
     private boolean isShutdownException(Throwable ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -100,7 +100,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             .with(WriterConfig.ERROR_SLEEP_MILLIS, 0L)
             .build();
 
-    private static final Duration TIMEOUT = Duration.ofSeconds(3000);
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -38,6 +38,7 @@ import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentTruncateOperation;
 import io.pravega.segmentstore.server.logs.operations.UpdateAttributesOperation;
+import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
@@ -99,7 +100,7 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
             .with(WriterConfig.ERROR_SLEEP_MILLIS, 0L)
             .build();
 
-    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration TIMEOUT = Duration.ofSeconds(3000);
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
@@ -227,6 +228,44 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
         context.storage.setConcatAsyncErrorInjector(new ErrorInjector<>(count -> count % failConcatAsyncEvery == 0, exceptionSupplier));
 
         testWriter(context);
+    }
+
+    /**
+     * Tests the StorageWriter in a scenario where the DurableLog is left throwing DataLogWriterNotPrimaryException. In
+     * this case, we need to restart the StorageWriter and expect the container recovery to resolve the original issue.
+     */
+    @Test
+    public void testWithDataSourceNotPrimaryErrors() throws Exception {
+        final int failWriteSyncEvery = 4;
+        Predicate<Throwable> errorPredicate = ex -> ex instanceof DataLogWriterNotPrimaryException;
+
+        @Cleanup
+        TestContext context = new TestContext(DEFAULT_CONFIG);
+        Supplier<Exception> exceptionSupplier = () -> new DataLogWriterNotPrimaryException("Problem interacting with Zookeeper");
+
+        // Simulate DataLogWriterNotPrimaryException in DurableLog from a failed truncation (e.g., KeeperException.BadVersionException).
+        context.dataSource.setAckAsyncErrorInjector(new ErrorInjector<>(count -> count % failWriteSyncEvery == 0, exceptionSupplier));
+
+        // Start the writer.
+        context.writer.startAsync();
+
+        // Create a bunch of segments and Transactions.
+        ArrayList<Long> segmentIds = createSegments(context);
+        HashMap<Long, ArrayList<Long>> transactionsBySegment = createTransactions(segmentIds, context);
+        ArrayList<Long> transactionIds = new ArrayList<>();
+        transactionsBySegment.values().forEach(transactionIds::addAll);
+
+        // Append data.
+        HashMap<Long, ByteArrayOutputStream> segmentContents = new HashMap<>();
+        appendDataBreadthFirst(segmentIds, segmentContents, context);
+        appendDataBreadthFirst(transactionIds, segmentContents, context);
+
+        // Wait for the Storage Writer to be shutdown.
+        ServiceListeners.awaitShutdown(context.writer, TIMEOUT, false);
+
+        // Ensure that the failure case is DataLogWriterNotPrimaryException.
+        Assert.assertTrue("Unexpected failure cause for DurableLog.",
+                errorPredicate.test(Exceptions.unwrap(context.writer.failureCause())));
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Include DataLogWriterNotPrimaryException as a critical exception for Storage Writer to be restarted.

**Purpose of the change**  
Fixes #4605 

**What the code does**  
This PR justs considers `DataLogWriterNotPrimaryException` as one of the critical exceptions that will induce the shutdown of the Storage Writer and the restart of a container on the same host if it applies. If we don't include that exception in the critical ones, the Storage Writer may get stuck getting `DataLogWriterNotPrimaryException` from the Bookkeeper log indefinitely. The expectation is that with the restart of the container, the Storage Writer can start working with the right Bookkeeper log version stored in Zookeeper, and prevent this exception from happening again. 

**How to verify it**  
All tests pass, including system tests (build 626). Added a new test to verify that after encountering `DataLogWriterNotPrimaryException` upon a truncation of the Bookkeeper log in the Storage Writer, a critical exception is found and the Storage Writer shuts down.
