### PR TITLE
Issue 4667: Segment store pods are not coming up with external access enabled

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -46,6 +46,8 @@ init_kubernetes() {
         local ns=${POD_NAMESPACE}
         local podname=${POD_NAME}
         # SERVICE_NAME is set by pravega-operator when external access is enabled from version 0.5.0 onwards
+        # SERVICE_NAME and POD_NAME are different in pravega-operator 0.5.0 onwards 
+
         if [ -z "${SERVICE_NAME}" ]; then
           local servicename=${podname}
         else

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -45,6 +45,7 @@ init_kubernetes() {
 
         local ns=${POD_NAMESPACE}
         local podname=${POD_NAME}
+        # SERVICE_NAME is set by pravega-operator when external access is enabled from version 0.5.0 onwards
         if [ -z "${SERVICE_NAME}" ]; then
           local servicename=${podname}
         else


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

**Change log description**  
With  pravega-operator `0.5.0`, pod name has changed and it is different from service name. We were using pod name to find the service details 

**Purpose of the change**  
Fixes #4667 

**What the code does**  
Changed the script to use service name instead of service name

**How to verify it**  
Verified external connectivity is working fine.
