### PR TITLE
Issue 3994 : List all Segments in Tier 2

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -17,8 +17,10 @@ import com.emc.object.s3.bean.AccessControlList;
 import com.emc.object.s3.bean.CanonicalUser;
 import com.emc.object.s3.bean.CopyPartResult;
 import com.emc.object.s3.bean.Grant;
+import com.emc.object.s3.bean.ListObjectsResult;
 import com.emc.object.s3.bean.MultipartPartETag;
 import com.emc.object.s3.bean.Permission;
+import com.emc.object.s3.bean.S3Object;
 import com.emc.object.s3.request.CompleteMultipartUploadRequest;
 import com.emc.object.s3.request.CopyPartRequest;
 import com.emc.object.s3.request.PutObjectRequest;
@@ -43,10 +45,13 @@ import io.pravega.segmentstore.storage.SyncStorage;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
@@ -181,6 +186,71 @@ public class ExtendedS3Storage implements SyncStorage {
         return false;
     }
 
+    @Override
+    public Iterator<SegmentProperties> listSegments() {
+        return new ExtendedS3SegmentIterator(s3object -> true);
+    }
+
+
+    public class ExtendedS3SegmentIterator implements Iterator<SegmentProperties> {
+
+        ListObjectsResult results;
+        S3Object current;
+        Iterator<S3Object> innerIterator;
+        java.util.function.Predicate<S3Object> patternMatchPredicate;
+
+        ExtendedS3SegmentIterator(java.util.function.Predicate<S3Object> patternMatchPredicate) {
+            this.results = client.listObjects(config.getBucket(), config.getPrefix());
+            this.innerIterator = results.getObjects().iterator();
+            this.patternMatchPredicate = patternMatchPredicate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            boolean nextBatch = false;
+            while (innerIterator != null) {
+                while (innerIterator.hasNext()) {
+                    current = innerIterator.next();
+                    if (patternMatchPredicate.test(current)) {
+                        return true;
+                    }
+                }
+                // End of the batch
+                if (!innerIterator.hasNext()) {
+                    // Already fetched the next batch
+                    if (nextBatch) {
+                        break;
+                    }
+                    // This batch was last if less than max keys were returned.
+                    if (results.getObjects().size() < results.getMaxKeys()) {
+                        break;
+                    }
+                    results = client.listMoreObjects(results);
+                    innerIterator = results.getObjects().iterator();
+                    nextBatch = true;
+                }
+            }
+            results = null;
+            innerIterator = null;
+            current = null;
+            return false;
+        }
+
+        @Override
+        public SegmentProperties next() {
+            if (null != current) {
+                AccessControlList acls = client.getObjectAcl(config.getBucket(), current.getKey());
+                boolean canWrite = acls.getGrants().stream().anyMatch(grant -> grant.getPermission().compareTo(Permission.WRITE) >= 0);
+                return StreamSegmentInformation.builder()
+                        .name(current.getKey().replaceFirst(config.getPrefix(), ""))
+                        .length(current.getSize())
+                        .sealed(!canWrite)
+                        .lastModified(new ImmutableDate(current.getLastModified().toInstant().toEpochMilli()))
+                        .build();
+            }
+            throw new NoSuchElementException();
+        }
+    }
     //endregion
 
     //region private sync implementation

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorage.java
@@ -46,6 +46,8 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.AccessControlException;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -185,6 +187,38 @@ public class FileSystemStorage implements SyncStorage {
     @Override
     public boolean supportsTruncation() {
         return false;
+    }
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "OS_OPEN_STREAM", justification = "Rare operation. The leaked object is collected by GC. In case of a iteraror in a for loop this would be fast.")
+    @Override
+    public Iterator<SegmentProperties> listSegments() {
+        if (log.isDebugEnabled()) {
+            log.debug("config.getRoot() {}", config.getRoot());
+        }
+        try {
+            return Files.find(Paths.get(config.getRoot()),
+                    Integer.MAX_VALUE,
+                    (filePath, fileAttr) -> fileAttr.isRegularFile())
+                    .map(path -> (SegmentProperties) getStreamSegmentInformation(config.getRoot(), path))
+                    .iterator();
+        } catch (IOException e) {
+            log.error("Hit an exception: ", e);
+        }
+        return Collections.emptyIterator();
+    }
+
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+    @SneakyThrows
+    private static StreamSegmentInformation getStreamSegmentInformation(String root, Path path) {
+        PosixFileAttributes attrs = Files.readAttributes(path.toAbsolutePath(),
+                PosixFileAttributes.class);
+        return StreamSegmentInformation.builder()
+                .name(Paths.get(root).relativize(path).toString())
+                .length(attrs.size())
+                .sealed(!(attrs.permissions().contains(OWNER_WRITE)))
+                .lastModified(new ImmutableDate(attrs.creationTime().toMillis()))
+                .build();
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
@@ -21,6 +21,7 @@ import io.pravega.test.common.ErrorInjector;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -196,6 +197,11 @@ public class TestStorage implements Storage {
     @Override
     public boolean supportsTruncation() {
         return true;
+    }
+
+    @Override
+    public CompletableFuture<Iterator<SegmentProperties>> listSegments() {
+        return null;
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -18,6 +18,7 @@ import io.pravega.segmentstore.contracts.SegmentProperties;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -136,6 +137,12 @@ public class AsyncStorageWrapper implements Storage {
     @Override
     public CompletableFuture<Boolean> exists(String streamSegmentName, Duration timeout) {
         return supplyAsync(() -> this.syncStorage.exists(streamSegmentName), streamSegmentName);
+    }
+
+
+    @Override
+    public CompletableFuture<Iterator<SegmentProperties>> listSegments() {
+        return CompletableFuture.completedFuture(this.syncStorage.listSegments());
     }
 
     //endregion

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -9,8 +9,11 @@
  */
 package io.pravega.segmentstore.storage;
 
+import io.pravega.segmentstore.contracts.SegmentProperties;
+
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -167,6 +170,13 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
      * @return True or false.
      */
     boolean supportsTruncation();
+
+    /**
+     * Lists all the segments stored on the storage device.
+     *
+     * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
+     */
+    CompletableFuture<Iterator<SegmentProperties>> listSegments();
 
     @Override
     void close();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SyncStorage.java
@@ -15,6 +15,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import java.io.InputStream;
+import java.util.Iterator;
 
 /**
  * Defines an abstraction for Permanent Storage.
@@ -212,6 +213,13 @@ public interface SyncStorage extends AutoCloseable {
      * @return True or false.
      */
     boolean supportsTruncation();
+
+    /**
+     * Lists all the segments stored on the storage device.
+     *
+     * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
+     */
+    Iterator<SegmentProperties> listSegments();
 
     @Override
     void close();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorage.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -193,6 +194,11 @@ public class InMemoryStorage implements SyncStorage {
     @Override
     public boolean supportsTruncation() {
         return false;
+    }
+
+    @Override
+    public Iterator<SegmentProperties> listSegments() {
+        return this.streamSegments.values().stream().map( s -> s.getInfo()).iterator();
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/noop/NoOpStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/noop/NoOpStorage.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SyncStorage;
 import java.io.InputStream;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -191,6 +192,11 @@ class NoOpStorage implements SyncStorage {
     @Override
     public boolean supportsTruncation() {
         return baseStorage.supportsTruncation();
+    }
+
+    @Override
+    public Iterator<SegmentProperties> listSegments() {
+        return baseStorage.listSegments();
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -449,6 +450,10 @@ public class AsyncStorageWrapperTests extends ThreadPooledTestSuite {
         public void initialize(long containerEpoch) {
         }
 
+        @Override
+        public Iterator<SegmentProperties> listSegments() {
+            return null;
+        }
         //endregion
     }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.storage;
 
+import com.google.common.collect.Iterators;
 import io.pravega.common.MathHelpers;
 import io.pravega.common.hash.RandomFactory;
 import io.pravega.segmentstore.contracts.BadOffsetException;
@@ -16,6 +17,8 @@ import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
+import io.pravega.segmentstore.storage.rolling.RollingStorage;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
@@ -24,11 +27,15 @@ import java.io.SequenceInputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import lombok.AccessLevel;
+import lombok.Cleanup;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
@@ -51,6 +58,8 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     protected static final int APPENDS_PER_SEGMENT = 10;
     protected static final String APPEND_FORMAT = "Segment_%s_Append_%d";
     private static final int SEGMENT_COUNT = 4;
+    private static final Random RANDOM = new Random();
+
 
     @Getter(AccessLevel.PROTECTED)
     @Setter(AccessLevel.PROTECTED)
@@ -87,6 +96,92 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the exists API.
+     */
+    @Test
+    public void testListSegmentsWithOneSegment() {
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+
+            Iterator<SegmentProperties> iterator = s.listSegments().join();
+            Assert.assertFalse(iterator.hasNext());
+
+            createSegment(segmentName, s);
+
+            iterator = s.listSegments().join();
+            Assert.assertTrue(iterator.hasNext());
+            SegmentProperties prop = iterator.next();
+            Assert.assertEquals(prop.getName(), segmentName);
+            Assert.assertFalse(iterator.hasNext());
+        }
+    }
+
+    /**
+     * Tests the ability to list Segments.
+     * @throws Exception if an unexpected error occurred.
+     */
+    @Test
+    public void testListSegments() throws Exception {
+        @Cleanup
+        val baseStorage = new InMemoryStorage();
+        @Cleanup
+        val s = new RollingStorage(baseStorage, new SegmentRollingPolicy(1));
+        Set<String> sealedSegments = new HashSet<>();
+        s.initialize(1);
+        int expectedCount = 50;
+        byte[] data = "data".getBytes();
+        for (int i = 0; i < expectedCount; i++) {
+            String segmentName = "segment-" + i;
+            val wh1 = s.create(segmentName);
+            // Write data.
+            s.write(wh1, 0, new ByteArrayInputStream(data), data.length);
+            if (RANDOM.nextInt(2) == 1) {
+                s.seal(wh1);
+                sealedSegments.add(segmentName);
+            }
+        }
+        Iterator<SegmentProperties> it = s.listSegments();
+        int actualCount = 0;
+        while (it.hasNext()) {
+            SegmentProperties curr = it.next();
+            //check the length matches
+            Assert.assertEquals(curr.getLength(), data.length);
+            if (sealedSegments.contains(curr.getName())) {
+                Assert.assertTrue(curr.isSealed());
+            } else {
+                Assert.assertFalse(curr.isSealed());
+            }
+            ++actualCount;
+        }
+        Assert.assertEquals(actualCount, expectedCount);
+    }
+
+    @Test
+    public void testListSegmentsWithDeletes() throws Exception {
+        @Cleanup
+        val baseStorage = new InMemoryStorage();
+        @Cleanup
+        val s = new RollingStorage(baseStorage, new SegmentRollingPolicy(1));
+        s.initialize(DEFAULT_EPOCH);
+        Set<String> deletedSegments = new HashSet<>();
+        int expectedCount = 50;
+        for (int i = 0; i < expectedCount; i++) {
+
+            String segmentName = "segment-" + i;
+            SegmentHandle handle = s.create(segmentName);
+            if (RANDOM.nextInt(2) == 1) {
+                s.delete(handle);
+                deletedSegments.add(segmentName);
+            }
+        }
+
+        Iterator<SegmentProperties> it = s.listSegments();
+        expectedCount -= deletedSegments.size();
+        Assert.assertEquals(expectedCount, Iterators.size(it));
+    }
+
+    /**
      * Tests the delete() method.
      */
     @Test
@@ -102,6 +197,8 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
             assertThrows("getStreamSegmentInfo() did not throw for deleted StreamSegment.",
                     () -> s.getStreamSegmentInfo(segmentName, null).join(),
                     ex -> ex instanceof StreamSegmentNotExistsException);
+            Iterator<SegmentProperties> iterator = s.listSegments().join();
+            Assert.assertFalse(iterator.hasNext());
         }
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -193,6 +193,16 @@ public final class NameUtils {
     }
 
     /**
+     * Checks whether given name is a Header Segment.
+     *
+     * @param segmentName The name of the segment.
+     * @return true if the name is Header Segment. False otherwise
+     */
+    public static boolean isHeaderSegment(String segmentName) {
+        return segmentName.endsWith(HEADER_SUFFIX);
+    }
+
+    /**
      * Gets the name of the Segment name from its Header Segment Name.
      *
      * @param headerSegmentName The name of the Header Segment.


### PR DESCRIPTION
**Changelog description**
Added list-segments API to retrieve the segments from Tier 2.

**Purpose of the change**
Fixes #3994.

**What the code does**
Basic implementation of Iterator over the header files in the storage returning SegmentProperties per file.
The iterator logic is tailored to the specific underlying storage depending on how the listing of entries works in that implementation.
For retrieving StreamSegmentInformation for a particular header file, RollingSegmentHandle is used.

**What this doesn't do**
As of now, the API support is only verified for the FileSystemStorage type. For other storage types such as s3 and HDFS, it will be considered later.

**How to verify it**
Unit tests added to verify feature.