### PR TITLE
Issue 4676: (PDP-34) Initial Implementation

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorageProvider.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorageProvider.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import com.emc.object.Range;
+import com.emc.object.s3.S3Client;
+import com.emc.object.s3.S3Exception;
+import com.emc.object.s3.S3ObjectMetadata;
+import com.emc.object.s3.bean.AccessControlList;
+import com.emc.object.s3.bean.CanonicalUser;
+import com.emc.object.s3.bean.CopyPartResult;
+import com.emc.object.s3.bean.Grant;
+import com.emc.object.s3.bean.MultipartPartETag;
+import com.emc.object.s3.bean.Permission;
+import com.emc.object.s3.request.CompleteMultipartUploadRequest;
+import com.emc.object.s3.request.CopyPartRequest;
+import com.emc.object.s3.request.PutObjectRequest;
+import com.emc.object.s3.request.SetObjectAclRequest;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.common.Exceptions;
+import io.pravega.common.io.StreamHelpers;
+import io.pravega.segmentstore.storage.chunklayer.BaseChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.Executor;
+
+/**
+ *  {@link io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider} for extended S3 based storage.
+ *
+ * Each chunk is represented as a single Object on the underlying storage.
+ *
+ * This implementation works under the assumption that data is only appended and never modified.
+ * The concat operation is implemented as multi part copy.
+ */
+
+@Slf4j
+public class ExtendedS3ChunkStorageProvider extends BaseChunkStorageProvider {
+
+    //region members
+    private final ExtendedS3StorageConfig config;
+    private final S3Client client;
+
+    //endregion
+
+    //region constructor
+    public ExtendedS3ChunkStorageProvider(Executor executor, S3Client client, ExtendedS3StorageConfig config) {
+        super(executor);
+        this.config = Preconditions.checkNotNull(config, "config");
+        this.client = Preconditions.checkNotNull(client, "client");
+    }
+    //endregion
+    //region implementation
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException {
+        if (!doesExist(chunkName)) {
+           throw new FileNotFoundException(chunkName);
+        }
+        return ChunkHandle.readHandle(chunkName);
+    }
+
+    @Override
+    protected  ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException {
+        if (!doesExist(chunkName)) {
+            throw new FileNotFoundException(chunkName);
+        }
+        return ChunkHandle.writeHandle(chunkName);
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        try {
+            if (fromOffset < 0 || bufferOffset < 0 || length < 0) {
+                throw new ArrayIndexOutOfBoundsException();
+            }
+
+            try (InputStream reader = client.readObjectStream(config.getBucket(),
+                    config.getPrefix() + handle.getChunkName(), Range.fromOffsetLength(fromOffset, length))) {
+                /*
+                 * TODO: This implementation assumes that if S3Client.readObjectStream returns null, then
+                 * the object does not exist and we throw StreamNotExistsException. The javadoc, however,
+                 * says that this call returns null in case of 304 and 412 responses. We need to
+                 * investigate what these responses mean precisely and react accordingly.
+                 *
+                 * See https://github.com/pravega/pravega/issues/1549
+                 */
+                if (reader == null) {
+                    throw new FileNotFoundException(handle.getChunkName());
+                }
+
+                int bytesRead = StreamHelpers.readAll(reader, buffer, bufferOffset, length);
+
+                return bytesRead;
+            }
+        } catch (Exception e) {
+            throwException(handle.getChunkName(), e);
+        }
+        return 0;
+    }
+
+    @Override
+    protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IOException, IndexOutOfBoundsException {
+        Preconditions.checkArgument(!handle.isReadOnly(), "handle must not be read-only.");
+        try {
+            client.putObject(this.config.getBucket(), this.config.getPrefix() + handle.getChunkName(),
+                    Range.fromOffsetLength(offset, length), data);
+            return (int) length;
+        } catch (Exception e) {
+            throwException(handle.getChunkName(), e);
+        }
+        return 0;
+    }
+
+    @Override
+    protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        int totalBytesConcated = 0;
+        try {
+            Preconditions.checkArgument(!target.isReadOnly(), "target handle must not be read-only.");
+            int partNumber = 1;
+
+            SortedSet<MultipartPartETag> partEtags = new TreeSet<>();
+            String targetPath = config.getPrefix() + target.getChunkName();
+            String uploadId = client.initiateMultipartUpload(config.getBucket(), targetPath);
+
+            // check whether the target exists
+            if (!doesExist(target.getChunkName())) {
+                throw new FileNotFoundException(target.getChunkName());
+            }
+
+            //Copy the first part
+            CopyPartRequest copyRequest = new CopyPartRequest(config.getBucket(),
+                    targetPath,
+                    config.getBucket(),
+                    targetPath,
+                    uploadId,
+                    partNumber++).withSourceRange(Range.fromOffset(0));
+            CopyPartResult copyResult = client.copyPart(copyRequest);
+
+            partEtags.add(new MultipartPartETag(copyResult.getPartNumber(), copyResult.getETag()));
+
+            //Copy the second part
+            for (ChunkHandle sourceHandle: sources) {
+                S3ObjectMetadata metadataResult = client.getObjectMetadata(config.getBucket(),
+                        config.getPrefix() + sourceHandle.getChunkName());
+                long objectSize = metadataResult.getContentLength(); // in bytes
+
+                copyRequest = new CopyPartRequest(config.getBucket(),
+                        config.getPrefix() + sourceHandle.getChunkName(),
+                        config.getBucket(),
+                        targetPath,
+                        uploadId,
+                        partNumber++).withSourceRange(Range.fromOffsetLength(0, objectSize));
+
+                copyResult = client.copyPart(copyRequest);
+                partEtags.add(new MultipartPartETag(copyResult.getPartNumber(), copyResult.getETag()));
+                totalBytesConcated += objectSize;
+            }
+
+            //Close the upload
+            client.completeMultipartUpload(new CompleteMultipartUploadRequest(config.getBucket(),
+                    targetPath, uploadId).withParts(partEtags));
+
+            for (ChunkHandle sourceHandle: sources) {
+                client.deleteObject(config.getBucket(), config.getPrefix() + sourceHandle.getChunkName());
+            }
+        } catch (RuntimeException e) {
+            throw e; // make spotbugs happy
+        } catch (Exception e) {
+            throwException(target.getChunkName(), e);
+        }
+        return totalBytesConcated;
+    }
+
+    @Override
+    protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException {
+        try {
+            setPermission(handle, isReadOnly ? Permission.READ : Permission.FULL_CONTROL);
+        } catch (Exception e) {
+            throwException(handle.getChunkName(), e);
+        }
+        return true;
+    }
+
+    private void setPermission(ChunkHandle handle, Permission permission) {
+        AccessControlList acl = client.getObjectAcl(config.getBucket(), config.getPrefix() + handle.getChunkName());
+        acl.getGrants().clear();
+        acl.addGrants(new Grant(new CanonicalUser(config.getAccessKey(), config.getAccessKey()), permission));
+
+        client.setObjectAcl(
+                new SetObjectAclRequest(config.getBucket(), config.getPrefix() + handle.getChunkName()).withAcl(acl));
+    }
+
+    private <T> T throwException(String chunkName, Exception e) throws IOException {
+        if (e instanceof S3Exception) {
+            S3Exception s3Exception = (S3Exception) e;
+            String errorCode = Strings.nullToEmpty(s3Exception.getErrorCode());
+
+            if (errorCode.equals("NoSuchKey")) {
+                throw new FileNotFoundException(chunkName);
+            }
+
+            if (errorCode.equals("PreconditionFailed")) {
+                throw new FileAlreadyExistsException(chunkName);
+            }
+
+            if (errorCode.equals("InvalidRange")
+                    || errorCode.equals("InvalidArgument")
+                    || errorCode.equals("MethodNotAllowed")
+                    || s3Exception.getHttpCode() == HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE) {
+                throw new IllegalArgumentException(chunkName, e);
+            }
+
+            if (errorCode.equals("AccessDenied")) {
+                throw new AccessDeniedException(chunkName);
+            }
+        }
+
+        if (e instanceof IndexOutOfBoundsException) {
+            throw new ArrayIndexOutOfBoundsException(e.getMessage());
+        }
+
+        throw Exceptions.sneakyThrow(e);
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException {
+        try {
+            S3ObjectMetadata result = client.getObjectMetadata(config.getBucket(),
+                    config.getPrefix() + chunkName);
+
+            AccessControlList acls = client.getObjectAcl(config.getBucket(), config.getPrefix() + chunkName);
+            ChunkInfo information = ChunkInfo.builder()
+                    .name(chunkName)
+                    .length(result.getContentLength())
+                    .build();
+
+            return information;
+        } catch (Exception e) {
+            throwException(chunkName, e);
+        }
+        return null;
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException {
+        try {
+            if (!client.listObjects(config.getBucket(), config.getPrefix() + chunkName).getObjects().isEmpty()) {
+                throw new FileAlreadyExistsException(chunkName);
+            }
+
+            S3ObjectMetadata metadata = new S3ObjectMetadata();
+            metadata.setContentLength((long) 0);
+
+            PutObjectRequest request = new PutObjectRequest(config.getBucket(), config.getPrefix() + chunkName, null);
+
+            AccessControlList acl = new AccessControlList();
+            acl.addGrants(new Grant(new CanonicalUser(config.getAccessKey(), config.getAccessKey()), Permission.FULL_CONTROL));
+            request.setAcl(acl);
+
+            /* Default behavior of putObject is to overwrite an existing object. This behavior can cause data loss.
+             * Here is one of the scenarios in which data loss is observed:
+             * 1. Host A owns the container and gets a create operation. It has not executed the putObject operation yet.
+             * 2. Ownership changes and host B becomes the owner of the container. It picks up putObject from the queue, executes it.
+             * 3. Host B gets a write operation which executes successfully.
+             * 4. Now host A schedules the putObject. This will overwrite the write by host B.
+             *
+             * The solution for this issue is to implement put-if-absent behavior by using Set-If-None-Match header as described here:
+             * http://www.emc.com/techpubs/api/ecs/v3-0-0-0/S3ObjectOperations_createOrUpdateObject_7916bd6f789d0ae0ff39961c0e660d00_ba672412ac371bb6cf4e69291344510e_detail.htm
+             * But this does not work. Currently all the calls to putObject API fail if made with reqest.setIfNoneMatch("*").
+             * once the issue with extended S3 API is fixed, addition of this one line will ensure put-if-absent semantics.
+             * See: https://github.com/pravega/pravega/issues/1564
+             *
+             * This issue is fixed in some versions of extended S3 implementation. The following code sets the IfNoneMatch
+             * flag based on configuration.
+             */
+            if (config.isUseNoneMatch()) {
+                request.setIfNoneMatch("*");
+            }
+            client.putObject(request);
+
+            return ChunkHandle.writeHandle(chunkName);
+        } catch (Exception e) {
+            throwException(chunkName, e);
+        }
+        return null;
+    }
+
+    @Override
+    protected  boolean doesExist(String chunkName) throws IOException, IllegalArgumentException {
+        try {
+            S3ObjectMetadata result = client.getObjectMetadata(config.getBucket(),
+                    config.getPrefix() + chunkName);
+            return true;
+        } catch (S3Exception e) {
+            if ( e.getErrorCode().equals("NoSuchKey")) {
+                return false;
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException {
+        try {
+            client.deleteObject(config.getBucket(), config.getPrefix() + handle.getChunkName());
+        } catch (Exception e) {
+            throwException(handle.getChunkName(), e);
+        }
+        return true;
+    }
+
+    //endregion
+
+}

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import com.emc.object.s3.S3Client;
+import com.emc.object.s3.S3Config;
+import com.emc.object.s3.jersey.S3JerseyClient;
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Factory for ExtendedS3 {@link Storage} implemented using {@link ChunkStorageManager} and {@link ExtendedS3ChunkStorageProvider}.
+ */
+public class ExtendedS3SimpleStorageFactory implements StorageFactory {
+    private final ExtendedS3StorageConfig config;
+    private final ExecutorService executor;
+
+    /**
+     * Creates a new instance of the {@link ExtendedS3SimpleStorageFactory} class.
+     *
+     * @param config   The Configuration to use.
+     * @param executor An executor to use for background operations.
+     */
+    public ExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ExecutorService executor) {
+        Preconditions.checkNotNull(config, "config");
+        Preconditions.checkNotNull(executor, "executor");
+        this.config = config;
+        this.executor = executor;
+    }
+
+    @Override
+    public Storage createStorageAdapter() {
+        ChunkStorageManager storageProvider = new ChunkStorageManager(
+                new ExtendedS3ChunkStorageProvider(this.executor, createS3Client(), this.config),
+                this.executor,
+                SegmentRollingPolicy.NO_ROLLING);
+        return storageProvider;
+    }
+
+    private S3Client createS3Client() {
+        S3Config s3Config = new S3Config(config.getS3Config());
+        S3JerseyClient client = new S3JerseyClient(s3Config);
+        return client;
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactoryCreator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import io.pravega.segmentstore.storage.ConfigSetup;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * {@link StorageFactoryCreator} for creating a Extended S3 based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class ExtendedS3SimpleStorageFactoryCreator implements StorageFactoryCreator {
+    @Override
+    public StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor) {
+        return new ExtendedS3SimpleStorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), executor);
+    }
+
+    @Override
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("EXTENDEDS3")
+                .chunkManagerSupported(true)
+                .legacyLayoutSupported(false)
+                .build();
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
@@ -12,6 +12,8 @@ package io.pravega.storage.extendeds3;
 import io.pravega.segmentstore.storage.ConfigSetup;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 public class ExtendedS3StorageFactoryCreator implements StorageFactoryCreator {
@@ -21,7 +23,11 @@ public class ExtendedS3StorageFactoryCreator implements StorageFactoryCreator {
     }
 
     @Override
-    public String getName() {
-        return "EXTENDEDS3";
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("EXTENDEDS3")
+                .chunkManagerSupported(false)
+                .legacyLayoutSupported(true)
+                .build();
     }
 }

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemChunkStorageProvider.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemChunkStorageProvider.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import io.pravega.common.Timer;
+import io.pravega.segmentstore.storage.chunklayer.BaseChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+/**
+ *  {@link io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider} for file system based storage.
+ *
+ * Each Chunk is represented as a single file on the underlying storage.
+ * The concat operation is implemented as append.
+ *
+ */
+
+@Slf4j
+public class FileSystemChunkStorageProvider extends BaseChunkStorageProvider {
+    //region members
+
+    private static final Set<PosixFilePermission> READ_ONLY_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
+
+    private static final Set<PosixFilePermission> READ_WRITE_PERMISSION = ImmutableSet.of(
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
+
+    private final FileSystemStorageConfig config;
+
+    //endregion
+
+    //region constructor
+
+    /**
+     * Creates a new instance of the FileSystemChunkStorageProvider class.
+     *
+     * @param config   The configuration to use.
+     * @param executor Executor to use.
+     */
+    public FileSystemChunkStorageProvider(Executor executor, FileSystemStorageConfig config)  {
+        super(executor);
+        this.config = Preconditions.checkNotNull(config, "config");
+    }
+
+    //endregion
+
+    //region
+
+    @VisibleForTesting
+    protected FileChannel getFileChannel(Path path, StandardOpenOption openOption) throws IOException {
+        try {
+            return FileChannel.open(path, openOption);
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundException(path.toString());
+        }
+    }
+
+    @VisibleForTesting
+    protected long getFileSize(Path path) throws IOException {
+        try {
+            return Files.size(path);
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundException(path.toString());
+        }
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException {
+        try {
+            PosixFileAttributes attrs = Files.readAttributes(Paths.get(config.getRoot(), chunkName),
+                    PosixFileAttributes.class);
+            ChunkInfo information = ChunkInfo.builder()
+                    .name(chunkName)
+                    .length(attrs.size())
+                    //.lastModified(new ImmutableDate(attrs.creationTime().toMillis()))
+                    .build();
+
+            return information;
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundException(chunkName);
+        }
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException {
+        FileAttribute<Set<PosixFilePermission>> fileAttributes = PosixFilePermissions.asFileAttribute(READ_WRITE_PERMISSION);
+
+        Path path = Paths.get(config.getRoot(), chunkName);
+        Path parent = path.getParent();
+        assert parent != null;
+        Files.createDirectories(parent);
+        Files.createFile(path, fileAttributes);
+        return ChunkHandle.writeHandle(chunkName);
+    }
+
+    @Override
+    protected boolean doesExist(String chunkName) throws IOException, IllegalArgumentException {
+        return Files.exists(Paths.get(config.getRoot(), chunkName));
+    }
+
+    @Override
+    protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException {
+        Files.delete(Paths.get(config.getRoot(), handle.getChunkName()));
+        return true;
+    }
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException {
+        Path path = Paths.get(config.getRoot(), chunkName);
+
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException(chunkName);
+        }
+
+        return ChunkHandle.readHandle(chunkName);
+    }
+
+    @Override
+    protected ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException {
+        Path path = Paths.get(config.getRoot(), chunkName);
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException(chunkName);
+        } else if (Files.isWritable(path)) {
+            return ChunkHandle.writeHandle(chunkName);
+        } else {
+            return ChunkHandle.readHandle(chunkName);
+        }
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        Timer timer = new Timer();
+
+        Path path = Paths.get(config.getRoot(), handle.getChunkName());
+
+        long fileSize = getFileSize(path);
+        if (fileSize < fromOffset) {
+            throw new IllegalArgumentException(String.format("Reading at offset (%d) which is beyond the " +
+                    "current size of chunk (%d).", fromOffset, fileSize));
+        }
+
+        try (FileChannel channel = getFileChannel(path, StandardOpenOption.READ)) {
+            int totalBytesRead = 0;
+            long readOffset = fromOffset;
+            do {
+                ByteBuffer readBuffer = ByteBuffer.wrap(buffer, bufferOffset, length);
+                int bytesRead = channel.read(readBuffer, readOffset);
+                bufferOffset += bytesRead;
+                totalBytesRead += bytesRead;
+                length -= bytesRead;
+                readOffset += bytesRead;
+            } while (length != 0);
+            return totalBytesRead;
+        }
+    }
+
+    @Override
+    protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IOException {
+        Timer timer = new Timer();
+
+        if (handle.isReadOnly()) {
+            throw new IllegalArgumentException("Write called on a readonly handle of chunk " + handle.getChunkName());
+        }
+
+        Path path = Paths.get(config.getRoot(), handle.getChunkName());
+
+        long totalBytesWritten = 0;
+        try (FileChannel channel = getFileChannel(path, StandardOpenOption.WRITE)) {
+            long fileSize = channel.size();
+            if (fileSize != offset) {
+                throw new IndexOutOfBoundsException(String.format("fileSize (%d) did not match offset (%d) for chunk %s", fileSize, offset, handle.getChunkName()));
+            }
+
+            // Wrap the input data into a ReadableByteChannel, but do not close it. Doing so will result in closing
+            // the underlying InputStream, which is not desirable if it is to be reused.
+            ReadableByteChannel sourceChannel = Channels.newChannel(data);
+            while (length != 0) {
+                long bytesWritten = channel.transferFrom(sourceChannel, offset, length);
+                assert bytesWritten > 0 : "Unable to make any progress transferring data.";
+                offset += bytesWritten;
+                totalBytesWritten += bytesWritten;
+                length -= bytesWritten;
+            }
+            channel.force(false);
+        }
+        return (int) totalBytesWritten;
+    }
+
+    @Override
+    protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        int totalBytesConcated = 0;
+        Path targetPath = Paths.get(config.getRoot(), target.getChunkName());
+        for (ChunkHandle source: sources) {
+            Preconditions.checkArgument(!target.getChunkName().equals(source.getChunkName()), "target and source can not be same.");
+            Path sourcePath = Paths.get(config.getRoot(), source.getChunkName());
+            long length = getFileSize(sourcePath);
+            long offset = getFileSize(targetPath);
+            try (FileChannel targetChannel = getFileChannel(targetPath, StandardOpenOption.WRITE);
+                 RandomAccessFile sourceFile = new RandomAccessFile(String.valueOf(sourcePath), "r")) {
+                while (length > 0) {
+                    long bytesTransferred = targetChannel.transferFrom(sourceFile.getChannel(), offset, length);
+                    offset += bytesTransferred;
+                    length -= bytesTransferred;
+                }
+                targetChannel.force(false);
+                Files.delete(sourcePath);
+                totalBytesConcated += length;
+            }
+        }
+        return totalBytesConcated;
+    }
+
+    @Override
+    protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        return false;
+    }
+
+    @Override
+    protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException {
+        Path path = null;
+        try {
+            path = Paths.get(config.getRoot(), handle.getChunkName());
+            Files.setPosixFilePermissions(path, isReadOnly ? READ_ONLY_PERMISSION : READ_WRITE_PERMISSION);
+            return true;
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundException(path.toString());
+        }
+    }
+    //endregion
+}

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Factory for ExtendedS3 {@link Storage} implemented using {@link ChunkStorageManager} and {@link FileSystemChunkStorageProvider}.
+ */
+public class FileSystemSimpleStorageFactory implements StorageFactory {
+    private final FileSystemStorageConfig config;
+    private final ExecutorService executor;
+
+    /**
+     * Creates a new instance of the {@link FileSystemSimpleStorageFactory} class.
+     *
+     * @param config   The Configuration to use.
+     * @param executor An executor to use for background operations.
+     */
+    public FileSystemSimpleStorageFactory(FileSystemStorageConfig config, ExecutorService executor) {
+        Preconditions.checkNotNull(config, "config");
+        Preconditions.checkNotNull(executor, "executor");
+        this.config = config;
+        this.executor = executor;
+    }
+
+    @Override
+    public Storage createStorageAdapter() {
+        ChunkStorageManager storageProvider = new ChunkStorageManager(
+                new FileSystemChunkStorageProvider(this.executor, this.config),
+                this.executor,
+                SegmentRollingPolicy.NO_ROLLING);
+        return storageProvider;
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactoryCreator.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import io.pravega.segmentstore.storage.ConfigSetup;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * {@link StorageFactoryCreator} for creating a file system based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class FileSystemSimpleStorageFactoryCreator implements StorageFactoryCreator {
+
+    @Override
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("FILESYSTEM")
+                .chunkManagerSupported(true)
+                .legacyLayoutSupported(false)
+                .build();
+    }
+
+    @Override
+    public StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor) {
+        return new FileSystemSimpleStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), executor);
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
@@ -12,13 +12,19 @@ package io.pravega.storage.filesystem;
 import io.pravega.segmentstore.storage.ConfigSetup;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 public class FileSystemStorageFactoryCreator implements StorageFactoryCreator {
 
     @Override
-    public String getName() {
-        return "FILESYSTEM";
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("FILESYSTEM")
+                .chunkManagerSupported(false)
+                .legacyLayoutSupported(true)
+                .build();
     }
 
     @Override

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSChunkStorageProvider.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSChunkStorageProvider.java
@@ -1,0 +1,295 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.hdfs;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.concurrent.Executor;
+
+import io.pravega.segmentstore.storage.chunklayer.BaseChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.io.IOUtils;
+
+/***
+ *  {@link io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider} for HDFS based storage.
+ *
+ * Each chunk is represented as a single Object on the underlying storage.
+ *
+ * This implementation works under the assumption that data is only appended and never modified.
+ * The concat operation is implemented using HDFS native concat operation.
+ */
+
+@Slf4j
+class HDFSChunkStorageProvider extends BaseChunkStorageProvider {
+    private static final FsPermission READWRITE_PERMISSION = new FsPermission(FsAction.READ_WRITE, FsAction.NONE, FsAction.NONE);
+    private static final FsPermission READONLY_PERMISSION = new FsPermission(FsAction.READ, FsAction.READ, FsAction.READ);
+
+    //region Members
+
+    private final HDFSStorageConfig config;
+    private FileSystem fileSystem;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the HDFSStorage class.
+     *
+     * @param config   The configuration to use.
+     */
+    HDFSChunkStorageProvider(Executor executor, HDFSStorageConfig config) {
+        super(executor);
+        Preconditions.checkNotNull(config, "config");
+        this.config = config;
+        initialize();
+    }
+
+    //endregion
+
+    //region AutoCloseable Implementation
+
+    @Override
+    public void close() {
+        if (!this.closed.getAndSet(true)) {
+            if (this.fileSystem != null) {
+                try {
+                    this.fileSystem.close();
+                    this.fileSystem = null;
+                } catch (IOException e) {
+                    log.warn("Could not close the HDFS filesystem: {}.", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        FileStatus last = fileSystem.getFileStatus(getFilePath(chunkName));
+        ChunkInfo result = ChunkInfo.builder().name(chunkName).length(last.getLen()).build();
+        return result;
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        try {
+            Path fullPath = getFilePath(chunkName);
+            // Create the file, and then immediately close the returned OutputStream, so that HDFS may properly create the file.
+            this.fileSystem.create(fullPath, READWRITE_PERMISSION, false, 0, this.config.getReplication(),
+                    this.config.getBlockSize(), null).close();
+            log.debug("Created '{}'.", fullPath);
+
+            // return handle
+            return ChunkHandle.writeHandle(chunkName);
+        } catch (org.apache.hadoop.fs.FileAlreadyExistsException e ) {
+            throw new FileAlreadyExistsException(chunkName);
+        }
+    }
+
+    @Override
+    protected boolean doesExist(String chunkName) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        FileStatus status = null;
+        try {
+            status = fileSystem.getFileStatus(getFilePath(chunkName));
+        } catch (IOException e) {
+            // HDFS could not find the file. Returning false.
+            log.warn("Got exception checking if file exists", e);
+        }
+        boolean exists = status != null;
+        return exists;
+    }
+
+    @Override
+    protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        boolean retValue = this.fileSystem.delete(getFilePath(handle.getChunkName()), true);
+        return retValue;
+    }
+
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        FileStatus status = fileSystem.getFileStatus(getFilePath(chunkName));
+        return ChunkHandle.readHandle(chunkName);
+    }
+
+    @Override
+    protected ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException {
+        ensureInitializedAndNotClosed();
+        FileStatus status = fileSystem.getFileStatus(getFilePath(chunkName));
+        return ChunkHandle.writeHandle(chunkName);
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        ensureInitializedAndNotClosed();
+
+        if (fromOffset < 0 || bufferOffset < 0 || length < 0 || buffer.length < bufferOffset + length) {
+            throw new ArrayIndexOutOfBoundsException(String.format(
+                    "Offset (%s) must be non-negative, and bufferOffset (%s) and length (%s) must be valid indices into buffer of size %s.",
+                    fromOffset, bufferOffset, length, buffer.length));
+        }
+
+        int totalBytesRead  = readInternal(handle, buffer, fromOffset, bufferOffset, length);
+        return totalBytesRead;
+
+    }
+
+    @Override
+    protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IOException, IndexOutOfBoundsException {
+        ensureInitializedAndNotClosed();
+        try (FSDataOutputStream stream = this.fileSystem.append(getFilePath(handle.getChunkName()))) {
+            if (stream.getPos() != offset) {
+                // Looks like the filesystem changed from underneath us. This could be our bug, but it could be something else.
+                throw new IndexOutOfBoundsException();
+            }
+
+            if (length == 0) {
+                // Exit here (vs at the beginning of the method), since we want to throw appropriate exceptions in case
+                // of Sealed or BadOffset
+                // Note: IOUtils.copyBytes with length == 0 will enter an infinite loop, hence the need for this check.
+                return 0;
+            }
+
+            // We need to be very careful with IOUtils.copyBytes. There are many overloads with very similar signatures.
+            // There is a difference between (InputStream, OutputStream, int, boolean) and (InputStream, OutputStream, long, boolean),
+            // in that the one with "int" uses the third arg as a buffer size, and the one with "long" uses it as the number
+            // of bytes to copy.
+            IOUtils.copyBytes(data, stream, (long) length, false);
+
+            stream.flush();
+        } finally {
+
+        }
+        return length;
+    }
+
+    @Override
+    protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        ensureInitializedAndNotClosed();
+        // Concat source file into target.
+        this.fileSystem.concat(getFilePath(target.getChunkName()), new Path[]{getFilePath(sources[0].getChunkName())});
+        return 0;
+    }
+
+    @Override
+    protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support chunk truncation.");
+    }
+
+    @Override
+    protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException {
+        this.fileSystem.setPermission(getFilePath(handle.getChunkName()), isReadOnly ? READONLY_PERMISSION : READWRITE_PERMISSION);
+        return true;
+    }
+
+    //endregion
+
+    //region Storage Implementation
+
+    @SneakyThrows(IOException.class)
+    public void initialize() {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        Preconditions.checkState(this.fileSystem == null, "HDFSStorage has already been initialized.");
+        Configuration conf = new Configuration();
+        conf.set("fs.default.name", this.config.getHdfsHostURL());
+        conf.set("fs.default.fs", this.config.getHdfsHostURL());
+        conf.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
+
+        // FileSystem has a bad habit of caching Clients/Instances based on target URI. We do not like this, since we
+        // want to own our implementation so that when we close it, we don't interfere with others.
+        conf.set("fs.hdfs.impl.disable.cache", "true");
+        if (!this.config.isReplaceDataNodesOnFailure()) {
+            // Default is DEFAULT, so we only set this if we want it disabled.
+            conf.set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER");
+        }
+
+        this.fileSystem = openFileSystem(conf);
+        log.info("Initialized (HDFSHost = '{}'", this.config.getHdfsHostURL());
+    }
+
+    FileSystem openFileSystem(Configuration conf) throws IOException {
+        return FileSystem.get(conf);
+    }
+
+
+    @Override
+    public boolean supportsTruncation() {
+        ensureInitializedAndNotClosed();
+        return false;
+    }
+    //endregion
+
+    //region Helpers
+    private void ensureInitializedAndNotClosed() {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        Preconditions.checkState(this.fileSystem != null, "HDFSStorage is not initialized.");
+    }
+
+    //endregion
+
+    //Region HDFS helper methods.
+
+    /**
+     * Gets an HDFS-friendly path prefix for the given chunk name by pre-pending the HDFS root from the config.
+     */
+    private String getPathPrefix(String chunkName) {
+        return this.config.getHdfsRoot() + Path.SEPARATOR + chunkName;
+    }
+
+    /**
+     * Gets the full HDFS Path to a file for the given chunk, startOffset and epoch.
+     */
+    private Path getFilePath(String chunkName) {
+        Preconditions.checkState(chunkName != null && chunkName.length() > 0, "chunkName must be non-null and non-empty");
+        return new Path(getPathPrefix(chunkName));
+    }
+
+    /**
+     * Determines whether the given FileStatus indicates the file is read-only.
+     *
+     * @param fs The FileStatus to check.
+     * @return True or false.
+     */
+    private boolean isReadOnly(FileStatus fs) {
+        return fs.getPermission().getUserAction() == FsAction.READ;
+    }
+
+    private int readInternal(ChunkHandle handle, byte[] buffer, long offset, int bufferOffset, int length) throws IOException {
+        //There is only one file per chunkName.
+        try (FSDataInputStream stream = this.fileSystem.open(getFilePath(handle.getChunkName()))) {
+            stream.readFully(offset, buffer, bufferOffset, length);
+        } catch (EOFException e) {
+            throw new IllegalArgumentException(String.format("Reading at offset (%d) which is beyond the current size of chunk.", offset));
+        }
+        return length;
+    }
+
+    //endregion
+}

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.hdfs;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Factory for ExtendedS3 {@link Storage} implemented using {@link ChunkStorageManager} and {@link HDFSChunkStorageProvider}.
+ */
+public class HDFSSimpleStorageFactory implements StorageFactory {
+    private final HDFSStorageConfig config;
+    private final Executor executor;
+
+    /**
+     * Creates a new instance of the HDFSStorageFactory class.
+     *
+     * @param config   The Configuration to use.
+     * @param executor An executor to use for background operations.
+     */
+    public HDFSSimpleStorageFactory(HDFSStorageConfig config, Executor executor) {
+        Preconditions.checkNotNull(config, "config");
+        Preconditions.checkNotNull(executor, "executor");
+        this.config = config;
+        this.executor = executor;
+    }
+
+    @Override
+    public Storage createStorageAdapter() {
+        ChunkStorageManager storageProvider = new ChunkStorageManager(
+                new HDFSChunkStorageProvider(this.executor, this.config),
+                this.executor,
+                SegmentRollingPolicy.NO_ROLLING);
+        return storageProvider;
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactoryCreator.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.hdfs;
+
+import io.pravega.segmentstore.storage.ConfigSetup;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * {@link StorageFactoryCreator} for creating an HDFS based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class HDFSSimpleStorageFactoryCreator implements StorageFactoryCreator {
+
+    @Override
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("HDFS")
+                .chunkManagerSupported(true)
+                .legacyLayoutSupported(false)
+                .build();
+    }
+
+    @Override
+    public StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor) {
+        return new HDFSSimpleStorageFactory(setup.getConfig(HDFSStorageConfig::builder), executor);
+    }
+}

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
@@ -12,13 +12,19 @@ package io.pravega.storage.hdfs;
 import io.pravega.segmentstore.storage.ConfigSetup;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 public class HDFSStorageFactoryCreator implements StorageFactoryCreator {
 
     @Override
-    public String getName() {
-        return "HDFS";
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("HDFS")
+                .chunkManagerSupported(false)
+                .legacyLayoutSupported(true)
+                .build();
     }
 
     @Override

--- a/bindings/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
+++ b/bindings/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
@@ -12,5 +12,8 @@
 # for more reference.
 
 io.pravega.storage.filesystem.FileSystemStorageFactoryCreator
+io.pravega.storage.filesystem.FileSystemSimpleStorageFactoryCreator
 io.pravega.storage.hdfs.HDFSStorageFactoryCreator
+io.pravega.storage.hdfs.HDFSSimpleStorageFactoryCreator
 io.pravega.storage.extendeds3.ExtendedS3StorageFactoryCreator
+io.pravega.storage.extendeds3.ExtendedS3SimpleStorageFactoryCreator

--- a/bindings/src/test/java/io/pravega/storage/IdempotentStorageTestBase.java
+++ b/bindings/src/test/java/io/pravega/storage/IdempotentStorageTestBase.java
@@ -132,9 +132,11 @@ public abstract class IdempotentStorageTestBase extends StorageTestBase {
 
     /**
      * This test case simulates two hosts writing at the same offset at the same time.
+     *
+     * @throws Exception if an unexpected error occurred.
      */
     @Test(timeout = 30000)
-    public void testParallelWriteTwoHosts() {
+    public void testParallelWriteTwoHosts() throws Exception {
         String segmentName = "foo_write";
         int appendCount = 5;
 
@@ -181,9 +183,12 @@ public abstract class IdempotentStorageTestBase extends StorageTestBase {
 
     /**
      * This test case simulates host crashing during concat and retrying the operation.
+     *
+     *
+     * @throws Exception if an unexpected error occurred.
      */
     @Test(timeout = 30000)
-    public void testPartialConcat() {
+    public void testPartialConcat() throws Exception {
         String segmentName = "foo_write";
         String concatSegmentName = "foo_concat";
         String newConcatSegmentName = "foo_concat0";

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageTests.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageTests.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkManagerRollingTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProviderTests;
+import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
+import io.pravega.segmentstore.storage.chunklayer.SystemJournalTests;
+import org.junit.After;
+import org.junit.Before;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Unit tests for {@link ExtendedS3ChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class ExtendedS3SimpleStorageTests extends SimpleStorageTests {
+    private ExtendedS3TestContext testContext = null;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        this.testContext = new ExtendedS3TestContext();
+    }
+
+    @After
+    public void after() throws Exception {
+        if (this.testContext != null) {
+            this.testContext.close();
+        }
+        super.after();
+    }
+
+    @Override
+    protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+        this.testContext = new ExtendedS3TestContext();
+        return new ExtendedS3ChunkStorageProvider(executor, testContext.client, testContext.adapterConfig);
+    }
+
+    /**
+     * {@link ChunkManagerRollingTests} tests for {@link ExtendedS3ChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class ExtendedS3StorageProviderRollingTests extends ChunkManagerRollingTests {
+        private ExtendedS3TestContext testContext = null;
+
+        @Before
+        public void setUp() throws Exception {
+            this.testContext = new ExtendedS3TestContext();
+        }
+
+        @After
+        public void tearDown() throws Exception {
+            if (this.testContext != null) {
+                this.testContext.close();
+            }
+        }
+
+        @Override
+        protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return new ExtendedS3ChunkStorageProvider(executor, testContext.client, testContext.adapterConfig);
+        }
+    }
+
+    /**
+     * {@link ChunkStorageProviderTests} tests for {@link ExtendedS3ChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class ExtendedS3ChunkStorageProviderTests extends ChunkStorageProviderTests {
+        private ExtendedS3TestContext testContext = null;
+
+        @Before
+        public void before() throws Exception {
+            super.before();
+            this.testContext = new ExtendedS3TestContext();
+        }
+
+        @After
+        public void after() throws Exception {
+            if (this.testContext != null) {
+                this.testContext.close();
+            }
+            super.after();
+        }
+
+        @Override
+        protected ChunkStorageProvider createChunkStorageProvider() throws Exception {
+            this.testContext = new ExtendedS3TestContext();
+            return new ExtendedS3ChunkStorageProvider(new ScheduledThreadPoolExecutor(getThreadPoolSize()), testContext.client, testContext.adapterConfig);
+        }
+    }
+
+    /**
+     * {@link SystemJournalTests} tests for {@link ExtendedS3ChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class ExtendedS3ChunkStorageSystemJournalTests extends SystemJournalTests {
+        private ExtendedS3TestContext testContext = null;
+
+        @Before
+        public void before() throws Exception {
+            super.before();
+            this.testContext = new ExtendedS3TestContext();
+        }
+
+        @After
+        public void after() throws Exception {
+            if (this.testContext != null) {
+                this.testContext.close();
+            }
+            super.after();
+        }
+
+        @Override
+        protected ChunkStorageProvider getStorageProvider() throws Exception {
+            this.testContext = new ExtendedS3TestContext();
+            return new ExtendedS3ChunkStorageProvider(executorService(), testContext.client, testContext.adapterConfig);
+        }
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -10,11 +10,6 @@
 package io.pravega.storage.extendeds3;
 
 import com.emc.object.s3.S3Client;
-import com.emc.object.s3.S3Config;
-import com.emc.object.s3.bean.ObjectKey;
-import com.emc.object.s3.jersey.S3JerseyClient;
-import com.emc.object.s3.request.DeleteObjectsRequest;
-import com.emc.object.util.ConfigUri;
 import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.Property;
@@ -28,13 +23,9 @@ import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.StatsProvider;
 import io.pravega.storage.IdempotentStorageTestBase;
-import io.pravega.test.common.TestUtils;
 
 import java.io.ByteArrayInputStream;
-import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.After;
@@ -51,11 +42,11 @@ import static org.junit.Assert.assertTrue;
  */
 @Slf4j
 public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
-    private TestContext setup;
+    private ExtendedS3TestContext setup;
 
     @Before
     public void setUp() throws Exception {
-        this.setup = new TestContext();
+        this.setup = new ExtendedS3TestContext();
         MetricsConfig metricsConfig = MetricsConfig.builder().with(MetricsConfig.ENABLE_STATISTICS, true).build();
         MetricsProvider.initialize(metricsConfig);
         StatsProvider statsProvider = MetricsProvider.getMetricsProvider();
@@ -264,11 +255,11 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
      * Tests the InMemoryStorage adapter with a RollingStorage wrapper.
      */
     public static class RollingStorageTests extends RollingStorageTestBase {
-        private TestContext setup;
+        private ExtendedS3TestContext setup;
 
         @Before
         public void setUp() throws Exception {
-            this.setup = new TestContext();
+            this.setup = new ExtendedS3TestContext();
         }
 
         @After
@@ -286,42 +277,4 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
     }
 
     //endregion
-
-    private static class TestContext {
-        private static final String BUCKET_NAME_PREFIX = "pravegatest-";
-        private final ExtendedS3StorageConfig adapterConfig;
-        private final S3JerseyClient client;
-        private final S3ImplBase s3Proxy;
-        private final int port = TestUtils.getAvailableListenPort();
-        private final String configUri = "http://127.0.0.1:" + port + "?identity=x&secretKey=x";
-        private final S3Config s3Config;
-
-        TestContext() throws Exception {
-            String bucketName = BUCKET_NAME_PREFIX + UUID.randomUUID().toString();
-            this.adapterConfig = ExtendedS3StorageConfig.builder()
-                    .with(ExtendedS3StorageConfig.CONFIGURI, configUri)
-                    .with(ExtendedS3StorageConfig.BUCKET, bucketName)
-                    .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
-                    .build();
-            s3Config = new ConfigUri<>(S3Config.class).parseUri(configUri);
-            s3Proxy = new S3ProxyImpl(configUri, s3Config);
-            s3Proxy.start();
-            client = new S3JerseyClientWrapper(s3Config, s3Proxy);
-            client.createBucket(bucketName);
-            List<ObjectKey> keys = client.listObjects(bucketName).getObjects().stream()
-                    .map(object -> new ObjectKey(object.getKey()))
-                    .collect(Collectors.toList());
-
-            if (!keys.isEmpty()) {
-                client.deleteObjects(new DeleteObjectsRequest(bucketName).withKeys(keys));
-            }
-        }
-
-        void close() throws Exception {
-            if (client != null) {
-                client.destroy();
-            }
-            s3Proxy.stop();
-        }
-    }
 }

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3TestContext.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3TestContext.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.extendeds3;
+
+import com.emc.object.s3.S3Config;
+import com.emc.object.s3.bean.ObjectKey;
+import com.emc.object.s3.jersey.S3JerseyClient;
+import com.emc.object.s3.request.DeleteObjectsRequest;
+import com.emc.object.util.ConfigUri;
+import io.pravega.test.common.TestUtils;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Test context Extended S3 tests.
+ */
+public class ExtendedS3TestContext {
+    public static final String BUCKET_NAME_PREFIX = "pravegatest-";
+    public final ExtendedS3StorageConfig adapterConfig;
+    public final S3JerseyClient client;
+    public final S3ImplBase s3Proxy;
+    public final int port = TestUtils.getAvailableListenPort();
+    public final String configUri = "http://127.0.0.1:" + port + "?identity=x&secretKey=x";
+    public final S3Config s3Config;
+
+    public ExtendedS3TestContext() throws Exception {
+        String bucketName = BUCKET_NAME_PREFIX + UUID.randomUUID().toString();
+        this.adapterConfig = ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, configUri)
+                .with(ExtendedS3StorageConfig.BUCKET, bucketName)
+                .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
+                .build();
+        s3Config = new ConfigUri<>(S3Config.class).parseUri(configUri);
+        s3Proxy = new S3ProxyImpl(configUri, s3Config);
+        s3Proxy.start();
+        client = new S3JerseyClientWrapper(s3Config, s3Proxy);
+        client.createBucket(bucketName);
+        List<ObjectKey> keys = client.listObjects(bucketName).getObjects().stream()
+                .map(object -> new ObjectKey(object.getKey()))
+                .collect(Collectors.toList());
+
+        if (!keys.isEmpty()) {
+            client.deleteObjects(new DeleteObjectsRequest(bucketName).withKeys(keys));
+        }
+    }
+
+    public void close() throws Exception {
+        if (client != null) {
+            client.destroy();
+        }
+        s3Proxy.stop();
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemChunkProviderMockTest.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemChunkProviderMockTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.channels.FileChannel;
+import java.nio.channels.spi.AbstractInterruptibleChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+public class FileSystemChunkProviderMockTest {
+    static final Duration TIMEOUT = Duration.ofSeconds(30);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+
+    private File baseDir = null;
+    private FileSystemStorageConfig storageConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        this.baseDir = Files.createTempDirectory("test_nfs").toFile().getAbsoluteFile();
+        this.storageConfig = FileSystemStorageConfig
+                .builder()
+                .with(FileSystemStorageConfig.ROOT, this.baseDir.getAbsolutePath())
+                .build();
+    }
+
+    @Test
+    public void doReadTest() throws Exception {
+        doReadTest(0, 1);
+
+        for (int bufferSize : new int[] {2, 3, 4, 1024}) {
+            for (int i : new int[] {0, 1, bufferSize / 2, bufferSize - 2, bufferSize -1}) {
+                doReadTest(i, bufferSize);
+            }
+        }
+    }
+
+    private void doReadTest(int index, int bufferSize) throws Exception {
+        // Set up mocks.
+        FileChannel channel = mock(FileChannel.class);
+        fixChannelMock(channel);
+        String segmentName = "test";
+
+        Executor executor = mock(Executor.class);
+
+        TestFileSystemStorage testStorage = new TestFileSystemStorage(executor, storageConfig, channel);
+        testStorage.setSizeToReturn(2L * bufferSize);
+        ChunkHandle handle = ChunkHandle.readHandle(segmentName);
+
+        // Force two reads.
+        ArgumentCaptor<Long> expectedArgs = ArgumentCaptor.forClass(Long.class);
+        when(channel.read(any(), anyLong())).thenReturn(index, bufferSize - index);
+
+        // Call method.
+        byte[] buffer = new byte[bufferSize];
+        testStorage.doRead(handle, 0, bufferSize, buffer, 0);
+
+        // Verify.
+        verify(channel, times(2)).read(any(), expectedArgs.capture());
+        List<Long> actualArgs = expectedArgs.getAllValues();
+        assertEquals(2, actualArgs.size());
+        assertEquals(0, actualArgs.get(0).longValue());
+        assertEquals(index, actualArgs.get(1).longValue());
+    }
+
+    private static void fixChannelMock(AbstractInterruptibleChannel mockFileChannel) throws Exception {
+        // Note : This is a workaround for NullPointerException.
+        // This will break when jdk decides to change implementation.
+        Field closeLockField = AbstractInterruptibleChannel.class.getDeclaredField("closeLock");
+        closeLockField.setAccessible(true);
+        closeLockField.set(mockFileChannel, new Object());
+    }
+
+    /**
+     * Test Class.
+     */
+    private static class TestFileSystemStorage extends FileSystemChunkStorageProvider {
+        private final FileChannel channel;
+
+        @Getter
+        @Setter
+        private long sizeToReturn;
+
+        public TestFileSystemStorage(Executor executor, FileSystemStorageConfig config, FileChannel channel) {
+            super(executor, config);
+            this.channel = channel;
+        }
+
+        @Override
+        protected FileChannel getFileChannel(Path path, StandardOpenOption openOption) throws IOException {
+            return channel;
+        }
+
+        @Override
+        protected long getFileSize(Path path) throws IOException {
+            return sizeToReturn;
+        }
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemSimpleStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemSimpleStorageTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.filesystem;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkManagerRollingTests;
+import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProviderTests;
+import io.pravega.segmentstore.storage.chunklayer.SystemJournalTests;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Unit tests for {@link FileSystemChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class FileSystemSimpleStorageTest extends SimpleStorageTests {
+    private static ChunkStorageProvider getChunkStorageProvider(Executor executor) throws IOException {
+        File baseDir = Files.createTempDirectory("test_nfs").toFile().getAbsoluteFile();
+        return new FileSystemChunkStorageProvider(executor, FileSystemStorageConfig
+                .builder()
+                .with(FileSystemStorageConfig.ROOT, baseDir.getAbsolutePath())
+                .build());
+    }
+
+    protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+        return getChunkStorageProvider(executor);
+    }
+
+    /**
+     * {@link ChunkManagerRollingTests} tests for {@link FileSystemChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class FileSystemRollingTests extends ChunkManagerRollingTests {
+        protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return getChunkStorageProvider(executor);
+        }
+
+    }
+
+    /**
+     * {@link ChunkStorageProviderTests} tests for {@link FileSystemChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class FileSystemChunkStorageProviderTests extends ChunkStorageProviderTests {
+        @Override
+        protected ChunkStorageProvider createChunkStorageProvider() throws Exception {
+            return getChunkStorageProvider(new ScheduledThreadPoolExecutor(getThreadPoolSize()));
+        }
+    }
+
+    /**
+     * {@link SystemJournalTests} tests for {@link FileSystemChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class FileSystemChunkStorageSystemJournalTests extends SystemJournalTests {
+        @Override
+        protected ChunkStorageProvider getStorageProvider() throws Exception {
+            return FileSystemSimpleStorageTest.getChunkStorageProvider(executorService());
+        }
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSSimpleStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSSimpleStorageTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.storage.hdfs;
+
+import io.pravega.common.io.FileHelpers;
+import io.pravega.segmentstore.storage.chunklayer.ChunkManagerRollingTests;
+import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProviderTests;
+import io.pravega.segmentstore.storage.chunklayer.SystemJournalTests;
+import lombok.Getter;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/***
+ * Unit tests for {@link HDFSChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+ */
+public class HDFSSimpleStorageTest extends SimpleStorageTests {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+    private TestContext testContext = new TestContext();
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        testContext.setUp();
+    }
+
+    @After
+    public void after() throws Exception {
+        testContext.tearDown();
+        super.after();
+    }
+
+    protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+        return testContext.getChunkStorage(executor);
+    }
+
+    /**
+     * {@link ChunkManagerRollingTests} tests for {@link HDFSChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class HDFSRollingTests extends ChunkManagerRollingTests {
+        @Rule
+        public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+        private TestContext testContext = new TestContext();
+
+        @Before
+        public void before() throws Exception {
+            super.before();
+            testContext.setUp();
+        }
+
+        @After
+        public void after() throws Exception {
+            testContext.tearDown();
+            super.after();
+        }
+
+        protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return testContext.getChunkStorage(executor);
+        }
+    }
+
+    /**
+     * {@link ChunkStorageProviderTests} tests for {@link HDFSChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class HDFSChunkStorageProviderTests extends ChunkStorageProviderTests {
+        @Rule
+        public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+        private TestContext testContext = new TestContext();
+
+        @Before
+        public void before() throws Exception {
+            testContext.setUp();
+            super.before();
+        }
+
+        @After
+        public void after() throws Exception {
+            testContext.tearDown();
+            super.after();
+        }
+
+        @Override
+        protected ChunkStorageProvider createChunkStorageProvider() throws Exception {
+            return testContext.getChunkStorage(new ScheduledThreadPoolExecutor(getThreadPoolSize()));
+        }
+    }
+
+    /**
+     * {@link SystemJournalTests} tests for {@link HDFSChunkStorageProvider} based {@link io.pravega.segmentstore.storage.Storage}.
+     */
+    public static class HDFSChunkStorageSystemJournalTests extends SystemJournalTests {
+        private TestContext testContext = new TestContext();
+
+        @Before
+        public void before() throws Exception {
+            testContext.setUp();
+            super.before();
+        }
+
+        @After
+        public void after() throws Exception {
+            testContext.tearDown();
+            super.after();
+        }
+
+        @Override
+        protected ChunkStorageProvider getStorageProvider() throws Exception {
+            return testContext.getChunkStorage(executorService());
+        }
+    }
+
+    /**
+     * Test context.
+     */
+    private static class TestContext {
+        @Getter
+        private File baseDir = null;
+
+        @Getter
+        private MiniDFSCluster hdfsCluster = null;
+
+        @Getter
+        private HDFSStorageConfig adapterConfig = null;
+
+        private void setUp() throws Exception {
+            this.baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
+            this.hdfsCluster = HDFSClusterHelpers.createMiniDFSCluster(this.baseDir.getAbsolutePath());
+            this.adapterConfig = HDFSStorageConfig
+                    .builder()
+                    .with(HDFSStorageConfig.REPLICATION, 1)
+                    .with(HDFSStorageConfig.URL, String.format("hdfs://localhost:%d/", hdfsCluster.getNameNodePort()))
+                    .build();
+        }
+
+        private void tearDown() {
+            if (hdfsCluster != null) {
+                hdfsCluster.shutdown();
+                hdfsCluster = null;
+                FileHelpers.deleteFileOrDirectory(baseDir);
+                baseDir = null;
+            }
+        }
+
+        private ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return new HDFSChunkStorageProvider(executor, adapterConfig);
+        }
+    }
+}

--- a/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/hdfs/HDFSStorageTest.java
@@ -198,6 +198,7 @@ public class HDFSStorageTest extends StorageTestBase {
 
             // Storage1 should be able to execute only read-only operations.
             verifyWriteOperationsFail(handle1, storage1);
+            verifyConcatOperationsFail(handle1, storage1);
             verifyReadOnlyOperationsSucceed(handle1, storage1);
 
             // Storage2 should be able to execute all operations.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentTruncatedException.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentTruncatedException.java
@@ -9,12 +9,16 @@
  */
 package io.pravega.segmentstore.contracts;
 
+import lombok.Getter;
+
 /**
  * An Exception that indicates a StreamSegment has been truncated and certain offsets cannot be accessed anymore.
  */
 public class StreamSegmentTruncatedException extends StreamSegmentException {
     private static final long serialVersionUID = 1L;
 
+    @Getter
+    long startOffset;
     /**
      * Creates a new instance of the StreamSegmentTruncatedException class.
      *
@@ -33,5 +37,17 @@ public class StreamSegmentTruncatedException extends StreamSegmentException {
      */
     public StreamSegmentTruncatedException(long startOffset) {
         super("", String.format("Segment truncated: Lowest accessible offset is %d.", startOffset));
+        this.startOffset = startOffset;
+    }
+
+    /**
+     * Creates a new instance of the StreamSegmentTruncatedException class.
+     * @param segmentName Name of the truncated Segment.
+     * @param startOffset First valid offset of the StreamSegment.
+     * @param requestedOffset Requested offset.
+     */
+    public StreamSegmentTruncatedException(String segmentName, long startOffset, long requestedOffset) {
+        super(segmentName, String.format("Segment truncated: Lowest accessible offset is %d. (%d was requested)", startOffset, requestedOffset));
+        this.startOffset = startOffset;
     }
 }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -172,8 +172,11 @@ public final class ServiceStarter {
     private void attachStorage(ServiceBuilder builder) {
         builder.withStorageFactory(setup -> {
             StorageLoader loader = new StorageLoader();
-            return loader.load(setup, this.serviceConfig.getStorageImplementation().toString(), setup.getStorageExecutor());
-
+            return loader.load(setup,
+                    this.serviceConfig.getStorageImplementation().toString(),
+                    this.serviceConfig.getStorageManager().equals(ServiceConfig.StorageManager.CHUNK_MANAGER),
+                    this.serviceConfig.getStorageLayout().equals(ServiceConfig.StorageLayout.LEGACY),
+                    setup.getStorageExecutor());
         });
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/StorageLoader.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/StorageLoader.java
@@ -28,12 +28,19 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class StorageLoader {
-    public StorageFactory load(ConfigSetup setup, String storageImplementation, ScheduledExecutorService executor) {
+    public StorageFactory load(ConfigSetup setup,
+                               String storageImplementation,
+                               boolean supportsChunkManager,
+                               boolean supportsLegacyLayout,
+                               ScheduledExecutorService executor) {
         ServiceLoader<StorageFactoryCreator> loader = ServiceLoader.load(StorageFactoryCreator.class);
         StorageExtraConfig noOpConfig = setup.getConfig(StorageExtraConfig::builder);
         for (StorageFactoryCreator factoryCreator : loader) {
-            log.info("Loading {}, trying {}", storageImplementation, factoryCreator.getName());
-            if (factoryCreator.getName().equals(storageImplementation)) {
+            log.info("Loading {}, trying {}", storageImplementation, factoryCreator.getStorageFactoryInfo());
+            if (factoryCreator.getStorageFactoryInfo().getName().equals(storageImplementation)
+              && factoryCreator.getStorageFactoryInfo().isChunkManagerSupported() == supportsChunkManager
+              && factoryCreator.getStorageFactoryInfo().isLegacyLayoutSupported() == supportsLegacyLayout
+            ) {
                 StorageFactory factory = factoryCreator.createFactory(setup, executor);
                 if (!noOpConfig.isStorageNoOpMode()) {
                     return factory;

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -15,13 +15,14 @@ import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
-import io.pravega.segmentstore.storage.ConfigSetup;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
 import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
-import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
 import io.pravega.segmentstore.storage.rolling.RollingStorage;
+import io.pravega.storage.extendeds3.ExtendedS3ChunkStorageProvider;
 import io.pravega.storage.extendeds3.ExtendedS3Storage;
 import io.pravega.storage.extendeds3.ExtendedS3StorageConfig;
 import io.pravega.storage.extendeds3.S3FileSystemImpl;
@@ -65,38 +66,21 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
     //region StreamSegmentStoreTestBase Implementation
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId, boolean useChunkStorage) {
         ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
-                .withStorageFactory(setup -> new LocalExtendedS3StorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), setup.getStorageExecutor()))
+                .withStorageFactory(setup -> useChunkStorage ?
+                         new LocalExtendedS3SimpleStorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), setup.getStorageExecutor())
+                       : new LocalExtendedS3StorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), setup.getStorageExecutor()))
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
                         getBookkeeper().getZkClient(), setup.getCoreExecutor()));
     }
 
-
-    /**
-     * We are declaring a local factory here because we need a factory that creates adapters that interact
-     * with the local file system for the purposes of testing. Ideally, however, we should mock the extended
-     * S3 service rather than implement the storage functionality directly in the adapter.
-     */
-    private class LocalExtendedS3StorageFactoryCreator implements StorageFactoryCreator {
-
-        @Override
-        public StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor) {
-            return new LocalExtendedS3StorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), executor);
-        }
-
-        @Override
-        public String getName() {
-            return "LocalExtendedStorageFactory";
-        }
-    }
-
     private class LocalExtendedS3StorageFactory implements StorageFactory {
 
-        private final ExtendedS3StorageConfig config;
-        private final ScheduledExecutorService storageExecutor;
+        protected final ExtendedS3StorageConfig config;
+        protected final ScheduledExecutorService storageExecutor;
 
         LocalExtendedS3StorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
             this.config = Preconditions.checkNotNull(config, "config");
@@ -114,7 +98,25 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
                     .withProperty("com.sun.jersey.client.property.connectTimeout", 100);
 
             S3JerseyClient client = new S3ClientWrapper(s3Config, filesystemS3);
+            return getStorage(client);
+        }
+
+        protected Storage getStorage(S3JerseyClient client) {
             return new AsyncStorageWrapper(new RollingStorage(new ExtendedS3Storage(client, config)), this.storageExecutor);
+        }
+    }
+
+    private class LocalExtendedS3SimpleStorageFactory extends LocalExtendedS3StorageFactory {
+
+        LocalExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
+            super(config, executor);
+        }
+
+        protected Storage getStorage(S3JerseyClient client) {
+            return new ChunkStorageManager(
+                    new ExtendedS3ChunkStorageProvider(this.storageExecutor, client, this.config),
+                    this.storageExecutor,
+                    SegmentRollingPolicy.NO_ROLLING);
         }
     }
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -13,6 +13,7 @@ import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
+import io.pravega.storage.filesystem.FileSystemSimpleStorageFactory;
 import io.pravega.storage.filesystem.FileSystemStorageConfig;
 import io.pravega.storage.filesystem.FileSystemStorageFactory;
 import org.junit.After;
@@ -40,12 +41,15 @@ public class FileSystemIntegrationTest extends BookKeeperIntegrationTestBase {
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId, boolean useChunkStorage) {
         ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
 
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
-                .withStorageFactory(setup -> new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor()))
+                .withStorageFactory(setup -> useChunkStorage ?
+                          new FileSystemSimpleStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor())
+                        : new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor())
+                        )
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
                         getBookkeeper().getZkClient(), setup.getCoreExecutor()));
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -14,18 +14,17 @@ import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
 import io.pravega.storage.hdfs.HDFSClusterHelpers;
+import io.pravega.storage.hdfs.HDFSSimpleStorageFactory;
 import io.pravega.storage.hdfs.HDFSStorageConfig;
 import io.pravega.storage.hdfs.HDFSStorageFactory;
 import lombok.val;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 
 /**
  * End-to-end tests for SegmentStore, with integrated Storage and DurableDataLog.
  */
-@Ignore ("Short term mitigation for #3503 until HDFSIntegrationTest gets completely rewritten/replaced as part of PDP-34.")
 public class HDFSIntegrationTest extends BookKeeperIntegrationTestBase {
     //region Test Configuration and Setup
 
@@ -70,11 +69,13 @@ public class HDFSIntegrationTest extends BookKeeperIntegrationTestBase {
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId, boolean useChunkStorage) {
         ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
-                .withStorageFactory(setup -> new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor()))
+                .withStorageFactory(setup -> useChunkStorage ?
+                          new HDFSSimpleStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor())
+                        : new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor()))
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), getBookkeeper().getZkClient(), setup.getCoreExecutor()));
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/StorageLoaderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/StorageLoaderTest.java
@@ -12,10 +12,19 @@ package io.pravega.segmentstore.server.host;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
+import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
 import io.pravega.segmentstore.storage.noop.NoOpStorageFactory;
 import io.pravega.segmentstore.storage.noop.StorageExtraConfig;
+import io.pravega.storage.extendeds3.ExtendedS3SimpleStorageFactory;
+import io.pravega.storage.extendeds3.ExtendedS3StorageConfig;
+import io.pravega.storage.extendeds3.ExtendedS3StorageFactory;
+import io.pravega.storage.filesystem.FileSystemSimpleStorageFactory;
+import io.pravega.storage.filesystem.FileSystemStorageFactory;
+import io.pravega.storage.hdfs.HDFSSimpleStorageFactory;
+import io.pravega.storage.hdfs.HDFSStorageFactory;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -40,7 +49,7 @@ public class StorageLoaderTest {
         ServiceBuilder builder = ServiceBuilder.newInMemoryBuilder(configBuilder.build())
                 .withStorageFactory(setup -> {
                     StorageLoader loader = new StorageLoader();
-                    expectedFactory = loader.load(setup, "INMEMORY", executor);
+                    expectedFactory = loader.load(setup, "INMEMORY", false, true,  executor);
                     return expectedFactory;
                 });
         builder.initialize();
@@ -54,11 +63,93 @@ public class StorageLoaderTest {
         builder = ServiceBuilder.newInMemoryBuilder(configBuilder.build())
                 .withStorageFactory(setup -> {
                     StorageLoader loader = new StorageLoader();
-                    expectedFactory = loader.load(setup, "INMEMORY", executor);
+                    expectedFactory = loader.load(setup, "INMEMORY", false, true, executor);
                     return expectedFactory;
                 });
         builder.initialize();
         assertTrue(expectedFactory instanceof InMemoryStorageFactory);
         builder.close();
+    }
+
+    @Test
+    public void testFileSystemStorage() throws Exception {
+        val storageType = ServiceConfig.StorageType.FILESYSTEM;
+        boolean isChunkManagerSupported = false;
+        boolean isLegacyLayout = true;
+        ServiceBuilder builder = getStorageFactory(storageType, "FILESYSTEM", isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof FileSystemStorageFactory);
+        builder.close();
+    }
+
+    @Test
+    public void testSimpleFileSystemStorage() throws Exception {
+        val storageType = ServiceConfig.StorageType.FILESYSTEM;
+        boolean isChunkManagerSupported = true;
+        boolean isLegacyLayout = false;
+        ServiceBuilder builder = getStorageFactory(storageType, "FILESYSTEM", isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof FileSystemSimpleStorageFactory);
+        builder.close();
+    }
+
+
+    @Test
+    public void testHDFSStorage() throws Exception {
+        val storageType = ServiceConfig.StorageType.HDFS;
+        boolean isChunkManagerSupported = false;
+        boolean isLegacyLayout = true;
+        ServiceBuilder builder = getStorageFactory(storageType, "HDFS", isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof HDFSStorageFactory);
+        builder.close();
+    }
+
+    @Test
+    public void testHDFSSimpleStorage() throws Exception {
+        val storageType = ServiceConfig.StorageType.HDFS;
+        boolean isChunkManagerSupported = true;
+        boolean isLegacyLayout = false;
+        ServiceBuilder builder = getStorageFactory(storageType, "HDFS", isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof HDFSSimpleStorageFactory);
+        builder.close();
+    }
+
+    @Test
+    public void testExtendedS3Storage() throws Exception {
+        val storageType = ServiceConfig.StorageType.EXTENDEDS3;
+        boolean isChunkManagerSupported = false;
+        boolean isLegacyLayout = true;
+        ServiceBuilder builder = getStorageFactory(storageType, "EXTENDEDS3",  isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof ExtendedS3StorageFactory);
+        builder.close();
+    }
+
+    @Test
+    public void testExtendedS3SimpleStorage() throws Exception {
+        val storageType = ServiceConfig.StorageType.EXTENDEDS3;
+        boolean isChunkManagerSupported = true;
+        boolean isLegacyLayout = false;
+        ServiceBuilder builder = getStorageFactory(storageType, "EXTENDEDS3", isChunkManagerSupported, isLegacyLayout);
+        assertTrue(expectedFactory instanceof ExtendedS3SimpleStorageFactory);
+        builder.close();
+    }
+
+    private ServiceBuilder getStorageFactory(ServiceConfig.StorageType storageType, String name, boolean isChunkManagerSupported, boolean isLegacyLayout) throws DurableDataLogException {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        ServiceBuilderConfig.Builder configBuilder = ServiceBuilderConfig
+                .builder()
+                .include(ServiceConfig.builder()
+                        .with(ServiceConfig.CONTAINER_COUNT, 1)
+                        .with(ServiceConfig.STORAGE_IMPLEMENTATION, storageType))
+                .include(ExtendedS3StorageConfig.builder()
+                                .with(ExtendedS3StorageConfig.CONFIGURI, "http://127.0.0.1?identity=x&secretKey=x")
+                                .with(ExtendedS3StorageConfig.BUCKET, "bucket"));
+
+        ServiceBuilder builder = ServiceBuilder.newInMemoryBuilder(configBuilder.build())
+                .withStorageFactory(setup -> {
+                    StorageLoader loader = new StorageLoader();
+                    expectedFactory = loader.load(setup, name, isChunkManagerSupported, isLegacyLayout,  executor);
+                    return expectedFactory;
+                });
+        builder.initialize();
+        return builder;
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -45,6 +45,8 @@ public class ServiceConfig {
     public static final Property<String> CLUSTER_NAME = Property.named("clusterName", "pravega-cluster");
     public static final Property<DataLogType> DATALOG_IMPLEMENTATION = Property.named("dataLogImplementation", DataLogType.INMEMORY);
     public static final Property<StorageType> STORAGE_IMPLEMENTATION = Property.named("storageImplementation", StorageType.HDFS);
+    public static final Property<StorageLayout> STORAGE_LAYOUT = Property.named("storageLayout", StorageLayout.TABLE_BASED);
+    public static final Property<StorageManager> STORAGE_MANAGER = Property.named("storageManager", StorageManager.CHUNK_MANAGER);
     public static final Property<Boolean> READONLY_SEGMENT_STORE = Property.named("readOnlySegmentStore", false);
     public static final Property<Long> CACHE_POLICY_MAX_SIZE = Property.named("cacheMaxSize", 4L * 1024 * 1024 * 1024);
     public static final Property<Integer> CACHE_POLICY_TARGET_UTILIZATION = Property.named("cacheTargetUtilizationPercent", (int) (100 * CachePolicy.DEFAULT_TARGET_UTILIZATION));
@@ -99,6 +101,36 @@ public class ServiceConfig {
          * InMemory Storage. Contents will be lost when the process exits.
          */
         INMEMORY
+    }
+
+    /**
+     * Type of StorageManager to use.
+     */
+    public enum StorageManager {
+        /**
+         * Does not use any StorageManager.
+         */
+        NONE,
+
+        /**
+         * Uses ChunkStorageManager.
+         */
+        CHUNK_MANAGER,
+    }
+
+    /**
+     * Type of Storage metadata layout to use.
+     */
+    public enum StorageLayout {
+        /**
+         * Uses RollingStorage based layout.
+         */
+        LEGACY,
+
+        /**
+         * Uses layout that stores data in table segments.
+         */
+        TABLE_BASED,
     }
 
     //endregion
@@ -221,6 +253,18 @@ public class ServiceConfig {
     private final StorageType storageImplementation;
 
     /**
+     * The Type of Storage Layout to use.
+     */
+    @Getter
+    private final StorageLayout storageLayout;
+
+    /**
+     * The Type of Storage manager to use.
+     */
+    @Getter
+    private final StorageManager storageManager;
+
+    /**
      * Whether this SegmentStore instance is Read-Only (i.e., it can only process reads from Storage and nothing else).
      * Note that if this is set to 'true', then many other settings will not apply. The most important other one to set
      * is 'Storage Implementation'.
@@ -317,6 +361,8 @@ public class ServiceConfig {
         this.clusterName = properties.get(CLUSTER_NAME);
         this.dataLogTypeImplementation = properties.getEnum(DATALOG_IMPLEMENTATION, DataLogType.class);
         this.storageImplementation = properties.getEnum(STORAGE_IMPLEMENTATION, StorageType.class);
+        this.storageLayout = properties.getEnum(STORAGE_LAYOUT, StorageLayout.class);
+        this.storageManager = properties.getEnum(STORAGE_MANAGER, StorageManager.class);
         this.readOnlySegmentStore = properties.getBoolean(READONLY_SEGMENT_STORE);
         this.secureZK = properties.getBoolean(SECURE_ZK);
         this.zkTrustStore = properties.get(ZK_TRUSTSTORE_LOCATION);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistry.java
@@ -92,10 +92,12 @@ class StreamSegmentContainerRegistry implements SegmentContainerRegistry {
     public SegmentContainer getContainer(int containerId) throws ContainerNotFoundException {
         Exceptions.checkNotClosed(this.closed.get(), this);
         ContainerWithHandle result = this.containers.getOrDefault(containerId, null);
-        if (result == null || Services.isTerminating(result.container.state())) {
+        if (result == null) {
             throw new ContainerNotFoundException(containerId);
         }
-
+        if (Services.isTerminating(result.container.state())) {
+            throw new ContainerNotFoundException(containerId);
+        }
         return result.container;
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/mocks/SynchronousStreamSegmentStoreTests.java
@@ -27,8 +27,8 @@ public class SynchronousStreamSegmentStoreTests extends StreamSegmentServiceTest
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId) {
-        return super.createBuilder(builderConfig, instanceId)
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId, boolean useChunkStorage) {
+        return super.createBuilder(builderConfig, instanceId, useChunkStorage)
                     .withStreamSegmentStore(setup -> {
                         StreamSegmentStore base = new StreamSegmentService(setup.getContainerRegistry(), setup.getSegmentToContainerMapper());
                         return new SynchronousStreamSegmentStore(base);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -91,7 +91,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule
@@ -99,7 +99,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     @Override
     protected int getThreadPoolSize() {
-        return 5;
+        return 50;
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceNoOpWriteOnlyTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceNoOpWriteOnlyTests.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.storage.noop.StorageExtraConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -24,6 +25,7 @@ import org.junit.Test;
  * because user segment write operation is no-oped.
  */
 @Slf4j
+@Ignore
 public class StreamSegmentServiceNoOpWriteOnlyTests extends StreamSegmentStoreTestBase {
 
     private NoOpStorageFactory storageFactory;
@@ -56,7 +58,7 @@ public class StreamSegmentServiceNoOpWriteOnlyTests extends StreamSegmentStoreTe
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId, boolean useChunkStorage) {
         return ServiceBuilder.newInMemoryBuilder(builderConfig.build())
                 .withStorageFactory(setup -> this.storageFactory)
                 .withDataLogFactory(setup -> this.durableDataLogFactory);
@@ -69,7 +71,13 @@ public class StreamSegmentServiceNoOpWriteOnlyTests extends StreamSegmentStoreTe
     @Override
     @Test
     public void testEndToEnd() throws Exception {
-        endToEndProcess(false);
+        endToEndProcess(false, false);
+    }
+
+    @Override
+    @Test
+    public void testEndToEndWithChunkManager() throws Exception {
+        endToEndProcess(false, true);
     }
 
     /**
@@ -79,6 +87,12 @@ public class StreamSegmentServiceNoOpWriteOnlyTests extends StreamSegmentStoreTe
     @Override
     @Test
     public void testEndToEndWithFencing() throws Exception {
-        endToEndProcessWithFencing(false);
+        endToEndProcessWithFencing(false, false);
+    }
+
+    @Override
+    @Test
+    public void testEndToEndWithFencingWithChunkManager() throws Exception {
+        endToEndProcessWithFencing(true, true);
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceNoOpWriteReadTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceNoOpWriteReadTests.java
@@ -60,7 +60,7 @@ public class StreamSegmentServiceNoOpWriteReadTests extends StreamSegmentStoreTe
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId, boolean useChunkStorage) {
         return ServiceBuilder.newInMemoryBuilder(builderConfig.build())
                              .withStorageFactory(setup -> this.storageFactory)
                              .withDataLogFactory(setup -> this.durableDataLogFactory);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentServiceTests.java
@@ -42,7 +42,7 @@ public class StreamSegmentServiceTests extends StreamSegmentStoreTestBase {
     }
 
     @Override
-    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId) {
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder builderConfig, int instanceId, boolean useChunkStorage) {
         return ServiceBuilder.newInMemoryBuilder(builderConfig.build())
                              .withStorageFactory(setup -> this.storageFactory)
                              .withDataLogFactory(setup -> this.durableDataLogFactory);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryCreator.java
@@ -24,8 +24,8 @@ public interface StorageFactoryCreator {
     StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor);
 
     /**
-     * The unique name for the storage factory.
-     * @return  Unique name for the storage factory.
+     * The properties of the storage factory.
+     * @return  The properties of the storage factory.
      */
-    String getName();
+    StorageFactoryInfo getStorageFactoryInfo();
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryInfo.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageFactoryInfo.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Information about the capabilities supported by a {@link StorageFactory}.
+ */
+@Data
+@Builder
+public class StorageFactoryInfo {
+    /**
+     * Name of storage binding.
+     */
+    String name;
+
+    /**
+     * Indicates whether {@link io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager} based storage is supported.
+     */
+    boolean chunkManagerSupported;
+
+    /**
+     * Indicates whether {@link AsyncStorageWrapper} and {@link io.pravega.segmentstore.storage.rolling.RollingStorage}
+     * based storage layout is supported.
+     */
+    boolean legacyLayoutSupported;
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/BaseChunkStorageProvider.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/BaseChunkStorageProvider.java
@@ -1,0 +1,441 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import io.pravega.common.LoggerHelpers;
+import io.pravega.common.Timer;
+import io.pravega.shared.MetricsNames;
+import io.pravega.shared.metrics.Counter;
+import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.OpStatsLogger;
+import io.pravega.shared.metrics.StatsLogger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Base implementation of {@link ChunkStorageProvider}.
+ * It implements common functionality for
+ * Delegates to specific implemntations by calling various abstract methods which must be overridden in derived classes.
+ */
+public abstract class BaseChunkStorageProvider implements ChunkStorageProvider {
+
+    protected static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BaseChunkStorageProvider.class);
+
+    protected static final StatsLogger STATS_LOGGER = MetricsProvider.createStatsLogger("BaseChunkStorageProvider");
+
+
+    protected static final OpStatsLogger READ_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_READ_LATENCY);
+    protected static final OpStatsLogger WRITE_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_WRITE_LATENCY);
+    protected static final OpStatsLogger CREATE_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_CREATE_LATENCY);
+    protected static final OpStatsLogger DELETE_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_DELETE_LATENCY);
+    protected static final OpStatsLogger CONCAT_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_CONCAT_LATENCY);
+
+    protected static final Counter READ_BYTES = STATS_LOGGER.createCounter(MetricsNames.STORAGE_READ_BYTES);
+    protected static final Counter WRITE_BYTES = STATS_LOGGER.createCounter(MetricsNames.STORAGE_WRITE_BYTES);
+    protected static final Counter CONCAT_BYTES = STATS_LOGGER.createCounter(MetricsNames.STORAGE_CONCAT_BYTES);
+
+    protected static final Counter CREATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_CREATE_COUNT);
+    protected static final Counter DELETE_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_DELETE_COUNT);
+    protected static final Counter CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_CONCAT_COUNT);
+
+    protected static final Counter LARGE_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);
+
+    protected final AtomicBoolean closed;
+    protected final Executor executor;
+
+    /**
+     * Constructor.
+     * @param executor Executor to use for async operations if any.
+     */
+    public BaseChunkStorageProvider(Executor executor) {
+        this.closed = new AtomicBoolean(false);
+        this.executor = Preconditions.checkNotNull(executor);
+    }
+
+    /**
+     * Gets a value indicating whether this Storage implementation supports truncate operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    @Override
+    public boolean supportsTruncation() {
+        return false;
+    }
+
+    /**
+     * Gets a value indicating whether this Storage implementation supports append operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    @Override
+    public boolean supportsAppend() {
+        return true;
+    }
+
+    /**
+     * Gets a value indicating whether this Storage implementation supports merge operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    @Override
+    public boolean supportsConcat() {
+        return false;
+    }
+
+    /**
+     * Determines whether named file/object exists in underlying storage.
+     *
+     * @param chunkName Name of the storage object to check.
+     * @return True if the object exists, false otherwise.
+     */
+    @Override
+    public boolean exists(String chunkName)  throws IOException {
+        // Validate parameters
+        Preconditions.checkArgument(null != chunkName, "chunkName must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "exists", chunkName);
+
+        // Call concrete implementation.
+        boolean retValue = doesExist(chunkName);
+
+        LoggerHelpers.traceLeave(log, "exists", traceId, chunkName);
+        return retValue;
+    }
+
+
+    /**
+     * Creates a new file.
+     *
+     * @param chunkName String name of the storage object to create.
+     * @return ChunkHandle A writable handle for the recently created chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    @Override
+    public ChunkHandle create(String chunkName) throws IOException {
+        // Validate parameters
+        Preconditions.checkArgument(null != chunkName, "chunkName must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "create", chunkName);
+        Timer timer = new Timer();
+
+        // Call concrete implementation.
+        ChunkHandle handle = doCreate(chunkName);
+
+        // Record metrics.
+        Duration elapsed = timer.getElapsed();
+        CREATE_LATENCY.reportSuccessEvent(elapsed);
+        CREATE_COUNT.inc();
+
+        log.debug("Create chunk={} latency={}.", chunkName, elapsed.toMillis());
+        LoggerHelpers.traceLeave(log, "create", traceId, chunkName);
+        return handle;
+    }
+
+    /**
+     * Deletes a file.
+     *
+     * @param handle ChunkHandle of the storage object to delete.
+     * @return True if the object was deleted, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    @Override
+    public boolean delete(ChunkHandle handle) throws IOException {
+        // Validate parameters
+        Preconditions.checkArgument(null != handle, "handle must not be null");
+        long traceId = LoggerHelpers.traceEnter(log, "delete", handle.getChunkName());
+        Timer timer = new Timer();
+
+        // Call concrete implementation.
+        boolean retValue = doDelete(handle);
+
+        // Record metrics.
+        Duration elapsed = timer.getElapsed();
+        DELETE_LATENCY.reportSuccessEvent(elapsed);
+        DELETE_COUNT.inc();
+
+        log.debug("Delete chunk={} latency={}.", handle.getChunkName(), elapsed.toMillis());
+        LoggerHelpers.traceLeave(log, "delete", traceId, handle.getChunkName());
+        return retValue;
+    }
+
+    /**
+     * Opens storage object for Read.
+     *
+     * @param chunkName String name of the storage object to read from.
+     * @return ChunkHandle A readable handle for the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    @Override
+    public ChunkHandle openRead(String chunkName) throws IOException, IllegalArgumentException {
+        // Validate parameters
+        Preconditions.checkArgument(null != chunkName, "chunkName must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "openRead", chunkName);
+
+        // Call concrete implementation.
+        ChunkHandle handle = doOpenRead(chunkName);
+
+        LoggerHelpers.traceLeave(log, "openRead", traceId, chunkName);
+        return handle;
+    }
+
+
+    /**
+     * Opens storage object for Write (or modifications).
+     *
+     * @param chunkName String name of the storage object to write to or modify.
+     * @return ChunkHandle A writable handle for the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    @Override
+    public ChunkHandle openWrite(String chunkName) throws IOException, IllegalArgumentException {
+        // Validate parameters
+        Preconditions.checkArgument(null != chunkName, "chunkName must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "openWrite", chunkName);
+
+        // Call concrete implementation.
+        ChunkHandle handle = doOpenWrite(chunkName);
+
+        LoggerHelpers.traceLeave(log, "openWrite", traceId, chunkName);
+        return handle;
+    }
+
+    /**
+     * Retrieves the ChunkInfo for given name.
+     *
+     * @param chunkName String name of the storage object to read from.
+     * @return ChunkInfo Information about the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    @Override
+    public ChunkInfo getInfo(String chunkName) throws IOException, IllegalArgumentException {
+        // Validate parameters
+        Preconditions.checkNotNull(chunkName);
+        long traceId = LoggerHelpers.traceEnter(log, "getInfo", chunkName);
+
+        // Call concrete implementation.
+        ChunkInfo info = doGetInfo(chunkName);
+
+        LoggerHelpers.traceLeave(log, "getInfo", traceId, chunkName);
+        return info;
+    }
+
+    /**
+     * Reads a range of bytes from the underlying storage object.
+     *
+     * @param handle       ChunkHandle of the storage object to read from.
+     * @param fromOffset   Offset in the file from which to start reading.
+     * @param length       Number of bytes to read.
+     * @param buffer       Byte buffer to which data is copied.
+     * @param bufferOffset Offset in the buffer at which to start copying read data.
+     * @return int Number of bytes read.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     * @throws IndexOutOfBoundsException If the index is out of bounds.
+     */
+    @Override
+    public int read(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        // Validate parameters
+        Preconditions.checkArgument(null != handle, "handle");
+        Preconditions.checkArgument(null != buffer, "buffer");
+        Preconditions.checkArgument(fromOffset >= 0, "fromOffset must be non-negative");
+        Preconditions.checkArgument(length >= 0 && length <= buffer.length, "length");
+        Preconditions.checkElementIndex(bufferOffset, buffer.length, "bufferOffset");
+
+        long traceId = LoggerHelpers.traceEnter(log, "read", handle.getChunkName(), fromOffset, bufferOffset, length);
+        Timer timer = new Timer();
+
+        // Call concrete implementation.
+        int bytesRead = doRead(handle, fromOffset, length, buffer, bufferOffset);
+
+        Duration elapsed = timer.getElapsed();
+        READ_LATENCY.reportSuccessEvent(elapsed);
+        READ_BYTES.add(bytesRead);
+
+        log.debug("Read chunk={} offset={} bytesWritten={} latency={}.", handle.getChunkName(), fromOffset, length, elapsed.toMillis());
+        LoggerHelpers.traceLeave(log, "read", traceId, bytesRead);
+        return bytesRead;
+    }
+
+    /**
+     * Writes the given data to the underlying storage object.
+     *
+     * @param handle ChunkHandle of the storage object to write to.
+     * @param offset Offset in the file to start writing.
+     * @param length Number of bytes to write.
+     * @param data   An InputStream representing the data to write.
+     * @return int Number of bytes written.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    @Override
+    public int write(ChunkHandle handle, long offset, int length, InputStream data) throws IOException {
+        // Validate parameters
+        Preconditions.checkArgument(null != handle, "handle must not be null");
+        Preconditions.checkArgument(null != data, "data must not be null");
+        Preconditions.checkArgument(offset >= 0, "offset must be non-negative");
+        Preconditions.checkArgument(length >= 0, "length must be non-negative");
+
+        long traceId = LoggerHelpers.traceEnter(log, "write", handle.getChunkName(), offset, length);
+        Timer timer = new Timer();
+
+        // Call concrete implementation.
+        int bytesWritten = doWrite(handle, offset, length, data);
+
+        Duration elapsed = timer.getElapsed();
+
+        WRITE_LATENCY.reportSuccessEvent(elapsed);
+        WRITE_BYTES.add(bytesWritten);
+
+        log.debug("Write chunk={} offset={} bytesWritten={} latency={}.", handle.getChunkName(), offset, length, elapsed.toMillis());
+        LoggerHelpers.traceLeave(log, "read", traceId, bytesWritten);
+        return bytesWritten;
+    }
+
+    /**
+     * Concatenates two or more chunks.
+     *
+     * @param target  String Name of the storage object to concat to.
+     * @param sources Array of ChunkHandle to existing chunks to be appended to the target. The chunks are appended in the same sequence the names are provided.
+     * @return int Number of bytes concatenated.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    @Override
+    public int concat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        // Validate parameters
+        Preconditions.checkArgument(null != target, "target must not be null");
+        Preconditions.checkArgument(null != sources, "sources must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "concat", target.getChunkName());
+        Timer timer = new Timer();
+
+        // Call concrete implementation.
+        int retValue = doConcat(target, sources);
+
+        Duration elapsed = timer.getElapsed();
+        log.debug("Concat target={} latency={}.", target.getChunkName(), elapsed.toMillis());
+
+        CONCAT_LATENCY.reportSuccessEvent(elapsed);
+        CONCAT_BYTES.add(0);
+        CONCAT_COUNT.inc();
+
+        LoggerHelpers.traceLeave(log, "concat", traceId, target.getChunkName());
+        return retValue;
+    }
+
+    /**
+     * Truncates a given chunk.
+     *
+     * @param handle ChunkHandle of the storage object to truncate.
+     * @param offset Offset to truncate to.
+     * @return True if the object was truncated, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    @Override
+    public boolean truncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        // Validate parameters
+        Preconditions.checkArgument(null != handle, "handle must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "truncate", handle.getChunkName());
+
+        // Call concrete implementation.
+        boolean retValue = doTruncate(handle, offset);
+
+        LoggerHelpers.traceLeave(log, "truncate", traceId, handle.getChunkName());
+        return retValue;
+    }
+
+    /**
+     * Sets readonly attribute for the chunk.
+     *
+     * @param handle ChunkHandle of the storage object.
+     * @param isReadonly True if chunk is set to be readonly.
+     * @return True if the operation was successful, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    @Override
+    public boolean setReadonly(ChunkHandle handle, boolean isReadonly) throws IOException, UnsupportedOperationException {
+        // Validate parameters
+        Preconditions.checkArgument(null != handle, "handle must not be null");
+
+        long traceId = LoggerHelpers.traceEnter(log, "setReadonly", handle.getChunkName());
+
+        // Call concrete implementation.
+        boolean retValue = doSetReadonly(handle, isReadonly);
+
+        LoggerHelpers.traceLeave(log, "setReadonly", traceId, handle.getChunkName());
+        return retValue;
+    }
+
+    /**
+     * Closes.
+     * @throws Exception
+     */
+    @Override
+    public void close() throws Exception {
+        this.closed.set(true);
+    }
+
+    /**
+     * Executes the given Callable and returns its result, while translating any Exceptions bubbling out of it into
+     * StreamSegmentExceptions.
+     *
+     * @param operation     The function to execute.
+     * @param <R>           Return type of the operation.
+     * @return CompletableFuture<R> of the return type of the operation.
+     */
+    private <R> CompletableFuture<R> execute(Callable<R> operation) {
+        return CompletableFuture.supplyAsync(() -> {
+            Exceptions.checkNotClosed(this.closed.get(), this);
+            try {
+                return operation.call();
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        }, this.executor);
+    }
+
+    abstract protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException;
+
+    abstract protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException;
+
+    abstract protected boolean doesExist(String chunkName) throws IOException, IllegalArgumentException;
+
+    abstract protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException;
+
+    abstract protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException;
+
+    abstract protected ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException;
+
+    abstract protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException;
+
+    abstract protected int  doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IOException, IndexOutOfBoundsException;
+
+    abstract protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException;
+
+    abstract protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException;
+
+    abstract protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException;
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkHandle.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkHandle.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Handle to a chunk.
+ */
+public class ChunkHandle {
+    private final String chunkName;
+    private final boolean isReadOnly;
+
+    /**
+     * Creates a new instance of ChunkHandle.
+     * @param chunkName Name of the segment.
+     * @param isReadOnly  Whether the segment is read only or not.
+     */
+    public ChunkHandle(String chunkName, boolean isReadOnly) {
+        this.chunkName = Preconditions.checkNotNull(chunkName, "chunkName");
+        this.isReadOnly = isReadOnly;
+    }
+
+    /**
+     * Gets name of the chunk.
+     * @return Name of the chunk.
+     */
+    public String getChunkName() {
+        return chunkName;
+    }
+
+    /**
+     * Returns whether the handle is read only.
+     * @return True if the handle is read only.
+     */
+    public boolean isReadOnly() {
+        return isReadOnly;
+    }
+
+    /**
+     * Creates a read only handle for a given chunk name.
+     * @param chunkName Name of the chunk.
+     * @return A readonly handle.
+     */
+    public static ChunkHandle readHandle(String chunkName) {
+        return new ChunkHandle(chunkName, true);
+    }
+
+    /**
+     * Creates a writable/updatable handle for a given chunk name.
+     * @param chunkName Name of the chunk.
+     * @return A writable/updatable handle.
+     */
+    public static ChunkHandle writeHandle(String chunkName) {
+        return new ChunkHandle(chunkName, false);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkInfo.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkInfo.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Chunk Information.
+ */
+@Builder
+@Data
+public class ChunkInfo {
+    /**
+     * Length of the chunk.
+     */
+    long length;
+
+    /**
+     * Name of the chunk.
+     */
+    String name;
+
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageManager.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageManager.java
@@ -1,0 +1,1220 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import io.pravega.common.LoggerHelpers;
+import io.pravega.common.io.BoundedInputStream;
+import io.pravega.common.util.ImmutableDate;
+import io.pravega.segmentstore.contracts.BadOffsetException;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.StreamSegmentException;
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentInformation;
+import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
+import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
+import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataAlreadyExistsException;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataNotFoundException;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataVersionMismatchException;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataWritesFencedOutException;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+//import static io.pravega.shared.NameUtils.getSegmentChunkName;
+
+/**
+ * Implements segment storage using {@link ChunkStorageProvider} and {@link ChunkMetadataStore}.
+ * The metadata about the segments is stored in metadataStore using two types of records {@link SegmentMetadata} and {@link ChunkMetadata}.
+ * Any changes to layout must be made inside a {@link MetadataTransaction} which will atomically change the records upon {@link MetadataTransaction#commit()}
+ */
+@Slf4j
+public class ChunkStorageManager implements Storage {
+    /**
+     * Default SegmentRollingPolicy to use.
+     */
+    @Getter
+    private SegmentRollingPolicy defaultRollingPolicy;
+
+    /**
+     * Metadata store containing all storage data.
+     */
+    @Getter
+    private ChunkMetadataStore metadataStore;
+
+    /**
+     * Underlying {@link ChunkStorageProvider} to use to read and write data.
+     */
+    @Getter
+    private ChunkStorageProvider chunkStorage;
+
+    /**
+     * Storage executor object.
+     */
+    private Executor executor;
+
+    /**
+     * Tracks whether this instance is closed or not.
+     */
+    private final AtomicBoolean closed;
+
+    /**
+     * Current epoch of the {@link Storage} instance.
+     */
+    @Getter
+    private long epoch;
+
+    /**
+     * Id of the current Container.
+     */
+    @Getter
+    private int containerId;
+
+    /**
+     * {@link SystemJournal} that logs all changes to system segment layout so that they can be are used during system bootstrap.
+     */
+    @Getter
+    private SystemJournal systemJournal;
+
+    /**
+     * Index of chunks for a segment by their start offsets.
+     */
+    private ConcurrentHashMap<String, ConcurrentSkipListMap<Long, String>> cachedReadIndex = new ConcurrentHashMap<String, ConcurrentSkipListMap<Long, String>>();
+
+    /**
+     * Creates a new instance of the ChunkStorageManager class.
+     * @param chunkStorage ChunkStorageProvider instance.
+     * @param executor    An Executor for async operations.
+     * @param defaultRollingPolicy A SegmentRollingPolicy to apply to every StreamSegment that does not have its own policy
+     *                             defined.
+     */
+    public ChunkStorageManager(ChunkStorageProvider chunkStorage, Executor executor, SegmentRollingPolicy defaultRollingPolicy) {
+        this.defaultRollingPolicy = Preconditions.checkNotNull(defaultRollingPolicy, "defaultRollingPolicy");
+        this.chunkStorage = Preconditions.checkNotNull(chunkStorage, "chunkStorage");
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+        this.closed = new AtomicBoolean(false);
+    }
+
+    /**
+     * Creates a new instance of the ChunkStorageManager class.
+     * @param chunkStorage ChunkStorageProvider instance.
+     * @param metadataStore Metadata store.
+     * @param executor    An Executor for async operations.
+     * @param defaultRollingPolicy A SegmentRollingPolicy to apply to every StreamSegment that does not have its own policy
+     *                             defined.
+     */
+    public ChunkStorageManager(ChunkStorageProvider chunkStorage, ChunkMetadataStore metadataStore, Executor executor, SegmentRollingPolicy defaultRollingPolicy) {
+        this.defaultRollingPolicy = Preconditions.checkNotNull(defaultRollingPolicy, "defaultRollingPolicy");
+        this.chunkStorage = Preconditions.checkNotNull(chunkStorage, "chunkStorage");
+        this.metadataStore = Preconditions.checkNotNull(metadataStore, "metadataStore");
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+        this.closed = new AtomicBoolean(false);
+    }
+
+    /**
+     * Initializes the ChunkStorageManager.
+     * @param metadataStore Metadata store.
+     * @param containerId container id.
+     * @param systemJournal SystemJournal that keeps track of changes to system segments and helps with bootstrap.
+     * @throws Exception Any exceptions.
+     */
+    public void initialize(int containerId, ChunkMetadataStore metadataStore, SystemJournal systemJournal) throws Exception {
+        this.containerId = containerId;
+        this.metadataStore = Preconditions.checkNotNull(metadataStore, "metadataStore");
+        this.systemJournal = Preconditions.checkNotNull(systemJournal, "systemJournal");
+        this.closed.set(false);
+    }
+
+    /**
+     * Initializes this instance with the given ContainerEpoch.
+     *
+     * @param containerEpoch The Container Epoch to initialize with.
+     */
+    @Override
+    public void initialize(long containerEpoch) {
+        this.epoch = containerEpoch;
+        //Preconditions.checkState(!closed.get());
+        this.closed.set(false);
+    }
+
+
+    /**
+     * Attempts to open the given Segment in read-write mode and make it available for use for this instance of the Storage
+     * adapter.
+     * A single active read-write SegmentHandle can exist at any given time for a particular Segment, regardless of owner,
+     * while a read-write SegmentHandle can coexist with any number of read-only SegmentHandles for that Segment (obtained
+     * by calling openRead()).
+     * This can be accomplished in a number of different ways based on the actual implementation of the Storage
+     * interface, but it can be compared to acquiring an exclusive lock on the given segment).
+     *
+     * @param streamSegmentName Name of the StreamSegment to be opened.
+     * @return A CompletableFuture that, when completed, will contain a read-write SegmentHandle that can be used to access
+     * the segment for read and write activities (ex: read, get, write, seal, concat).
+     * If the segment is sealed, then a Read-Only handle is returned.
+     * <p>
+     * If the operation failed, it will be failed with the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * </ul>
+     */
+    @Override
+    public CompletableFuture<SegmentHandle> openWrite(String streamSegmentName) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "openWrite", streamSegmentName);
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                if (null == segmentMetadata || !segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+                segmentMetadata.checkInvariants();
+                // This segment was created by an older segment store. Need to start a fresh new chunk.
+                if (segmentMetadata.getOwnerEpoch() < this.epoch) {
+                    log.debug("openWrite:Segment needs ownership change. segment: {} ", segmentMetadata.getName());
+                    // Claim ownership.
+                    // This is safe because the previous instance is definitely not an owner anymore. (even if this instance is no more owner)
+                    segmentMetadata.setOwnerEpoch(this.epoch);
+                    segmentMetadata.setOwnershipChanged(true);
+
+                    // Get the last chunk
+                    String lastChunkName = segmentMetadata.getLastChunk();
+                    if (null != lastChunkName) {
+                        ChunkMetadata lastChunk = (ChunkMetadata) metadataStore.get(txn, lastChunkName);
+                        ChunkInfo chunkInfo = chunkStorage.getInfo(lastChunkName);
+                        Preconditions.checkState( chunkInfo != null);
+                        Preconditions.checkState( lastChunk != null);
+                        // Adjust its length;
+                        if (chunkInfo.getLength() != lastChunk.getLength()) {
+                            Preconditions.checkState( chunkInfo.getLength() > lastChunk.getLength());
+                            // Whatever length you see right now is the final "sealed" length of the last chunk.
+                            lastChunk.setLength((int) chunkInfo.getLength());
+                            segmentMetadata.setLength(segmentMetadata.getLastChunkStartOffset() + lastChunk.getLength());
+                            metadataStore.update(txn, lastChunk);
+                            log.debug("openWrite:Length of last chunk addjusted. segment: {}, last chunk: {} Length: {}",
+                                    segmentMetadata.getName(),
+                                    lastChunk.getName(),
+                                    chunkInfo.getLength());
+                        }
+                    }
+                    // Update and commit
+                    // If This instance is fenced this update will fail.
+                    metadataStore.update(txn, segmentMetadata);
+                    txn.commit();
+                }
+                // If created by newer instance then abort.
+                if (segmentMetadata.getOwnerEpoch() > this.epoch) {
+                    throw new StorageNotPrimaryException(streamSegmentName);
+                }
+
+                // This instance is the owner, return a handle.
+                val retValue = SegmentStorageHandle.writeHandle(streamSegmentName);
+                LoggerHelpers.traceLeave(log, "openWrite", traceId, retValue);
+                return retValue;
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            } catch (StreamSegmentException se) {
+                throw se;
+            }
+        });
+    }
+
+    /**
+     * Creates a new StreamSegment in this Storage Layer with the given Rolling Policy.
+     *
+     * @param streamSegmentName The full name of the StreamSegment.
+     * @param rollingPolicy     The Rolling Policy to apply to this StreamSegment.
+     * @param timeout           Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will contain a read-write SegmentHandle that can be used to access
+     * * the segment for read and write activities (ex: read, get, write, seal, concat). If the operation failed, it will contain the cause of the
+     * failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentExistsException: When the given Segment already exists in Storage.
+     * </ul>
+     */
+    @Override
+    public CompletableFuture<SegmentHandle> create(String streamSegmentName, SegmentRollingPolicy rollingPolicy, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "create", streamSegmentName, rollingPolicy);
+
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                // Retrieve metadata and make sure it does not exist.
+                SegmentMetadata oldSegmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                if (null != oldSegmentMetadata) {
+                    throw new StreamSegmentExistsException(streamSegmentName);
+                }
+
+                // Create a new record.
+                SegmentMetadata newSegmentMetatadata = SegmentMetadata.builder()
+                        .name(streamSegmentName)
+                        .maxRollinglength(rollingPolicy.getMaxLength() == 0 ? SegmentRollingPolicy.NO_ROLLING.getMaxLength() : rollingPolicy.getMaxLength())
+                        .ownerEpoch(this.epoch)
+                        .build();
+
+                newSegmentMetatadata.setActive(true);
+                metadataStore.create(txn, newSegmentMetatadata);
+                // commit.
+                txn.commit();
+
+                val retValue =  SegmentStorageHandle.writeHandle(streamSegmentName);
+                LoggerHelpers.traceLeave(log, "create", traceId, retValue);
+                return retValue;
+            } catch (StorageMetadataAlreadyExistsException ex) {
+                throw new StreamSegmentExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            }
+            //return SegmentStorageHandle.writeHandle(streamSegmentName);
+        });
+    }
+
+    /**
+     * Writes the given data to the StreamSegment.
+     *
+     * @param handle  A read-write SegmentHandle that points to a Segment to write to.
+     * @param offset  The offset in the StreamSegment to write data at.
+     * @param data    An InputStream representing the data to write.
+     * @param length  The length of the InputStream.
+     * @param timeout Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate the operation succeeded. If the operation failed,
+     * it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> BadOffsetException: When the given offset does not match the actual length of the segment in storage.
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * <li> StorageNotPrimaryException: When this Storage instance is no longer primary for this Segment (it was fenced out).
+     * </ul>
+     * @throws IllegalArgumentException If handle is read-only.
+     */
+    @Override
+    public CompletableFuture<Void> write(SegmentHandle handle, long offset, InputStream data, int length, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "write", handle, offset, length);
+            // Validate preconditions.
+            Preconditions.checkNotNull(handle, "handle");
+            Preconditions.checkNotNull(data, "data");
+            String streamSegmentName = handle.getSegmentName();
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            Preconditions.checkArgument(!handle.isReadOnly(), "handle");
+
+            ArrayList<String> systemLogRecords = new ArrayList<>();
+            HashMap<Long, String> newReadIndexEntries = new HashMap<Long, String>();
+            int chunksAddedCount = 0;
+
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                boolean didSegmentLayoutChange = false;
+
+                // Retrieve metadata.
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+
+                // Validate preconditions.
+                if (null == segmentMetadata || !segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+
+                segmentMetadata.checkInvariants();
+
+                if (segmentMetadata.isSealed()) {
+                    throw new StreamSegmentSealedException(streamSegmentName);
+                }
+
+                if (segmentMetadata.getOwnerEpoch() > this.epoch) {
+                    throw new StorageNotPrimaryException(streamSegmentName);
+                }
+
+                // Check if this is a first write after ownership changed.
+                boolean isFirstWriteAfterFailover =  segmentMetadata.isOwnershipChanged();
+
+                // Write data  to the last segment.
+                int bytesRemaining = length;
+                long currentOffset = offset;
+
+                ChunkMetadata lastChunkMetadata = null;
+                ChunkHandle chunkHandle = null;
+                ChunkMetadata chunkWrittenMetadata = null;
+
+                while (bytesRemaining > 0) {
+                    // Validate that offset is correct.
+                    if ((segmentMetadata.getLength()) != currentOffset) {
+                        throw new BadOffsetException(streamSegmentName, segmentMetadata.getLength(), currentOffset);
+                    }
+
+                    // Get the last chunk segmentMetadata for the segment.
+                    if (null != segmentMetadata.getLastChunk()) {
+                        lastChunkMetadata = (ChunkMetadata) metadataStore.get(txn, segmentMetadata.getLastChunk());
+                    }
+
+                    // Check if new chunk needs to be added.
+                    // This could be either because there are no existing chunks or last chunk has reached max rolling length.
+                    if ( null == lastChunkMetadata
+                        || (lastChunkMetadata.getLength() >= segmentMetadata.getMaxRollinglength())
+                        || isFirstWriteAfterFailover
+                        || !chunkStorage.supportsAppend()) {
+
+                        // Create new chunk
+                        String newChunkName = getNewChunkName(streamSegmentName,
+                                segmentMetadata.getLength());
+
+                        chunkWrittenMetadata = ChunkMetadata.builder()
+                                .name(newChunkName)
+                                .build();
+                        chunkHandle = chunkStorage.create(newChunkName);
+
+                        // Record the creation of new chunk.
+                        chunksAddedCount++;
+                        addSystemLogRecord(systemLogRecords, streamSegmentName, segmentMetadata.getLength(), lastChunkMetadata, newChunkName);
+
+                        // Update read index.
+                        newReadIndexEntries.put(segmentMetadata.getLength(), newChunkName);
+
+                        // update first and last chunks.
+                        segmentMetadata.setLastChunk(newChunkName);
+                        if (lastChunkMetadata == null) {
+                            segmentMetadata.setFirstChunk(newChunkName);
+                        } else {
+                            lastChunkMetadata.setNextChunk(newChunkName);
+                        }
+
+                        // Update the transaction.
+                        metadataStore.update(txn, chunkWrittenMetadata);
+                        if (lastChunkMetadata != null) {
+                            metadataStore.update(txn, lastChunkMetadata);
+                        }
+                        metadataStore.update(txn, segmentMetadata);
+                        segmentMetadata.setLastChunkStartOffset(segmentMetadata.getLength());
+
+                        //
+                        if (isFirstWriteAfterFailover) {
+                            segmentMetadata.setOwnerEpoch(this.epoch);
+                            isFirstWriteAfterFailover = false;
+                            segmentMetadata.setOwnershipChanged(false);
+                            log.debug("write: First write after failover. segment: {}", streamSegmentName);
+                        }
+                        didSegmentLayoutChange = true;
+                        log.debug("write: New chunk added. segment: {} chunk: {} offset:{}", streamSegmentName, newChunkName, segmentMetadata.getLength());
+                    } else {
+                        // No new chunk needed just write data to existing chunk.
+                        chunkWrittenMetadata = lastChunkMetadata;
+                        chunkHandle = chunkStorage.openWrite(lastChunkMetadata.getName());
+                    }
+
+                    // Calculate the data that needs to be written.
+                    long offsetToWriteAt = currentOffset - segmentMetadata.getLastChunkStartOffset();
+                    int bytesToWrite = (int) Math.min(bytesRemaining, segmentMetadata.getMaxRollinglength() - offsetToWriteAt);
+                    Preconditions.checkState(0 != bytesToWrite, "Attempt to write zero bytes");
+
+                    try {
+                        int bytesWritten;
+                        // Finally write the data.
+                        try (BoundedInputStream bis = new BoundedInputStream(data, bytesToWrite)) {
+                            bytesWritten = chunkStorage.write(chunkHandle, offsetToWriteAt, bytesToWrite, bis);
+                        }
+                        if (0 == bytesWritten) {
+                            // Log warning
+                            log.warn("No bytes written");
+                        }
+
+                        // Update the
+                        bytesRemaining -= bytesWritten;
+                        currentOffset += bytesWritten;
+
+                        // Update the metadata for segment and chunk.
+                        Preconditions.checkState(bytesWritten >= 0);
+                        segmentMetadata.setLength(segmentMetadata.getLength() + bytesWritten);
+                        chunkWrittenMetadata.setLength(chunkWrittenMetadata.getLength() + bytesWritten);
+                        metadataStore.update(txn, chunkWrittenMetadata);
+                        metadataStore.update(txn, segmentMetadata);
+                    } catch (IndexOutOfBoundsException e) {
+                        throw new BadOffsetException(streamSegmentName, chunkStorage.getInfo(chunkHandle.getChunkName()).getLength(), offset);
+                    }
+                }
+
+                // Check invariants.
+                segmentMetadata.checkInvariants();
+                // if layout did not change or it is system segment then commit with lazyWrite.
+                txn.commit(!didSegmentLayoutChange || isSystemSegment(streamSegmentName));
+
+                if (isSystemSegment(streamSegmentName) && chunksAddedCount > 0) {
+                    Preconditions.checkState(chunksAddedCount == systemLogRecords.size());
+                    systemJournal.commitRecords(systemLogRecords);
+
+                    // Update the read index.
+                    val readIndex = getReadIndex(streamSegmentName);
+                    for (val entry : newReadIndexEntries.entrySet()) {
+                        readIndex.put(entry.getKey(), entry.getValue());
+                    }
+                }
+
+                LoggerHelpers.traceLeave(log, "write", traceId, handle, offset);
+                return null;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw new BadOffsetException(streamSegmentName, offset, offset); // TODO FIX THIS
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            } catch (Exception ex) {
+                throw ex;
+            }
+        });
+    }
+
+    private boolean isSystemSegment(String streamSegmentName) {
+        return null != systemJournal && systemJournal.isSystemSegment(streamSegmentName);
+    }
+
+    private void addSystemLogRecord(ArrayList<String> systemLogRecords, String streamSegmentName, long offset, ChunkMetadata lastChunkMetadata, String newChunkName) {
+        if (isSystemSegment(streamSegmentName)) {
+            val systemLogRecord = systemJournal.getChunkAddedRecord(streamSegmentName,
+                offset,
+                lastChunkMetadata == null ? null : lastChunkMetadata.getName(),
+                newChunkName);
+            systemLogRecords.add(systemLogRecord);
+        }
+    }
+
+    /**
+     * Seals a StreamSegment. No further modifications are allowed on the StreamSegment after this operation completes.
+     *
+     * @param handle  A read-write SegmentHandle that points to a Segment to Seal.
+     * @param timeout Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate that the operation completed. If the operation
+     * failed, it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * <li> StorageNotPrimaryException: When this Storage instance is no longer primary for this Segment (it was fenced out).
+     * </ul>
+     * @throws IllegalArgumentException If handle is read-only.
+     */
+    @Override
+    public CompletableFuture<Void> seal(SegmentHandle handle, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "seal", handle);
+            Preconditions.checkNotNull(handle, "handle");
+            String streamSegmentName = handle.getSegmentName();
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            Preconditions.checkArgument(!handle.isReadOnly(), "handle");
+
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                // Validate preconditions.
+                if (null == segmentMetadata || !segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+
+                if (segmentMetadata.getOwnerEpoch() > this.epoch) {
+                    throw new StorageNotPrimaryException(streamSegmentName);
+                }
+
+                // seal if it is not already sealed.
+                if (!segmentMetadata.isSealed()) {
+                    segmentMetadata.setSealed(true);
+                    metadataStore.update(txn, segmentMetadata);
+                    txn.commit();
+                }
+                LoggerHelpers.traceLeave(log, "seal", traceId, handle);
+                return null;
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            }
+        });
+    }
+
+    /**
+     * Concatenates two StreamSegments together. The Source StreamSegment will be appended as one atomic block at the end
+     * of the Target StreamSegment (but only if its length equals the given offset), after which the Source StreamSegment
+     * will cease to exist. Prior to this operation, the Source StreamSegment must be sealed.
+     *
+     * @param targetHandle  A read-write SegmentHandle that points to the Target StreamSegment. After this operation
+     *                      is complete, this is the surviving StreamSegment.
+     * @param offset        The offset in the Target StreamSegment to concat at.
+     * @param sourceSegment The Source StreamSegment. This StreamSegment will be concatenated to the Target StreamSegment.
+     *                      After this operation is complete, this StreamSegment will no longer exist.
+     * @param timeout       Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate the operation succeeded. If the operation failed,
+     * it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> BadOffsetException: When the given offset does not match the actual length of the target segment in storage.
+     * <li> StreamSegmentNotExistsException: When the either the source Segment or the target Segment do not exist in Storage.
+     * <li> StorageNotPrimaryException: When this Storage instance is no longer primary for the target Segment (it was fenced out).
+     * <li> IllegalStateException: When the Source Segment is not Sealed.
+     * </ul>
+     * @throws IllegalArgumentException If targetHandle is read-only.
+     */
+    @Override
+    public CompletableFuture<Void> concat(SegmentHandle targetHandle, long offset, String sourceSegment, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "concat", targetHandle, offset, sourceSegment);
+
+            String targetSegmentName = targetHandle.getSegmentName();
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+
+                // Validate preconditions.
+                SegmentMetadata targetSegmentMetadata = (SegmentMetadata) metadataStore.get(txn, targetSegmentName);
+                if (null == targetSegmentMetadata || !targetSegmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(targetSegmentName);
+                }
+
+                targetSegmentMetadata.checkInvariants();
+
+                SegmentMetadata sourceSegmentMetadata = (SegmentMetadata) metadataStore.get(txn, sourceSegment);
+                if (null == sourceSegmentMetadata || !sourceSegmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(sourceSegment);
+                }
+
+                sourceSegmentMetadata.checkInvariants();
+
+                if (!sourceSegmentMetadata.isSealed()) {
+                    throw new IllegalStateException();
+                }
+
+                if (targetSegmentMetadata.getOwnerEpoch() > this.epoch) {
+                    throw new StorageNotPrimaryException(targetSegmentMetadata.getName());
+                }
+
+                if (sourceSegmentMetadata.getStartOffset() != 0) {
+                    throw new StreamSegmentTruncatedException(targetSegmentName, targetSegmentMetadata.getLength(), 0);
+                }
+
+                // The Entire source is before end of target, just treat it as no-op.
+                if (offset + sourceSegmentMetadata.getLength() <= targetSegmentMetadata.getLength()) {
+                    return null;
+                }
+
+                // Update list of chunks by appending sources list of chunks.
+                ChunkMetadata targetLastChunk = (ChunkMetadata) metadataStore.get(txn, targetSegmentMetadata.getLastChunk());
+                ChunkMetadata sourceFirstChunk = (ChunkMetadata) metadataStore.get(txn, sourceSegmentMetadata.getFirstChunk());
+
+                if (targetLastChunk != null) {
+                    targetLastChunk.setNextChunk(sourceFirstChunk.getName());
+                } else {
+                    targetSegmentMetadata.setFirstChunk(sourceFirstChunk.getName());
+                }
+
+                // Update segments's last chunk to point to the sources last segment.
+                targetSegmentMetadata.setLastChunk(sourceSegmentMetadata.getLastChunk());
+
+                // Update the length of segment.
+                targetSegmentMetadata.setLastChunkStartOffset(targetSegmentMetadata.getLength() + sourceSegmentMetadata.getLastChunkStartOffset());
+                targetSegmentMetadata.setLength(targetSegmentMetadata.getLength() + sourceSegmentMetadata.getLength() - sourceSegmentMetadata.getStartOffset());
+
+                metadataStore.update(txn, targetLastChunk);
+                metadataStore.update(txn, sourceFirstChunk);
+                metadataStore.update(txn, targetSegmentMetadata);
+                metadataStore.delete(txn, sourceSegment);
+
+                if (chunkStorage.supportsConcat() && null != targetLastChunk ) {
+                    defrag(txn, targetSegmentMetadata, targetLastChunk.getName());
+                }
+
+                targetSegmentMetadata.checkInvariants();
+
+                // Finally commit transaction.
+                txn.commit();
+                LoggerHelpers.traceLeave(log, "concat", traceId, targetHandle, offset, sourceSegment);
+
+                // Update the read index.
+                cachedReadIndex.remove(sourceSegment);
+
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(targetSegmentName, ex);
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(targetSegmentName, ex);
+            }
+
+            return null;
+        });
+    }
+
+    private void defrag(MetadataTransaction txn, SegmentMetadata targetSegmentMetadata, String targetChunkName) throws Exception {
+        // Iterate through chunk list
+        while (null != targetChunkName) {
+            ChunkMetadata target = (ChunkMetadata) metadataStore.get(txn, targetChunkName);
+
+            ArrayList<String> sources = new ArrayList<>();
+            long size = target.getLength();
+
+            String nextChunkName = target.getNextChunk();
+            ChunkMetadata next = null;
+
+            // Gather list of chunks that can be appended together.
+            while (null != nextChunkName) {
+                next = (ChunkMetadata) metadataStore.get(txn, nextChunkName);
+
+                if (size + next.getLength() <= targetSegmentMetadata.getMaxRollinglength()) {
+                    sources.add(nextChunkName);
+                    size += next.getLength();
+                } else {
+                    break;
+                }
+                nextChunkName = next.getNextChunk();
+            }
+            // Note - After this loop is exited nextChunkName points to chunk next to last one to be concat.
+            // Which means target should now point to it as next after concat is complete.
+
+            // If there are chunks that can be appended together then concat them.
+            if (sources.size() > 0) {
+                // Concat
+                ChunkHandle[] arr = new ChunkHandle[sources.size()];
+                arr = sources.stream().map(chunkName -> ChunkHandle.readHandle(chunkName)).collect(Collectors.toList()).toArray(arr);
+                int length = chunkStorage.concat(ChunkHandle.writeHandle(targetChunkName), arr);
+
+                // Set the pointers
+                target.setLength(size);
+                target.setNextChunk(nextChunkName);
+
+                // If target is the last chunk after this then update metadata accordingly
+                if (null == nextChunkName) {
+                    targetSegmentMetadata.setLastChunk(target.getName());
+                    targetSegmentMetadata.setLastChunkStartOffset(targetSegmentMetadata.getLength() - target.getLength());
+                }
+
+                // Update metadata for affected chunks.
+                for (String chunkName : sources) {
+                    metadataStore.delete(txn, chunkName);
+                }
+                metadataStore.update(txn, target);
+                metadataStore.update(txn, targetSegmentMetadata);
+            }
+
+            // Move on to next place in list where we can concat.
+            targetChunkName = nextChunkName;
+        }
+    }
+
+    /**
+     * Deletes a StreamSegment.
+     *
+     * @param handle  A read-write SegmentHandle that points to a Segment to Delete.
+     * @param timeout Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate the operation succeeded. If the operation failed,
+     * it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * <li> StorageNotPrimaryException: When this Storage instance is no longer primary for this Segment (it was fenced out).
+     * </ul>
+     * @throws IllegalArgumentException If handle is read-only.
+     */
+    @Override
+    public CompletableFuture<Void> delete(SegmentHandle handle, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "delete", handle);
+            String streamSegmentName = handle.getSegmentName();
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+
+                if (null != segmentMetadata) {
+                    if (segmentMetadata.getOwnerEpoch() > this.epoch) {
+                        throw new StorageNotPrimaryException(streamSegmentName);
+                    }
+
+                    segmentMetadata.setActive(false);
+
+                    // Delete chunks
+                    String currentChunkName = segmentMetadata.getFirstChunk();
+                    ChunkMetadata currentMetadata;
+                    ArrayList<String> chunksToDelete = new ArrayList<>();
+                    while (currentChunkName != null) {
+                        currentMetadata = (ChunkMetadata) metadataStore.get(txn, currentChunkName);
+                        // Delete underlying file.
+                        chunksToDelete.add(currentChunkName);
+                        currentChunkName = currentMetadata.getNextChunk();
+                        metadataStore.delete(txn, currentMetadata.getName());
+                    }
+
+                    // Commit.
+                    metadataStore.delete(txn, streamSegmentName);
+                    txn.commit();
+
+                    for (String toDelete : chunksToDelete) {
+                        chunkStorage.delete(chunkStorage.openWrite(toDelete));
+                    }
+
+                    // Update the read index.
+                    cachedReadIndex.remove(streamSegmentName);
+                }
+                LoggerHelpers.traceLeave(log, "delete", traceId, handle);
+                return null;
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            }
+        });
+    }
+
+    /**
+     * Truncates all data in the given StreamSegment prior to the given offset. This does not fill the truncated data
+     * in the segment with anything, nor does it "shift" the remaining data to the beginning. After this operation is
+     * complete, any attempt to access the truncated data will result in an exception.
+     * <p>
+     * Notes:
+     * * Depending on implementation, this may not truncate at the exact offset. It may truncate at some point prior to
+     * the given offset, but it will never truncate beyond the offset.
+     *
+     * @param handle  A read-write SegmentHandle that points to a Segment to write to.
+     * @param offset  The offset in the StreamSegment to truncate to.
+     * @param timeout Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will indicate the operation succeeded. If the operation failed,
+     * it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * </ul>
+     */
+    @Override
+    public CompletableFuture<Void> truncate(SegmentHandle handle, long offset, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "truncate", handle, offset);
+            String streamSegmentName = handle.getSegmentName();
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+
+                if (!segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+
+                if (segmentMetadata.getOwnerEpoch() > this.epoch) {
+                    throw new StorageNotPrimaryException(streamSegmentName);
+                }
+
+                if (segmentMetadata.getLength() <= offset || segmentMetadata.getStartOffset() > offset) {
+                    throw new IllegalArgumentException(streamSegmentName);
+                }
+
+                if (segmentMetadata.getStartOffset() == offset) {
+                    // Nothing to do
+                    return null;
+                }
+
+                String currentChunkName = segmentMetadata.getFirstChunk();
+                ChunkMetadata currentMetadata;
+                long oldLength = segmentMetadata.getLength();
+                long startOffset = segmentMetadata.getFirstChunkStartOffset();
+                ArrayList<String> chunksToDelete = new ArrayList<>();
+                while (currentChunkName != null) {
+                    currentMetadata = (ChunkMetadata) metadataStore.get(txn, currentChunkName);
+                    Preconditions.checkState(null != currentMetadata, "currentMetadata is null.");
+
+                    // If for given chunk start <= offset < end  then we have found the chunk that will be the first chunk.
+                    if ((startOffset <= offset) && (startOffset + currentMetadata.getLength() > offset)) {
+                        break;
+                    }
+
+                    startOffset += currentMetadata.getLength();
+                    chunksToDelete.add(currentMetadata.getName());
+
+                    // move to next chunk
+                    currentChunkName = currentMetadata.getNextChunk();
+                }
+                segmentMetadata.setFirstChunk(currentChunkName);
+                segmentMetadata.setStartOffset(offset);
+                segmentMetadata.setFirstChunkStartOffset(startOffset);
+                for (String toDelete : chunksToDelete) {
+                    metadataStore.delete(txn, toDelete);
+                }
+                metadataStore.update(txn, segmentMetadata);
+
+                // Check invariants.
+                Preconditions.checkState(segmentMetadata.getLength() == oldLength, "truncate should not change segment length");
+                segmentMetadata.checkInvariants();
+
+                // Finally commit.
+                txn.commit(chunksToDelete.size() == 0); // if layout did not change then commit with lazyWrite.
+
+                if (null != systemJournal && systemJournal.isSystemSegment(streamSegmentName)) {
+                    systemJournal.commitRecord(systemJournal.getSegmentTruncatedRecord(streamSegmentName,
+                                                                    offset,
+                                                                    segmentMetadata.getFirstChunk(),
+                                                                    startOffset));
+                }
+
+                for (String toDelete : chunksToDelete) {
+                    chunkStorage.delete(chunkStorage.openWrite(toDelete));
+                }
+
+                // Update the read index by removing all entries below truncate offset.
+                val readIndex = getReadIndex(streamSegmentName);
+                if (null != readIndex) {
+                    val headMap = readIndex.headMap(segmentMetadata.getStartOffset());
+                    if (null != headMap) {
+                        ArrayList<Long> keysToRemove = new ArrayList<Long>();
+                        keysToRemove.addAll(headMap.keySet());
+                        for (val keyToRemove : keysToRemove) {
+                            cachedReadIndex.remove(keyToRemove);
+                        }
+                    }
+                }
+
+                LoggerHelpers.traceLeave(log, "truncate", traceId, handle, offset);
+                return null;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            }
+            //return null;
+        });
+    }
+
+    /**
+     * Gets a value indicating whether this Storage implementation can truncate Segments.
+     *
+     * @return True or false.
+     */
+    @Override
+    public boolean supportsTruncation() {
+        return true;
+    }
+
+    /**
+     * Opens the given Segment in read-only mode without acquiring any locks or blocking on any existing write-locks and
+     * makes it available for use for this instance of Storage.
+     * Multiple read-only Handles can coexist at any given time and allow concurrent read-only access to the Segment,
+     * regardless of whether there is another non-read-only SegmentHandle that modifies the segment at that time.
+     *
+     * @param streamSegmentName Name of the StreamSegment to be opened in read-only mode.
+     * @return A CompletableFuture that, when completed, will contain a read-only SegmentHandle that can be used to
+     * access the segment for non-modify activities (ex: read, get). If the operation failed, it will be failed with the
+     * cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * </ul>
+     */
+    @Override
+    public CompletableFuture<SegmentHandle> openRead(String streamSegmentName) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "openRead", streamSegmentName);
+            // Validate preconditions and return handle.
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                if (null == segmentMetadata || !segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+                val retValue = SegmentStorageHandle.readHandle(streamSegmentName);
+                LoggerHelpers.traceLeave(log, "openRead", traceId, retValue);
+                return retValue;
+
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            }
+        });
+    }
+
+    /**
+     * Reads a range of bytes from the StreamSegment.
+     *
+     * @param handle       A SegmentHandle (read-only or read-write) that points to a Segment to read from.
+     * @param offset       The offset in the StreamSegment to read data from.
+     * @param buffer       A buffer to use for reading data.
+     * @param bufferOffset The offset in the buffer to start writing data to.
+     * @param length       The number of bytes to read.
+     * @param timeout      Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will contain the number of bytes read. If the operation failed,
+     * it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * </ul>
+     * @throws ArrayIndexOutOfBoundsException If bufferOffset or bufferOffset + length are invalid for the buffer.
+     */
+    @Override
+    public CompletableFuture<Integer> read(SegmentHandle handle, long offset, byte[] buffer, int bufferOffset, int length, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "read", handle, offset, length);
+            // Validate preconditions.
+            Preconditions.checkNotNull(handle, "handle");
+            Preconditions.checkNotNull(buffer, "buffer");
+            String streamSegmentName = handle.getSegmentName();
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            if (bufferOffset < 0 || bufferOffset > buffer.length || bufferOffset + length >  buffer.length) {
+                throw new ArrayIndexOutOfBoundsException("bufferOffset");
+            }
+
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+
+                // Validate preconditions.
+                if (null == segmentMetadata || !segmentMetadata.isActive()) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+
+                segmentMetadata.checkInvariants();
+
+                if (length == 0) {
+                    return 0;
+                }
+
+                if ( offset > segmentMetadata.getLength() || offset < 0) {
+                    throw new ArrayIndexOutOfBoundsException("offset = " + offset + "  segmentMetadata =" + segmentMetadata);
+                }
+
+                if (offset < segmentMetadata.getStartOffset() ) {
+                    throw new StreamSegmentTruncatedException(streamSegmentName, segmentMetadata.getStartOffset(), offset);
+                }
+
+                String currentChunkName = segmentMetadata.getFirstChunk();
+                ChunkMetadata chunkToReadFrom = null;
+
+                if (null == currentChunkName) {
+                    throw new ArrayIndexOutOfBoundsException("offset");
+                }
+
+                int bytesRemaining = length;
+                int currentBufferOffset = bufferOffset;
+                long currentOffset = offset;
+                int totalBytesRead = 0;
+
+                // Find the first chunk that contains the data.
+                long startOffsetForCurrentChunk = segmentMetadata.getFirstChunkStartOffset();
+
+                // Find the name of the chunk in the cached read index that is floor to required offset.
+                val readIndex = getReadIndex(streamSegmentName);
+                if (readIndex.size() > 0) {
+                    val floorEntry = readIndex.floorEntry(offset);
+                    if (null != floorEntry) {
+                        startOffsetForCurrentChunk = floorEntry.getKey();
+                        currentChunkName = floorEntry.getValue();
+                    }
+                }
+
+                // Navigate to the chunk that contains the first byte of requested data.
+                while (currentChunkName != null) {
+                    chunkToReadFrom = (ChunkMetadata) metadataStore.get(txn, currentChunkName);
+                    Preconditions.checkState(null != chunkToReadFrom, "chunkToReadFrom is null");
+                    if (   startOffsetForCurrentChunk <= currentOffset
+                        && startOffsetForCurrentChunk + chunkToReadFrom.getLength() > currentOffset) {
+                        // we have found a chunk that contains first byte we want to read
+                        log.debug("read: found chunk to read segment: {} chunk: {}", streamSegmentName, chunkToReadFrom);
+                        break;
+                    }
+                    currentChunkName = chunkToReadFrom.getNextChunk();
+                    startOffsetForCurrentChunk += chunkToReadFrom.getLength();
+
+                    // Update read index with newly visited chunk.
+                    if (null != currentChunkName) {
+                        readIndex.put(startOffsetForCurrentChunk, currentChunkName);
+                    }
+                }
+
+                // Now read.
+                while (bytesRemaining > 0 && null != currentChunkName) {
+                    int bytesToRead = Math.min(bytesRemaining, Math.toIntExact(chunkToReadFrom.getLength() - (currentOffset - startOffsetForCurrentChunk)));
+                    //assert bytesToRead != 0;
+
+                    if (currentOffset >= startOffsetForCurrentChunk + chunkToReadFrom.getLength()) {
+                        // The current chunk is over. Move to the next one.
+                        currentChunkName = chunkToReadFrom.getNextChunk();
+                        if (null != currentChunkName) {
+                            startOffsetForCurrentChunk += chunkToReadFrom.getLength();
+                            chunkToReadFrom = (ChunkMetadata) metadataStore.get(txn, currentChunkName);
+                            log.debug("read: reading from next chunk segment: {} chunk: {}", streamSegmentName, chunkToReadFrom);
+                        }
+                    } else {
+                        Preconditions.checkState(bytesToRead != 0, "bytesToRead is 0");
+                        // Read data from the chunk.
+                        ChunkHandle chunkHandle = chunkStorage.openRead(chunkToReadFrom.getName());
+                        int bytesRead = chunkStorage.read(chunkHandle, currentOffset - startOffsetForCurrentChunk, bytesToRead, buffer, currentBufferOffset);
+
+                        bytesRemaining -= bytesRead;
+                        currentOffset += bytesRead;
+                        currentBufferOffset += bytesRead;
+                        totalBytesRead += bytesRead;
+                    }
+                }
+
+                if (0 == totalBytesRead) {
+                    log.debug("zero bytes read");
+                }
+                LoggerHelpers.traceLeave(log, "read", traceId, handle, offset, totalBytesRead);
+                return totalBytesRead;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            } catch (Exception ex) {
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * Gets current information about a StreamSegment.
+     *
+     * @param streamSegmentName The full name of the StreamSegment.
+     * @param timeout           Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will contain the information requested about the StreamSegment.
+     * If the operation failed, it will contain the cause of the failure. Notable exceptions:
+     * <ul>
+     * <li> StreamSegmentNotExistsException: When the given Segment does not exist in Storage.
+     * </ul>
+     */
+    @Override
+    public CompletableFuture<SegmentProperties> getStreamSegmentInfo(String streamSegmentName, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "getStreamSegmentInfo", streamSegmentName);
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                if (null == segmentMetadata ) {
+                    throw new StreamSegmentNotExistsException(streamSegmentName);
+                }
+                segmentMetadata.checkInvariants();
+
+                val retValue = StreamSegmentInformation.builder()
+                        .name(streamSegmentName)
+                        .sealed(segmentMetadata.isSealed())
+                        .length(segmentMetadata.getLength())
+                        .startOffset(segmentMetadata.getStartOffset())
+                        .lastModified(new ImmutableDate(segmentMetadata.getLastModified()))
+                        .build();
+                LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, retValue);
+                return retValue;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            } catch (StorageMetadataVersionMismatchException ex) {
+                throw ex;
+            } catch (StorageMetadataWritesFencedOutException ex) {
+                throw new StorageNotPrimaryException(streamSegmentName, ex);
+            }
+        });
+    }
+
+    /**
+     * Determines whether the given StreamSegment exists or not.
+     *
+     * @param streamSegmentName The name of the StreamSegment.
+     * @param timeout           Timeout for the operation.
+     * @return A CompletableFuture that, when completed, will contain the information requested. If the operation failed,
+     * it will contain the cause of the failure.
+     */
+    @Override
+    public CompletableFuture<Boolean> exists(String streamSegmentName, Duration timeout) {
+        checkInitialized();
+        return execute( () -> {
+            long traceId = LoggerHelpers.traceEnter(log, "exists", streamSegmentName);
+            Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, streamSegmentName);
+                val retValue = segmentMetadata == null ? false : segmentMetadata.isActive();
+                LoggerHelpers.traceLeave(log, "exists", traceId, retValue);
+                return retValue;
+            } catch (StorageMetadataNotFoundException ex) {
+                throw new StreamSegmentNotExistsException(streamSegmentName, ex);
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (null != this.metadataStore) {
+                this.metadataStore.close();
+            }
+        } catch (Exception e) {
+
+        }
+        this.closed.set(true);
+    }
+
+    /**
+     *
+     * @param streamSegmentName
+     * @return
+     */
+    private ConcurrentSkipListMap<Long, String> getReadIndex(String streamSegmentName) {
+        ConcurrentSkipListMap<Long, String> readIndex;
+        if (cachedReadIndex.containsKey(streamSegmentName)) {
+            readIndex = cachedReadIndex.get(streamSegmentName);
+        } else {
+            val newReadIndex = new ConcurrentSkipListMap<Long, String>();
+            val oldReadIndex = cachedReadIndex.putIfAbsent(streamSegmentName, newReadIndex);
+            readIndex = null != oldReadIndex ? oldReadIndex : newReadIndex;
+        }
+        return readIndex;
+    }
+
+    /**
+     * Executes the given Callable and returns its result, while translating any Exceptions bubbling out of it into
+     * StreamSegmentExceptions.
+     *
+     * @param operation     The function to execute.
+     * @param <R>           Return type of the operation.
+     * @return CompletableFuture<R> of the return type of the operation.
+     */
+    private <R> CompletableFuture<R> execute(Callable<R> operation) {
+        return CompletableFuture.supplyAsync(() -> {
+            Exceptions.checkNotClosed(this.closed.get(), this);
+            try {
+                return operation.call();
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        }, this.executor);
+    }
+
+    private String getNewChunkName(String segmentName, long offset) throws Exception {
+        //String name = getSegmentChunkName(segmentName, offset);
+        //return name;
+        return java.util.UUID.randomUUID().toString();
+    }
+
+    private void checkInitialized() {
+        Preconditions.checkState(null != this.metadataStore);
+        Preconditions.checkState(0 != this.epoch);
+        Preconditions.checkState(!closed.get());
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageProvider.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageProvider.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Defines an abstraction for Permanent Storage.
+ * Note: not all operations defined here are needed.
+ */
+public interface ChunkStorageProvider extends AutoCloseable {
+    /**
+     * Gets a value indicating whether this Storage implementation supports truncate operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    boolean supportsTruncation();
+
+
+    /**
+     * Gets a value indicating whether this Storage implementation supports append operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    boolean supportsAppend();
+
+
+    /**
+     * Gets a value indicating whether this Storage implementation supports merge operation on underlying storage object.
+     *
+     * @return True or false.
+     */
+    boolean supportsConcat();
+
+    /**
+     * Determines whether named file/object exists in underlying storage.
+     *
+     * @param chunkName Name of the storage object to check.
+     * @return True if the object exists, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    boolean exists(String chunkName) throws IOException;
+
+    /**
+     * Creates a new file.
+     *
+     * @param chunkName String name of the storage object to create.
+     * @return ChunkHandle A writable handle for the recently created chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    ChunkHandle create(String chunkName) throws IOException;
+
+    /**
+     * Deletes a file.
+     *
+     * @param handle ChunkHandle of the storage object to delete.
+     * @return True if the object was deleted, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    boolean delete(ChunkHandle handle) throws IOException;
+
+    /**
+     * Opens storage object for Read.
+     *
+     * @param chunkName String name of the storage object to read from.
+     * @return ChunkHandle A readable handle for the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    ChunkHandle openRead(String chunkName) throws IOException, IllegalArgumentException;
+
+    /**
+     * Opens storage object for Write (or modifications).
+     *
+     * @param chunkName String name of the storage object to write to or modify.
+     * @return ChunkHandle A writable handle for the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    ChunkHandle openWrite(String chunkName) throws IOException, IllegalArgumentException;
+
+    /**
+     * Retrieves the ChunkInfo for given name.
+     *
+     * @param chunkName String name of the storage object to read from.
+     * @return ChunkInfo Information about the given chunk.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     */
+    ChunkInfo getInfo(String chunkName) throws IOException, IllegalArgumentException;
+
+    /**
+     * Reads a range of bytes from the underlying storage object.
+     *
+     * @param handle ChunkHandle of the storage object to read from.
+     * @param fromOffset Offset in the file from which to start reading.
+     * @param length Number of bytes to read.
+     * @param buffer Byte buffer to which data is copied.
+     * @param bufferOffset Offset in the buffer at which to start copying read data.
+     * @return int Number of bytes read.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws IllegalArgumentException If argument is invalid.
+     * @throws NullPointerException  If the parameter is null.
+     * @throws IndexOutOfBoundsException If the index is out of bounds.
+     */
+    int read(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException;
+
+
+    /**
+     * Writes the given data to the underlying storage object.
+     *
+     * @param handle ChunkHandle of the storage object to write to.
+     * @param offset Offset in the file to start writing.
+     * @param length Number of bytes to write.
+     * @param data An InputStream representing the data to write.
+     * @return int Number of bytes written.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     */
+    int write(ChunkHandle handle, long offset, int length, InputStream data) throws IOException;
+
+    /**
+     * Concatenates two or more chunks.
+     *
+     * @param target String Name of the storage object to concat to.
+     * @param sources Array of ChunkHandle to existing chunks to be appended to the target. The chunks are appended in the same sequence the names are provided.
+     * @return int Number of bytes concatenated.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    int concat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException;
+
+    /**
+     * Truncates a given chunk.
+     *
+     * @param handle ChunkHandle of the storage object to truncate.
+     * @param offset Offset to truncate to.
+     * @return True if the object was truncated, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    boolean truncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException;
+
+    /**
+     * Sets readonly attribute for the chunk.
+     *
+     * @param handle ChunkHandle of the storage object.
+     * @param isReadonly True if chunk is set to be readonly.
+     * @return True if the operation was successful, false otherwise.
+     * @throws IOException Throws IOException in case of I/O related exceptions.
+     * @throws UnsupportedOperationException If this operation is not supported by this provider.
+     */
+    boolean setReadonly(ChunkHandle handle, boolean isReadonly) throws IOException, UnsupportedOperationException;
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SegmentStorageHandle.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SegmentStorageHandle.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentHandle;
+
+public class SegmentStorageHandle implements SegmentHandle {
+    private final String segmentName;
+    private final boolean isReadOnly;
+
+    /**
+     * Creates a new instance of segment handle.
+     * @param streamSegmentName Name of the segment.
+     * @param isReadOnly  Whether the segment is read only or not.
+     */
+    public SegmentStorageHandle(String streamSegmentName, boolean isReadOnly) {
+        this.segmentName = Preconditions.checkNotNull(streamSegmentName, "segmentName");
+        this.isReadOnly = isReadOnly;
+    }
+
+    /**
+     * Gets the name of the Segment, as perceived by users of the Storage interface.
+     */
+    @Override
+    public String getSegmentName() {
+        return segmentName;
+    }
+
+    /**
+     * Gets a value indicating whether this Handle was open in ReadOnly mode (true) or ReadWrite mode (false).
+     * @return True if the handle is read only.
+     */
+    @Override
+    public boolean isReadOnly() {
+        return isReadOnly;
+    }
+
+    /**
+     * Creates a read only handle for a given segment name.
+     * @param streamSegmentName Name of the segment.
+     * @return A read only handle.
+     */
+    public static SegmentStorageHandle readHandle(String streamSegmentName) {
+        return new SegmentStorageHandle(streamSegmentName, true);
+    }
+
+    /**
+     * Creates a writable/updatable handle for a given segment name.
+     * @param streamSegmentName Name of the segment.
+     * @return A writable/updatable handle.
+     */
+    public static SegmentStorageHandle writeHandle(String streamSegmentName) {
+        return new SegmentStorageHandle(streamSegmentName, false);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -1,0 +1,402 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
+import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataException;
+import io.pravega.shared.NameUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * This class implements system journaling functionality for critical storage system segments which is useful for bootstrap after failover.
+ * It records any layout changes to storage system segments
+ */
+@Slf4j
+public class SystemJournal {
+    // TODO : Remove this from the final code.
+    private static final ArrayList<String> DEBUG_LOG = new ArrayList<>();
+    private static final String ADD_RECORD = "ADD";
+    private static final String TRUNCATE_RECORD = "TRUNCATE";
+
+    private static final Object LOCK = new Object();
+
+    private ChunkStorageProvider chunkStorage;
+    private ChunkMetadataStore metadataStore;
+
+    /**
+     * Epoch of the current instance.
+     */
+    @Getter
+    @Setter
+    private long epoch;
+
+    /**
+     * Container id of the owner container.
+     */
+    @Getter
+    @Setter
+    private int containerId;
+
+    /**
+     * Sting prefix for all system segments.
+     */
+    @Getter
+    @Setter
+    private String systemSegmentsPrefix;
+
+    /**
+     * System segments to track.
+     */
+    @Getter
+    @Setter
+    private String[] systemSegments;
+
+    /**
+     * Offset at which next log will be written.
+     */
+    @Getter
+    @Setter
+    private long systemJournalOffset;
+
+    /**
+     * Name of the system journal chunk.
+     */
+    @Getter
+    @Setter
+    private String systemJournalName;
+
+    /**
+     * Default {@link SegmentRollingPolicy} for the system segments.
+     */
+    @Getter
+    @Setter
+    private SegmentRollingPolicy segmentRollingPolicy;
+
+    /**
+     * Constructs an instance of {@link SystemJournal}.
+     * @param containerId Container id of the owner container.
+     * @param epoch Epoch of the current container instance.
+     * @param chunkStorage ChunkStorageProvider instance to use for writing all logs.
+     * @param metadataStore ChunkMetadataStore for owner container.
+     * @param segmentRollingPolicy Default SegmentRollingPolicy for system segments.
+     */
+    public SystemJournal(int containerId, long epoch, ChunkStorageProvider chunkStorage, ChunkMetadataStore metadataStore, SegmentRollingPolicy segmentRollingPolicy)  {
+        this.chunkStorage = Preconditions.checkNotNull(chunkStorage, "chunkStorage");
+        this.metadataStore = Preconditions.checkNotNull(metadataStore, "metadataStore");
+        this.segmentRollingPolicy = Preconditions.checkNotNull(segmentRollingPolicy, "segmentRollingPolicy");
+        this.containerId = containerId;
+        this.epoch = epoch;
+        this.systemJournalName = NameUtils.getSystemJournalFileName(containerId, epoch);
+        this.systemSegments = getChunkStorageSystemSegments(containerId);
+        this.systemSegmentsPrefix = NameUtils.INTERNAL_SCOPE_NAME;
+    }
+
+    /**
+     * Initlaizes this instance.
+     * @throws Exception Exception if any.
+     */
+    public void initialize() throws Exception {
+        chunkStorage.create(systemJournalName);
+    }
+
+    /**
+     * Commits a given system log record to the underlying log chunk.
+     * @param logLine Log line to persist.
+     * @throws IOException Exception if any.
+     */
+    public void commitRecord(String logLine) throws IOException {
+        synchronized (LOCK) {
+            // Open the underlying chunk to write.
+            ChunkHandle h = null;
+            if (chunkStorage.supportsAppend()) {
+                if (!chunkStorage.exists(systemJournalName)) {
+                    h = chunkStorage.create(systemJournalName);
+                } else {
+                    h = chunkStorage.openWrite(systemJournalName);
+                }
+            }
+
+            if (!chunkStorage.supportsAppend()) {
+                h = chunkStorage.create(systemJournalName + "_" + systemJournalOffset);
+            }
+
+            // Persist
+            byte[] bytes = logLine.getBytes();
+            val bytesWritten = chunkStorage.write(h, systemJournalOffset, bytes.length, new ByteArrayInputStream(bytes));
+            Preconditions.checkState(bytesWritten == bytes.length);
+            systemJournalOffset += bytesWritten;
+            DEBUG_LOG.add(logLine);
+        }
+    }
+
+    /**
+     * Commits a given list of system log records to the underlying log chunk.
+     * @param records List of records to log to.
+     * @throws IOException Exception in case of any error.
+     */
+    synchronized public void commitRecords(List<String> records) throws IOException {
+        Preconditions.checkState(null != records);
+        Preconditions.checkState(records.size() > 0);
+        synchronized (LOCK) {
+            // Open the underlying chunk to write.
+            ChunkHandle h = null;
+            if (chunkStorage.supportsAppend()) {
+                if (!chunkStorage.exists(systemJournalName)) {
+                    h = chunkStorage.create(systemJournalName);
+                } else {
+                    h = chunkStorage.openWrite(systemJournalName);
+                }
+            }
+
+            // Persist
+            for (String logLine : records) {
+                if (!chunkStorage.supportsAppend()) {
+                    h = chunkStorage.create(systemJournalName + "_" + systemJournalOffset);
+                }
+                byte[] bytes = logLine.getBytes();
+                val bytesWritten = chunkStorage.write(h, systemJournalOffset, bytes.length, new ByteArrayInputStream(bytes));
+                Preconditions.checkState(bytesWritten == bytes.length);
+                systemJournalOffset += bytesWritten;
+                DEBUG_LOG.add(logLine);
+            }
+        }
+    }
+
+    /**
+     * Formats a log record for newly added chunk.
+     * @param segmentName Name of the segment.
+     * @param offset offset at which new chunk was added.
+     * @param oldChunkName Name of the previous last chunk.
+     * @param newChunkName Name of the new last chunk.
+     * @return Formatted log record string.
+     */
+    public String getChunkAddedRecord(String segmentName, long offset, String oldChunkName, String newChunkName) {
+        return ADD_RECORD
+            + ":" + segmentName
+            + ":" + (oldChunkName == null ? "" : oldChunkName)
+            + ":" + (newChunkName == null ? "" : newChunkName)
+            + ":" + offset + "\n";
+    }
+
+    /**
+     * Formats a log record for trucate operation on given segment.
+     * @param segmentName Name of the segment.
+     * @param offset Offset at which the segment is truncated.
+     * @param firstChunkName Name of the new first chunk.
+     * @param startOffset Offset at which new chunk starts. The actual start offset of the segment may be anywhere in that chunk.
+     * @return Formatted log record string.
+     */
+    public String getSegmentTruncatedRecord(String segmentName, long offset, String firstChunkName, long startOffset) {
+        return TRUNCATE_RECORD
+                + ":" + segmentName
+                + ":" + offset
+                + ":" + firstChunkName
+                + ":" + startOffset + "\n";
+    }
+
+    /**
+     * Bootstrap the metadata about critical storage segments by reading and processing the journal.
+     * @throws Exception Exception in case of any error.
+     */
+    synchronized public void bootstrap() throws Exception {
+        synchronized (LOCK) {
+            try (val txn = metadataStore.beginTransaction()) {
+                // Step 1: Create segment metadata.
+                for (String systemSegment : systemSegments) {
+                    SegmentMetadata segmentMetadata = SegmentMetadata.builder()
+                            .name(systemSegment)
+                            .ownerEpoch(epoch)
+                            .maxRollinglength(segmentRollingPolicy.getMaxLength())
+                            .build();
+                    segmentMetadata.setActive(true).setOwnershipChanged(true);
+                    segmentMetadata.checkInvariants();
+                    metadataStore.create(txn, segmentMetadata);
+                }
+
+                // We only need to apply the final truncate offset.
+                val finalTruncateOffsets = new HashMap<String, Long>();
+                val finalFirstChunkStartsAtOffsets = new HashMap<String, Long>();
+
+                // Step 2: For each epoch, find the corresponding system journal file.
+                for (int i = 0; i < epoch; i++) {
+                    long offset = 0;
+                    String systemlog = NameUtils.getSystemJournalFileName(containerId, i);
+                    if (!chunkStorage.supportsAppend()) {
+                        systemlog = systemlog + "_" + offset;
+                    }
+                    if (chunkStorage.exists(systemlog)) {
+                        val info = chunkStorage.getInfo(systemlog);
+                        val h = chunkStorage.openRead(systemlog);
+                        byte[] contents = new byte[Math.toIntExact(info.getLength())];
+                        long fromOffset = 0;
+                        int remaining = contents.length;
+                        while (remaining > 0) {
+                            int bytesRead = chunkStorage.read(h, fromOffset, remaining, contents, Math.toIntExact(fromOffset));
+                            remaining -= bytesRead;
+                            fromOffset += bytesRead;
+                        }
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(contents)));
+                        String fullContent = new String(contents);
+                        String line;
+
+                        while ((line = reader.readLine()) != null) {
+                            String[] parts = line.split(":");
+                            if (ADD_RECORD.equals(parts[0]) && parts.length == 5) {
+                                String segmentName = parts[1];
+                                String oldChunkName = parts[2];
+                                String newChunkName = parts[3];
+                                offset = Long.parseLong(parts[4]);
+                                SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, segmentName);
+                                segmentMetadata.checkInvariants();
+                                // set length.
+                                long oldLength = segmentMetadata.getLength();
+                                segmentMetadata.setLength(offset);
+                                metadataStore.create(txn, ChunkMetadata.builder()
+                                        .name(newChunkName)
+                                        .build());
+
+                                // Set first and last pointers.
+                                if (!oldChunkName.isEmpty()) {
+                                    ChunkMetadata oldChunk = (ChunkMetadata) metadataStore.get(txn, oldChunkName);
+                                    oldChunk.setNextChunk(newChunkName);
+                                    oldChunk.setLength(Math.toIntExact(offset - oldLength));
+                                    metadataStore.update(txn, oldChunk);
+                                } else {
+                                    segmentMetadata.setFirstChunk(newChunkName);
+                                }
+                                segmentMetadata.setLastChunk(newChunkName);
+                                segmentMetadata.setLastChunkStartOffset(offset);
+                                segmentMetadata.checkInvariants();
+                                // Save the segment metadata.
+                                metadataStore.update(txn, segmentMetadata);
+                            }
+                            if (TRUNCATE_RECORD.equals(parts[0]) && parts.length == 5) {
+                                String segmentName = parts[1];
+                                long truncateAt = Long.parseLong(parts[2]);
+                                String firstChunkName = parts[3];
+                                long truncateStartAt = Long.parseLong(parts[4]);
+                                finalTruncateOffsets.put(segmentName, truncateAt);
+                                finalFirstChunkStartsAtOffsets.put(segmentName, truncateStartAt);
+                            }
+                        }
+                    }
+                }
+
+                // Step 3: Adjust the length of the last chunk.
+                for (String systemSegment : systemSegments) {
+                    SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, systemSegment);
+                    segmentMetadata.checkInvariants();
+                    if (null != segmentMetadata.getLastChunk()) {
+                        val chunkInfo = chunkStorage.getInfo(segmentMetadata.getLastChunk());
+                        long length = chunkInfo.getLength();
+
+                        ChunkMetadata lastChunk = (ChunkMetadata) metadataStore.get(txn, segmentMetadata.getLastChunk());
+                        if (null != lastChunk) {
+                            lastChunk.setLength(Math.toIntExact(length));
+                            metadataStore.update(txn, lastChunk);
+                        } else {
+                            log.debug("Problem");
+                        }
+                        segmentMetadata.setLength(segmentMetadata.getLength() + length);
+                    }
+                    Preconditions.checkState(segmentMetadata.isOwnershipChanged());
+                    segmentMetadata.checkInvariants();
+                    metadataStore.update(txn, segmentMetadata);
+                }
+
+                // Step 4: Apply the truncate offsets.
+                for (String systemSegment : systemSegments) {
+                    if (finalTruncateOffsets.containsKey(systemSegment)) {
+                        val truncateAt = finalTruncateOffsets.get(systemSegment);
+                        val firstChunkStartsAt = finalFirstChunkStartsAtOffsets.get(systemSegment);
+                        truncate(txn, systemSegment, truncateAt, firstChunkStartsAt);
+                    }
+                }
+
+                // Step 5: Finally commit all data.
+                txn.commit(true, true);
+            }
+        }
+    }
+
+    /**
+     * Truncate the segment metadata.
+     */
+    private void truncate(MetadataTransaction txn, String segmentName, long truncateAt, long firstChunkStartsAt) throws StorageMetadataException {
+        SegmentMetadata segmentMetadata = (SegmentMetadata) metadataStore.get(txn, segmentName);
+        segmentMetadata.checkInvariants();
+        String currentChunkName = segmentMetadata.getFirstChunk();
+        ChunkMetadata currentMetadata;
+        long startOffset = segmentMetadata.getFirstChunkStartOffset();
+        while (null != currentChunkName) {
+            currentMetadata = (ChunkMetadata) metadataStore.get(txn, currentChunkName);
+            // If for given chunk start <= truncateAt < end  then we have found the chunk that will be the first chunk.
+            if ((startOffset <= truncateAt) && (startOffset + currentMetadata.getLength() > truncateAt)) {
+                break;
+            }
+
+            startOffset += currentMetadata.getLength();
+            // move to next chunk
+            currentChunkName = currentMetadata.getNextChunk();
+            metadataStore.delete(txn, currentMetadata.getName());
+        }
+        Preconditions.checkState(firstChunkStartsAt == startOffset);
+        segmentMetadata.setFirstChunk(currentChunkName);
+        segmentMetadata.setStartOffset(truncateAt);
+        segmentMetadata.setFirstChunkStartOffset(firstChunkStartsAt);
+        segmentMetadata.checkInvariants();
+
+    }
+
+    /**
+     * Indicates whether given segment is a system segment.
+     * @param segmentName Name of the sgement to check.
+     * @return True if given segment is a system segment.
+     */
+    public boolean isSystemSegment(String segmentName) {
+        if (segmentName.startsWith(systemSegmentsPrefix)) {
+            for (String systemSegment: systemSegments) {
+                if (segmentName.equals(systemSegment)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets the names of the critical storage segments.
+     * @param containerId Container if of the owner container.
+     * @return Array of names of the critical storage segments.
+     */
+    public static String[] getChunkStorageSystemSegments(int containerId) {
+        return new String[]{
+                NameUtils.getStorageMetadataSegmentName(containerId),
+                NameUtils.getAttributeSegmentName(NameUtils.getStorageMetadataSegmentName(containerId)),
+                NameUtils.getMetadataSegmentName(containerId),
+                NameUtils.getAttributeSegmentName(NameUtils.getMetadataSegmentName(containerId))
+        };
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -1,0 +1,383 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.metadata;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Implements Base metadata store.
+ */
+@Slf4j
+public class BaseMetadataStore implements ChunkMetadataStore {
+    private static final int MAX_ENTRIES_IN_TXN_BUFFER = 5000; //TODO : load from the config
+    private final Object lock = new Object();
+    private final AtomicBoolean fenced;
+    /**
+     *  Monotonically increasing number. Keeps track of versions independent of external persistence or transaction mechanism.
+     */
+    private final AtomicLong version;
+
+    /**
+     * Buffer for reading and writting transaction data entries to underlying KV store.
+     * This allows lazy storing and avoiding unnecessary load for recently/frequently updated key value pairs.
+     */
+    @GuardedBy("lock")
+    private final ConcurrentHashMap<String, TransactionData> bufferedTxnData;
+
+    @Getter
+    @Setter
+    int maxCacheSize = MAX_ENTRIES_IN_TXN_BUFFER;
+
+    /**
+     * Constructs a BaseMetadataStore object.
+     */
+    public BaseMetadataStore() {
+        version = new AtomicLong(System.currentTimeMillis()); // Start with unique number.
+        fenced = new AtomicBoolean(false);
+        bufferedTxnData = new ConcurrentHashMap<>(); // Don't think we need anything fancy here. But we'll measure and see.
+    }
+
+    /**
+     * Begins a new transaction.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     * @return
+     *
+     */
+    @Override
+    public MetadataTransaction beginTransaction() throws StorageMetadataException {
+        return new MetadataTransaction(this);
+    }
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @param lazyWrite true if data can be written lazily.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    @Override
+    public void commit(MetadataTransaction txn, boolean lazyWrite) throws StorageMetadataException  {
+        commit(txn, lazyWrite, false);
+    }
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    @Override
+    public void commit(MetadataTransaction txn) throws StorageMetadataException {
+        commit(txn, false, false);
+    }
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @param lazyWrite true if data can be written lazily.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    @Override
+    public void commit(MetadataTransaction txn, boolean lazyWrite, boolean skipStoreCheck) throws StorageMetadataException  {
+        if (fenced.get()) {
+            throw new StorageMetadataWritesFencedOutException("Transaction writer is fenced off.");
+        }
+
+        Map<String, TransactionData> txnData = txn.getData();
+
+        ArrayList<String> modifiedKeys = new ArrayList<>();
+        ArrayList<TransactionData> modifiedValues = new ArrayList<>();
+
+        // Step 1 : If bufferedTxnData data was flushed, then read it back from external source and re-insert in bufferedTxnData cache.
+        // This step is kind of thread safe
+        for (Map.Entry<String, TransactionData> entry : txnData.entrySet()) {
+            String key = entry.getKey();
+            if (skipStoreCheck) {
+                log.debug("Skipping loading key from the store key = {}", key);
+            } else {
+                // This check is safe to be outside the lock
+                if (!bufferedTxnData.containsKey(key)) {
+
+                    // NOTE: This call to read MUST be outside the lock, it is most likely cause re-entry.
+                    log.debug("Loading key from the store key = {}", key);
+                    TransactionData fromDb = read(key);
+                    log.debug("Done Loading key from the store key = {}", key);
+                    if (null != fromDb) {
+                        // If some other transaction beat us then use that value.
+                        // If any transaction was committed after we checked then it must have latest value,
+                        // otherwise the bufferedTxnData will have same value. so ignore what was retrieved.
+                        synchronized (lock) {
+                            bufferedTxnData.putIfAbsent(key, fromDb);
+                        }
+                    }
+                }
+            }
+
+        }
+
+        // Step 2 : Check whether transaction is safe to commit.
+        // This check needs to be atomic, with absolutely no possibility of re-entry
+        synchronized (lock) {
+            for (Map.Entry<String, TransactionData> entry : txnData.entrySet()) {
+                String key = entry.getKey();
+                if (entry.getValue().isModified() || entry.getValue().isDeleted()) {
+                    modifiedKeys.add(key);
+                    modifiedValues.add(entry.getValue());
+                }
+                // make sure none of the keys used in this transaction have changed.
+                TransactionData globalData = bufferedTxnData.get(key);
+                if (bufferedTxnData.containsKey(key)) {
+                    //if (bufferedTxnData.get(key).isDeleted() && !txnData.get(key).isDeleted()) {
+                    if (bufferedTxnData.get(key).isDeleted()) {
+                        // allow create after delete.
+                        continue;
+                    }
+                    if (bufferedTxnData.get(key).getVersion() > txnData.get(key).getVersion()) {
+                        throw new StorageMetadataVersionMismatchException(
+                                String.format("Transaction uses stale data. Key version changed key:{} expected:{} actual:{}",
+                                        key, bufferedTxnData.get(key).getVersion(), txnData.get(key).getVersion()));
+                    }
+                }
+            }
+
+            // If we reach here then it means transaction is safe to commit.
+
+            // Step 3: Insert
+            long committedVersion = version.incrementAndGet();
+            HashMap<String, TransactionData> toAdd = new HashMap<String, TransactionData>();
+            for (String key : modifiedKeys) {
+                TransactionData data = txnData.get(key);
+                data.setVersion(committedVersion);
+                data.setPersisted(false);
+                toAdd.put(key, data);
+            }
+            bufferedTxnData.putAll(toAdd);
+        }
+
+        //  Step 4 : evict cache if required.
+        //if (bufferedTxnData.size() > maxCacheSize) {
+        //    bufferedTxnData.entrySet().removeIf(entry -> entry.getValue().isPersisted());
+        //}
+
+        // Step 4: Commit externally.
+        // This operation may call external storage which might end up in re-entrant call, so don't have any locks here.
+        if (!lazyWrite || (bufferedTxnData.size() > maxCacheSize)) {
+            log.debug("Persisting all modified keys");
+            writeAll(modifiedValues);
+            log.debug("Done persisting all modified keys");
+        }
+        // Mark written keys as persisted.
+        for (String key: modifiedKeys) {
+            TransactionData data = bufferedTxnData.get(key);
+            data.setPersisted(true);
+        }
+
+        //  Step 5 : evict cache if required.
+        if (bufferedTxnData.size() > maxCacheSize) {
+            bufferedTxnData.entrySet().removeIf(entry -> entry.getValue().isPersisted());
+        }
+
+        //  Step 6: finally clear
+        txnData.clear();
+    }
+
+    /**
+     * Aborts given transaction.
+     * @param txn transaction to abort.
+     * @throws StorageMetadataException If there are any errors.
+     */
+    public void abort(MetadataTransaction txn) throws StorageMetadataException  {
+    }
+
+    /**
+     * Retrieves the metadata for given key.
+     * @param txn Transaction.
+     * @param key key to use to retrieve metadata.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     * @return Metadata for given key.
+     */
+    @Override
+    public StorageMetadata get(MetadataTransaction txn, String key) throws StorageMetadataException  {
+        if (null != key) {
+            Map<String, TransactionData> txnData = txn.getData();
+            TransactionData data = null;
+
+            if (txnData.containsKey(key)) {
+                data = txnData.get(key);
+            } else {
+                TransactionData globalData = null;
+                synchronized (lock) {
+                    globalData = bufferedTxnData.get(key);
+                }
+                if (null != globalData) {
+                    data = globalData.toBuilder().value(globalData.getValue().copy()).build();
+                    txnData.put(key, data);
+                }
+            }
+
+            if (data != null) {
+                if (data.isDeleted()) {
+                    return null;
+                }
+                return data.getValue();
+            }
+
+            // NOTE: This call to read MUST be outside the lock, it is most likely cause re-entry.
+            TransactionData retValue = null;
+            try {
+                retValue = read(key);
+            } catch (StorageMetadataNotFoundException ex) {
+                log.debug("Key not found in store.");
+            }
+
+            if (null != retValue
+                && !retValue.isDeleted()
+                && null != retValue.getValue()) {
+                retValue.setVersion(version.get());
+
+                // Put this value in bufferedTxnData cache.
+                synchronized (lock) {
+                    TransactionData oldValue = bufferedTxnData.putIfAbsent(key, retValue);
+                    if (oldValue != null) {
+                        retValue = oldValue;
+                    }
+                }
+
+                // Also put this in transaction local view.
+                // Make copy so that bufferedTxnData data is not affected by update inside the transactions.
+                txnData.put(key, TransactionData.builder()
+                        .value(retValue.getValue())
+                        .dbObject(retValue.getDbObject())
+                        .version(retValue.getVersion())
+                        .modified(true)
+                        .build());
+                return retValue.getValue();
+            }
+        }
+        return null;
+    }
+
+    protected TransactionData read( String key) throws StorageMetadataException {
+        return null;
+    }
+
+    protected void writeAll(Collection<TransactionData> dataList) throws StorageMetadataException {
+    }
+
+    /**
+     * Updates existing metadata.
+     * @param txn Transaction.
+     * @param metadata metadata record.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    @Override
+    public void update(MetadataTransaction txn, StorageMetadata metadata) throws StorageMetadataException  {
+        if (metadata == null) {
+            return;
+        }
+        Map<String, TransactionData> txnData = txn.getData();
+        synchronized (lock) {
+            TransactionData data = bufferedTxnData.get(metadata.getKey());
+
+            txnData.put(metadata.getKey(), TransactionData.builder()
+                    .value(metadata)
+                    .dbObject(data == null ? null : data.getDbObject())
+                    .version(data == null ? 0 : data.getVersion())
+                    .modified(true)
+                    .isPersisted(false)
+                    .build());
+        }
+    }
+
+    /**
+     * Creates a new metadata record.
+     * @param txn Transaction.
+     * @param metadata  metadata record.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    @Override
+    public void create(MetadataTransaction txn, StorageMetadata metadata) throws StorageMetadataException  {
+        Map<String, TransactionData> txnData = txn.getData();
+        txnData.put(metadata.getKey(), TransactionData.builder().value(metadata).modified(true).build() );
+    }
+
+    /**
+     * Deletes a metadata record given the key.
+     * @param txn Transaction.
+     * @param key key to use to retrieve metadata.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    @Override
+    public void delete(MetadataTransaction txn, String key) throws StorageMetadataException {
+        Map<String, TransactionData> txnData = txn.getData();
+        TransactionData data;
+        if (txnData.containsKey(key)) {
+            data = txnData.get(key);
+            data.setDeleted(true);
+            data.setPersisted(false);
+        } else {
+            synchronized (lock) {
+                if (bufferedTxnData.containsKey(key)) {
+                    data = bufferedTxnData.get(key);
+                    txnData.put(key, TransactionData.builder()
+                            .value(data.getValue())
+                            .dbObject(data == null ? null : data.getDbObject())
+                            .version(data == null ? 0 : data.getVersion())
+                            .deleted(true)
+                            .modified(true)
+                            .isPersisted(false)
+                            .build());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        ArrayList<TransactionData> modifiedValues = new ArrayList<>();
+        bufferedTxnData.entrySet().stream().filter(entry -> !entry.getValue().isPersisted()).forEach(entry -> modifiedValues.add(entry.getValue()));
+        if (modifiedValues.size() > 0) {
+            writeAll(modifiedValues);
+        }
+    }
+
+    /**
+     * Marks the store as fenced.
+     */
+    public void markFenced() {
+        this.fenced.set(true);
+    }
+
+    /**
+     * Stores the transaction data.
+     */
+    @Builder(toBuilder = true)
+    @Data
+    public static class TransactionData {
+        private long version;
+        private Object dbObject;
+        private boolean deleted;
+        private boolean modified;
+        private boolean isPersisted;
+        private StorageMetadata value;
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents chunk metadata.
+ */
+@Builder(toBuilder = true)
+@Data
+public class ChunkMetadata implements StorageMetadata {
+    String name;
+    long length;
+    String nextChunk;
+
+    @Override
+    public String getKey() {
+        return name;
+    }
+
+    @Override
+    public StorageMetadata copy() {
+        return toBuilder().build();
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Storage Metadata store.
+ */
+public interface ChunkMetadataStore extends AutoCloseable {
+    /**
+     * Begins a new transaction.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     * @return
+     *
+     */
+    MetadataTransaction beginTransaction() throws StorageMetadataException;
+
+    /**
+     * Retrieves the metadata for given key.
+     * @param txn Transaction.
+     * @param key key to use to retrieve metadata.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     * @return
+     */
+    StorageMetadata get(MetadataTransaction txn, String key) throws StorageMetadataException;
+
+    /**
+     * Updates existing metadata.
+     * @param txn Transaction.
+     * @param metadata metadata record.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    void update(MetadataTransaction txn, StorageMetadata metadata) throws StorageMetadataException;
+
+    /**
+     * Creates a new metadata record.
+     * @param txn Transaction.
+     * @param metadata  metadata record.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    void create(MetadataTransaction txn, StorageMetadata metadata) throws StorageMetadataException;
+
+    /**
+     * Deletes a metadata record given the key.
+     * @param txn Transaction.
+     * @param key key to use to retrieve metadata.
+     * @throws StorageMetadataException Exception related to storage metadata operations.
+     */
+    void delete(MetadataTransaction txn, String key) throws StorageMetadataException;
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @param lazyWrite true if data can be written lazily.
+     * @param skipStoreCheck true if data is not to be reloaded from store.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    void commit(MetadataTransaction txn, boolean lazyWrite, boolean skipStoreCheck) throws StorageMetadataException;
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @param lazyWrite true if data can be written lazily.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    void commit(MetadataTransaction txn, boolean lazyWrite) throws StorageMetadataException;
+
+
+    /**
+     * Commits given transaction.
+     * @param txn transaction to commit.
+     * @throws StorageMetadataException StorageMetadataVersionMismatchException if transaction can not be commited.
+     */
+    void commit(MetadataTransaction txn) throws StorageMetadataException;
+
+    /**
+     * Aborts given transaction.
+     * @param txn transaction to abort.
+     * @throws StorageMetadataException If there are any errors.
+     */
+    void abort(MetadataTransaction txn) throws StorageMetadataException;
+
+    /**
+     * Fences the store.
+     */
+    void markFenced();
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/MetadataTransaction.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/MetadataTransaction.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.metadata;
+
+import com.google.common.base.Preconditions;
+
+import lombok.Getter;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implemenation of the MetadataTransaction.
+ * This implementation delegates all calls to underlying storage.
+ */
+public class MetadataTransaction implements AutoCloseable {
+    @Getter
+    UUID id;
+    ChunkMetadataStore store;
+    boolean isCommited = false;
+    @Getter
+    private final ConcurrentHashMap<String, BaseMetadataStore.TransactionData> data;
+
+    public MetadataTransaction(ChunkMetadataStore store)  {
+        id = UUID.randomUUID();
+        this.store = Preconditions.checkNotNull(store, "store");
+        data = new ConcurrentHashMap<String, BaseMetadataStore.TransactionData>();
+    }
+
+    /**
+     * Commits the transaction.
+     * @throws Exception If transaction could not be commited.
+     */
+    public void commit() throws Exception {
+        store.commit(this, false, false);
+        isCommited = true;
+    }
+
+
+    /**
+     * Commits the transaction.
+     * @param lazyWrite true if data can be written lazily.
+     * @throws Exception If transaction could not be commited.
+     */
+    public void commit(boolean lazyWrite) throws Exception {
+        store.commit(this, lazyWrite, false);
+        isCommited = true;
+    }
+
+    /**
+     * Commits the transaction.
+     * @param lazyWrite true if data can be written lazily.
+     * @param skipStoreCheck true if data is not to be reloaded from store.
+     * @throws Exception If transaction could not be commited.
+     */
+    public void commit(boolean lazyWrite, boolean skipStoreCheck) throws Exception {
+        store.commit(this, lazyWrite, skipStoreCheck);
+        isCommited = true;
+    }
+
+    /**
+     * Aborts the transaction.
+     * @throws Exception If transaction could not be commited.
+     */
+    public void abort() throws Exception {
+        store.abort(this);
+    }
+
+    public void close() throws Exception {
+        if (!isCommited) {
+            store.abort(this);
+        }
+    }
+}
+

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+import com.google.common.base.Preconditions;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class SegmentMetadata implements StorageMetadata {
+    public static final int ACTIVE  = 0x0001;
+    public static final int SEALED  = 0x0002;
+    public static final int DELETED = 0x0004;
+    public static final int OWNERSHIP_CHANGED = 0x0008;
+
+    String name;
+
+    long length;
+
+    long startOffset;
+
+    int status;
+
+    long maxRollinglength;
+
+    String firstChunk;
+
+    String lastChunk;
+
+    long lastModified;
+
+    long firstChunkStartOffset;
+
+    long lastChunkStartOffset;
+
+    long ownerEpoch;
+
+    @Override
+    public String getKey() {
+        return name;
+    }
+
+    @Override
+    public StorageMetadata copy() {
+        return toBuilder().build();
+    }
+
+    public SegmentMetadata setActive(boolean value) {
+        return setFlag(ACTIVE, value);
+    }
+
+    public SegmentMetadata setSealed(boolean value) {
+        return setFlag(SEALED, value);
+    }
+
+    public SegmentMetadata setOwnershipChanged(boolean value) {
+        return setFlag(OWNERSHIP_CHANGED, value);
+    }
+
+    public boolean isActive() {
+        return getFlag(ACTIVE);
+    }
+
+    public boolean isSealed() {
+        return getFlag(SEALED);
+    }
+
+    public boolean isOwnershipChanged() {
+        return getFlag(OWNERSHIP_CHANGED);
+    }
+
+    public void checkInvariants() {
+        Preconditions.checkState(length >= 0);
+        Preconditions.checkState(startOffset >= 0);
+        Preconditions.checkState(firstChunkStartOffset >= 0);
+        Preconditions.checkState(lastChunkStartOffset >= 0);
+        Preconditions.checkState(firstChunkStartOffset <= startOffset);
+        Preconditions.checkState(length >= lastChunkStartOffset);
+        Preconditions.checkState(firstChunkStartOffset <= lastChunkStartOffset);
+    }
+
+    private SegmentMetadata setFlag(int mask, boolean value) {
+        status = value ? (status | mask ) : (status & (~mask));
+        return this;
+    }
+
+    private boolean getFlag(int mask) {
+        return (status & mask) != 0;
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadata.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+import java.io.Serializable;
+
+/**
+ * Storage Metadata.
+ */
+public interface StorageMetadata extends Serializable {
+
+    /**
+     * Retrieves the key associated with the metadata.
+     * @return key.
+     */
+    String getKey();
+
+    StorageMetadata copy();
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataAlreadyExistsException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataAlreadyExistsException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Exception thrown when storage metadata with given key already exists.
+ */
+public class StorageMetadataAlreadyExistsException extends StorageMetadataException {
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     */
+    public StorageMetadataAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     * @param cause   The causing exception.
+     */
+    public StorageMetadataAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Exception related to storage metadata operations.
+ */
+public class StorageMetadataException extends Exception {
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     */
+    public StorageMetadataException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     * @param cause   The causing exception.
+     */
+    public StorageMetadataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataNotFoundException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataNotFoundException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Exception thrown when storage metadata with given key does not exist.
+ */
+public class StorageMetadataNotFoundException extends StorageMetadataException {
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     */
+    public StorageMetadataNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     * @param cause   The causing exception.
+     */
+    public StorageMetadataNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataVersionMismatchException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataVersionMismatchException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Exception thrown when there is version mismatch.
+ */
+public class StorageMetadataVersionMismatchException extends StorageMetadataException {
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     */
+    public StorageMetadataVersionMismatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     * @param cause   The causing exception.
+     */
+    public StorageMetadataVersionMismatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataWritesFencedOutException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataWritesFencedOutException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+/**
+ * Exception thrown when current instance is write fenced out.
+ */
+public class StorageMetadataWritesFencedOutException extends StorageMetadataException {
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     */
+    public StorageMetadataWritesFencedOutException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     * @param message The message for this exception.
+     * @param cause   The causing exception.
+     */
+    public StorageMetadataWritesFencedOutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.util.ArrayView;
+import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
+import io.pravega.segmentstore.contracts.tables.TableEntry;
+import io.pravega.segmentstore.contracts.tables.TableKey;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public class TableBasedMetadataStore extends BaseMetadataStore {
+    TableStore tableStore;
+    String tableName;
+    Duration timeout = Duration.ofSeconds(1L);
+    AtomicBoolean isTableInitialized = new AtomicBoolean(false);
+
+    public TableBasedMetadataStore(String tableName, TableStore tableStore) {
+        this.tableStore = Preconditions.checkNotNull(tableStore, "tableStore");
+        this.tableName = Preconditions.checkNotNull(tableName, "tableName");
+    }
+
+    @Override
+    protected TransactionData read( String key) throws StorageMetadataException {
+        ensureInitialized();
+        List<ArrayView> keys = new ArrayList<>();
+        keys.add(new ByteArraySegment(key.getBytes()));
+        try {
+            List<TableEntry> retValue = this.tableStore.get(tableName, keys, timeout).get();
+            if (retValue.size() == 1) {
+                TableEntry entry = retValue.get(0);
+                if (null != entry) {
+                    val arr = entry.getValue();
+                    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(arr.array(), arr.arrayOffset(), arr.getLength()));
+                    StorageMetadata metadata = (StorageMetadata) input.readObject();
+                    TransactionData txnData = TransactionData.builder()
+                            .value(metadata)
+                            .dbObject(entry.getKey().getVersion())
+                            .deleted(false)
+                            .modified(false)
+                            .build();
+                    return txnData;
+                }
+            }
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new StorageMetadataException("Error while reading", e);
+        }
+        return null;
+    }
+
+    @Override
+    protected void writeAll(Collection<TransactionData> dataList) throws StorageMetadataException {
+        ensureInitialized();
+        List<TableEntry> toUpdate = new ArrayList<>();
+        HashMap<TableEntry, TransactionData> map = new HashMap<TableEntry, TransactionData>();
+        List<TableKey> keysToDelete = new ArrayList<>();
+        try {
+            for (TransactionData txnData : dataList) {
+                StorageMetadata metadata = txnData.getValue();
+                long version = TableKey.NOT_EXISTS;
+                if (null != txnData.getDbObject()) {
+                    version = ((Long) txnData.getDbObject()).longValue();
+                }
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream out = new ObjectOutputStream(bos);
+
+                if (txnData.isDeleted()) {
+                    keysToDelete.add(TableKey.versioned(new ByteArraySegment(metadata.getKey().getBytes()),
+                            TableKey.NO_VERSION)); //version));
+                    out.writeObject(null);
+                } else {
+                    out.writeObject(metadata);
+                }
+
+                out.flush();
+                val bytes = bos.toByteArray();
+
+                TableEntry tableEntry = TableEntry.versioned(
+                        new ByteArraySegment(metadata.getKey().getBytes()),
+                        new ByteArraySegment(bytes),
+                        version);
+                map.put(tableEntry, txnData);
+                toUpdate.add(tableEntry);
+            }
+
+            // Now put uploaded keys.
+            List<Long> ret = this.tableStore.put(tableName, toUpdate, timeout).get();
+
+            // Delete deleted keys.
+            int i = 0;
+            for (TableEntry tableEntry : toUpdate) {
+                map.get(tableEntry).setDbObject(ret.get(i));
+                i++;
+            }
+            this.tableStore.remove(tableName, keysToDelete, timeout).get();
+        } catch (RuntimeException e) {
+            throw e; // To make spotbugs happy.
+        } catch (java.util.concurrent.ExecutionException e) {
+            handleException(e.getCause());
+            return;
+        } catch (Exception e) {
+            handleException(e);
+            return;
+        }
+
+    }
+
+    private void handleException(Throwable e) throws StorageMetadataException {
+        if (e instanceof DataLogWriterNotPrimaryException) {
+            throw new StorageMetadataWritesFencedOutException("Transaction failed. Writer fenced off", e);
+        }
+        if (e instanceof BadKeyVersionException) {
+            throw new StorageMetadataVersionMismatchException("Transaction failed. Version Mismatch.", e);
+        }
+        if (e.getCause() != null) {
+            if (e.getCause().getCause() instanceof BadKeyVersionException) {
+                throw new StorageMetadataWritesFencedOutException("Transaction writer is fenced off.", e);
+            }
+            if (e.getCause().getCause() instanceof DataLogWriterNotPrimaryException) {
+                throw new StorageMetadataVersionMismatchException("Transaction failed. Writer fenced off", e);
+            }
+        } else {
+            log.debug("e.getCause()=null", e);
+        }
+        throw new StorageMetadataException("Transaction failed", e);
+    }
+
+    private void ensureInitialized() {
+        if (!isTableInitialized.get()) {
+            try {
+                this.tableStore.createSegment(tableName, timeout).join();
+                log.info("Created table segment {}", tableName);
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof StreamSegmentExistsException) {
+                    log.info("Table segment {} already exists.", tableName);
+                }
+            }
+            isTableInitialized.set(true);
+        }
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/AbstractInMemoryChunkStorageProvider.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/AbstractInMemoryChunkStorageProvider.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import io.pravega.segmentstore.storage.chunklayer.BaseChunkStorageProvider;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.concurrent.Executor;
+
+/**
+ * Base class for InMemory mock implementations.
+ * Allows to simulate ChunkStorageProvider with different supported properties.
+ */
+abstract public class AbstractInMemoryChunkStorageProvider extends BaseChunkStorageProvider {
+    @Getter
+    @Setter
+    boolean shouldSupportTruncation = false;
+
+    @Getter
+    @Setter
+    boolean shouldSupportAppend = true;
+
+    @Getter
+    @Setter
+    boolean shouldSupportConcat = false;
+
+    public AbstractInMemoryChunkStorageProvider(Executor executor) {
+        super(executor);
+    }
+
+
+    @Override
+    public boolean supportsTruncation() {
+        return shouldSupportTruncation;
+    }
+
+    @Override
+    public boolean supportsAppend() {
+        return shouldSupportAppend;
+    }
+
+    @Override
+    public boolean supportsConcat() {
+        return shouldSupportConcat;
+    }
+
+    abstract public void addChunk(String chunkName, long length);
+
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryChunkStorageProvider.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryChunkStorageProvider.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+/**
+ * In-Memory mock for ChunkStorageProvider. Contents is destroyed when object is garbage collected.
+ */
+public class InMemoryChunkStorageProvider extends AbstractInMemoryChunkStorageProvider {
+    ConcurrentHashMap<String, InMemoryChunk> chunks = new ConcurrentHashMap<String, InMemoryChunk>();
+
+    //region Members
+    public InMemoryChunkStorageProvider(Executor executor) {
+        super(executor);
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException {
+        Preconditions.checkNotNull(chunkName);
+        InMemoryChunk chunk = chunks.get(chunkName);
+        if (null == chunk) {
+            throw new FileNotFoundException(chunkName);
+        }
+        return ChunkInfo.builder()
+                .length(chunk.getLength())
+                .name(chunkName)
+                .build();
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException {
+        Preconditions.checkNotNull(chunkName);
+        if (null != chunks.putIfAbsent(chunkName, new InMemoryChunk(chunkName))) {
+            throw new FileAlreadyExistsException(chunkName);
+        }
+        return new ChunkHandle(chunkName, false);
+    }
+
+    @Override
+    protected boolean doesExist(String chunkName) throws IOException, IllegalArgumentException {
+        return chunks.containsKey(chunkName);
+    }
+
+    @Override
+    protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException {
+        chunks.remove(handle.getChunkName());
+        return true;
+    }
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException {
+        if (chunks.containsKey(chunkName)) {
+            return new ChunkHandle(chunkName, true);
+        }
+        throw new FileNotFoundException(chunkName);
+    }
+
+    @Override
+    protected ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException {
+        if (chunks.containsKey(chunkName)) {
+            return new ChunkHandle(chunkName, false);
+        }
+        throw new FileNotFoundException(chunkName);
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        InMemoryChunk chunk = getInMemoryChunk(handle);
+        if (fromOffset >=  chunk.getLength()) {
+            throw new IOException("Attempt to read at wrong offset");
+        }
+        if (length == 0) {
+            throw new IOException("Attempt to read 0 bytes");
+        }
+
+        // This is implemented this way to simulate possibility of partial read.
+        InMemoryChunkData matchingData = null;
+
+        // TODO : This is OK for now. This is just test code, but need binary search here.
+        for (InMemoryChunkData data : chunk.inMemoryChunkDataList) {
+            if ( data.start <= fromOffset && data.start + data.length > fromOffset) {
+                matchingData = data;
+                break;
+
+            }
+        }
+
+        if (null != matchingData) {
+            int startIndex = (int) (fromOffset - matchingData.start);
+            byte[] source = matchingData.getData();
+            int i;
+            for (i = 0; i < length && bufferOffset + i < buffer.length && startIndex + i < source.length; i++) {
+                buffer[bufferOffset + i] = source[startIndex + i];
+            }
+            return i;
+        }
+        throw new IOException("No data was read");
+    }
+
+    @Override
+    protected int  doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IndexOutOfBoundsException, IOException {
+        InMemoryChunk chunk = getInMemoryChunk(handle);
+        long oldLength = chunk.getLength();
+        if (offset !=  chunk.getLength()) {
+            throw new IndexOutOfBoundsException("Attempt to write at wrong offset");
+        }
+        if (length == 0) {
+            throw new IndexOutOfBoundsException("Attempt to write 0 bytes");
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(length);
+        byte[] bytes = new byte[length];
+        int totalBytesRead = 0;
+        int bytesRead = 0;
+        while ((bytesRead = data.read(bytes)) != -1) {
+            out.write(bytes, totalBytesRead, bytesRead);
+            totalBytesRead += bytesRead;
+        }
+        Preconditions.checkState(length == totalBytesRead);
+
+        byte[] writtenBytes = out.toByteArray();
+        Preconditions.checkState(writtenBytes.length == totalBytesRead);
+        chunk.append(writtenBytes);
+        Preconditions.checkState(oldLength + totalBytesRead == chunk.getLength());
+        return totalBytesRead;
+    }
+
+    private InMemoryChunk getInMemoryChunk(ChunkHandle handle) throws FileNotFoundException {
+        String chunkName = handle.getChunkName();
+        InMemoryChunk retValue = chunks.get(chunkName);
+        if (null == retValue) {
+            throw new FileNotFoundException(handle.getChunkName());
+        }
+        return retValue;
+    }
+
+    @Override
+    protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        InMemoryChunk targetChunk = getInMemoryChunk(target);
+        synchronized (targetChunk) {
+            for (ChunkHandle source : sources) {
+                InMemoryChunk chunk = getInMemoryChunk(source);
+                for (InMemoryChunkData inMemoryChunkData : chunk.getInMemoryChunkDataList()) {
+                    targetChunk.append(inMemoryChunkData.getData());
+                }
+                delete(source);
+            }
+            return 0;
+        }
+    }
+
+    @Override
+    protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        return false;
+    }
+
+    @Override
+    protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException {
+        InMemoryChunk chunk = getInMemoryChunk(handle);
+        chunk.setReadOnly(isReadOnly);
+        return true;
+    }
+
+    @Override
+    public void addChunk(String chunkName, long length) {
+        InMemoryChunk inMemoryChunk = new InMemoryChunk(chunkName);
+        inMemoryChunk.append(new byte[Math.toIntExact(length)]);
+        chunks.put(chunkName, inMemoryChunk);
+    }
+
+    /**
+     * In memory chunk.
+     */
+    static class InMemoryChunk {
+        @Getter
+        @Setter
+        long length;
+
+        @Getter
+        @Setter
+        String name;
+
+        @Getter
+        @Setter
+        boolean isReadOnly;
+
+        @Getter
+        List<InMemoryChunkData> inMemoryChunkDataList = new ArrayList<>();
+
+        public InMemoryChunk(String name) {
+            this.name = name;
+        }
+
+        public void append(byte[] data) {
+            synchronized (inMemoryChunkDataList) {
+                inMemoryChunkDataList.add(InMemoryChunkData.builder()
+                        .data(data)
+                        .length(data.length)
+                        .start(length)
+                        .build());
+                length += data.length;
+            }
+        }
+    }
+
+    /**
+     * Stores the actual chunk data.
+     */
+    @Builder
+    static class InMemoryChunkData {
+        @Getter
+        @Setter
+        long start;
+
+        @Getter
+        @Setter
+        long length;
+
+        @Getter
+        @Setter
+        byte[] data;
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.mocks;
+
+import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
+import io.pravega.segmentstore.storage.metadata.StorageMetadataException;
+import lombok.val;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * InMemoryMetadataStore stores the key-values in memory.
+ */
+public class InMemoryMetadataStore extends BaseMetadataStore {
+
+    /**
+     * Write through cache.
+     */
+    private final Map<String, TransactionData> backingStore = new ConcurrentHashMap<>();
+
+    protected TransactionData read( String key) throws StorageMetadataException {
+        return backingStore.get(key);
+    }
+
+    protected void writeAll(Collection<TransactionData> dataList) throws StorageMetadataException {
+        for (TransactionData data : dataList) {
+            backingStore.put(data.getValue().getKey(), data);
+        }
+    }
+
+    public static InMemoryMetadataStore clone(InMemoryMetadataStore original) {
+        InMemoryMetadataStore cloneStore = new InMemoryMetadataStore();
+        for (val entry : original.backingStore.entrySet()) {
+            cloneStore.backingStore.put(entry.getKey(),
+                    entry.getValue().toBuilder().value(entry.getValue().getValue().copy()).build());
+        }
+        return cloneStore;
+    }
+}
+

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactory.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManager;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * In-Memory mock for StorageFactory. Contents is destroyed when object is garbage collected.
+ */
+public class InMemorySimpleStorageFactory implements StorageFactory, AutoCloseable {
+    @VisibleForTesting
+    protected ScheduledExecutorService executor;
+
+    private Storage singletonStorage;
+    private ChunkStorageProvider singletonChunkStorageProvider;
+    private boolean reuseStorage;
+    public InMemorySimpleStorageFactory(ScheduledExecutorService executor) {
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+    }
+
+    public InMemorySimpleStorageFactory() {
+    }
+
+    public InMemorySimpleStorageFactory(ScheduledExecutorService executor, boolean reuseStorage) {
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+        this.reuseStorage = reuseStorage;
+    }
+
+    public InMemorySimpleStorageFactory(ScheduledExecutorService executor, Storage storage) {
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+        this.singletonStorage = Preconditions.checkNotNull(storage, "Storage");
+        this.reuseStorage = true;
+    }
+
+    public InMemorySimpleStorageFactory(ScheduledExecutorService executor, ChunkStorageProvider chunkStorageProvider) {
+        this.executor = Preconditions.checkNotNull(executor, "executor");
+        this.singletonChunkStorageProvider = Preconditions.checkNotNull(chunkStorageProvider, "chunkStorageProvider");
+        this.reuseStorage = false;
+    }
+
+    @Override
+    public Storage createStorageAdapter() {
+        synchronized (this) {
+            if (reuseStorage) {
+                if (null != singletonStorage) {
+                    return singletonStorage;
+                }
+                singletonStorage = getStorage();
+                return singletonStorage;
+            }
+            return getStorage();
+        }
+    }
+
+    private Storage getStorage() {
+        if (null == singletonChunkStorageProvider) {
+            return newStorage(executor);
+        } else {
+            return newStorage(executor, singletonChunkStorageProvider);
+        }
+    }
+
+    @Override
+    public void close() {
+        // ?
+    }
+
+    /**
+     * Creates a new InMemory Storage, without a rolling wrapper.
+     *
+     * @param executor An Executor to use for async operations.
+     * @return A new InMemoryStorage.
+     */
+    @VisibleForTesting
+    public static Storage newStorage(Executor executor) {
+        return newStorage(executor,  new InMemoryChunkStorageProvider(executor));
+    }
+
+    /**
+     * Creates a new InMemory Storage, without a rolling wrapper.
+     *
+     * @param executor An Executor to use for async operations.
+     * @param chunkStorageProvider  ChunkStorageProvider to use.
+     * @return A new InMemoryStorage.
+     */
+    @VisibleForTesting
+    public static Storage newStorage(Executor executor, ChunkStorageProvider chunkStorageProvider) {
+        //TableStore tableStore = new InMemoryTableStore(executor);
+        //tableStore.createSegment("InMemoryStorageFactory", null).join();
+        ChunkStorageManager chunkStorageManager = new ChunkStorageManager(
+                chunkStorageProvider,
+                //new TableBasedMetadataStore("InMemoryStorageFactory", tableStore),
+                executor,
+                SegmentRollingPolicy.NO_ROLLING);
+        chunkStorageManager.initialize(1);
+        return chunkStorageManager;
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactoryCreator.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import io.pravega.segmentstore.storage.ConfigSetup;
+import io.pravega.segmentstore.storage.StorageFactory;
+import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+import lombok.val;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public class InMemorySimpleStorageFactoryCreator implements StorageFactoryCreator {
+
+    @Override
+    public StorageFactory createFactory(ConfigSetup setup, ScheduledExecutorService executor) {
+        val factory = new InMemorySimpleStorageFactory(executor, true);
+        return factory;
+    }
+
+    @Override
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("INMEMORY")
+                .chunkManagerSupported(true)
+                .legacyLayoutSupported(false)
+                .build();
+    }
+
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
@@ -12,6 +12,8 @@ package io.pravega.segmentstore.storage.mocks;
 import io.pravega.segmentstore.storage.ConfigSetup;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
+import io.pravega.segmentstore.storage.StorageFactoryInfo;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 public class InMemoryStorageFactoryCreator implements StorageFactoryCreator {
@@ -23,8 +25,12 @@ public class InMemoryStorageFactoryCreator implements StorageFactoryCreator {
     }
 
     @Override
-    public String getName() {
-        return "INMEMORY";
+    public StorageFactoryInfo getStorageFactoryInfo() {
+        return StorageFactoryInfo.builder()
+                .name("INMEMORY")
+                .chunkManagerSupported(false)
+                .legacyLayoutSupported(true)
+                .build();
     }
 
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryTableStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryTableStore.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import io.pravega.common.Exceptions;
+import io.pravega.common.util.ArrayView;
+import io.pravega.common.util.AsyncIterator;
+import io.pravega.common.util.ByteArraySegment;
+import io.pravega.common.util.HashedArray;
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
+import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
+import io.pravega.segmentstore.contracts.tables.IteratorItem;
+import io.pravega.segmentstore.contracts.tables.KeyNotExistsException;
+import io.pravega.segmentstore.contracts.tables.TableEntry;
+import io.pravega.segmentstore.contracts.tables.TableKey;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.val;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@ThreadSafe
+public class InMemoryTableStore  implements TableStore {
+
+    private static final AtomicReference<InMemoryTableStore> SINGLETON = new AtomicReference<InMemoryTableStore>();
+
+    @GuardedBy("tables")
+    private final HashMap<String, TableData> tables = new HashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    @NonNull
+    private final Executor executor;
+
+    public static synchronized InMemoryTableStore getSINGLETON(Executor executor) {
+        SINGLETON.compareAndSet(null, new InMemoryTableStore(executor));
+        return SINGLETON.get();
+    }
+    //region TableStore Implementation
+
+    @Override
+    public CompletableFuture<Void> createSegment(String segmentName, Duration timeout) {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        return CompletableFuture.runAsync(() -> {
+            synchronized (this.tables) {
+                if (this.tables.containsKey(segmentName)) {
+                    throw new CompletionException(new StreamSegmentExistsException(segmentName));
+                }
+
+                this.tables.put(segmentName, new TableData(segmentName));
+            }
+        }, this.executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteSegment(String segmentName, boolean mustBeEmpty, Duration timeout) {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        return CompletableFuture.runAsync(() -> {
+            synchronized (this.tables) {
+                if (this.tables.remove(segmentName) == null) {
+                    throw new CompletionException(new StreamSegmentNotExistsException(segmentName));
+                }
+            }
+        }, this.executor);
+    }
+
+    @Override
+    public CompletableFuture<List<Long>> put(String segmentName, List<TableEntry> entries, Duration timeout) {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        return CompletableFuture.supplyAsync(() -> getTableData(segmentName).put(entries), this.executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> remove(String segmentName, Collection<TableKey> keys, Duration timeout) {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        return CompletableFuture.runAsync(() -> getTableData(segmentName).remove(keys), this.executor);
+    }
+
+    @Override
+    public CompletableFuture<List<TableEntry>> get(String segmentName, List<ArrayView> keys, Duration timeout) {
+        Exceptions.checkNotClosed(this.closed.get(), this);
+        return CompletableFuture.supplyAsync(() -> getTableData(segmentName).get(keys), this.executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> merge(String targetSegmentName, String sourceSegmentName, Duration timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Void> seal(String segmentName, Duration timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<AsyncIterator<IteratorItem<TableKey>>> keyIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<AsyncIterator<IteratorItem<TableEntry>>> entryIterator(String segmentName, byte[] serializedState, Duration fetchTimeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @SneakyThrows(StreamSegmentNotExistsException.class)
+    private TableData getTableData(String segmentName) {
+        synchronized (this.tables) {
+            TableData result = this.tables.get(segmentName);
+            if (result == null) {
+                throw new StreamSegmentNotExistsException(segmentName);
+            }
+            return result;
+        }
+    }
+
+    //endregion
+
+    //region TableData
+
+    @ThreadSafe
+    @RequiredArgsConstructor
+    private static class TableData {
+        private final AtomicLong nextVersion = new AtomicLong();
+        @GuardedBy("this")
+        private final HashMap<HashedArray, TableEntry> entries = new HashMap<>();
+        private final String segmentName;
+
+        synchronized List<Long> put(List<TableEntry> entries) {
+            validateKeys(entries, TableEntry::getKey);
+            return entries
+                    .stream()
+                    .map(e -> {
+                        long version = this.nextVersion.incrementAndGet();
+                        val key = new HashedArray(e.getKey().getKey().getCopy());
+                        this.entries.put(key,
+                                TableEntry.versioned(key, new ByteArraySegment(e.getValue().getCopy()), version));
+                        return version;
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        synchronized void remove(Collection<TableKey> keys) {
+            validateKeys(keys, k -> k);
+            keys.forEach(k -> this.entries.remove(new HashedArray(k.getKey())));
+        }
+
+        synchronized List<TableEntry> get(List<ArrayView> keys) {
+            return keys.stream().map(k -> this.entries.get(new HashedArray(k))).collect(Collectors.toList());
+        }
+
+        @GuardedBy("this")
+        private <T> void validateKeys(Collection<T> items, Function<T, TableKey> getKey) {
+            items.stream()
+                    .map(getKey)
+                    .filter(TableKey::hasVersion)
+                    .forEach(k -> {
+                        TableEntry e = this.entries.get(new HashedArray(k.getKey()));
+                        if (e == null) {
+                            if (k.getVersion() != TableKey.NOT_EXISTS) {
+                                throw new CompletionException(new KeyNotExistsException(this.segmentName, k.getKey()));
+                            }
+                        } else if (k.getVersion() != e.getKey().getVersion()) {
+                            throw new CompletionException(new BadKeyVersionException(this.segmentName, Collections.emptyMap()));
+                        }
+                    });
+        }
+    }
+
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/noop/NoOpChunkStorageProvider.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/noop/NoOpChunkStorageProvider.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.noop;
+
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.chunklayer.ChunkHandle;
+import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
+import io.pravega.segmentstore.storage.mocks.AbstractInMemoryChunkStorageProvider;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.val;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+/*
+ NoOp implementation.
+ */
+public class NoOpChunkStorageProvider extends AbstractInMemoryChunkStorageProvider {
+    @Getter
+    @Setter
+    ConcurrentHashMap<String, ChunkData> chunkMetadata = new ConcurrentHashMap<>();
+
+
+    public NoOpChunkStorageProvider(Executor executor) {
+        super(executor);
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws IOException, IllegalArgumentException {
+        ChunkData chunkData = chunkMetadata.get(chunkName);
+        if (null == chunkData) {
+            throw new FileNotFoundException(chunkName);
+        }
+        return ChunkInfo.builder().name(chunkName).length(chunkData.length).build();
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws IOException, IllegalArgumentException {
+        ChunkData chunkData = chunkMetadata.get(chunkName);
+        if (null != chunkData) {
+            throw new FileAlreadyExistsException(chunkName);
+        }
+        chunkMetadata.put(chunkName, new ChunkData());
+        return ChunkHandle.writeHandle(chunkName);
+    }
+
+    @Override
+    protected boolean doesExist(String chunkName) throws IOException, IllegalArgumentException {
+        return chunkMetadata.containsKey(chunkName);
+    }
+
+    @Override
+    protected boolean doDelete(ChunkHandle handle) throws IOException, IllegalArgumentException {
+        Preconditions.checkNotNull(null != handle, "handle");
+        Preconditions.checkNotNull(handle.getChunkName(), "handle");
+        chunkMetadata.remove(handle.getChunkName());
+        return true;
+    }
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws IOException, IllegalArgumentException {
+        ChunkData chunkData = chunkMetadata.get(chunkName);
+        if (null == chunkData) {
+            throw new FileNotFoundException(chunkName);
+        }
+        return ChunkHandle.readHandle(chunkName);
+    }
+
+    @Override
+    protected ChunkHandle doOpenWrite(String chunkName) throws IOException, IllegalArgumentException {
+        ChunkData chunkData = chunkMetadata.get(chunkName);
+        if (null == chunkData) {
+            throw new FileNotFoundException(chunkName);
+        }
+        return ChunkHandle.writeHandle(chunkName);
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws IOException, NullPointerException, IndexOutOfBoundsException {
+        // TODO: Add validation
+        ChunkData chunkData = chunkMetadata.get(handle.getChunkName());
+        if (null == chunkData) {
+            throw new FileNotFoundException(handle.getChunkName());
+        }
+
+        if (fromOffset >= chunkData.length || fromOffset + length > chunkData.length) {
+            throw new IndexOutOfBoundsException("fromOffset");
+        }
+
+        if (fromOffset < 0 || bufferOffset < 0 || length < 0 || buffer.length < bufferOffset + length) {
+            throw new ArrayIndexOutOfBoundsException(String.format(
+                    "Offset (%s) must be non-negative, and bufferOffset (%s) and length (%s) must be valid indices into buffer of size %s.",
+                    fromOffset, bufferOffset, length, buffer.length));
+        }
+
+        return length;
+    }
+
+    @Override
+    protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws IOException, IndexOutOfBoundsException {
+        // TODO: Add validation
+        ChunkData chunkData = chunkMetadata.get(handle.getChunkName());
+        if (null == chunkData) {
+            throw new FileNotFoundException(handle.getChunkName());
+        }
+        if (offset != chunkData.length) {
+            throw new IndexOutOfBoundsException("");
+        }
+        chunkData.length = offset + length;
+        chunkMetadata.put(handle.getChunkName(), chunkData);
+        return length;
+    }
+
+    @Override
+    protected int doConcat(ChunkHandle target, ChunkHandle... sources) throws IOException, UnsupportedOperationException {
+        int total = 0;
+        val targetChunkData = chunkMetadata.get(target.getChunkName());
+        for (ChunkHandle chunkHandle : sources) {
+            val chunkData = chunkMetadata.get(chunkHandle.getChunkName());
+            total += chunkData.length;
+            chunkMetadata.remove(chunkHandle.getChunkName());
+        }
+        targetChunkData.length += total;
+        return total;
+    }
+
+    @Override
+    protected boolean doTruncate(ChunkHandle handle, long offset) throws IOException, UnsupportedOperationException {
+        return false;
+    }
+
+    @Override
+    protected boolean doSetReadonly(ChunkHandle handle, boolean isReadOnly) throws IOException, UnsupportedOperationException {
+        Preconditions.checkNotNull(null != handle, "handle");
+        Preconditions.checkNotNull(handle.getChunkName(), "handle");
+        String chunkName = handle.getChunkName();
+        ChunkData chunkData = chunkMetadata.get(handle.getChunkName());
+        if (null == chunkData) {
+            throw new FileNotFoundException(chunkName);
+        }
+        chunkData.isReadonly = isReadOnly;
+        return false;
+    }
+
+    @Override
+    public void addChunk(String chunkName, long length) {
+        ChunkData chunkData = new ChunkData();
+        chunkData.length = length;
+        chunkMetadata.put(chunkName, chunkData);
+    }
+
+    /**
+     * Stores the chunk data.
+     */
+    public static class ChunkData {
+        public long length;
+        public boolean isReadonly;
+    }
+}

--- a/segmentstore/storage/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
+++ b/segmentstore/storage/src/main/resources/META-INF/services/io.pravega.segmentstore.storage.StorageFactoryCreator
@@ -12,3 +12,4 @@
 # for more reference.
 
 io.pravega.segmentstore.storage.mocks.InMemoryStorageFactoryCreator
+io.pravega.segmentstore.storage.mocks.InMemorySimpleStorageFactoryCreator

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkManagerRollingTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkManagerRollingTests.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorageProvider;
+import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
+import io.pravega.segmentstore.storage.rolling.RollingStorageTestBase;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for  {@link ChunkStorageManager} and {@link ChunkStorageProvider} based implementation that exercise scenarios
+ * for {@link io.pravega.segmentstore.storage.rolling.RollingStorage}.
+ */
+public abstract class ChunkManagerRollingTests extends RollingStorageTestBase {
+    ChunkStorageProvider chunkStorageProvider;
+    ChunkMetadataStore chunkMetadataStore;
+
+    /**
+     * Creates a new instance of the Storage implementation to be tested. This will be cleaned up (via close()) upon
+     * test termination.
+     */
+    @Override
+    protected Storage createStorage() throws Exception {
+        useOldLayout = false;
+        Executor executor = executorService();
+        // Initialize
+        synchronized (ChunkManagerRollingTests.class) {
+            if (null == chunkStorageProvider) {
+                chunkMetadataStore = getMetadataStore();
+                chunkStorageProvider = getChunkStorage(executor);
+            }
+        }
+        return new ChunkStorageManager(chunkStorageProvider,
+                chunkMetadataStore,
+                executor,
+                SegmentRollingPolicy.NO_ROLLING);
+    }
+
+    /**
+     * Creates a ChunkStorageProvider.
+     * @param executor Storage executor to use.
+     * @return ChunkStorageProvider.
+     * @throws Exception If any unexpected error occurred.
+     */
+    protected ChunkStorageProvider getChunkStorage(Executor executor) throws Exception {
+        return new InMemoryChunkStorageProvider(executor);
+    }
+
+    /**
+     * Creates a ChunkMetadataStore.
+     * @return ChunkMetadataStore
+     * @throws Exception If any unexpected error occurred.
+     */
+    protected ChunkMetadataStore getMetadataStore()  throws Exception {
+        return new InMemoryMetadataStore();
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageManagerTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageManagerTests.java
@@ -1,0 +1,850 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
+import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
+import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
+import io.pravega.segmentstore.storage.mocks.AbstractInMemoryChunkStorageProvider;
+import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
+import io.pravega.segmentstore.storage.noop.NoOpChunkStorageProvider;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for {@link ChunkStorageManager}.
+ * The focus is on testing the ChunkStorageManager implementation itself very thoroughly.
+ * It uses either {@link NoOpChunkStorageProvider} as {@link ChunkStorageProvider}.
+ */
+@Slf4j
+public class ChunkStorageManagerTests extends ThreadPooledTestSuite {
+    protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+    }
+
+    @After
+    public void after() throws Exception {
+        super.after();
+    }
+
+    public ChunkStorageProvider getChunkStorageProvider() throws Exception {
+        return new NoOpChunkStorageProvider(executorService());
+    }
+
+    public TestContext getTestContext()  throws Exception {
+        return new TestContext(executorService());
+    }
+
+    /**
+     * Test initialization.
+     * @throws Exception
+     */
+    @Test
+    public void testInitialization() throws Exception {
+        val storageProvider = getChunkStorageProvider();
+        val metadataStore = new InMemoryMetadataStore();
+        val policy = SegmentRollingPolicy.NO_ROLLING;
+        val storageManager = new ChunkStorageManager(storageProvider,  executorService(), policy);
+        val systemJournal = new SystemJournal(42, 1, storageProvider, metadataStore, policy);
+        storageManager.initialize(1);
+
+        Assert.assertNull(storageManager.getMetadataStore());
+        Assert.assertEquals(storageProvider, storageManager.getChunkStorage());
+        Assert.assertEquals(policy, storageManager.getDefaultRollingPolicy());
+        Assert.assertEquals(1, storageManager.getEpoch());
+
+        storageManager.initialize(42, metadataStore, systemJournal);
+        Assert.assertEquals(metadataStore, storageManager.getMetadataStore());
+        Assert.assertEquals(storageProvider, storageManager.getChunkStorage());
+        Assert.assertEquals(policy, storageManager.getDefaultRollingPolicy());
+        Assert.assertEquals(1, storageManager.getEpoch());
+        Assert.assertEquals(42, storageManager.getContainerId());
+    }
+
+    /**
+     * Test exceptions for opertions on non-existent chunk.
+     */
+    @Test
+    public void testSegmentNotExistsExceptionForNonExistent() throws Exception {
+        String testSegmentName = "foo";
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(1); // Force rollover after each byte.
+        TestContext testContext = getTestContext();
+        Assert.assertFalse(testContext.storageManager.exists(testSegmentName, null).get());
+
+        AssertExtensions.assertFutureThrows(
+                "getStreamSegmentInfo succeeded on missing segment.",
+                testContext.storageManager.getStreamSegmentInfo(testSegmentName, null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on missing segment.",
+                testContext.storageManager.seal(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "openWrite succeeded on missing segment.",
+                testContext.storageManager.openWrite(testSegmentName),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "openRead succeeded on missing segment.",
+                testContext.storageManager.openRead(testSegmentName),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "write succeeded on missing segment.",
+                testContext.storageManager.write(SegmentStorageHandle.writeHandle(testSegmentName), 0, new ByteArrayInputStream(new byte[1]), 1, null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "read succeeded on missing segment.",
+                testContext.storageManager.read(SegmentStorageHandle.readHandle(testSegmentName), 0, new byte[1], 0, 1, null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "Concat succeeded on missing segment.",
+                testContext.storageManager.concat(SegmentStorageHandle.readHandle(testSegmentName), 0, "inexistent", null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+    }
+
+    /**
+     * Test scenarios when storage is no more primary.
+     */
+    @Test
+    public void testStorageNotPrimaryException() throws Exception {
+        String testSegmentName = "foo";
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(2);
+        int maxRollingLength = 1;
+        int ownerEpoch = 100;
+        testContext.insertMetadata(testSegmentName, maxRollingLength, ownerEpoch);
+
+        // These operations should always succeed.
+        testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).join();
+        val h = testContext.storageManager.openRead(testSegmentName).join();
+        testContext.storageManager.read(h, 0, new byte[0], 0, 0, null);
+
+        // These operations should never succeed.
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on segment not owned.",
+                testContext.storageManager.seal(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "openWrite succeeded on segment not owned.",
+                testContext.storageManager.openWrite(testSegmentName),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "delete succeeded on segment not owned.",
+                testContext.storageManager.delete(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "write succeeded on segment not owned.",
+                testContext.storageManager.write(SegmentStorageHandle.writeHandle(testSegmentName),
+                        0,
+                        new ByteArrayInputStream(new byte[10]),
+                        10,
+                        null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "truncate succeeded on segment not owned.",
+                testContext.storageManager.truncate(SegmentStorageHandle.writeHandle(testSegmentName),
+                        0, null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        testContext.insertMetadata("source", maxRollingLength, 1);
+        testContext.storageManager.seal(SegmentStorageHandle.writeHandle("source"), null).join();
+        AssertExtensions.assertFutureThrows(
+                "concat succeeded on segment not owned.",
+                testContext.storageManager.concat(SegmentStorageHandle.readHandle(testSegmentName), 0, "source", null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+    }
+
+    /**
+     * Test scenarios when storage is no more after fencing.
+     */
+    @Test
+    public void testStorageNotPrimaryExceptionOnFencing() throws Exception {
+        String testSegmentName = "foo";
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(2);
+        int maxRollingLength = 1;
+        testContext.insertMetadata(testSegmentName, maxRollingLength, 100);
+        testContext.insertMetadata("source", maxRollingLength, 1);
+        testContext.storageManager.seal(SegmentStorageHandle.writeHandle("source"), null).join();
+
+        testContext.metadataStore.markFenced();
+
+        // These operations should always succeed.
+        testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).join();
+        val h = testContext.storageManager.openRead(testSegmentName).join();
+        testContext.storageManager.read(h, 0, new byte[0], 0, 0, null);
+
+        // These operations should never succeed.
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on segment not owned.",
+                testContext.storageManager.seal(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "delete succeeded on segment not owned.",
+                testContext.storageManager.delete(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "concat succeeded on segment not owned.",
+                testContext.storageManager.concat(SegmentStorageHandle.readHandle(testSegmentName), 0, "source", null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "create succeeded on segment not owned.",
+                testContext.storageManager.create("newSegment", null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+        AssertExtensions.assertFutureThrows(
+                "truncate succeeded on segment not owned.",
+                testContext.storageManager.truncate(SegmentStorageHandle.writeHandle(testSegmentName),
+                        0, null),
+                ex -> ex instanceof StorageNotPrimaryException);
+
+    }
+
+    /**
+     * Test scenarios when storage is no more primary with fencing after OpenWrite.
+     */
+    @Test
+    public void testStorageNotPrimaryExceptionOnFencingAfterOpenWrite() throws Exception {
+        String testSegmentName = "foo";
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(2);
+        int maxRollingLength = 1;
+        testContext.insertMetadata(testSegmentName, maxRollingLength, 100);
+        testContext.insertMetadata("source", maxRollingLength, 1);
+        testContext.storageManager.seal(SegmentStorageHandle.writeHandle("source"), null).join();
+
+        // These operations should always succeed.
+        testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).join();
+        val hr = testContext.storageManager.openRead(testSegmentName).join();
+        testContext.storageManager.read(hr, 0, new byte[0], 0, 0, null);
+
+        val hw = testContext.storageManager.openWrite(testSegmentName);
+
+        testContext.metadataStore.markFenced();
+        AssertExtensions.assertFutureThrows(
+                "write succeeded on segment not owned.",
+                testContext.storageManager.write(SegmentStorageHandle.writeHandle(testSegmentName),
+                        0,
+                        new ByteArrayInputStream(new byte[10]),
+                        10,
+                        null),
+                ex -> ex instanceof StorageNotPrimaryException);
+    }
+
+    /**
+     * Test simple scenario.
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleScenario() throws Exception {
+        String testSegmentName = "foo";
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 5 byte.
+        TestContext testContext = getTestContext();
+
+        // Step 1: Create segment.
+        val h = testContext.storageManager.create(testSegmentName, policy, null).get();
+        Assert.assertEquals(h.getSegmentName(), testSegmentName);
+        Assert.assertFalse(h.isReadOnly());
+
+        // Check metadata is stored.
+        val segmentMetadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        Assert.assertNotNull(segmentMetadata);
+        Assert.assertEquals(segmentMetadata.getName(), testSegmentName);
+        Assert.assertEquals(segmentMetadata.getKey(), testSegmentName);
+
+        // Check exists
+        Assert.assertTrue(testContext.storageManager.exists(testSegmentName, null).get());
+
+        // Check getStreamSegmentInfo.
+        SegmentProperties info = testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).get();
+        Assert.assertFalse(info.isSealed());
+        Assert.assertFalse(info.isDeleted());
+        Assert.assertEquals(info.getName(), testSegmentName);
+        Assert.assertEquals(info.getLength(), 0);
+        Assert.assertEquals(info.getStartOffset(), 0);
+
+        // Write some data.
+        long writeAt = 0;
+        for (int i = 1; i < 5; i++) {
+            testContext.storageManager.write(h, writeAt, new ByteArrayInputStream(new byte[i]), i, null).join();
+            writeAt += i;
+        }
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, 2, 5, 0, 10);
+
+        // Check getStreamSegmentInfo.
+        info = testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).get();
+        Assert.assertFalse(info.isSealed());
+        Assert.assertFalse(info.isDeleted());
+        Assert.assertEquals(info.getName(), testSegmentName);
+        Assert.assertEquals(info.getLength(), 10);
+        Assert.assertEquals(info.getStartOffset(), 0);
+
+        // Open write handle.
+        val hWrite = testContext.storageManager.openWrite(testSegmentName).get();
+        Assert.assertEquals(hWrite.getSegmentName(), testSegmentName);
+        Assert.assertFalse(hWrite.isReadOnly());
+
+        testContext.storageManager.write(hWrite, 10, new ByteArrayInputStream(new byte[4]), 4, null).join();
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, 2, 7, 0, 14);
+
+        info = testContext.storageManager.getStreamSegmentInfo(testSegmentName, null).get();
+        Assert.assertFalse(info.isSealed());
+        Assert.assertFalse(info.isDeleted());
+        Assert.assertEquals(info.getName(), testSegmentName);
+        Assert.assertEquals(info.getLength(), 14);
+        Assert.assertEquals(info.getStartOffset(), 0);
+
+        // Make sure calling create again does not succeed
+        AssertExtensions.assertFutureThrows(
+                "Create succeeded on missing segment.",
+                testContext.storageManager.create(testSegmentName, policy, null),
+                ex -> ex instanceof StreamSegmentExistsException);
+
+        testContext.storageManager.delete(hWrite, null);
+    }
+
+    /**
+     * Test Read.
+     * @throws Exception
+     */
+    @Test
+    public void testRead() throws Exception {
+        String testSegmentName = "foo";
+        TestContext testContext = getTestContext();
+        // Setup a segment with 5 chunks with given lengths.
+        val segment = testContext.insertMetadata(testSegmentName, 1024, 1,
+                new long[] { 1, 2, 3, 4, 5});
+
+        int total = 15;
+
+        val h = testContext.storageManager.openRead(testSegmentName).get();
+
+        // Read all bytes at once.
+        byte[] output = new byte[total];
+        int bytesRead = testContext.storageManager.read(h, 0, output, 0, total, null).get();
+        Assert.assertEquals(total, bytesRead);
+
+        // Read bytes at varying lengths but same starting offset.
+        for (int i = 0; i < 15; i++) {
+            bytesRead = testContext.storageManager.read(h, 0, output, 0,  i, null).get();
+            Assert.assertEquals(i, bytesRead);
+        }
+
+        // Read bytes at varying lengths and different offsets.
+        for (int i = 0; i < 15; i++) {
+            bytesRead = testContext.storageManager.read(h, 15 - i - 1, output, 0,  i, null).get();
+            Assert.assertEquals(i, bytesRead);
+        }
+
+        // Read bytes at varying sizes.
+        int totalBytesRead = 0;
+        for (int i = 5; i > 0; i--) {
+            bytesRead = testContext.storageManager.read(h, 0, output, totalBytesRead, i, null).get();
+            totalBytesRead += bytesRead;
+            Assert.assertEquals(i, bytesRead);
+        }
+        Assert.assertEquals(total, totalBytesRead);
+    }
+
+    /**
+     * Test various operations on deleted segment.
+     * @throws Exception
+     */
+    @Test
+    public void testSegmentNotExistsExceptionForDeleted() throws Exception {
+        String testSegmentName = "foo";
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(1); // Force rollover after each byte.
+        TestContext testContext = getTestContext();
+        Assert.assertFalse(testContext.storageManager.exists(testSegmentName, null).get());
+
+        // Step 1: Create segment.
+        val h = testContext.storageManager.create(testSegmentName, policy, null).get();
+        Assert.assertEquals(h.getSegmentName(), testSegmentName);
+        Assert.assertFalse(h.isReadOnly());
+        val segmentMetadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        Assert.assertNotNull(segmentMetadata);
+        Assert.assertEquals(segmentMetadata.getName(), testSegmentName);
+        Assert.assertEquals(segmentMetadata.getKey(), testSegmentName);
+        Assert.assertTrue(testContext.storageManager.exists(testSegmentName, null).get());
+
+        testContext.storageManager.delete(h, null).join();
+        Assert.assertFalse(testContext.storageManager.exists(testSegmentName, null).get());
+        val segmentMetadataAfterDelete = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        Assert.assertNull(segmentMetadataAfterDelete);
+
+        AssertExtensions.assertFutureThrows(
+                "getStreamSegmentInfo succeeded on missing segment.",
+                testContext.storageManager.getStreamSegmentInfo(testSegmentName, null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on missing segment.",
+                testContext.storageManager.seal(SegmentStorageHandle.writeHandle(testSegmentName), null),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on missing segment.",
+                testContext.storageManager.openWrite(testSegmentName),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        AssertExtensions.assertFutureThrows(
+                "Seal succeeded on missing segment.",
+                testContext.storageManager.openRead(testSegmentName),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+    }
+
+    /**
+     * Test failover scenario on empty segment.
+     * @throws Exception
+     */
+    @Test
+    public void testOpenWriteAfterFailoverWithNoData() throws Exception {
+        String testSegmentName = "foo";
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(2);
+        int maxRollingLength = 1;
+        int ownerEpoch = 1;
+        testContext.insertMetadata(testSegmentName, maxRollingLength, ownerEpoch);
+
+        val hWrite = testContext.storageManager.openWrite(testSegmentName).get();
+        Assert.assertEquals(hWrite.getSegmentName(), testSegmentName);
+        Assert.assertFalse(hWrite.isReadOnly());
+
+        val metadataAfter = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        Assert.assertEquals(2, metadataAfter.getOwnerEpoch());
+
+    }
+
+    /**
+     * Test failover scenario.
+     * @throws Exception
+     */
+    @Test
+    public void testFailoverBehavior() throws Exception {
+        String testSegmentName = "foo";
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(1000);
+
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(1);
+        val h = testContext.storageManager.create(testSegmentName, policy, null).get();
+        int writeAt = 0;
+        for (int epoch = 2; epoch < 5; epoch++) {
+            testContext.storageManager.initialize(epoch);
+
+            val hWrite = testContext.storageManager.openWrite(testSegmentName).get();
+            Assert.assertEquals(hWrite.getSegmentName(), testSegmentName);
+            Assert.assertFalse(hWrite.isReadOnly());
+
+            testContext.storageManager.write(h, writeAt, new ByteArrayInputStream(new byte[10]), 10, null).join();
+
+            val metadataAfter = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+            Assert.assertEquals(epoch, metadataAfter.getOwnerEpoch());
+            writeAt += 10;
+        }
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, new long[] {10, 10, 10});
+    }
+
+    /**
+     * Test failover scenario for segment with only one chunk.
+     * @throws Exception
+     */
+    @Test
+    public void testOpenWriteAfterFailoverWithSingleChunk() throws Exception {
+        String testSegmentName = "foo";
+        int ownerEpoch = 2;
+        int maxRollingLength = 100;
+        long[] chunks = new long[] { 10 };
+        int lastChunkLengthInStorage = 12;
+
+        testOpenWriteAfterFailover(testSegmentName, ownerEpoch, maxRollingLength, chunks, lastChunkLengthInStorage);
+
+    }
+
+    private void testOpenWriteAfterFailover(String testSegmentName, int ownerEpoch, int maxRollingLength, long[] chunks, int lastChunkLengthInStorage) throws Exception {
+        TestContext testContext = getTestContext();
+        testContext.storageManager.initialize(ownerEpoch);
+        val inserted = testContext.insertMetadata(testSegmentName, maxRollingLength, ownerEpoch-1, chunks);
+        // Set bigger offset
+        testContext.addChunk(inserted.getLastChunk(), lastChunkLengthInStorage);
+        val hWrite = testContext.storageManager.openWrite(testSegmentName).get();
+        Assert.assertEquals(hWrite.getSegmentName(), testSegmentName);
+        Assert.assertFalse(hWrite.isReadOnly());
+
+        val metadataAfter = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        Assert.assertEquals(ownerEpoch, metadataAfter.getOwnerEpoch());
+        Assert.assertEquals(lastChunkLengthInStorage, metadataAfter.getLength());
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, chunks, lastChunkLengthInStorage);
+    }
+
+    /**
+     * Test simple concat.
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleConcat() throws Exception {
+        TestContext testContext = getTestContext();
+        for (int maxChunkLength = 1; maxChunkLength <= 3; maxChunkLength++) {
+            testSimpleConcat(testContext, maxChunkLength, 1, 1);
+            testSimpleConcat(testContext, maxChunkLength, 1, 2);
+            testSimpleConcat(testContext, maxChunkLength, 2, 1);
+            testSimpleConcat(testContext, maxChunkLength, 2, 2);
+            testSimpleConcat(testContext, maxChunkLength, 3, 3);
+        }
+    }
+
+    private void testSimpleConcat(TestContext testContext, int maxChunkLength, int nChunks1, int nChunks2) throws Exception {
+        String targetSegmentName = "target" + UUID.randomUUID().toString();
+        String sourceSegmentName = "source" + UUID.randomUUID().toString();
+
+        // Populate segments.
+        val h1 = populateSegment(testContext, targetSegmentName, maxChunkLength, nChunks1);
+        val h2 = populateSegment(testContext, sourceSegmentName, maxChunkLength, nChunks2);
+
+        // Concat.
+        testContext.storageManager.seal(h2, null).join();
+        testContext.storageManager.concat(h1, (long) nChunks1 * (long) maxChunkLength, sourceSegmentName, null).join();
+
+        // Validate.
+        TestUtils.checkSegmentLayout(testContext.metadataStore, targetSegmentName, maxChunkLength, nChunks1 + nChunks2, 0, ((long) nChunks1 + (long) nChunks2) * maxChunkLength);
+    }
+
+    @Test
+    public void testSimpleConcatWithDefrag() throws Exception {
+        TestContext testContext = getTestContext();
+        ((AbstractInMemoryChunkStorageProvider) testContext.storageProvider).setShouldSupportConcat(true);
+
+        for (int maxChunkLength = 1; maxChunkLength <= 3; maxChunkLength++) {
+            testSimpleConcat(testContext, maxChunkLength, 1, 1);
+            testSimpleConcat(testContext, maxChunkLength, 1, 2);
+            testSimpleConcat(testContext, maxChunkLength, 2, 1);
+            testSimpleConcat(testContext, maxChunkLength, 2, 2);
+            testSimpleConcat(testContext, maxChunkLength, 3, 3);
+        }
+    }
+
+    @Test
+    public void testBasicConcatWithDefrag() throws Exception {
+        TestContext testContext = getTestContext();
+        ((AbstractInMemoryChunkStorageProvider) testContext.storageProvider).setShouldSupportConcat(true);
+
+        // Populate segments
+        val source = testContext.insertMetadata("source", 1024, 1,
+                new long[] { 1, 2, 3, 4, 5});
+        val target = testContext.insertMetadata("target", 1024, 1,
+                new long[] {10});
+
+        // Concat.
+        testContext.storageManager.seal(SegmentStorageHandle.writeHandle("source"), null).join();
+        testContext.storageManager.concat(SegmentStorageHandle.writeHandle("target"),
+                0,
+                "source",
+                null).join();
+
+        // Validate.
+        TestUtils.checkSegmentLayout(testContext.metadataStore, "target", new long[] {25});
+    }
+
+    @Test
+    public void testSimpleTruncate() throws Exception {
+        testTruncate(1, 5, 10, 5, 10);
+    }
+
+    @Test
+    public void testRepeatedTruncates() throws Exception {
+        TestContext testContext = getTestContext();
+        String testSegmentName = "testSegmentName";
+
+        // Populate sgement.
+        val h1 = populateSegment(testContext, testSegmentName, 3, 3);
+        byte[] buffer = new byte[10];
+
+        // Perform series of truncates.
+        for (int truncateAt = 0; truncateAt < 9; truncateAt++) {
+            testContext.storageManager.truncate(h1, truncateAt, null).join();
+            TestUtils.checkSegmentLayout(testContext.metadataStore,  testSegmentName, 3,  3 - (truncateAt / 3), truncateAt, 9);
+            val metadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+            // length doesn't change.
+            Assert.assertEquals(9, metadata.getLength());
+            // start offset should match i.
+            Assert.assertEquals(truncateAt, metadata.getStartOffset());
+            // Each time the first offest is multiple of 3
+            Assert.assertEquals(3 * (truncateAt / 3), metadata.getFirstChunkStartOffset());
+
+            // try to read some bytes.
+            val bytesRead = testContext.storageManager.read(h1, truncateAt, buffer, 0, 9 - truncateAt, null).get().intValue();
+            Assert.assertEquals(9 - truncateAt, bytesRead);
+            if (truncateAt > 0) {
+                AssertExtensions.assertFutureThrows(
+                        "read succeeded on missing segment.",
+                        testContext.storageManager.read(h1, truncateAt - 1, buffer, 0, 9 - truncateAt, null),
+                        ex -> ex instanceof StreamSegmentTruncatedException);
+            }
+        }
+    }
+
+    @Test
+    public void testRepeatedTruncatesOnLargeChunkVaryingSizes() throws Exception {
+        TestContext testContext = getTestContext();
+        String testSegmentName = "testSegmentName";
+        // Set up.
+        val h1 = populateSegment(testContext, testSegmentName, 10, 1);
+        byte[] buffer = new byte[10];
+
+        int truncateAt = 0;
+        for (int i = 0; i < 4; i++) {
+            testContext.storageManager.truncate(h1, truncateAt, null).join();
+
+            // Check layout.
+            TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, new long[] { 10 });
+
+            // Validate.
+            val metadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+            Assert.assertEquals(10, metadata.getLength());
+            Assert.assertEquals(truncateAt, metadata.getStartOffset());
+            Assert.assertEquals(0, metadata.getFirstChunkStartOffset());
+
+            // validate read.
+            val bytesRead = testContext.storageManager.read(h1, truncateAt, buffer, 0, 10 - truncateAt, null).get().intValue();
+            Assert.assertEquals(10 - truncateAt, bytesRead);
+            truncateAt += i;
+        }
+    }
+
+    @Test
+    public void testRepeatedTruncatesOnLargeChunk() throws Exception {
+        TestContext testContext = getTestContext();
+        String testSegmentName = "testSegmentName";
+        // Populate.
+        val h1 = populateSegment(testContext, testSegmentName, 10, 1);
+        byte[] buffer = new byte[10];
+        for (int truncateAt = 0; truncateAt < 9; truncateAt++) {
+            testContext.storageManager.truncate(h1, truncateAt, null).join();
+
+            // Check layout.
+            TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, new long[] { 10 });
+
+            // Validate info
+            val metadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+            Assert.assertEquals(10, metadata.getLength());
+            Assert.assertEquals(truncateAt, metadata.getStartOffset());
+            Assert.assertEquals(0, metadata.getFirstChunkStartOffset());
+
+            // Validate read.
+            val bytesRead = testContext.storageManager.read(h1, truncateAt, buffer, 0, 10 - truncateAt, null).get().intValue();
+            Assert.assertEquals(10 - truncateAt, bytesRead);
+        }
+    }
+
+    @Test
+    public void testTruncateVariousOffsets() throws Exception {
+        long maxChunkSize = 3;
+        int numberOfChunks = 4;
+        for (int i = 0; i < numberOfChunks; i++) {
+            for (int j = 0; j < maxChunkSize; j++) {
+                val truncateAt = i * maxChunkSize + j;
+                testTruncate(maxChunkSize, truncateAt, numberOfChunks, numberOfChunks - i, maxChunkSize * numberOfChunks);
+            }
+        }
+    }
+
+
+    @Test
+    public void testBaseTruncate() throws Exception {
+        testTruncate(1, 1, 2, 1, 2);
+        testTruncate(1, 2, 4, 2, 4);
+
+        testTruncate(3, 1, 2, 2, 6);
+        testTruncate(3, 3, 4, 3, 12);
+    }
+
+    private void testTruncate(long maxChunkLength, long truncateAt, int chunksCountBefore, int chunksCountAfter, long expectedLength) throws Exception {
+        TestContext testContext = getTestContext();
+        String testSegmentName = "testSegmentName";
+
+        // Populate
+        val h1 = populateSegment(testContext, testSegmentName, maxChunkLength, chunksCountBefore);
+
+        // Perform truncate.
+        testContext.storageManager.truncate(h1, truncateAt, null).join();
+
+        // Check layout.
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, maxChunkLength, chunksCountAfter, truncateAt, expectedLength);
+    }
+
+
+
+    private SegmentHandle populateSegment(TestContext testContext, String targetSegmentName, long maxChunkLength, int numberOfchunks) throws Exception {
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(maxChunkLength); // Force rollover after each byte.
+        // Create segment
+        val h = testContext.storageManager.create(targetSegmentName, policy, null).get();
+
+        // Write some data.
+        long dataSize = numberOfchunks * maxChunkLength;
+        testContext.storageManager.write(h, 0, new ByteArrayInputStream(new byte[Math.toIntExact(dataSize)]), Math.toIntExact(dataSize), null).join();
+
+        TestUtils.checkSegmentLayout(testContext.metadataStore, targetSegmentName, maxChunkLength, numberOfchunks, 0, dataSize);
+        return h;
+    }
+
+    /**
+     * Test context.
+     */
+    public static class TestContext {
+        ChunkStorageProvider storageProvider;
+        ChunkMetadataStore metadataStore;
+        ChunkStorageManager storageManager;
+
+        Executor executor;
+
+        public TestContext(Executor executor)  throws Exception {
+            this.executor = executor;
+            storageProvider = getChunkStorageProvider();
+            metadataStore = new InMemoryMetadataStore();
+            storageManager = new ChunkStorageManager(storageProvider, metadataStore, this.executor, SegmentRollingPolicy.NO_ROLLING);
+            storageManager.initialize(1);
+        }
+
+        /**
+         * Gets {@link ChunkStorageProvider} to use for the tests.
+         */
+        public ChunkStorageProvider getChunkStorageProvider()  throws Exception {
+            return new NoOpChunkStorageProvider(this.executor);
+        }
+
+        /**
+         * Creates and inserts metadata for a test segment.
+         */
+        public SegmentMetadata insertMetadata(String testSegmentName, int maxRollingLength, int ownerEpoch) throws Exception {
+            try (val txn = metadataStore.beginTransaction()) {
+                SegmentMetadata segmentMetadata = SegmentMetadata.builder()
+                    .maxRollinglength(maxRollingLength)
+                    .name(testSegmentName)
+                    .ownerEpoch(ownerEpoch)
+                    .build();
+                segmentMetadata.setActive(true);
+                metadataStore.create(txn, segmentMetadata);
+                txn.commit();
+                return segmentMetadata;
+            }
+        }
+
+        /**
+         * Creates and inserts metadata for a test segment.
+         */
+        public SegmentMetadata insertMetadata(String testSegmentName, long maxRollingLength, int ownerEpoch, long[] chunkLengths) throws Exception {
+            try (val txn = metadataStore.beginTransaction()) {
+                String firstChunk = null;
+                String lastChunk = null;
+
+                // Add chunks.
+                long length = 0;
+                long startOfLast = 0;
+                for (int i = 0; i < chunkLengths.length; i++) {
+                    String chunkName = testSegmentName + "_chunk_" + Integer.toString(i);
+                    ChunkMetadata chunkMetadata = ChunkMetadata.builder()
+                            .name(chunkName)
+                            .length(chunkLengths[i])
+                            .nextChunk(i == chunkLengths.length -1 ? null : testSegmentName + "_chunk_" + Integer.toString(i + 1))
+                            .build();
+                    length += chunkLengths[i];
+                    metadataStore.create(txn, chunkMetadata);
+
+                    addChunk(chunkName, chunkLengths[i]);
+                }
+
+                // Fix the first and last
+                if (chunkLengths.length > 0) {
+                    firstChunk = testSegmentName + "_chunk_0";
+                    lastChunk = testSegmentName + "_chunk_" + Integer.toString(chunkLengths.length -1);
+                    startOfLast = length - chunkLengths[chunkLengths.length -1];
+                }
+
+                // Finally save
+                SegmentMetadata segmentMetadata = SegmentMetadata.builder()
+                        .maxRollinglength(maxRollingLength)
+                        .name(testSegmentName)
+                        .ownerEpoch(ownerEpoch)
+                        .firstChunk(firstChunk)
+                        .lastChunk(lastChunk)
+                        .length(length)
+                        .lastChunkStartOffset(startOfLast)
+                        .build();
+                segmentMetadata.setActive(true);
+                metadataStore.create(txn, segmentMetadata);
+
+                txn.commit();
+                return segmentMetadata;
+            }
+        }
+
+        /*
+        // Useful methods - unused. Commented to avoid chekstyle violation.
+        private void insertMetadata(StorageMetadata storageMetadata) throws Exception {
+            try (val txn = metadataStore.beginTransaction()) {
+                metadataStore.create(txn, storageMetadata);
+                txn.commit();
+            }
+        }
+
+        private void updateMetadata(StorageMetadata storageMetadata) throws Exception {
+            try (val txn = metadataStore.beginTransaction()) {
+                metadataStore.create(txn, storageMetadata);
+                txn.commit();
+            }
+        }
+        */
+
+        /**
+         * Adds chunk of specified length to the underlying {@link ChunkStorageProvider}.
+         */
+        public void addChunk(String chunkName, long length) {
+            ((AbstractInMemoryChunkStorageProvider) storageProvider).addChunk(chunkName, length);
+        }
+   }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageProviderTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageProviderTests.java
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.common.io.BoundedInputStream;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests specifically targeted at test {@link ChunkStorageProvider} implementation.
+ */
+public abstract class ChunkStorageProviderTests extends ThreadPooledTestSuite {
+    Random rnd = new Random();
+    ChunkStorageProvider chunkStorage;
+
+    /**
+     * Derived classes should return appropriate {@link ChunkStorageProvider}.
+     */
+    abstract protected ChunkStorageProvider createChunkStorageProvider()  throws Exception;
+
+    @Override
+    @Before
+    public void before() throws Exception {
+        super.before();
+        chunkStorage = createChunkStorageProvider();
+    }
+
+    @Override
+    @After
+    public void after() throws Exception {
+        if (null != chunkStorage) {
+            chunkStorage.close();
+        }
+        super.before();
+    }
+
+    /**
+     * Populate the data.
+     * @param data
+     */
+    protected void populate(byte[] data) {
+        rnd.nextBytes(data);
+    }
+
+    /**
+     * Test basic chunk lifecycle.
+     */
+    @Test
+    public void testChunkLifeCycle() throws Exception {
+        // try reading non existent chunk
+        String chunkName = "testchunk";
+        testNotExists(chunkName);
+
+        // Perform basic operations.
+        ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+
+        chunkHandle = chunkStorage.openRead(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(true, chunkHandle.isReadOnly());
+
+        chunkHandle = chunkStorage.openWrite(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+        testAlreadyExists(chunkName);
+
+        assertEquals(true, chunkStorage.delete(chunkHandle));
+        testNotExists(chunkName);
+    }
+
+    /**
+     * Test basic read and write.
+     */
+    @Test
+    public void testSimpleReadWrite() throws Exception {
+        String chunkName = "testchunk";
+
+        // Create.
+        ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+
+        // Write.
+        byte[] writeBuffer = new byte[10];
+        populate(writeBuffer);
+        int bytesWritten = chunkStorage.write(chunkHandle, 0, writeBuffer.length, new ByteArrayInputStream(writeBuffer));
+        assertEquals(writeBuffer.length, bytesWritten);
+
+        // Read back.
+        byte[] readBuffer = new byte[writeBuffer.length];
+        int bytesRead = chunkStorage.read(chunkHandle, 0, writeBuffer.length, readBuffer, 0);
+        assertEquals(writeBuffer.length, bytesRead);
+        assertArrayEquals(writeBuffer, readBuffer);
+
+        // Delete.
+        assertEquals(true, chunkStorage.delete(chunkHandle));
+    }
+
+    /**
+     * Test consecutive reads.
+     */
+    @Test
+    public void testConsecutiveReads() throws Exception {
+        String chunkName = "testchunk";
+
+        // Create.
+        ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+
+        // Write
+        byte[] writeBuffer = new byte[15];
+        populate(writeBuffer);
+        int bytesWritten = chunkStorage.write(chunkHandle, 0, writeBuffer.length, new ByteArrayInputStream(writeBuffer));
+        assertEquals(writeBuffer.length, bytesWritten);
+
+        // Read back in multiple reads.
+        byte[] readBuffer = new byte[writeBuffer.length];
+
+        int totalBytesRead = 0;
+        for (int i = 1; i <= 5; i++) {
+            int remaining = i;
+            while (remaining > 0) {
+                int bytesRead = chunkStorage.read(chunkHandle, totalBytesRead, remaining, readBuffer, totalBytesRead);
+                remaining -= bytesRead;
+                totalBytesRead += bytesRead;
+            }
+        }
+        assertEquals(writeBuffer.length, totalBytesRead);
+        assertArrayEquals(writeBuffer, readBuffer);
+
+        // Delete.
+        assertEquals(true, chunkStorage.delete(chunkHandle));
+    }
+
+    /**
+     * Test consecutive writes.
+     */
+    @Test
+    public void testConsecutiveWrites() throws Exception {
+        String chunkName = "testchunk";
+
+        // Create.
+        ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+
+        // Write multiple times.
+        byte[] writeBuffer = new byte[15];
+        populate(writeBuffer);
+        int totalBytesWritten = 0;
+        for (int i = 1; i <= 5; i++) {
+            int bytesWritten = chunkStorage.write(chunkHandle, totalBytesWritten, i, new ByteArrayInputStream(writeBuffer, totalBytesWritten, i));
+            assertEquals(i, bytesWritten);
+            totalBytesWritten += i;
+        }
+
+        // Read back.
+        byte[] readBuffer = new byte[writeBuffer.length];
+        int totalBytesRead = 0;
+        int remaining = writeBuffer.length;
+        while (remaining > 0) {
+            int bytesRead = chunkStorage.read(chunkHandle, totalBytesRead, remaining, readBuffer, totalBytesRead);
+            remaining -= bytesRead;
+            totalBytesRead += bytesRead;
+        }
+        assertEquals(writeBuffer.length, totalBytesRead);
+        assertArrayEquals(writeBuffer, readBuffer);
+
+        // Delete.
+        assertEquals(true, chunkStorage.delete(chunkHandle));
+    }
+
+    /**
+     * Test simple reads and writes for exceptions.
+     */
+    @Test
+    public void testSimpleReadWriteExceptions() throws Exception {
+        String chunkName = "testchunk";
+
+        ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+        assertEquals(chunkName, chunkHandle.getChunkName());
+        assertEquals(false, chunkHandle.isReadOnly());
+        byte[] writeBuffer = new byte[10];
+        populate(writeBuffer);
+        int length = writeBuffer.length;
+        int bytesWritten = chunkStorage.write(chunkHandle, 0, length, new ByteArrayInputStream(writeBuffer));
+        assertEquals(length, bytesWritten);
+
+        byte[] readBuffer = new byte[writeBuffer.length];
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, -1, readBuffer, 0),
+                ex -> ex instanceof IllegalArgumentException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, -1, 0, readBuffer, 0),
+                ex -> ex instanceof IllegalArgumentException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, 0, readBuffer, -1),
+                ex -> ex instanceof IndexOutOfBoundsException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, 0, null, 0),
+                ex -> ex instanceof IllegalArgumentException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, length + 1, readBuffer, 0),
+                ex -> ex instanceof IllegalArgumentException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, length, new byte[length - 1], 0),
+                ex -> ex instanceof IllegalArgumentException);
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () ->  chunkStorage.read(chunkHandle, 0, length, readBuffer, length),
+                ex -> ex instanceof IndexOutOfBoundsException);
+
+        assertEquals(true, chunkStorage.delete(chunkHandle));
+    }
+
+
+    /**
+     * Test one simple scenario involving all operations.
+     */
+    @Test
+    public void testSimpleScenario() throws Exception {
+
+        String chunknameA = "A";
+        String chunknameB = "B";
+        assertFalse(chunkStorage.exists(chunknameA));
+        assertFalse(chunkStorage.exists(chunknameB));
+
+        // Create chunks
+        chunkStorage.create(chunknameA);
+        chunkStorage.create(chunknameB);
+
+        assertTrue(chunkStorage.exists(chunknameA));
+        assertTrue(chunkStorage.exists(chunknameB));
+
+        ChunkInfo chunkInfoA = chunkStorage.getInfo(chunknameA);
+        assertEquals(chunknameA, chunkInfoA.getName());
+        assertEquals(0, chunkInfoA.getLength());
+
+        // Open wirtable handles
+        ChunkHandle handleA = chunkStorage.openWrite(chunknameA);
+        ChunkHandle handleB = chunkStorage.openWrite(chunknameB);
+        assertFalse(handleA.isReadOnly());
+        assertFalse(handleB.isReadOnly());
+
+        // Write some data to A
+        byte[] bytes = new byte[10];
+        int totalBytesWritten = 0;
+        for (int i = 1; i < 5; i++) {
+            try (BoundedInputStream bis = new BoundedInputStream(new ByteArrayInputStream(bytes), i)) {
+                int bytesWritten = chunkStorage.write(handleA, totalBytesWritten, i, bis);
+                assertEquals(i, bytesWritten);
+            }
+            totalBytesWritten += i;
+        }
+
+        chunkInfoA = chunkStorage.getInfo(chunknameA);
+        assertEquals(totalBytesWritten, chunkInfoA.getLength());
+
+        // Write some data to segment B
+        chunkStorage.write(handleB, 0,  bytes.length, new ByteArrayInputStream(bytes));
+        totalBytesWritten += bytes.length;
+        ChunkInfo chunkInfoB = chunkStorage.getInfo(chunknameB);
+        assertEquals(chunknameB, chunkInfoB.getName());
+        assertEquals(bytes.length, chunkInfoB.getLength());
+
+        // Read some data
+        int totalBytesRead = 0;
+        byte[] buffer = new byte[10];
+        for (int i = 1; i < 5; i++) {
+            totalBytesRead += chunkStorage.read(handleA, totalBytesRead, i, buffer,  totalBytesRead);
+        }
+
+        // Concat
+        if (chunkStorage.supportsConcat()) {
+            chunkInfoA = chunkStorage.getInfo(chunknameA);
+            chunkInfoB = chunkStorage.getInfo(chunknameB);
+
+            chunkStorage.concat(handleA, handleB);
+
+            ChunkInfo chunkInfoAAfterConcat = chunkStorage.getInfo(chunknameA);
+            assertEquals(chunkInfoA.getLength() + chunkInfoB.getLength(), chunkInfoAAfterConcat.getLength());
+        }
+        // delete
+        chunkStorage.delete(handleA);
+        chunkStorage.delete(handleB);
+    }
+
+    /**
+     * Test default capabilities.
+     */
+    @Test
+    public void testCapabilities() {
+        assertEquals(true, chunkStorage.supportsAppend());
+        assertEquals(false, chunkStorage.supportsTruncation());
+        assertEquals(false, chunkStorage.supportsConcat());
+    }
+
+    private void testAlreadyExists(String chunkName) throws InterruptedException, java.util.concurrent.ExecutionException, IOException {
+        try {
+            ChunkHandle chunkHandle = chunkStorage.create(chunkName);
+            Assert.fail("FileAlreadyExistsException was expected");
+        } catch (FileAlreadyExistsException e) {
+            //Assert.assertTrue(e.getCause().getClass().getName().endsWith("FileAlreadyExistsException"));
+            //Assert.assertTrue(e.getCause().getMessage().endsWith(chunkName));
+        }
+    }
+
+    private void testNotExists(String chunkName) throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
+        assertEquals(Boolean.FALSE, chunkStorage.exists(chunkName));
+
+        AssertExtensions.assertThrows(
+                " getInfo should throw exception.",
+                () -> chunkStorage.getInfo(chunkName),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+
+        AssertExtensions.assertThrows(
+                " openRead should throw exception.",
+                () -> chunkStorage.openRead(chunkName),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+
+        AssertExtensions.assertThrows(
+                " openWrite should throw exception.",
+                () -> chunkStorage.openWrite(chunkName),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+
+        AssertExtensions.assertThrows(
+                " getInfo should throw exception.",
+                () -> chunkStorage.getInfo(chunkName),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+
+        // TODO Fix this
+        AssertExtensions.assertThrows(
+                " setReadonly should throw exception.",
+                () -> chunkStorage.setReadonly(ChunkHandle.writeHandle(chunkName), false),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+
+        AssertExtensions.assertThrows(
+                " read should throw exception.",
+                () -> chunkStorage.read(ChunkHandle.writeHandle(chunkName), 0, 1, new byte[1], 0),
+                ex -> ex instanceof FileNotFoundException && ex.getMessage().contains(chunkName));
+    }
+
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.contracts.BadOffsetException;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
+import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.StorageTestBase;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
+import io.pravega.test.common.AssertExtensions;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static io.pravega.test.common.AssertExtensions.assertMayThrow;
+
+/**
+ * Scenario tests using ChunkStorageManager, ChunkStorageProvider and ChunkMetadataStore together.
+ *
+ * The derived classes are expected to override getChunkStorage to return instance of specific type derived from ChunkStorageProvider.
+ * In addition the method populate can be overriden to handle implementation specific logic. (Eg. NoOpChunkStorageProvider)
+ *
+ */
+@Slf4j
+public abstract class SimpleStorageTests extends StorageTestBase {
+
+    private static final int WRITE_COUNT = 5;
+    ChunkStorageProvider chunkStorageProvider;
+    ChunkMetadataStore chunkMetadataStore;
+    /**
+     * Creates a new instance of the Storage implementation to be tested. This will be cleaned up (via close()) upon
+     * test termination.
+     */
+    @Override
+    protected Storage createStorage() throws Exception {
+        Executor executor = executorService();
+        synchronized (SimpleStorageTests.class) {
+            if (null == chunkStorageProvider) {
+                chunkMetadataStore = getMetadataStore();
+                chunkStorageProvider = getChunkStorage(executor);
+            }
+        }
+        ChunkStorageManager chunkStorageManager = new ChunkStorageManager(chunkStorageProvider, chunkMetadataStore, executor, SegmentRollingPolicy.NO_ROLLING);
+        return chunkStorageManager;
+    }
+
+    abstract protected ChunkStorageProvider getChunkStorage(Executor executor) throws Exception;
+
+    protected Storage forkStorage(ChunkStorageManager storage) throws Exception {
+        Executor executor = executorService();
+        ChunkStorageManager forkedChunkStorageManager = new ChunkStorageManager(storage.getChunkStorage(),
+                getCloneMetadataStore(storage.getMetadataStore()),
+                executor,
+                SegmentRollingPolicy.NO_ROLLING);
+        return forkedChunkStorageManager;
+    }
+
+    protected ChunkMetadataStore getMetadataStore()  throws Exception {
+        return new InMemoryMetadataStore();
+    }
+
+    protected static ChunkMetadataStore getCloneMetadataStore(ChunkMetadataStore metadataStore)  throws Exception {
+        return InMemoryMetadataStore.clone((InMemoryMetadataStore) metadataStore);
+    }
+
+    /**
+     * Tests fencing abilities. We create two different Storage objects with different owner ids.
+     * Part 1: Creation:
+     * * We create the Segment on Storage1:
+     * ** We verify that Storage1 can execute all operations.
+     * ** We verify that Storage2 can execute only read-only operations.
+     * * We open the Segment on Storage2:
+     * ** We verify that Storage1 can execute only read-only operations.
+     * ** We verify that Storage2 can execute all operations.
+     */
+    @Test
+    @Override
+    public void testFencing() throws Exception {
+        final long epoch1 = 1;
+        final long epoch2 = 2;
+        final String segmentName = "segment";
+        try (val storage1 = createStorage();
+             val storage2 = createStorage()) {
+            storage1.initialize(epoch1);
+            storage2.initialize(epoch2);
+
+            // Create segment in Storage1 (thus Storage1 owns it for now).
+            storage1.create(segmentName, TIMEOUT).join();
+
+            // Storage1 should be able to execute all operations.
+            SegmentHandle handle1 = storage1.openWrite(segmentName).join();
+            verifyWriteOperationsSucceed(handle1, storage1);
+            verifyReadOnlyOperationsSucceed(handle1, storage1);
+
+            // Open the segment in Storage2 (thus Storage2 owns it for now).
+            SegmentHandle handle2 = storage2.openWrite(segmentName).join();
+
+            // Storage1 should be able to execute only read-only operations.
+            verifyWriteOperationsFail(handle1, storage1);
+            verifyReadOnlyOperationsSucceed(handle1, storage1);
+
+            // Storage2 should be able to execute all operations.
+            verifyReadOnlyOperationsSucceed(handle2, storage2);
+            verifyWriteOperationsSucceed(handle2, storage2);
+
+            // Seal and Delete (these should be run last, otherwise we can't run our test).
+            verifyFinalWriteOperationsFail(handle1, storage1);
+            verifyFinalWriteOperationsSucceed(handle2, storage2);
+        }
+    }
+
+    @Test
+    public void testZombieFencing() throws Exception {
+        final long epoch1 = 1;
+        final long epoch2 = 2;
+        final String segmentName = "segment";
+        try (val storage1 = createStorage()) {
+            storage1.initialize(epoch1);
+
+            // Create segment in Storage1 (thus Storage1 owns it for now).
+            storage1.create(segmentName, TIMEOUT).join();
+
+            // Storage1 should be able to execute all operations.
+            SegmentHandle handle1 = storage1.openWrite(segmentName).join();
+            verifyWriteOperationsSucceed(handle1, storage1);
+            verifyReadOnlyOperationsSucceed(handle1, storage1);
+
+            try (val storage2 = forkStorage((ChunkStorageManager) storage1)) {
+                storage2.initialize(epoch2);
+                // Open the segment in Storage2 (thus Storage2 owns it for now).
+                SegmentHandle handle2 = storage2.openWrite(segmentName).join();
+
+                ((ChunkStorageManager) storage1).getMetadataStore().markFenced();
+
+                // Storage1 should be able to execute only read-only operations.
+                verifyWriteOperationsFail(handle1, storage1);
+                verifyReadOnlyOperationsSucceed(handle1, storage1);
+
+                // Storage2 should be able to execute all operations.
+                verifyReadOnlyOperationsSucceed(handle2, storage2);
+                verifyWriteOperationsSucceed(handle2, storage2);
+
+                // Seal and Delete (these should be run last, otherwise we can't run our test).
+                verifyFinalWriteOperationsFail(handle1, storage1);
+                verifyFinalWriteOperationsSucceed(handle2, storage2);
+            }
+        }
+    }
+
+    /**
+     * Tests a read scenario with no issues or failures.
+     */
+    @Test
+    public void testNormalRead() throws Exception {
+        // Write data.
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+            SegmentHandle handle = s.openWrite(segmentName).join();
+
+            long expectedLength = 0;
+
+            ByteArrayOutputStream writtenData = new ByteArrayOutputStream();
+            for (int i = 0; i < WRITE_COUNT; i++) {
+                byte[] data = new byte[i + 1];
+                populate(data);
+                s.write(handle, expectedLength, new ByteArrayInputStream(data), data.length, null).join();
+                writtenData.write(data);
+                expectedLength += data.length;
+            }
+
+            // Check written data via a Read Operation, from every offset from 0 to length/2
+            byte[] expectedData = writtenData.toByteArray();
+            val readHandle = s.openRead(segmentName).join();
+            for (int startOffset = 0; startOffset < expectedLength / 2; startOffset++) {
+                int readLength = (int) (expectedLength - 2 * startOffset);
+                byte[] actualData = new byte[readLength];
+                int readBytes = s.read(readHandle, startOffset, actualData, 0, actualData.length, null).join();
+
+                Assert.assertEquals("Unexpected number of bytes read with start offset " + startOffset, actualData.length, readBytes);
+                AssertExtensions.assertArrayEquals("Unexpected data read back with start offset " + startOffset,
+                        expectedData, startOffset, actualData, 0, readLength);
+            }
+        }
+    }
+
+
+    /**
+     * Tests general GetInfoOperation behavior.
+     */
+    @Test
+    public void testGetInfo() throws Exception {
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+            SegmentHandle handle = s.openWrite(segmentName).join();
+
+            long expectedLength = 0;
+
+            for (int i = 0; i < WRITE_COUNT; i++) {
+                byte[] data = new byte[i + 1];
+                s.write(handle, expectedLength, new ByteArrayInputStream(data), data.length, null).join();
+                expectedLength += data.length;
+            }
+
+            SegmentProperties result = s.getStreamSegmentInfo(segmentName, null).join();
+
+            validateProperties("pre-seal", segmentName, result, expectedLength, false);
+
+            // Seal.
+            s.seal(handle, null).join();
+            result = s.getStreamSegmentInfo(segmentName, null).join();
+            validateProperties("post-seal", segmentName, result, expectedLength, true);
+
+            // Inexistent segment.
+            AssertExtensions.assertFutureThrows(
+                    "GetInfo succeeded on missing segment.",
+                    s.getStreamSegmentInfo("non-existent", null),
+                    ex -> ex instanceof StreamSegmentNotExistsException);
+        }
+    }
+
+    private void validateProperties(String stage, String segmentName, SegmentProperties sp, long expectedLength, boolean expectedSealed) {
+        Assert.assertNotNull("No result from GetInfoOperation (" + stage + ").", sp);
+        Assert.assertEquals("Unexpected name (" + stage + ").", segmentName, sp.getName());
+        Assert.assertEquals("Unexpected length (" + stage + ").", expectedLength, sp.getLength());
+        Assert.assertEquals("Unexpected sealed status (" + stage + ").", expectedSealed, sp.isSealed());
+    }
+
+    /**
+     * Tests the exists API.
+     */
+    @Test
+    public void testExists() throws Exception {
+        final int epoch = 1;
+        final int offset = 0;
+
+        String segmentName = "foo_open";
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+
+            // Not exists.
+            Assert.assertFalse("Unexpected result for missing segment (no files).", s.exists("nonexistent", null).join());
+        }
+    }
+
+    @Test
+    public void testSimpleReadWrite() throws Exception {
+        String segmentName = createSegmentName("testSimpleReadWrite");
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+            Assert.assertTrue("Expected the segment to exist.", s.exists(segmentName, null).join());
+
+            SegmentHandle writeHandle = s.openWrite(segmentName).join();
+            Assert.assertEquals(segmentName, writeHandle.getSegmentName());
+            Assert.assertEquals(false, writeHandle.isReadOnly());
+
+            byte[] writeBuffer = new byte[10];
+            populate(writeBuffer);
+
+            s.write(writeHandle, 0, new ByteArrayInputStream(writeBuffer), writeBuffer.length, null).join();
+
+            SegmentHandle readHandle = s.openRead(segmentName).join();
+            Assert.assertEquals(segmentName, readHandle.getSegmentName());
+            Assert.assertEquals(true, readHandle.isReadOnly());
+            byte[] readBuffer = new byte[writeBuffer.length];
+            int bytesRead = s.read(readHandle, 0, readBuffer,  0, writeBuffer.length, null).get();
+            Assert.assertEquals(writeBuffer.length, bytesRead);
+            Assert.assertArrayEquals(writeBuffer, readBuffer);
+        }
+    }
+
+    @Test
+    public void testConsecutiveReads() throws Exception {
+        String segmentName = createSegmentName("testConsecutiveReads");
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+            Assert.assertTrue("Expected the segment to exist.", s.exists(segmentName, null).join());
+
+            SegmentHandle writeHandle = s.openWrite(segmentName).join();
+            Assert.assertEquals(segmentName, writeHandle.getSegmentName());
+            Assert.assertEquals(false, writeHandle.isReadOnly());
+
+            byte[] writeBuffer = new byte[15];
+            populate(writeBuffer);
+
+            s.write(writeHandle, 0, new ByteArrayInputStream(writeBuffer), writeBuffer.length, null).join();
+
+            SegmentHandle readHandle = s.openRead(segmentName).join();
+            Assert.assertEquals(segmentName, readHandle.getSegmentName());
+            Assert.assertEquals(true, readHandle.isReadOnly());
+
+            byte[] readBuffer = new byte[writeBuffer.length];
+
+            int totalBytesRead = 0;
+            for (int i = 1; i <= 5; i++) {
+                int remaining = i;
+                while (remaining > 0) {
+                    int bytesRead = s.read(readHandle, totalBytesRead, readBuffer,  totalBytesRead, remaining, null).get();
+                    remaining -= bytesRead;
+                    totalBytesRead += bytesRead;
+                }
+            }
+            Assert.assertEquals(writeBuffer.length, totalBytesRead);
+            Assert.assertArrayEquals(writeBuffer, readBuffer);
+        }
+    }
+
+    @Test
+    public void testConsecutiveWrites() throws Exception {
+        String segmentName = createSegmentName("testConsecutiveWrites");
+        try (Storage s = createStorage()) {
+            s.initialize(DEFAULT_EPOCH);
+            createSegment(segmentName, s);
+            Assert.assertTrue("Expected the segment to exist.", s.exists(segmentName, null).join());
+
+            SegmentHandle writeHandle = s.openWrite(segmentName).join();
+            Assert.assertEquals(segmentName, writeHandle.getSegmentName());
+            Assert.assertEquals(false, writeHandle.isReadOnly());
+
+            byte[] writeBuffer = new byte[15];
+            populate(writeBuffer);
+
+            int totalBytesWritten = 0;
+            for (int i = 1; i <= 5; i++) {
+                s.write(writeHandle, totalBytesWritten, new ByteArrayInputStream(writeBuffer, totalBytesWritten, i), i, null).join();
+                totalBytesWritten += i;
+            }
+
+            SegmentHandle readHandle = s.openRead(segmentName).join();
+            Assert.assertEquals(segmentName, readHandle.getSegmentName());
+            Assert.assertEquals(true, readHandle.isReadOnly());
+            byte[] readBuffer = new byte[writeBuffer.length];
+            int bytesRead = s.read(readHandle, 0, readBuffer,  0, writeBuffer.length, null).get();
+            Assert.assertEquals(writeBuffer.length, bytesRead);
+            Assert.assertArrayEquals(writeBuffer, readBuffer);
+        }
+    }
+
+
+    //region synchronization unit tests
+
+    /**
+     * This test case simulates two hosts writing at the same offset at the same time.
+     * @throws Exception if an unexpected error occurred.
+     */
+    @Test(timeout = 30000)
+    public void testParallelWriteTwoHosts() throws Exception {
+        String segmentName = "foo_write";
+        int appendCount = 1;
+
+        try (Storage s1 = createStorage();
+             Storage s2 = createStorage()) {
+            s1.initialize(DEFAULT_EPOCH);
+            s2.initialize(DEFAULT_EPOCH);
+            s1.create(segmentName, TIMEOUT).join();
+            SegmentHandle writeHandle1 = s1.openWrite(segmentName).join();
+            SegmentHandle writeHandle2 = s2.openWrite(segmentName).join();
+            long offset = 0;
+            byte[] writeData = populate("Segment_%s_Append".length());
+            for (int j = 0; j < appendCount; j++) {
+                ByteArrayInputStream dataStream1 = new ByteArrayInputStream(writeData);
+                ByteArrayInputStream dataStream2 = new ByteArrayInputStream(writeData);
+                CompletableFuture<Void> f1 = s1.write(writeHandle1, offset, dataStream1, writeData.length, TIMEOUT);
+                // TODO FIX THIS.
+                f1.join();
+                CompletableFuture<Void> f2 = s2.write(writeHandle2, offset, dataStream2, writeData.length, TIMEOUT);
+                //f2.join();
+                assertMayThrow("Write expected to complete OR throw BadOffsetException." +
+                                "threw an unexpected exception.",
+                        () -> CompletableFuture.allOf(f1, f2),
+                        ex -> ex instanceof BadOffsetException);
+
+                // Make sure at least one operation is success.
+                Assert.assertTrue("At least one of the two parallel writes should succeed.",
+                        !f1.isCompletedExceptionally() || !f2.isCompletedExceptionally());
+                offset += writeData.length;
+            }
+            Assert.assertTrue( "Writes at the same offset are expected to be idempotent.",
+                    s1.getStreamSegmentInfo(segmentName, TIMEOUT).join().getLength() == offset);
+
+            offset = 0;
+            byte[] readBuffer = new byte[writeData.length];
+            for (int j = 0; j < appendCount; j++) {
+                int bytesRead = s1.read(writeHandle1, j * readBuffer.length, readBuffer,
+                        0, readBuffer.length, TIMEOUT).join();
+                Assert.assertEquals(String.format("Unexpected number of bytes read from offset %d.", offset),
+                        readBuffer.length, bytesRead);
+                AssertExtensions.assertArrayEquals(String.format("Unexpected read result from offset %d.", offset),
+                        readBuffer, 0, readBuffer, 0, bytesRead);
+            }
+
+            s1.delete(writeHandle1, TIMEOUT).join();
+        }
+    }
+
+    /**
+     * This test case simulates host crashing during concat and retrying the operation.
+     * @throws Exception if an unexpected error occurred.
+     */
+    @Test(timeout = 30000)
+    public void testPartialConcat() throws Exception {
+        String segmentName = "foo_write";
+        String concatSegmentName = "foo_concat";
+        String newConcatSegmentName = "foo_concat0";
+
+        int offset = 0;
+
+        try ( Storage s1 = createStorage()) {
+            s1.initialize(DEFAULT_EPOCH);
+
+            s1.create(segmentName, TIMEOUT).join();
+            s1.create(concatSegmentName, TIMEOUT).join();
+
+            SegmentHandle writeHandle1 = s1.openWrite(segmentName).join();
+            SegmentHandle writeHandle2 = s1.openWrite(concatSegmentName).join();
+
+            byte[] writeData = populate("Segment_%s_Append".length());
+            ByteArrayInputStream dataStream1 = new ByteArrayInputStream(writeData);
+            ByteArrayInputStream dataStream2 = new ByteArrayInputStream(writeData);
+
+            s1.write(writeHandle1, offset, dataStream1, writeData.length, TIMEOUT).join();
+            s1.write(writeHandle2, offset, dataStream2, writeData.length, TIMEOUT).join();
+
+            s1.seal(writeHandle2, TIMEOUT).join();
+
+            // This will append the segments and delete the concat segment.
+            s1.concat(writeHandle1, writeData.length, concatSegmentName, TIMEOUT).join();
+            long lengthBeforeRetry = s1.getStreamSegmentInfo(segmentName, TIMEOUT).join().getLength();
+
+            // Create the segment again.
+            s1.create(newConcatSegmentName, TIMEOUT).join();
+            writeHandle2 = s1.openWrite(newConcatSegmentName).join();
+            dataStream2 = new ByteArrayInputStream(writeData);
+            s1.write(writeHandle2, offset, dataStream2, writeData.length, TIMEOUT).join();
+            s1.seal(writeHandle2, TIMEOUT).join();
+
+            //Concat at the same offset again
+            s1.concat(writeHandle1, writeData.length, newConcatSegmentName, TIMEOUT).join();
+            long lengthAfterRetry = s1.getStreamSegmentInfo(segmentName, TIMEOUT).join().getLength();
+            Assert.assertTrue( String.format("Concatenation of same segment at the same offset(%d) should result in " +
+                            "same segment size(%d), but is (%d)", writeData.length, lengthBeforeRetry,
+                    lengthAfterRetry),
+                    lengthBeforeRetry == lengthAfterRetry);
+
+            //Verify the data
+            byte[] readBuffer = new byte[writeData.length];
+            for (int j = 0; j < 2; j++) {
+                int bytesRead = s1.read(writeHandle1, j * readBuffer.length, readBuffer,
+                        0, readBuffer.length, TIMEOUT).join();
+                Assert.assertEquals(String.format("Unexpected number of bytes read from offset %d.", offset),
+                        readBuffer.length, bytesRead);
+                AssertExtensions.assertArrayEquals(String.format("Unexpected read result from offset %d.", offset),
+                        readBuffer, (int) offset, readBuffer, 0, bytesRead);
+            }
+            s1.delete(writeHandle1, TIMEOUT).join();
+        }
+    }
+
+    //endregion
+
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.SegmentRollingPolicy;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorageProvider;
+import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.val;
+import lombok.var;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+
+/**
+ * Tests for testing bootstrap functionality with {@link SystemJournal}.
+ */
+public class SystemJournalTests extends ThreadPooledTestSuite {
+    protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+    }
+
+    @After
+    public void after() throws Exception {
+        super.after();
+    }
+
+    protected ChunkMetadataStore getMetadataStore() throws Exception {
+        return new InMemoryMetadataStore();
+    }
+
+    protected ChunkStorageProvider getStorageProvider() throws Exception {
+        return new InMemoryChunkStorageProvider(executorService());
+    }
+
+    protected String[] getSystemSegments(String systemSegmentName) {
+        return new String[]{systemSegmentName};
+    }
+
+    @Test
+    public void testSimpleBootstrapWithOneFailover() throws Exception {
+        ChunkStorageProvider storageProvider = getStorageProvider();
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+        String systemSegmentName = "test";
+        int containerId = 42;
+        long epoch = 1;
+        val policy = new SegmentRollingPolicy(8);
+
+        SystemJournal journalBefore = new SystemJournal(containerId, epoch, storageProvider, metadataStoreBeforeCrash, policy);
+        journalBefore.setSystemSegmentsPrefix(systemSegmentName);
+        journalBefore.setSystemSegments(getSystemSegments(systemSegmentName));
+        long offset = 0;
+
+        // Epoch 1
+        ChunkStorageManager chunkStorageManager1 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager1.initialize(containerId, metadataStoreBeforeCrash, journalBefore);
+        chunkStorageManager1.initialize(epoch);
+
+        var h = chunkStorageManager1.create(systemSegmentName, new SegmentRollingPolicy(8), null).join();
+        val b1 = "Hello".getBytes();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(b1), b1.length, null);
+        offset += b1.length;
+        val b2 = " World".getBytes();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(b2), b2.length, null);
+        offset += b2.length;
+
+        // Epoch 2
+        epoch++;
+        SystemJournal journalAfter = new SystemJournal(containerId, epoch, storageProvider, metadataStoreAfterCrash, policy);
+        journalAfter.setSystemSegments(getSystemSegments(systemSegmentName));
+        journalAfter.setSystemSegmentsPrefix(systemSegmentName);
+
+        ChunkStorageManager chunkStorageManager2 = new ChunkStorageManager(storageProvider, executorService(), new SegmentRollingPolicy(8));
+        chunkStorageManager2.initialize(containerId, metadataStoreAfterCrash, journalAfter);
+        chunkStorageManager2.initialize(epoch);
+
+        journalAfter.bootstrap();
+
+        val info = chunkStorageManager2.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(b1.length + b2.length, info.getLength());
+        byte[] out = new byte[b1.length + b2.length];
+        val hr = chunkStorageManager2.openRead(systemSegmentName).join();
+        chunkStorageManager2.read(hr, 0, out, 0, b1.length + b2.length, null).join();
+        Assert.assertEquals("Hello World", new String(out));
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTwoFailovers() throws Exception {
+        ChunkStorageProvider storageProvider = getStorageProvider();
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+        String systemSegmentName = "test";
+        int containerId = 42;
+        long epoch = 1;
+        val policy = new SegmentRollingPolicy(8);
+
+        SystemJournal journalBefore = new SystemJournal(containerId, epoch, storageProvider, metadataStoreBeforeCrash, policy);
+        journalBefore.setSystemSegmentsPrefix(systemSegmentName);
+        journalBefore.setSystemSegments(getSystemSegments(systemSegmentName));
+        long offset = 0;
+
+        // Epoch 1
+        ChunkStorageManager chunkStorageManager1 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager1.initialize(containerId, metadataStoreBeforeCrash, journalBefore);
+        chunkStorageManager1.initialize(epoch);
+
+        var h = chunkStorageManager1.create(systemSegmentName, new SegmentRollingPolicy(8), null).join();
+        val b1 = "Hello".getBytes();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(b1), b1.length, null);
+        offset += b1.length;
+
+        // Epoch 2
+        epoch++;
+        SystemJournal journalAfter = new SystemJournal(containerId, epoch, storageProvider, metadataStoreAfterCrash, policy);
+        journalAfter.setSystemSegments(getSystemSegments(systemSegmentName));
+        journalAfter.setSystemSegmentsPrefix(systemSegmentName);
+
+        ChunkStorageManager chunkStorageManager2 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager2.initialize(containerId, metadataStoreAfterCrash, journalAfter);
+        chunkStorageManager2.initialize(epoch);
+
+        journalAfter.bootstrap();
+        var h2 = chunkStorageManager2.openWrite(systemSegmentName).join();
+
+        // Write Junk Data to
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream("junk".getBytes()), 4, null);
+
+        val b2 = " World".getBytes();
+        chunkStorageManager2.write(h2, offset, new ByteArrayInputStream(b2), b2.length, null);
+        offset += b2.length;
+
+        val info = chunkStorageManager2.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(b1.length + b2.length, info.getLength());
+        byte[] out = new byte[b1.length + b2.length];
+        val hr = chunkStorageManager2.openRead(systemSegmentName).join();
+        chunkStorageManager2.read(hr, 0, out, 0, b1.length + b2.length, null).join();
+        Assert.assertEquals("Hello World", new String(out));
+    }
+
+    @Test
+    public void testSimpleBootstrapWithMultipleFailovers() throws Exception {
+        ChunkStorageProvider storageProvider = getStorageProvider();
+
+        String systemSegmentName = "test";
+        int containerId = 42;
+        long epoch = 0;
+        val policy = new SegmentRollingPolicy(100);
+
+        long offset = 0;
+        ChunkStorageManager oldhunkStorageManager = null;
+        SegmentHandle oldHandle = null;
+        for (int i = 1; i < 10; i++) {
+            // Epoch 2
+            epoch++;
+            ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+            SystemJournal journalInLoop = new SystemJournal(containerId, epoch, storageProvider, metadataStoreAfterCrash, policy);
+            journalInLoop.setSystemSegments(getSystemSegments(systemSegmentName));
+            journalInLoop.setSystemSegmentsPrefix(systemSegmentName);
+
+            ChunkStorageManager chunkStorageManagerInLoop = new ChunkStorageManager(storageProvider, executorService(), policy);
+            chunkStorageManagerInLoop.initialize(containerId, metadataStoreAfterCrash, journalInLoop);
+            chunkStorageManagerInLoop.initialize(epoch);
+
+            journalInLoop.bootstrap();
+
+            var h = chunkStorageManagerInLoop.openWrite(systemSegmentName).join();
+
+            if (null != oldhunkStorageManager) {
+                oldhunkStorageManager.write(oldHandle, offset, new ByteArrayInputStream("junk".getBytes()), 4, null);
+            }
+
+            val b1 = "Test".getBytes();
+            chunkStorageManagerInLoop.write(h, offset, new ByteArrayInputStream(b1), b1.length, null);
+            offset += b1.length;
+            val b2 = Integer.toString(i).getBytes();
+            chunkStorageManagerInLoop.write(h, offset, new ByteArrayInputStream(b2), b2.length, null);
+            offset += b2.length;
+
+            oldhunkStorageManager = chunkStorageManagerInLoop;
+            oldHandle = h;
+        }
+
+        epoch++;
+        ChunkMetadataStore metadataStoreFinal = getMetadataStore();
+
+        SystemJournal journalFinal = new SystemJournal(containerId, epoch, storageProvider, metadataStoreFinal, policy);
+        journalFinal.setSystemSegments(getSystemSegments(systemSegmentName));
+        journalFinal.setSystemSegmentsPrefix(systemSegmentName);
+
+        ChunkStorageManager chunkStorageManagerFinal = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManagerFinal.initialize(containerId, metadataStoreFinal, journalFinal);
+        chunkStorageManagerFinal.initialize(epoch);
+
+        journalFinal.bootstrap();
+
+        val info = chunkStorageManagerFinal.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(offset, info.getLength());
+        byte[] out = new byte[Math.toIntExact(offset)];
+        val hr = chunkStorageManagerFinal.openRead(systemSegmentName).join();
+        chunkStorageManagerFinal.read(hr, 0, out, 0, Math.toIntExact(offset), null).join();
+        var expected = "Test1Test2Test3Test4Test5Test6Test7Test8Test9";
+        var actual = new String(out);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTruncateInsideSecondChunk() throws Exception {
+        String initialGarbage = "JUNKJUNKJUNK";
+        String garbageAfterFailure = "junk";
+        String validWriteBeforeFailure = "Hello";
+        String validWriteAfterFailure = " World";
+        int maxLength = 8;
+
+        testBootstrapWithTruncate(initialGarbage, garbageAfterFailure, validWriteBeforeFailure, validWriteAfterFailure, maxLength);
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTruncateInsideFirstChunk() throws Exception {
+        String initialGarbage = "JUNK";
+        String garbageAfterFailure = "junk";
+        String validWriteBeforeFailure = "Hello";
+        String validWriteAfterFailure = " World";
+        int maxLength = 8;
+
+        testBootstrapWithTruncate(initialGarbage, garbageAfterFailure, validWriteBeforeFailure, validWriteAfterFailure, maxLength);
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTruncateOnChunkBoundary() throws Exception {
+        String initialGarbage = "JUNKJUNK";
+        String garbageAfterFailure = "junk";
+        String validWriteBeforeFailure = "Hello";
+        String validWriteAfterFailure = " World";
+        int maxLength = 8;
+
+        testBootstrapWithTruncate(initialGarbage, garbageAfterFailure, validWriteBeforeFailure, validWriteAfterFailure, maxLength);
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTruncateSingleChunk() throws Exception {
+        String initialGarbage = "JUNKJUNK";
+        String garbageAfterFailure = "junk";
+        String validWriteBeforeFailure = "Hello";
+        String validWriteAfterFailure = " World";
+        int maxLength = 80;
+
+        testBootstrapWithTruncate(initialGarbage, garbageAfterFailure, validWriteBeforeFailure, validWriteAfterFailure, maxLength);
+    }
+
+    private void testBootstrapWithTruncate(String initialGarbage, String garbageAfterFailure, String validWriteBeforeFailure, String validWriteAfterFailure, int maxLength) throws Exception {
+        ChunkStorageProvider storageProvider = getStorageProvider();
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+        String systemSegmentName = "test";
+
+        int containerId = 42;
+        long epoch = 1;
+        val policy = new SegmentRollingPolicy(maxLength);
+
+        SystemJournal journalBefore = new SystemJournal(containerId, epoch, storageProvider, metadataStoreBeforeCrash, policy);
+        journalBefore.setSystemSegmentsPrefix(systemSegmentName);
+        journalBefore.setSystemSegments(getSystemSegments(systemSegmentName));
+        long offset = 0;
+
+        // Epoch 1
+        ChunkStorageManager chunkStorageManager1 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager1.initialize(containerId, metadataStoreBeforeCrash, journalBefore);
+        chunkStorageManager1.initialize(epoch);
+
+        var h = chunkStorageManager1.create(systemSegmentName, new SegmentRollingPolicy(maxLength), null).join();
+        val b1 = validWriteBeforeFailure.getBytes();
+        byte[] garbage1 = initialGarbage.getBytes();
+        int garbage1Length = garbage1.length;
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(garbage1), garbage1Length, null);
+        offset += garbage1Length;
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(b1), b1.length, null);
+        offset += b1.length;
+        chunkStorageManager1.truncate(h, garbage1Length, null);
+
+        // Epoch 2
+        epoch++;
+        SystemJournal journalAfter = new SystemJournal(containerId, epoch, storageProvider, metadataStoreAfterCrash, policy);
+        journalAfter.setSystemSegments(getSystemSegments(systemSegmentName));
+        journalAfter.setSystemSegmentsPrefix(systemSegmentName);
+
+        ChunkStorageManager chunkStorageManager2 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager2.initialize(containerId, metadataStoreAfterCrash, journalAfter);
+        chunkStorageManager2.initialize(epoch);
+
+        journalAfter.bootstrap();
+        var h2 = chunkStorageManager2.openWrite(systemSegmentName).join();
+
+        // Write Junk Data to
+        val innerGarbageBytes = garbageAfterFailure.getBytes();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(innerGarbageBytes), innerGarbageBytes.length, null);
+
+        val b2 = validWriteAfterFailure.getBytes();
+        chunkStorageManager2.write(h2, offset, new ByteArrayInputStream(b2), b2.length, null);
+        offset += b2.length;
+
+        val info = chunkStorageManager2.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(b1.length + b2.length + garbage1Length, info.getLength());
+        Assert.assertEquals(garbage1Length, info.getStartOffset());
+        byte[] out = new byte[b1.length + b2.length];
+        val hr = chunkStorageManager2.openRead(systemSegmentName).join();
+        chunkStorageManager2.read(hr, garbage1Length, out, 0, b1.length + b2.length, null).join();
+        Assert.assertEquals(validWriteBeforeFailure + validWriteAfterFailure, new String(out));
+    }
+
+    @Test
+    public void testSimpleBootstrapWithTwoTruncates() throws Exception {
+        ChunkStorageProvider storageProvider = getStorageProvider();
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+        String systemSegmentName = "test";
+        int containerId = 42;
+        long epoch = 1;
+        val policy = new SegmentRollingPolicy(8);
+
+        SystemJournal journalBefore = new SystemJournal(containerId, epoch, storageProvider, metadataStoreBeforeCrash, policy);
+        journalBefore.setSystemSegmentsPrefix(systemSegmentName);
+        journalBefore.setSystemSegments(getSystemSegments(systemSegmentName));
+        long offset = 0;
+
+        // Epoch 1
+        ChunkStorageManager chunkStorageManager1 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager1.initialize(containerId, metadataStoreBeforeCrash, journalBefore);
+        chunkStorageManager1.initialize(epoch);
+
+        var h = chunkStorageManager1.create(systemSegmentName, new SegmentRollingPolicy(8), null).join();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream("JUNKJUNKJUNK".getBytes()), 12, null);
+        offset += 12;
+        val b1 = "Hello".getBytes();
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream(b1), b1.length, null);
+        offset += b1.length;
+        chunkStorageManager1.truncate(h, 6, null);
+
+        // Epoch 2
+        epoch++;
+        SystemJournal journalAfter = new SystemJournal(containerId, epoch, storageProvider, metadataStoreAfterCrash, policy);
+        journalAfter.setSystemSegments(getSystemSegments(systemSegmentName));
+        journalAfter.setSystemSegmentsPrefix(systemSegmentName);
+
+        ChunkStorageManager chunkStorageManager2 = new ChunkStorageManager(storageProvider, executorService(), policy);
+        chunkStorageManager2.initialize(containerId, metadataStoreAfterCrash, journalAfter);
+        chunkStorageManager2.initialize(epoch);
+
+        journalAfter.bootstrap();
+        var h2 = chunkStorageManager2.openWrite(systemSegmentName).join();
+
+        // Write Junk Data to
+        chunkStorageManager1.write(h, offset, new ByteArrayInputStream("junk".getBytes()), 4, null);
+
+        val b2 = " World".getBytes();
+        chunkStorageManager2.write(h2, offset, new ByteArrayInputStream(b2), b2.length, null);
+        offset += b2.length;
+
+        chunkStorageManager2.truncate(h, 12, null);
+
+        val info = chunkStorageManager2.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(b1.length + b2.length + 12, info.getLength());
+        Assert.assertEquals(12, info.getStartOffset());
+        byte[] out = new byte[b1.length + b2.length];
+        val hr = chunkStorageManager2.openRead(systemSegmentName).join();
+        chunkStorageManager2.read(hr, 12, out, 0, b1.length + b2.length, null).join();
+        Assert.assertEquals("Hello World", new String(out));
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
+import io.pravega.segmentstore.storage.metadata.StorageMetadata;
+import lombok.val;
+import org.junit.Assert;
+
+/**
+ * Test utility.
+ */
+public class TestUtils {
+    public static void checkSegmentLayout(ChunkMetadataStore metadataStore, String targetSegmentName, long lengthOfChunk, int numberOfchunks, long expectedStartOffset, long expectedLength) throws Exception {
+        val segmentMetadata = getSegmentMetadata(metadataStore, targetSegmentName);
+        Assert.assertNotNull(segmentMetadata);
+        Assert.assertEquals(expectedLength, segmentMetadata.getLength());
+        Assert.assertEquals(expectedStartOffset, segmentMetadata.getStartOffset());
+        // Assert
+        Assert.assertNotNull(segmentMetadata.getFirstChunk());
+        Assert.assertNotNull(segmentMetadata.getLastChunk());
+
+        int i = 0;
+        String current = segmentMetadata.getFirstChunk();
+        while (null != current) {
+            val chunk = getChunkMetadata(metadataStore, current);
+            current = chunk.getNextChunk();
+            Assert.assertEquals(lengthOfChunk, chunk.getLength());
+            i++;
+        }
+        Assert.assertEquals(numberOfchunks, i);
+    }
+
+    public static void checkSegmentLayout(ChunkMetadataStore metadataStore, String targetSegmentName, long[] expectedLengths) throws Exception {
+        checkSegmentLayout(metadataStore, targetSegmentName, expectedLengths, expectedLengths[expectedLengths.length - 1]);
+    }
+
+    public static void checkSegmentLayout(ChunkMetadataStore metadataStore, String targetSegmentName, long[] expectedLengths, long lastChunkLengthInStorage) throws Exception {
+        val segmentMetadata = getSegmentMetadata(metadataStore, targetSegmentName);
+        Assert.assertNotNull(segmentMetadata);
+
+        // Assert
+        Assert.assertNotNull(segmentMetadata.getFirstChunk());
+        Assert.assertNotNull(segmentMetadata.getLastChunk());
+        int expectedLength = 0;
+        int i = 0;
+        String current = segmentMetadata.getFirstChunk();
+        while (null != current) {
+            val chunk = getChunkMetadata(metadataStore, current);
+            current = chunk.getNextChunk();
+
+            Assert.assertEquals("Chunk " + Integer.toString(i) + " has unexpected length",
+                    i == expectedLengths.length-1 ? lastChunkLengthInStorage : expectedLengths[i],
+                    chunk.getLength());
+            expectedLength += chunk.getLength();
+            i++;
+        }
+        Assert.assertEquals(expectedLengths.length, i);
+        Assert.assertEquals(expectedLength, segmentMetadata.getLength());
+    }
+
+    public static StorageMetadata get(ChunkMetadataStore metadataStore, String key) throws Exception {
+        try (val txn = metadataStore.beginTransaction()) {
+            return metadataStore.get(txn, key);
+        }
+    }
+
+    public static SegmentMetadata getSegmentMetadata(ChunkMetadataStore metadataStore, String key) throws Exception {
+        try (val txn = metadataStore.beginTransaction()) {
+            return (SegmentMetadata) metadataStore.get(txn, key);
+        }
+    }
+
+    public static ChunkMetadata getChunkMetadata(ChunkMetadataStore metadataStore, String key) throws Exception {
+        try (val txn = metadataStore.beginTransaction()) {
+            return (ChunkMetadata) metadataStore.get(txn, key);
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.metadata;
+
+import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+/**
+ * Unit tests for ChunkMetadataStoreTests.
+ */
+public class ChunkMetadataStoreTests {
+
+    public static final String KEY0 = "donald";
+    public static final String KEY1 = "micky";
+    public static final String KEY3 = "pluto";
+
+    public static final String VALUE0 = "duck";
+    public static final String VALUE1 = "rat";
+    public static final String VALUE2 = "dog";
+    public static final String VALUE4 = "mouse";
+    public static final String VALUE5 = "avian";
+    public static final String VALUE6 = "bird";
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(300);
+
+    protected ChunkMetadataStore metadataStore;
+
+
+    @Before
+    public void setUp() {
+        metadataStore = new InMemoryMetadataStore();
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+
+    @Test
+    public void testSimpleScenario() throws Exception {
+        try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+            // NO value should be found.
+            Assert.assertNull(metadataStore.get(txn, KEY0));
+            Assert.assertNull(metadataStore.get(txn, KEY1));
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+
+            // Create data
+            metadataStore.create(txn, new TestData(KEY0, VALUE0));
+            metadataStore.create(txn, new TestData(KEY1, VALUE1));
+            metadataStore.create(txn, new TestData(KEY3, VALUE2));
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            // Update
+            metadataStore.create(txn, new TestData(KEY1, VALUE4));
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            // delete
+            metadataStore.delete(txn, KEY3);
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+            metadataStore.commit(txn, false);
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // See the effect of transaction after words
+        try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+            assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn2, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn2, KEY3));
+
+            metadataStore.update(txn2, new TestData(KEY0, VALUE6));
+            metadataStore.delete(txn2, KEY1);
+            assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+            Assert.assertNull(metadataStore.get(txn2, KEY3));
+            Assert.assertNull(metadataStore.get(txn2, KEY1));
+            // Implicitly aborted
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // Should have no effect;
+        try (MetadataTransaction txn3 = metadataStore.beginTransaction()) {
+            assertEquals((TestData) metadataStore.get(txn3, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn3, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn3, KEY3));
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+
+    @Test
+    public void testSimpleScenarioWithLazyCommit() throws Exception {
+        try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+            // NO value should be found.
+            Assert.assertNull(metadataStore.get(txn, KEY0));
+            Assert.assertNull(metadataStore.get(txn, KEY1));
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+
+            // Create data
+            metadataStore.create(txn, new TestData(KEY0, VALUE0));
+            metadataStore.create(txn, new TestData(KEY1, VALUE1));
+            metadataStore.create(txn, new TestData(KEY3, VALUE2));
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            // Update
+            metadataStore.create(txn, new TestData(KEY1, VALUE4));
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            // delete
+            metadataStore.delete(txn, KEY3);
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+            metadataStore.commit(txn, true);
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // See the effect of transaction after words
+        try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+            assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn2, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn2, KEY3));
+
+            metadataStore.update(txn2, new TestData(KEY0, VALUE6));
+            metadataStore.delete(txn2, KEY1);
+            assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+            Assert.assertNull(metadataStore.get(txn2, KEY3));
+            Assert.assertNull(metadataStore.get(txn2, KEY1));
+            // Implicitly aborted
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // Should have no effect;
+        try (MetadataTransaction txn3 = metadataStore.beginTransaction()) {
+            assertEquals((TestData) metadataStore.get(txn3, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn3, KEY1), KEY1, VALUE4);
+            Assert.assertNull(metadataStore.get(txn3, KEY3));
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+
+    @Ignore("Not sure this is a valid case. But keeping it for now.")
+    @Test
+    public void testTransactionFailedForMultipleDeletes() throws Exception {
+        // Set up.
+        try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+            Assert.assertNull(metadataStore.get(txn, KEY1));
+            // Create data.
+            metadataStore.create(txn, new TestData(KEY1, VALUE1));
+            // Validate the data is present in local transaction view.
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            // Commit.
+            metadataStore.commit(txn, false);
+            // Validate same data is present after commit.
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // Step 1 : Start a parallel transaction.
+        try (MetadataTransaction txn0 = metadataStore.beginTransaction()) {
+            // Step 1 A : In new transaction, delete a key.
+            metadataStore.delete(txn0, KEY1);
+            // Step 1 B : Validate data is not present in local transaction view before commit.
+            Assert.assertNull(metadataStore.get(txn0, KEY1));
+
+            // Step 2 : Start yet another parallel transaction.
+            try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+                // Data should be visible in a second transaction.
+                assertEquals((TestData) metadataStore.get(txn2, KEY1), KEY1, VALUE1);
+                // Step 2 A: delete a key.
+                metadataStore.delete(txn2, KEY1);
+                Assert.assertNull(metadataStore.get(txn2, KEY1));
+
+                // Step 2 B: commit
+                metadataStore.commit(txn2, false);
+                Assert.assertNull(metadataStore.get(txn2, KEY1));
+            } catch (Exception e) {
+                throw e;
+            }
+
+            // Step 3 : Now commit, which should fail.
+            try {
+                metadataStore.commit(txn0, false);
+                Assert.fail("Transaction should be aborted.");
+            } catch (StorageMetadataVersionMismatchException e) {
+            }
+        }
+    }
+
+    @Test
+    public void testTransactionFailedForMultipleUpdates() throws Exception {
+        // Step 1: Set up
+        try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+            Assert.assertNull(metadataStore.get(txn, KEY0));
+            Assert.assertNull(metadataStore.get(txn, KEY1));
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+            // Create data
+            metadataStore.create(txn, new TestData(KEY0, VALUE0));
+            metadataStore.create(txn, new TestData(KEY1, VALUE1));
+            metadataStore.create(txn, new TestData(KEY3, VALUE2));
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            metadataStore.commit(txn, false);
+
+            // Same data after commit.
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // Step 2: Create a test transaction
+        try (MetadataTransaction txn0 = metadataStore.beginTransaction()) {
+
+            // Step 2 A: Make some updates, but don't commit yet.
+            metadataStore.update(txn0, new TestData(KEY0, VALUE5));
+            assertEquals((TestData) metadataStore.get(txn0, KEY0), KEY0, VALUE5);
+            assertEquals((TestData) metadataStore.get(txn0, KEY3), KEY3, VALUE2);
+
+            // Step 3 : Start a parallel transaction
+            try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+                // Step 3 A: Make some updates, but don't commit yet.
+                metadataStore.update(txn2, new TestData(KEY0, VALUE6));
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+
+                // Step 3 B: Commit. It should succeed.
+                metadataStore.commit(txn2, false);
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+
+            } catch (Exception e) {
+                throw e;
+            }
+
+            // Step 4 : Start a second parallel transaction
+            try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+                // Step 4 : Data committed by earlier transaction should be visible to other new transactions
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+            } catch (Exception e) {
+                throw e;
+            }
+
+            // A committed transactions should not have any effect on this transaction.
+            assertEquals((TestData) metadataStore.get(txn0, KEY0), KEY0, VALUE5);
+            assertEquals((TestData) metadataStore.get(txn0, KEY3), KEY3, VALUE2);
+
+            try {
+                metadataStore.commit(txn0, false);
+                Assert.fail("Transaction should be aborted.");
+            } catch (StorageMetadataVersionMismatchException e) {
+            }
+        }
+    }
+
+    @Test
+    public void testTransactionFailedForMultipleOperations() throws Exception {
+
+        // Set up the data there are 3 keys
+        try (MetadataTransaction txn = metadataStore.beginTransaction()) {
+            Assert.assertNull(metadataStore.get(txn, KEY0));
+            Assert.assertNull(metadataStore.get(txn, KEY1));
+            Assert.assertNull(metadataStore.get(txn, KEY3));
+            // Create data
+            metadataStore.create(txn, new TestData(KEY0, VALUE0));
+            metadataStore.create(txn, new TestData(KEY1, VALUE1));
+            metadataStore.create(txn, new TestData(KEY3, VALUE2));
+
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+            metadataStore.commit(txn, false);
+
+            // Same data after commit.
+            assertEquals((TestData) metadataStore.get(txn, KEY0), KEY0, VALUE0);
+            assertEquals((TestData) metadataStore.get(txn, KEY1), KEY1, VALUE1);
+            assertEquals((TestData) metadataStore.get(txn, KEY3), KEY3, VALUE2);
+
+        } catch (Exception e) {
+            throw e;
+        }
+
+        // Start a test transaction
+        try (MetadataTransaction txn0 = metadataStore.beginTransaction()) {
+            // Update/delete some keys but don't commit .
+            // We wan to see that these changes do not affect other transactions
+            metadataStore.update(txn0, new TestData(KEY0, VALUE5));
+            metadataStore.delete(txn0, KEY1);
+            assertEquals((TestData) metadataStore.get(txn0, KEY0), KEY0, VALUE5);
+            assertEquals((TestData) metadataStore.get(txn0, KEY3), KEY3, VALUE2);
+            Assert.assertNull(metadataStore.get(txn0, KEY1));
+
+            // Another Transaction that must be able modify its view data and commit
+            try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+
+                metadataStore.update(txn2, new TestData(KEY0, VALUE6));
+                metadataStore.delete(txn2, KEY1);
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+                Assert.assertNull(metadataStore.get(txn2, KEY1));
+                metadataStore.commit(txn2, false);
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+                Assert.assertNull(metadataStore.get(txn2, KEY1));
+            } catch (Exception e) {
+                throw e;
+            }
+
+            // Yet another Transaction that must be able modify its view data and commit
+            try (MetadataTransaction txn2 = metadataStore.beginTransaction()) {
+
+                assertEquals((TestData) metadataStore.get(txn2, KEY0), KEY0, VALUE6);
+                assertEquals((TestData) metadataStore.get(txn2, KEY3), KEY3, VALUE2);
+                Assert.assertNull(metadataStore.get(txn2, KEY1));
+            } catch (Exception e) {
+                throw e;
+            }
+
+            // A committed transaction should not have any effect on this transaction.
+            assertEquals((TestData) metadataStore.get(txn0, KEY0), KEY0, VALUE5);
+            assertEquals((TestData) metadataStore.get(txn0, KEY3), KEY3, VALUE2);
+            Assert.assertNull(metadataStore.get(txn0, KEY1));
+
+            // However when it tries to commit this should fail.
+            try {
+                metadataStore.commit(txn0, false);
+                Assert.fail("Transaction should be aborted.");
+            } catch (StorageMetadataVersionMismatchException e) {
+
+            }
+        }
+    }
+
+    private void assertEquals(TestData data, String key, String value) {
+        Assert.assertEquals("Should get the same data",  key, data.getKey());
+        Assert.assertEquals("Should get the same data", value, data.getValue());
+    }
+
+    /**
+     *
+     */
+    @Builder(toBuilder = true)
+    static class TestData implements StorageMetadata {
+
+        @Getter
+        @Setter
+        String key;
+
+        @Getter
+        @Setter
+        String value;
+
+        /**
+         *
+         * @param key
+         * @param value
+         */
+        public TestData(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public StorageMetadata copy() {
+            return toBuilder().build();
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageTests.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.mocks;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkManagerRollingTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageManagerTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProviderTests;
+import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Unit tests for InMemorySimpleStorage.
+ */
+public class InMemorySimpleStorageTests extends SimpleStorageTests {
+    private static ChunkStorageProvider getChunkStorageProvider(Executor executor) throws IOException {
+        return new InMemoryChunkStorageProvider(executor);
+    }
+
+    protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+        return getChunkStorageProvider(executor);
+    }
+
+    public static class InMemorySimpleStorageRollingTests extends ChunkManagerRollingTests {
+        protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return getChunkStorageProvider(executor);
+        }
+    }
+
+    public static class InMemorySimpleStorageProviderTests extends ChunkStorageProviderTests {
+        @Override
+        protected ChunkStorageProvider createChunkStorageProvider() throws Exception {
+            return getChunkStorageProvider(new ScheduledThreadPoolExecutor(getThreadPoolSize()));
+        }
+    }
+
+    public static class InMemorySimpleStorage extends ChunkStorageManagerTests {
+
+        @Override
+        public ChunkStorageProvider getChunkStorageProvider() throws Exception {
+            return InMemorySimpleStorageTests.getChunkStorageProvider(executorService());
+        }
+
+        public TestContext getTestContext()  throws Exception {
+            return new InMemorySimpleStorageTestContext(executorService());
+        }
+
+        public class InMemorySimpleStorageTestContext extends ChunkStorageManagerTests.TestContext {
+            InMemorySimpleStorageTestContext(ExecutorService executorService)  throws Exception {
+                super(executorService);
+            }
+
+            @Override
+            public ChunkStorageProvider getChunkStorageProvider() throws Exception {
+                return InMemorySimpleStorageTests.getChunkStorageProvider(executorService());
+            }
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/noop/NoOpSimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/noop/NoOpSimpleStorageTests.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.noop;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkManagerRollingTests;
+import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProvider;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageProviderTests;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Unit tests for NoOpSimpleStorage using SimpleStorageTests.
+ */
+public class NoOpSimpleStorageTests extends SimpleStorageTests {
+    private static ChunkStorageProvider getChunkStorageProvider(Executor executor) throws IOException {
+        return new NoOpChunkStorageProvider(executor);
+    }
+
+    protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+        return getChunkStorageProvider(executor);
+    }
+
+    @Override
+    protected void populate(byte[] data) {
+        // Do nothing keep data uninitialized.
+    }
+
+    /**
+     * Unit tests for NoOpChunkStorageProvider using ChunkManagerRollingTests
+     */
+    public static class NoOpRollingTests extends ChunkManagerRollingTests {
+        protected ChunkStorageProvider getChunkStorage(Executor executor)  throws Exception {
+            return getChunkStorageProvider(executor);
+        }
+
+        @Override
+        protected void populate(byte[] data) {
+            // Do nothing keep data uninitialized.
+        }
+    }
+
+    /**
+     * Unit tests for NoOpChunkStorageProvider using ChunkStorageProviderTests
+     */
+    public static class NoOpChunkStorageProviderTests extends ChunkStorageProviderTests {
+        @Override
+        protected ChunkStorageProvider createChunkStorageProvider() throws Exception {
+            return getChunkStorageProvider(new ScheduledThreadPoolExecutor(getThreadPoolSize()));
+        }
+
+        @Override
+        protected void populate(byte[] data) {
+            // Do nothing keep data uninitialized.
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
@@ -29,6 +29,13 @@ import org.junit.Test;
 public abstract class RollingStorageTestBase extends StorageTestBase {
     protected static final long DEFAULT_ROLLING_SIZE = (int) (APPEND_FORMAT.length() * 1.5);
 
+    /**
+     * Indicates the layout format to test.
+     * For AsycStorageWrapper and RollingStorage it is set to true.
+     * For ChunkStorageManager set to false.
+     */
+    protected boolean useOldLayout = true;
+
     @Override
     public void testFencing() throws Exception {
         // Fencing is left up to the underlying Storage implementation to handle. There's nothing to test here.
@@ -79,13 +86,15 @@ public abstract class RollingStorageTestBase extends StorageTestBase {
         writeStream.write(writeBuffer);
 
         // Get a read handle, which will also fetch the number of chunks for us.
-        val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
-        Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
-        val writtenData = writeStream.toByteArray();
-        byte[] readBuffer = new byte[writtenData.length];
-        int bytesRead = s.read(readHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
-        Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
-        Assert.assertArrayEquals("Unexpected data read back.", writtenData, readBuffer);
+        if (useOldLayout) {
+            val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
+            Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
+            val writtenData = writeStream.toByteArray();
+            byte[] readBuffer = new byte[writtenData.length];
+            int bytesRead = s.read(readHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
+            Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
+            Assert.assertArrayEquals("Unexpected data read back.", writtenData, readBuffer);
+        }
     }
 
     @Test
@@ -120,8 +129,10 @@ public abstract class RollingStorageTestBase extends StorageTestBase {
         writeStream.write(writeBuffer);
 
         // Get a read handle, which will also fetch the number of chunks for us.
-        val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
-        Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
+        if (useOldLayout) {
+            val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
+            Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
+        }
     }
 
     @Test
@@ -149,24 +160,26 @@ public abstract class RollingStorageTestBase extends StorageTestBase {
         s.write(writeHandle, 0, sequenceInputStream, totalWriteLength, TIMEOUT).join();
 
         // Check rollover actually happened as expected.
-        RollingSegmentHandle checkHandle = (RollingSegmentHandle) s.openWrite(segmentName).join();
-        val chunks = checkHandle.chunks();
-        int numberOfRollovers = totalWriteLength / maxLength;
-        Assert.assertEquals(numberOfRollovers + 1, chunks.size());
+        if (useOldLayout) {
+            RollingSegmentHandle checkHandle = (RollingSegmentHandle) s.openWrite(segmentName).join();
+            val chunks = checkHandle.chunks();
+            int numberOfRollovers = totalWriteLength / maxLength;
+            Assert.assertEquals(numberOfRollovers + 1, chunks.size());
 
-        for (int i = 0; i < numberOfRollovers; i++) {
-            Assert.assertEquals(maxLength * i, chunks.get(i).getStartOffset());
-            Assert.assertEquals(maxLength, chunks.get(i).getLength());
+            for (int i = 0; i < numberOfRollovers; i++) {
+                Assert.assertEquals(maxLength * i, chunks.get(i).getStartOffset());
+                Assert.assertEquals(maxLength, chunks.get(i).getLength());
+            }
+            // Last chunk has index == numberOfRollovers, as list is 0 based.
+            Assert.assertEquals(numberOfRollovers * maxLength, chunks.get(numberOfRollovers).getStartOffset());
+            Assert.assertEquals(1, chunks.get(numberOfRollovers).getLength());
+
+            // Now validate the contents written.
+            val readHandle = s.openRead(segmentName).join();
+            byte[] output = new byte[totalWriteLength];
+            s.read(readHandle, 0, output, 0, totalWriteLength, TIMEOUT).join();
+            Assert.assertEquals(seq1 + seq2, new String(output));
         }
-        // Last chunk has index == numberOfRollovers, as list is 0 based.
-        Assert.assertEquals(numberOfRollovers * maxLength, chunks.get(numberOfRollovers).getStartOffset());
-        Assert.assertEquals(1, chunks.get(numberOfRollovers).getLength());
-
-        // Now validate the contents written.
-        val readHandle = s.openRead(segmentName).join();
-        byte[] output = new byte[totalWriteLength];
-        s.read(readHandle, 0, output, 0, totalWriteLength, TIMEOUT).join();
-        Assert.assertEquals(seq1 + seq2, new String(output));
     }
 
     @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -74,6 +74,16 @@ public final class NameUtils {
     private static final String METADATA_SEGMENT_NAME_FORMAT = "_system/containers/metadata_%d";
 
     /**
+     * Format for Storage Metadata Segment name.
+     */
+    private static final String STORAGE_METADATA_SEGMENT_NAME_FORMAT = "_system/containers/storage_metadata_%d";
+
+    /**
+     * Format for Container System Journal file name.
+     */
+    private static final String SYSJOURNAL_NAME_FORMAT = "_sysjournal_epoch%d_container%d";
+
+    /**
      * The Transaction unique identifier is made of two parts, each having a length of 16 bytes (64 bits in Hex).
      */
     private static final int TRANSACTION_PART_LENGTH = Long.BYTES * 8 / 4;
@@ -98,6 +108,7 @@ public final class NameUtils {
      */
     @Getter(AccessLevel.PACKAGE)
     private static final String MARK_PREFIX = INTERNAL_NAME_PREFIX + "MARK";
+
 
     //endregion
 
@@ -225,6 +236,28 @@ public final class NameUtils {
     public static String getMetadataSegmentName(int containerId) {
         Preconditions.checkArgument(containerId >= 0, "containerId must be a non-negative number.");
         return String.format(METADATA_SEGMENT_NAME_FORMAT, containerId);
+    }
+
+    /**
+     * Gets the name of the Segment that is used to store the Container's Segment Metadata. There is one such Segment
+     * per container.
+     *
+     * @param containerId The Id of the Container.
+     * @return The Metadata Segment name.
+     */
+    public static String getStorageMetadataSegmentName(int containerId) {
+        Preconditions.checkArgument(containerId >= 0, "containerId must be a non-negative number.");
+        return String.format(STORAGE_METADATA_SEGMENT_NAME_FORMAT, containerId);
+    }
+
+    /**
+     * Gets file name of SystemJournal for given container instance.
+     * @param containerId The Id of the Container.
+     * @param epoch Epoch of the container instance.
+     * @return
+     */
+    public static String getSystemJournalFileName(int containerId, long epoch) {
+        return String.format(SYSJOURNAL_NAME_FORMAT, epoch, containerId);
     }
 
     /**
@@ -579,5 +612,8 @@ public final class NameUtils {
         sb.append(stream);
         return sb.toString();
     }
+    // endregion
+
+
     // endregion
 }

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -285,6 +285,8 @@ public class InProcPravegaCluster implements AutoCloseable {
                         .with(ServiceConfig.DATALOG_IMPLEMENTATION, isInMemStorage ?
                                 ServiceConfig.DataLogType.INMEMORY :
                                 ServiceConfig.DataLogType.BOOKKEEPER)
+                        .with(ServiceConfig.STORAGE_MANAGER, ServiceConfig.StorageManager.NONE)
+                        .with(ServiceConfig.STORAGE_LAYOUT, ServiceConfig.StorageLayout.LEGACY)
                         .with(ServiceConfig.STORAGE_IMPLEMENTATION, isInMemStorage ?
                                 ServiceConfig.StorageType.INMEMORY :
                                 ServiceConfig.StorageType.FILESYSTEM))

--- a/test/testcommon/src/main/java/io/pravega/test/common/ThreadPooledTestSuite.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/ThreadPooledTestSuite.java
@@ -24,13 +24,13 @@ public abstract class ThreadPooledTestSuite {
     private ScheduledExecutorService executorService = null;
 
     @Before
-    public void before() {
+    public void before() throws Exception {
         int threadPoolSize = getThreadPoolSize();
         this.executorService = threadPoolSize == INLINE_THREAD_COUNT ? new InlineExecutor() : createExecutorService(threadPoolSize);
     }
 
     @After
-    public void after() throws InterruptedException {
+    public void after() throws Exception {
         this.executorService.shutdownNow();
         this.executorService.awaitTermination(5, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
**NOTE** This is a draft PR. A few config related minor changes coming soon.

Issue 4676: (PDP-34) Initial Implementation.
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Initial implementation of PDP 34.

**Purpose of the change**  
Fixes #4676 - Initial implementation of PDP -34

**What the code does**  
_Design :_ 
- This PR implements following design.  https://github.com/pravega/pravega/wiki/PDP-34:-Simplified-Tier-2

_General Comments:_ 
- The code is added in a manner so that older AsyncStorage+Sync based code continues to work. Reusing and refactoring code wherever possible.
- The ChunkStorageProvider interface is synchronous for simplicity of implementation. We'll change it to Async if required at later date.

_In scope :_ The initial implementation includes following.
- Implementation of Storage interface using new design ( viz. ChunkStorageManager + ChunkMetadataStore + ChunkStorageProvider ). The implementation should also re-implement RollingStorage functionality.
- Implementation for ChunkStorageProvider using NFS, HDFS and ExtendedS3
- Implementation of No Op and InMemory ChunkStorageProviders for testing.
- Initial implementation uses TableSegment based implementation for storing storage metadata.
- This implementation also updates container bootstrap logic so that system boots up correctly.
- New configuration options are provided so that this new experimental feature can be turned on in Pravega deployments.
- The end to end StreamSegmentStore tests should pass.
 
_out of scope :_ 
- This initial implementation does not implement actual provider that supports only immutable writes. (Although it should include design elements to support that.)
- The initial implementation does not support upgrade path.
- Non-critical performance improvements. (Especially on read path. Coming very very soon)


**How to verify it**  
- [ ] New or old unit tests should pass.
- [ ] System tests should pass. 
- [ ] Longevity tests.
- [ ] Perf tests ?

**Suggested Sequence for review**  

1. Interfaces `ChunkStorageProvider`, `ChunkMetadataStore` 
2. ChunkStorage Implementations - Base class `BaseChunkStorageProvider`.  For testing `NoOpChunkStorageProvider` and `InMemoryChunkStorageProvider`. New Storage Bindings `ExtendedS3ChunkStorageProvider` , `FileSystemChunkStorageProvider` and `HDFSChunkStorageProvider`
3. The core of the Implementation . `ChunkStorageManager` .
4. Lots of good new tests cases.  `ChunkManagerRollingTests`, `ChunkStorageManagerTests`, `ChunkStorageProviderTests`, `SimpleStorageTests`. Other Storage tests are refactored to work with new implementation.
5. Metadata store implementation - `BaseMetadataStore` and the implementation `TableBasedMetadataStore` and `InMemoryMetadataStore`. The data stored is `SegmentMetadata`, `ChunkMetadata`.
6. Bootstrap logic `SystemJournal` and Storage initialization logic in `StreamSegmentContainer`
7. Configuration related changes.
8. General test changes.
