### PR TITLE
Issue 4642 - Use Java truststore path and password mounted by operator.

### DIFF
--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -37,7 +37,7 @@ add_system_property_ecs_config_uri() {
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
     password="changeit"
-    trust="/etc/ssl/certs/java/cacerts"
+    trustStore="/etc/ssl/certs/java/cacerts"
     certificate="ecs-certificate.pem"
 
     if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD"; then

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -36,12 +36,21 @@ add_system_property_ecs_config_uri() {
 
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
-    password=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD`
-    trustStore=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH`
+    password="changeit"
+    trust="/etc/ssl/certs/java/cacerts"
+    certificate="ecs-certificate.pem"
 
-    CERTS=/etc/ssl/certs/java/ecs-certs/*.pem
-    for cert in $CERTS
-    do
-      yes | keytool -importcert -storepass "${password}" -file "${cert}" -keystore "${trustStore}" || true
-    done
+    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD"; then
+        password=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD`
+    fi
+    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH"; then
+        trustStore=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH`
+    fi
+    if test -f "/etc/secret-volume/ECS_CERTIFICATE_NAME"; then
+        certificate=`cat /etc/secret-volume/ECS_CERTIFICATE_NAME`
+    fi
+
+    if test -f "/etc/secret-volume/${certificate}"; then
+        yes | keytool -importcert -storepass "${password}" -file "/etc/secret-volume/${certificate}" -keystore "${trustStore}" || true
+    fi
 }

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -36,9 +36,12 @@ add_system_property_ecs_config_uri() {
 
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
-    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    password=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD`
+    trustStore=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH`
+
+    CERTS=/etc/ssl/certs/java/ecs-certs/*.pem
     for cert in $CERTS
     do
-      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+      yes | keytool -importcert -storepass "${password}" -file "${cert}" -keystore "${trustStore}" || true
     done
 }

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -40,12 +40,6 @@ add_certs_into_truststore() {
     trustStore="/etc/ssl/certs/java/cacerts"
     certificate="ecs-certificate.pem"
 
-    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD"; then
-        password=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD`
-    fi
-    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH"; then
-        trustStore=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH`
-    fi
     if test -f "/etc/secret-volume/ECS_CERTIFICATE_NAME"; then
         certificate=`cat /etc/secret-volume/ECS_CERTIFICATE_NAME`
     fi


### PR DESCRIPTION
**Change log description**  
Instead of hard-coding, now the Java Truststore path and password get mounted from pravega manifest by pravega-operator.
This change is to start using the mounted path and password in the script to add ECS certificate into Java truststore.

**Purpose of the change**  
Fixes #4642 

**What the code does**  
Inside docker/pravega/scripts/common.sh:
Retrieve password from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD
Retrieve truststore file path from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH
Then scan /etc/ssl/certs/java/ecs-certs to add all the found PEM files into Java Truststore.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
With https://... ECS configUri, Pravega segmentstore is able to write/read to/from ECS
