### PR TITLE
Issue 4642 - cherry-pick into r0.7 for ECS TLS support

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Metrics.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Metrics.java
@@ -33,4 +33,5 @@ final class ExtendedS3Metrics {
     static final Counter CREATE_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_CREATE_COUNT);
     static final Counter DELETE_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_DELETE_COUNT);
     static final Counter CONCAT_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_CONCAT_COUNT);
+    static final Counter LARGE_CONCAT_COUNT = EXTENDED_S3_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);
 }

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -39,6 +39,8 @@ import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SyncStorage;
+
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.SortedSet;
@@ -386,23 +388,57 @@ public class ExtendedS3Storage implements SyncStorage {
      * completeMultiPartUpload call. Specifically, to concatenate, we are copying the target segment T and the
      * source segment S to T, so essentially we are doing T <- T + S.
      */
-    private Void doConcat(SegmentHandle targetHandle, long offset, String sourceSegment) throws StreamSegmentNotExistsException {
+    private Void doConcat(SegmentHandle targetHandle, long offset, String sourceSegment) throws Exception {
         Preconditions.checkArgument(!targetHandle.isReadOnly(), "target handle must not be read-only.");
         long traceId = LoggerHelpers.traceEnter(log, "concat", targetHandle.getSegmentName(), offset, sourceSegment);
         Timer timer = new Timer();
-        SortedSet<MultipartPartETag> partEtags = new TreeSet<>();
-        String targetPath = config.getPrefix() + targetHandle.getSegmentName();
-        String uploadId = client.initiateMultipartUpload(config.getBucket(), targetPath);
 
+        String targetPath = config.getPrefix() + targetHandle.getSegmentName();
         // check whether the target exists
         if (!doExists(targetHandle.getSegmentName())) {
             throw new StreamSegmentNotExistsException(targetHandle.getSegmentName());
         }
         // check whether the source is sealed
         SegmentProperties si = doGetStreamSegmentInfo(sourceSegment);
+        String sourcePath = config.getPrefix() + sourceSegment;
         Preconditions.checkState(si.isSealed(), "Cannot concat segment '%s' into '%s' because it is not sealed.",
                 sourceSegment, targetHandle.getSegmentName());
 
+        if (config.getSmallObjectSizeLimitForConcat() < si.getLength()) {
+            doConcatWithMultipartUpload(targetPath, sourceSegment, offset);
+            ExtendedS3Metrics.LARGE_CONCAT_COUNT.inc();
+        } else {
+            doConcatWithAppend(targetPath, sourcePath, offset, si.getLength());
+        }
+        // Now delete the source object.
+        client.deleteObject(config.getBucket(), sourcePath);
+
+        Duration elapsed = timer.getElapsed();
+        log.debug("Concat target={} source={} offset={} bytesWritten={} latency={}.", targetHandle.getSegmentName(), sourceSegment, offset, si.getLength(), elapsed.toMillis());
+
+        ExtendedS3Metrics.CONCAT_LATENCY.reportSuccessEvent(elapsed);
+        ExtendedS3Metrics.CONCAT_BYTES.add(si.getLength());
+        ExtendedS3Metrics.CONCAT_COUNT.inc();
+
+        LoggerHelpers.traceLeave(log, "concat", traceId);
+
+        return null;
+    }
+
+    private void doConcatWithAppend(String targetPath, String sourcePath, long offset, long length) throws Exception {
+        try (InputStream reader = client.readObjectStream(config.getBucket(),
+                sourcePath, Range.fromOffsetLength(0, length))) {
+            client.putObject(this.config.getBucket(),
+                    targetPath,
+                    Range.fromOffsetLength(offset, length),
+                    new BufferedInputStream(reader, Math.toIntExact(length)));
+        }
+    }
+
+    private void doConcatWithMultipartUpload(String targetPath, String sourceSegment, long offset) {
+        String uploadId = client.initiateMultipartUpload(config.getBucket(), targetPath);
+
+        SortedSet<MultipartPartETag> partEtags = new TreeSet<>();
         //Copy the first part
         CopyPartRequest copyRequest = new CopyPartRequest(config.getBucket(),
                 targetPath,
@@ -432,19 +468,6 @@ public class ExtendedS3Storage implements SyncStorage {
         //Close the upload
         client.completeMultipartUpload(new CompleteMultipartUploadRequest(config.getBucket(),
                 targetPath, uploadId).withParts(partEtags));
-
-        client.deleteObject(config.getBucket(), config.getPrefix() + sourceSegment);
-        Duration elapsed = timer.getElapsed();
-
-        log.debug("Concat target={} source={} offset={} bytesWritten={} latency={}.", targetHandle.getSegmentName(), sourceSegment, offset, si.getLength(), elapsed.toMillis());
-
-        ExtendedS3Metrics.CONCAT_LATENCY.reportSuccessEvent(elapsed);
-        ExtendedS3Metrics.CONCAT_BYTES.add(si.getLength());
-        ExtendedS3Metrics.CONCAT_COUNT.inc();
-
-        LoggerHelpers.traceLeave(log, "concat", traceId);
-
-        return null;
     }
 
     private Void doDelete(SegmentHandle handle) {

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -30,6 +30,7 @@ public class ExtendedS3StorageConfig {
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> PREFIX = Property.named("prefix", "/");
     public static final Property<Boolean> USENONEMATCH = Property.named("useNoneMatch", false);
+    public static final Property<Integer> SMALL_OBJECT_THRESHOLD = Property.named("smallObjectSizeLimitForConcat", 1024 * 1024);
 
     private static final String COMPONENT_CODE = "extendeds3";
     private static final String PATH_SEPARATOR = "/";
@@ -75,6 +76,14 @@ public class ExtendedS3StorageConfig {
     @Getter
     private final boolean useNoneMatch;
 
+    /**
+     * Size of ECS objects in bytes above which it is no longer considered a small object.
+     * For small source objects, to implement concat ExtendedS3Storage reads complete objects and appends it to target
+     * instead of using multi part upload.
+     */
+    @Getter
+    private final int smallObjectSizeLimitForConcat;
+
     //endregion
 
     //region Constructor
@@ -93,6 +102,7 @@ public class ExtendedS3StorageConfig {
         String givenPrefix = Preconditions.checkNotNull(properties.get(PREFIX), "prefix");
         this.prefix = givenPrefix.endsWith(PATH_SEPARATOR) ? givenPrefix : givenPrefix + PATH_SEPARATOR;
         this.useNoneMatch = properties.getBoolean(USENONEMATCH);
+        this.smallObjectSizeLimitForConcat = properties.getInt(SMALL_OBJECT_THRESHOLD);
     }
 
     /**

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -185,10 +185,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
             assertEquals(2, ExtendedS3Metrics.DELETE_LATENCY.toOpStatsData().getNumSuccessfulEvents());
             assertTrue(0 < ExtendedS3Metrics.DELETE_LATENCY.toOpStatsData().getAvgLatencyMillis());
 
-        } finally {
-
         }
-
     }
 
     /**
@@ -224,6 +221,29 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
             // Verify with prefix
             assertFalse(s.exists(segmentName1, null).get());
             assertFalse(s.exists(segmentName1 + "$header", null).get());
+        }
+    }
+
+    /**
+     * Tests the concat() method forcing to use multipart upload.
+     *
+     * @throws Exception if an unexpected error occurred.
+     */
+    @Test
+    public void testConcatWithMultipartUpload() throws Exception {
+        val adapterConfig = ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, setup.configUri)
+                .with(ExtendedS3StorageConfig.BUCKET, setup.adapterConfig.getBucket())
+                .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
+                .with(ExtendedS3StorageConfig.USENONEMATCH, true)
+                .with(ExtendedS3StorageConfig.SMALL_OBJECT_THRESHOLD, 1)
+                .build();
+        final String context = createSegmentName("Concat");
+        assertEquals(0, ExtendedS3Metrics.LARGE_CONCAT_COUNT.get());
+        try (Storage s = createStorage(setup.client, adapterConfig, executorService())) {
+            testConcat(context, s);
+            assertTrue(ExtendedS3Metrics.LARGE_CONCAT_COUNT.get() > 0);
+            assertEquals(ExtendedS3Metrics.CONCAT_COUNT.get(), ExtendedS3Metrics.LARGE_CONCAT_COUNT.get());
         }
     }
 

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/S3ProxyImpl.java
@@ -29,13 +29,15 @@ import com.emc.object.s3.request.PutObjectRequest;
 import com.emc.object.s3.request.SetObjectAclRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Properties;
 import lombok.Synchronized;
+import lombok.val;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.gaul.s3proxy.AuthenticationType;
 import org.gaul.s3proxy.S3Proxy;
 import org.jclouds.ContextBuilder;
@@ -108,22 +110,22 @@ public class S3ProxyImpl extends S3ImplBase {
     @Synchronized
     @Override
     public void putObject(String bucketName, String key, Range range, Object content) {
-        byte[] totalByes = new byte[Math.toIntExact(range.getLast() + 1)];
+        byte[] existingBytes = new byte[Math.toIntExact(range.getFirst())];
         try {
             if (range.getFirst() != 0) {
-                int bytesRead = client.getObject(bucketName, key).getObject().read(totalByes, 0,
+                int bytesRead = client.getObject(bucketName, key).getObject().read(existingBytes, 0,
                         Math.toIntExact(range.getFirst()));
                 if (bytesRead != range.getFirst()) {
-                    throw new IllegalStateException("Unable to read from the object " + key);
+                    throw new S3Exception("InvalidRange", HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE, "InvalidRange", key);
                 }
             }
-            int bytesRead = ((InputStream) content).read(totalByes, Math.toIntExact(range.getFirst()),
-                    Math.toIntExact(range.getLast() + 1 - range.getFirst()));
-
-            if (bytesRead != range.getLast() + 1 - range.getFirst()) {
-                throw new IllegalStateException("Not able to read from input stream.");
+            val contentBytes  = IOUtils.toByteArray((InputStream) content);
+            if (contentBytes.length != Math.toIntExact(range.getLast()  - range.getFirst() + 1)) {
+                throw new S3Exception("InvalidRange", HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE, "InvalidRange", key);
             }
-            client.putObject(new PutObjectRequest(bucketName, key, (Object) new ByteArrayInputStream(totalByes)));
+
+            val objectAfterPut = ArrayUtils.addAll(existingBytes, contentBytes);
+            client.putObject(new PutObjectRequest(bucketName, key, (Object) objectAfterPut));
             aclMap.put(key, aclMap.get(key).withSize(range.getLast() - 1));
         } catch (IOException e) {
             throw new S3Exception("NoObject", HttpStatus.SC_NOT_FOUND, "NoSuchKey", key);

--- a/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/netty/impl/FlowHandler.java
@@ -256,8 +256,11 @@ public class FlowHandler extends ChannelInboundHandlerAdapter implements AutoClo
             final AppendBatchSizeTracker batchSizeTracker = getAppendBatchSizeTracker(dataAppended.getRequestId());
             if (batchSizeTracker != null) {
                 long pendingAckCount = batchSizeTracker.recordAck(dataAppended.getEventNumber());
-                metricNotifier.updateSuccessMetric(CLIENT_OUTSTANDING_APPEND_COUNT, writerTags(dataAppended.getWriterId().toString()),
-                                                   pendingAckCount);
+                // Only publish client side metrics when there is some metrics notifier configured for efficiency.
+                if (!metricNotifier.equals(MetricNotifier.NO_OP_METRIC_NOTIFIER)) {
+                    metricNotifier.updateSuccessMetric(CLIENT_OUTSTANDING_APPEND_COUNT, writerTags(dataAppended.getWriterId().toString()),
+                            pendingAckCount);
+                }
             }
         }
         // Obtain ReplyProcessor and process the reply.

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -115,7 +115,8 @@ class EventSegmentReaderImpl implements EventSegmentReader {
     }
 
     private void readEventDataFromSegmentInputStream(ByteBuffer result) throws EndOfSegmentException, SegmentTruncatedException, TimeoutException {
-        if (in.read(result, PARTIAL_DATA_TIMEOUT) == 0) {
+        //SSS can return empty events incase of @link{io.pravega.segmentstore.server.host.handler.PravegaRequestProcessor.ReadCancellationException}
+        if (in.read(result, PARTIAL_DATA_TIMEOUT) == 0 && result.limit() != 0) {
             log.warn("Timeout while trying to read Event data from segment {} at offset {}. The buffer capacity is {} bytes and the data read so far is {} bytes",
                     in.getSegmentId(), in.getOffset(), result.limit(), result.position());
             throw new TimeoutException("Timeout while trying to read event data");

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -247,7 +247,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "createScope", scopeName, requestId);
 
         final CompletableFuture<CreateScopeStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<CreateScopeStatus> callback = new RPCAsyncCallback<>(requestId, "createScope");
+            RPCAsyncCallback<CreateScopeStatus> callback = new RPCAsyncCallback<>(requestId, "createScope", scopeName);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "createScope", scopeName)
                                                         .createScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
             return callback.getFuture();
@@ -287,7 +287,7 @@ public class ControllerImpl implements Controller {
         try {
             final Function<ContinuationToken, CompletableFuture<Map.Entry<ContinuationToken, Collection<Stream>>>> function =
                     token -> this.retryConfig.runAsync(() -> {
-                        RPCAsyncCallback<StreamsInScopeResponse> callback = new RPCAsyncCallback<>(requestId, "listStreams");
+                        RPCAsyncCallback<StreamsInScopeResponse> callback = new RPCAsyncCallback<>(requestId, "listStreams", scopeName);
                         ScopeInfo scopeInfo = ScopeInfo.newBuilder().setScope(scopeName).build();
                         new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "listStreams", scopeName)
                                                                     .listStreamsInScope(StreamsInScopeRequest
@@ -324,7 +324,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "deleteScope", scopeName, requestId);
 
         final CompletableFuture<DeleteScopeStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<DeleteScopeStatus> callback = new RPCAsyncCallback<>(requestId, "deleteScope");
+            RPCAsyncCallback<DeleteScopeStatus> callback = new RPCAsyncCallback<>(requestId, "deleteScope", scopeName);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "deleteScope", scopeName)
                                                         .deleteScope(ScopeInfo.newBuilder().setScope(scopeName).build(), callback);
             return callback.getFuture();
@@ -365,7 +365,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "createStream", streamConfig, requestId);
 
         final CompletableFuture<CreateStreamStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<CreateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "createStream");
+            RPCAsyncCallback<CreateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "createStream", scope, streamName, streamConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "createStream", scope, streamName)
                                                         .createStream(ModelHelper.decode(scope, streamName, streamConfig), callback);
             return callback.getFuture();
@@ -408,7 +408,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "updateStream", streamConfig, requestId);
 
         final CompletableFuture<UpdateStreamStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "updateStream");
+            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "updateStream", scope, streamName, streamConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "updateStream", scope, streamName)
                                                         .updateStream(ModelHelper.decode(scope, streamName, streamConfig), callback);
             return callback.getFuture();
@@ -452,7 +452,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "truncateStream", streamCut, requestId);
 
         final CompletableFuture<UpdateStreamStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "truncateStream");
+            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "truncateStream", scope, stream);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "truncateStream", scope, stream)
                                                         .truncateStream(ModelHelper.decode(scope, stream, streamCut), callback);
             return callback.getFuture();
@@ -559,7 +559,7 @@ public class ControllerImpl implements Controller {
 
         long traceId = LoggerHelpers.traceEnter(log, "checkScale", stream);
         final CompletableFuture<ScaleStatusResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<ScaleStatusResponse> callback = new RPCAsyncCallback<>(traceId, "checkScale");
+            RPCAsyncCallback<ScaleStatusResponse> callback = new RPCAsyncCallback<>(traceId, "checkScale", stream, scaleEpoch);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).checkScale(ScaleStatusRequest.newBuilder()
                             .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
                             .setEpoch(scaleEpoch)
@@ -597,7 +597,7 @@ public class ControllerImpl implements Controller {
         Preconditions.checkNotNull(newKeyRanges, "newKeyRanges");
 
         final CompletableFuture<ScaleResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<ScaleResponse> callback = new RPCAsyncCallback<>(requestId, method);
+            RPCAsyncCallback<ScaleResponse> callback = new RPCAsyncCallback<>(requestId, method, stream);
             long scaleTimestamp = System.currentTimeMillis();
             new ControllerClientTagger(client, timeoutMillis)
                     .withTag(requestId, method, stream.getScope(), stream.getStreamName(), String.valueOf(scaleTimestamp))
@@ -625,7 +625,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "sealStream", scope, streamName, requestId);
 
         final CompletableFuture<UpdateStreamStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "sealStream");
+            RPCAsyncCallback<UpdateStreamStatus> callback = new RPCAsyncCallback<>(requestId, "sealStream", scope, streamName);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "sealStream", scope, streamName)
                                                         .sealStream(ModelHelper.createStreamInfo(scope, streamName), callback);
             return callback.getFuture();
@@ -665,7 +665,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "deleteStream", scope, streamName, requestId);
 
         final CompletableFuture<DeleteStreamStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<DeleteStreamStatus> callback = new RPCAsyncCallback<>(requestId, "deleteStream");
+            RPCAsyncCallback<DeleteStreamStatus> callback = new RPCAsyncCallback<>(requestId, "deleteStream", scope, streamName);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "deleteStream", scope, streamName)
                                                         .deleteStream(ModelHelper.createStreamInfo(scope, streamName), callback);
             return callback.getFuture();
@@ -703,7 +703,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "getSegmentsAtTime", stream, timestamp);
 
         final CompletableFuture<SegmentsAtTime> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<SegmentsAtTime> callback = new RPCAsyncCallback<>(traceId, "getSegmentsAtTime");
+            RPCAsyncCallback<SegmentsAtTime> callback = new RPCAsyncCallback<>(traceId, "getSegmentsAtTime", stream, timestamp);
             StreamInfo streamInfo = ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName());
             GetSegmentsRequest request = GetSegmentsRequest.newBuilder()
                     .setStreamInfo(streamInfo)
@@ -732,7 +732,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "getSuccessors", segment);
 
         final CompletableFuture<SuccessorResponse> resultFuture = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<SuccessorResponse> callback = new RPCAsyncCallback<>(traceId, "getSuccessors");
+            RPCAsyncCallback<SuccessorResponse> callback = new RPCAsyncCallback<>(traceId, "getSuccessors", segment);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                   .getSegmentsImmediatelyFollowing(ModelHelper.decode(segment), callback);
             return callback.getFuture();
@@ -822,7 +822,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "getCurrentSegments", scope, stream);
 
         final CompletableFuture<SegmentRanges> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<SegmentRanges> callback = new RPCAsyncCallback<>(traceId, "getCurrentSegments");
+            RPCAsyncCallback<SegmentRanges> callback = new RPCAsyncCallback<>(traceId, "getCurrentSegments", scope, stream);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                   .getCurrentSegments(ModelHelper.createStreamInfo(scope, stream), callback);
             return callback.getFuture();
@@ -852,7 +852,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "getEndpointForSegment", qualifiedSegmentName);
 
         final CompletableFuture<NodeUri> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<NodeUri> callback = new RPCAsyncCallback<>(traceId, "getEndpointForSegment");
+            RPCAsyncCallback<NodeUri> callback = new RPCAsyncCallback<>(traceId, "getEndpointForSegment", qualifiedSegmentName);
             Segment segment = Segment.fromScopedName(qualifiedSegmentName);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                   .getURI(ModelHelper.createSegmentId(segment.getScope(),
@@ -876,7 +876,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "isSegmentOpen", segment);
 
         final CompletableFuture<SegmentValidityResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<SegmentValidityResponse> callback = new RPCAsyncCallback<>(traceId, "isSegmentOpen");
+            RPCAsyncCallback<SegmentValidityResponse> callback = new RPCAsyncCallback<>(traceId, "isSegmentOpen", segment);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).isSegmentValid(ModelHelper.createSegmentId(segment.getScope(),
                     segment.getStreamName(),
                     segment.getSegmentId()),
@@ -899,7 +899,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "createTransaction", stream, lease);
 
         final CompletableFuture<CreateTxnResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<CreateTxnResponse> callback = new RPCAsyncCallback<>(traceId, "createTransaction");
+            RPCAsyncCallback<CreateTxnResponse> callback = new RPCAsyncCallback<>(traceId, "createTransaction", stream, lease);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).createTransaction(
                     CreateTxnRequest.newBuilder()
                             .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
@@ -934,7 +934,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "pingTransaction", stream, txId, lease);
 
         final CompletableFuture<PingTxnStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<PingTxnStatus> callback = new RPCAsyncCallback<>(traceId, "pingTransaction");
+            RPCAsyncCallback<PingTxnStatus> callback = new RPCAsyncCallback<>(traceId, "pingTransaction", txId, lease);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).pingTransaction(PingTxnRequest.newBuilder()
                                                  .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(), stream.getStreamName()))
                                                  .setTxnId(ModelHelper.decode(txId))
@@ -963,7 +963,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "commitTransaction", stream, txId);
 
         final CompletableFuture<TxnStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>(traceId, "commitTransaction");
+            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>(traceId, "commitTransaction", stream, writerId, timestamp, txId);
             TxnRequest.Builder txnRequest = TxnRequest.newBuilder()
                                                       .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
                                                                                                   stream.getStreamName()))
@@ -1002,7 +1002,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "abortTransaction", stream, txId);
 
         final CompletableFuture<TxnStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>(traceId, "abortTransaction");
+            RPCAsyncCallback<TxnStatus> callback = new RPCAsyncCallback<>(traceId, "abortTransaction", stream, txId);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).abortTransaction(TxnRequest.newBuilder()
                             .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
                                     stream.getStreamName()))
@@ -1037,7 +1037,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "checkTransactionStatus", stream, txId);
 
         final CompletableFuture<TxnState> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<TxnState> callback = new RPCAsyncCallback<>(traceId, "checkTransactionStatus");
+            RPCAsyncCallback<TxnState> callback = new RPCAsyncCallback<>(traceId, "checkTransactionStatus", stream, txId);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).checkTransactionState(TxnRequest.newBuilder()
                             .setStreamInfo(ModelHelper.createStreamInfo(stream.getScope(),
                                     stream.getStreamName()))
@@ -1064,7 +1064,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "noteTimestampFromWriter", writer, stream);
 
         final CompletableFuture<TimestampResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<TimestampResponse> callback = new RPCAsyncCallback<>(traceId, "lastWrittenPosition");
+            RPCAsyncCallback<TimestampResponse> callback = new RPCAsyncCallback<>(traceId, "lastWrittenPosition", writer, stream, timestamp);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).noteTimestampFromWriter(TimestampFromWriter.newBuilder()
                                                               .setWriter(writer)
                                                               .setTimestamp(timestamp)
@@ -1091,7 +1091,7 @@ public class ControllerImpl implements Controller {
         Preconditions.checkNotNull(writerId, "writerId");
         long traceId = LoggerHelpers.traceEnter(log, "writerShutdown", writerId, stream);
         final CompletableFuture<RemoveWriterResponse> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<RemoveWriterResponse> callback = new RPCAsyncCallback<>(traceId, "writerShutdown");
+            RPCAsyncCallback<RemoveWriterResponse> callback = new RPCAsyncCallback<>(traceId, "writerShutdown", writerId, stream);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS).removeWriter(RemoveWriterRequest.newBuilder()
                                                        .setWriter(writerId)
                                                        .setStream(ModelHelper.createStreamInfo(stream.getScope(),
@@ -1134,7 +1134,7 @@ public class ControllerImpl implements Controller {
         long traceId = LoggerHelpers.traceEnter(log, "getOrRefreshDelegationTokenFor", scope, streamName);
 
         final CompletableFuture<DelegationToken> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<DelegationToken> callback = new RPCAsyncCallback<>(traceId, "getOrRefreshDelegationTokenFor");
+            RPCAsyncCallback<DelegationToken> callback = new RPCAsyncCallback<>(traceId, "getOrRefreshDelegationTokenFor", scope, streamName);
             client.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                   .getDelegationToken(ModelHelper.createStreamInfo(scope, streamName), callback);
             return callback.getFuture();
@@ -1153,12 +1153,14 @@ public class ControllerImpl implements Controller {
     private static final class RPCAsyncCallback<T> implements StreamObserver<T> {
         private final long traceId;
         private final String method;
+        private final Object[] parameters;
         private T result = null;
         private final CompletableFuture<T> future = new CompletableFuture<>();
 
-        RPCAsyncCallback(long traceId, String method) {
+        RPCAsyncCallback(long traceId, String method, Object... args) {
             this.traceId = traceId;
             this.method = method;
+            parameters = args;
         }
 
         @Override
@@ -1168,7 +1170,7 @@ public class ControllerImpl implements Controller {
 
         @Override
         public void onError(Throwable t) {
-            log.warn("gRPC call for {} with trace id {} failed with server error.", method, traceId, t);
+            log.warn("gRPC call for {} with trace id {} and parameters {} failed with server error.", method, traceId, parameters, t);
             if (t instanceof RuntimeException) {
                 future.completeExceptionally(t);
             } else {

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -989,7 +989,7 @@ public class ControllerImpl implements Controller {
             if (txnStatus.getStatus().equals(TxnStatus.Status.SUCCESS)) {                
                 return null;
             }
-            log.info("Unable to commit " + txnStatus + " because of " + txnStatus.getStatus());
+            log.warn("Unable to commit transaction {} commit status is {}", txId, txnStatus.getStatus());
             throw Exceptions.sneakyThrow(new TxnFailedException("Commit transaction failed with status: " + txnStatus.getStatus()));
         });
     }
@@ -1024,7 +1024,7 @@ public class ControllerImpl implements Controller {
             if (txnStatus.getStatus().equals(TxnStatus.Status.SUCCESS)) {                
                 return null;
             }
-            log.info("Unable to abort " + txnStatus + " because of " + txnStatus.getStatus());
+            log.warn("Unable to abort transaction {} abort status is {} ", txId, txnStatus.getStatus());
             throw new RuntimeException("Error aborting transaction: " + txnStatus.getStatus());
         });
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -25,6 +25,7 @@ import io.pravega.client.stream.TxnFailedException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.NonNull;
@@ -111,28 +112,29 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
 
         @Override
         public void commit() throws TxnFailedException {
-            throwIfClosed();
-            for (SegmentTransaction<Type> tx : inner.values()) {
-                tx.close();
-            }
-            getAndHandleExceptions(controller.commitTransaction(stream, writerId, null, txId), TxnFailedException::new);
-            pinger.stopPing(txId);
-            closed.set(true);
+            commitTransaction(null);
         }
-        
+
         @Override
         public void commit(long timestamp) throws TxnFailedException {
+            commitTransaction(timestamp);
+        }
+
+        private void commitTransaction(Long timestamp) throws TxnFailedException {
+            log.info("Commit transaction {}", txId);
             throwIfClosed();
             for (SegmentTransaction<Type> tx : inner.values()) {
                 tx.close();
             }
-            getAndHandleExceptions(controller.commitTransaction(stream, writerId, timestamp, txId), TxnFailedException::new);
+            final CompletableFuture<Void> future = controller.commitTransaction(stream, writerId, timestamp, txId);
+            getAndHandleExceptions(future, TxnFailedException::new);
             pinger.stopPing(txId);
             closed.set(true);
         }
 
         @Override
         public void abort() {
+            log.info("Abort transaction {}", txId);
             if (!closed.get()) {
                 pinger.stopPing(txId);
                 for (SegmentTransaction<Type> tx : inner.values()) {
@@ -149,6 +151,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
 
         @Override
         public Status checkStatus() {
+            log.info("Check transaction status {}", txId);
             return getAndHandleExceptions(controller.checkTransactionStatus(stream, txId), RuntimeException::new);
         }
 
@@ -176,6 +179,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
     public Transaction<Type> beginTxn() {
         TxnSegments txnSegments = getAndHandleExceptions(controller.createTransaction(stream, config.getTransactionTimeoutTime()),
                 RuntimeException::new);
+        log.info("Transaction {} created", txnSegments.getTxnId());
         UUID txnId = txnSegments.getTxnId();
         Map<Segment, SegmentTransaction<Type>> transactions = new HashMap<>();
         DelegationTokenProvider tokenProvider = null;

--- a/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/netty/impl/FlowHandlerTest.java
@@ -18,6 +18,8 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.ChannelPromise;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.shared.metrics.ClientMetricKeys;
+import io.pravega.shared.metrics.MetricNotifier;
 import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.Reply;
@@ -50,6 +52,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
@@ -107,7 +110,7 @@ public class FlowHandlerTest {
         when(ch.write(any(Object.class))).thenReturn(completedFuture);
         when(ch.newPromise()).thenReturn(promise);
 
-        flowHandler = new FlowHandler("testConnection");
+        flowHandler = new FlowHandler("testConnection", new TestMetricNotifier());
     }
 
     @Test
@@ -351,7 +354,29 @@ public class FlowHandlerTest {
         verify(replyProcessor).processingFailure(any(ConnectionFailedException.class));
 
         // verify any attempt to send msg over the connection will throw a ConnectionFailedException.
-        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection1.send(mock(WireCommand.class))  );
-        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection2.send(mock(WireCommand.class))  );
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection1.send(mock(WireCommand.class)));
+        AssertExtensions.assertThrows(ConnectionFailedException.class, () -> connection2.send(mock(WireCommand.class)));
+    }
+
+    /**
+     * Added a mock MetricNotifier different from the default one to exercise reporting metrics from client side.
+     */
+    static class TestMetricNotifier implements MetricNotifier {
+        @Override
+        public void updateSuccessMetric(ClientMetricKeys metricKey, String[] metricTags, long value) {
+            NO_OP_METRIC_NOTIFIER.updateSuccessMetric(metricKey, metricTags, value);
+            assertNotNull(metricKey);
+        }
+
+        @Override
+        public void updateFailureMetric(ClientMetricKeys metricKey, String[] metricTags, long value) {
+            NO_OP_METRIC_NOTIFIER.updateFailureMetric(metricKey, metricTags, value);
+            assertNotNull(metricKey);
+        }
+
+        @Override
+        public void close() {
+            NO_OP_METRIC_NOTIFIER.close();
+        }
     }
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -11,6 +11,7 @@ package io.pravega.client.stream.impl;
 
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentOutputStreamFactory;
+import io.pravega.client.segment.impl.SegmentSealedException;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
@@ -31,7 +32,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.spy;
 
 public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
     @Rule
@@ -81,6 +85,86 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
     }
 
     @Test
+    public void testTxnCommit() throws TxnFailedException, SegmentSealedException {
+        String scope = "scope";
+        String streamName = "stream";
+        StreamImpl stream = new StreamImpl(scope, streamName);
+        Segment segment = new Segment(scope, streamName, 0);
+        UUID txid = UUID.randomUUID();
+        EventWriterConfig config = EventWriterConfig.builder().build();
+        SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+        Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        FakeSegmentOutputStream outputStream = spy(new FakeSegmentOutputStream(segment));
+        FakeSegmentOutputStream bad = new FakeSegmentOutputStream(segment);
+        Mockito.when(controller.createTransaction(eq(stream), anyLong()))
+               .thenReturn(CompletableFuture.completedFuture(new TxnSegments(getSegments(segment), txid)));
+        Mockito.when(controller.commitTransaction(eq(stream), anyString(), isNull(), eq(txid))).thenReturn(CompletableFuture.completedFuture(null));
+        Mockito.when(controller.pingTransaction(eq(stream), eq(txid), anyLong())).thenReturn(CompletableFuture.completedFuture(Transaction.PingStatus.OPEN));
+        Mockito.when(controller.checkTransactionStatus(eq(stream), eq(txid))).thenReturn(CompletableFuture.completedFuture(Transaction.Status.OPEN));
+        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any()))
+               .thenReturn(outputStream);
+        Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(bad);
+
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        @Cleanup
+        TransactionalEventStreamWriter<String> writer = new TransactionalEventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
+                config, executorService());
+        Transaction<String> txn = writer.beginTxn();
+        txn.writeEvent("Foo");
+        assertTrue(bad.unacked.isEmpty());
+        assertEquals(1, outputStream.unacked.size());
+        outputStream.unacked.get(0).getAckFuture().complete(null);
+        txn.checkStatus();
+        Mockito.verify(controller, Mockito.times(1)).checkTransactionStatus(eq(stream), eq(txid));
+
+        // invoke commit of transaction.
+        txn.commit();
+        // verify if segments are flushed and closed.
+        Mockito.verify(outputStream, Mockito.times(1)).close();
+        Mockito.verify(controller, Mockito.times(1)).commitTransaction(eq(stream), anyString(), isNull(), eq(txid));
+        assertTrue(bad.unacked.isEmpty());
+        assertTrue(outputStream.unacked.isEmpty());
+    }
+
+    @Test
+    public void testTxnAbort() throws TxnFailedException, SegmentSealedException {
+        String scope = "scope";
+        String streamName = "stream";
+        StreamImpl stream = new StreamImpl(scope, streamName);
+        Segment segment = new Segment(scope, streamName, 0);
+        UUID txid = UUID.randomUUID();
+        EventWriterConfig config = EventWriterConfig.builder().build();
+        SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+        Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        FakeSegmentOutputStream outputStream = spy(new FakeSegmentOutputStream(segment));
+        FakeSegmentOutputStream bad = new FakeSegmentOutputStream(segment);
+        Mockito.when(controller.createTransaction(eq(stream), anyLong()))
+               .thenReturn(CompletableFuture.completedFuture(new TxnSegments(getSegments(segment), txid)));
+        Mockito.when(controller.pingTransaction(eq(stream), eq(txid), anyLong())).thenReturn(CompletableFuture.completedFuture(Transaction.PingStatus.OPEN));
+        Mockito.when(controller.abortTransaction(eq(stream), eq(txid))).thenReturn(CompletableFuture.completedFuture(null));
+        Mockito.when(streamFactory.createOutputStreamForTransaction(eq(segment), eq(txid), any(), any()))
+               .thenReturn(outputStream);
+        Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(bad);
+
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        @Cleanup
+        TransactionalEventStreamWriter<String> writer = new TransactionalEventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
+                config, executorService());
+        Transaction<String> txn = writer.beginTxn();
+        txn.writeEvent("Foo");
+        assertTrue(bad.unacked.isEmpty());
+        assertEquals(1, outputStream.unacked.size());
+        outputStream.unacked.get(0).getAckFuture().complete(null);
+        // invoke commit of transaction.
+        txn.abort();
+        // verify if segments are flushed and closed.
+        Mockito.verify(outputStream, Mockito.times(1)).close();
+        Mockito.verify(controller, Mockito.times(1)).abortTransaction(eq(stream), eq(txid));
+    }
+
+    @Test
     public void testTxnFailed() {
         String scope = "scope";
         String streamName = "stream";
@@ -113,5 +197,4 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         assertTrue(bad.unacked.isEmpty());
         assertEquals(1, outputStream.unacked.size());
     }
-
 }

--- a/client/src/test/resources/logback-test.xml
+++ b/client/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/client/src/test/resources/logback.xml
+++ b/client/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/config/config.properties
+++ b/config/config.properties
@@ -448,6 +448,16 @@ extendeds3.configUri=http://localhost:9020?identity=user&secretKey=password
 # Prefix is optional.
 # extendeds3.prefix=
 
+# Size of ECS objects in bytes above which it is no longer considered a small object.
+# This value is used to optimize transactions performance when size of transaction segments is small.
+# For small transaction segments, to implement concat ExtendedS3Storage reads complete source segment and appends it to target
+# instead of using multipart upload.
+# smallObjectSizeLimitForConcat is optional.
+# Valid values: Positive integer.
+# Default value: 1048576 (1MB).
+# Recommended values: 1 MB.
+# extendeds3.smallObjectSizeLimitForConcat=1048576
+
 ##endregion
 
 ##region filesystem settings

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <logger name="org.apache.zookeeper" level="WARN"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -319,7 +319,7 @@ public class LocalController implements Controller {
 
     @Override
     public CompletableFuture<Transaction.PingStatus> pingTransaction(Stream stream, UUID txId, long lease) {
-        return controller.pingTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txId), lease)
+        return controller.pingTransaction(stream.getScope(), stream.getStreamName(), txId, lease)
                          .thenApply(status -> {
                              try {
                                  return ModelHelper.encode(status.getStatus(), stream + " " + txId);
@@ -333,20 +333,20 @@ public class LocalController implements Controller {
     public CompletableFuture<Void> commitTransaction(Stream stream, final String writerId, final Long timestamp, UUID txnId) {
         long time = Optional.ofNullable(timestamp).orElse(Long.MIN_VALUE);
         return controller
-                .commitTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId), writerId, time)
+                .commitTransaction(stream.getScope(), stream.getStreamName(), txnId, writerId, time)
                 .thenApply(x -> null);
     }
 
     @Override
-    public CompletableFuture<Void> abortTransaction(Stream stream, UUID txId) {
+    public CompletableFuture<Void> abortTransaction(Stream stream, UUID txnId) {
         return controller
-                .abortTransaction(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txId))
+                .abortTransaction(stream.getScope(), stream.getStreamName(), txnId)
                 .thenApply(x -> null);
     }
 
     @Override
     public CompletableFuture<Transaction.Status> checkTransactionStatus(Stream stream, UUID txnId) {
-        return controller.checkTransactionStatus(stream.getScope(), stream.getStreamName(), ModelHelper.decode(txnId))
+        return controller.checkTransactionStatus(stream.getScope(), stream.getStreamName(), txnId)
                 .thenApply(status -> ModelHelper.encode(status.getState(), stream + " " + txnId));
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -107,8 +107,8 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                             log.debug("Cannot commit transaction on stream {}/{}. Postponing", scope, stream);
                         } else {
                             log.error("Exception while attempting to commit transaction on stream {}/{}", scope, stream, e);
+                            TransactionMetrics.getInstance().commitTransactionFailed(scope, stream);
                         }
-                        TransactionMetrics.getInstance().commitTransactionFailed(scope, stream);
                         future.completeExceptionally(cause);
                     } else {
                         if (r >= 0) {

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -62,6 +62,7 @@ import io.pravega.controller.stream.api.grpc.v1.ControllerServiceGrpc;
 
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -354,8 +355,9 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
 
     @Override
     public void commitTransaction(TxnRequest request, StreamObserver<TxnStatus> responseObserver) {
+        final UUID txnId = ModelHelper.encode(request.getTxnId());
         log.info("commitTransaction called for stream {}/{}, txnId={}.", request.getStreamInfo().getScope(),
-                request.getStreamInfo().getStream(), request.getTxnId());
+                request.getStreamInfo().getStream(), txnId);
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(
                         request.getStreamInfo().getScope(),
@@ -363,47 +365,50 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> controllerService.commitTransaction(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
-                        request.getTxnId(), request.getWriterId(), request.getTimestamp()),
+                        txnId, request.getWriterId(), request.getTimestamp()),
                 responseObserver);
     }
 
     @Override
     public void abortTransaction(TxnRequest request, StreamObserver<TxnStatus> responseObserver) {
+        final UUID txnId = ModelHelper.encode(request.getTxnId());
         log.info("abortTransaction called for stream {}/{}, txnId={}.", request.getStreamInfo().getScope(),
-                request.getStreamInfo().getStream(), request.getTxnId());
+                request.getStreamInfo().getStream(), txnId);
         authenticateExecuteAndProcessResults( () -> this.grpcAuthHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
                 AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> controllerService.abortTransaction(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
-                        request.getTxnId()),
+                        txnId),
                 responseObserver);
     }
 
     @Override
     public void pingTransaction(PingTxnRequest request, StreamObserver<PingTxnStatus> responseObserver) {
+        final UUID txnId = ModelHelper.encode(request.getTxnId());
         log.info("pingTransaction called for stream {}/{}, txnId={}", request.getStreamInfo().getScope(),
-                request.getStreamInfo().getStream(), request.getTxnId());
+                request.getStreamInfo().getStream(), txnId);
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
                 AuthHandler.Permissions.READ_UPDATE),
                delegationToken  -> controllerService.pingTransaction(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
-                        request.getTxnId(),
+                        txnId,
                         request.getLease()),
                 responseObserver);
     }
 
     @Override
     public void checkTransactionState(TxnRequest request, StreamObserver<TxnState> responseObserver) {
+        final UUID txnId = ModelHelper.encode(request.getTxnId());
         log.info("checkTransactionState called for stream {}/{}, txnId={}.", request.getStreamInfo().getScope(),
-                request.getStreamInfo().getStream(), request.getTxnId());
+                request.getStreamInfo().getStream(), txnId);
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorization(
                 AuthResourceRepresentation.ofStreamInScope(request.getStreamInfo().getScope(), request.getStreamInfo().getStream()),
                 AuthHandler.Permissions.READ),
                 delegationToken -> controllerService.checkTransactionStatus(request.getStreamInfo().getScope(),
                         request.getStreamInfo().getStream(),
-                        request.getTxnId()),
+                        txnId),
                 responseObserver);
     }
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStoreHelper.java
@@ -50,6 +50,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static io.pravega.controller.server.WireCommandFailedException.Reason.ConnectionDropped;
+import static io.pravega.controller.server.WireCommandFailedException.Reason.ConnectionFailed;
 import static io.pravega.controller.store.stream.AbstractStreamMetadataStore.DATA_NOT_FOUND_PREDICATE;
 
 /**
@@ -176,7 +178,7 @@ public class PravegaTablesStoreHelper {
                 new TableEntryImpl<>(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), KeyVersion.NOT_EXISTS), value));
         Supplier<String> errorMessage = () -> String.format("addNewEntry: key: %s table: %s", key, tableName);
         return withRetries(() -> segmentHelper.updateTableEntries(tableName, entries, authToken.get(), RequestTag.NON_EXISTENT_ID),
-                errorMessage)
+                errorMessage, true)
                 .exceptionally(e -> {
                     Throwable unwrap = Exceptions.unwrap(e);
                     if (unwrap instanceof StoreException.WriteConflictException) {
@@ -257,7 +259,7 @@ public class PravegaTablesStoreHelper {
         List<TableEntry<byte[], byte[]>> entries = Collections.singletonList(
                 new TableEntryImpl<>(new TableKeyImpl<>(key.getBytes(Charsets.UTF_8), version), value));
         return withRetries(() -> segmentHelper.updateTableEntries(tableName, entries, authToken.get(), RequestTag.NON_EXISTENT_ID),
-                () -> String.format("updateEntry: key: %s table: %s", key, tableName))
+                () -> String.format("updateEntry: key: %s table: %s", key, tableName), true)
                 .thenApplyAsync(x -> {
                     KeyVersion first = x.get(0);
                     log.trace("entry for key {} updated to table {} with new version {}", key, tableName, first.getSegmentVersion());
@@ -529,8 +531,10 @@ public class PravegaTablesStoreHelper {
     <T> CompletableFuture<T> expectingDataExists(CompletableFuture<T> future, T toReturn) {
         return Futures.exceptionallyExpecting(future, e -> Exceptions.unwrap(e) instanceof StoreException.DataExistsException, toReturn);
     }
-
-    private <T> Supplier<CompletableFuture<T>> exceptionalCallback(Supplier<CompletableFuture<T>> future, Supplier<String> errorMessageSupplier) {
+    
+    private <T> Supplier<CompletableFuture<T>> exceptionalCallback(Supplier<CompletableFuture<T>> future, 
+                                                                   Supplier<String> errorMessageSupplier, 
+                                                                   boolean throwOriginalOnCFE) {
         return () -> CompletableFuture.completedFuture(null).thenComposeAsync(v -> future.get(), executor).exceptionally(t -> {
             String errorMessage = errorMessageSupplier.get();
             Throwable cause = Exceptions.unwrap(t);
@@ -540,6 +544,9 @@ public class PravegaTablesStoreHelper {
                 switch (wcfe.getReason()) {
                     case ConnectionDropped:
                     case ConnectionFailed:
+                        toThrow = throwOriginalOnCFE ? wcfe : 
+                                StoreException.create(StoreException.Type.CONNECTION_ERROR, wcfe, errorMessage);        
+                        break;
                     case UnknownHost:
                         toThrow = StoreException.create(StoreException.Type.CONNECTION_ERROR, wcfe, errorMessage);
                         break;
@@ -586,17 +593,27 @@ public class PravegaTablesStoreHelper {
      * are thrown back
      */
     private <T> CompletableFuture<T> withRetries(Supplier<CompletableFuture<T>> futureSupplier, Supplier<String> errorMessage) {
-        return RetryHelper.withRetriesAsync(exceptionalCallback(futureSupplier, errorMessage),
-                e -> {
-                    Throwable unwrap = Exceptions.unwrap(e);
-                    return unwrap instanceof StoreException.StoreConnectionException;
-                }, numOfRetries, executor)
+        return withRetries(futureSupplier, errorMessage, false);
+    }
+
+    private <T> CompletableFuture<T> withRetries(Supplier<CompletableFuture<T>> futureSupplier, Supplier<String> errorMessage, 
+                                         boolean throwOriginalOnCfe) {
+        return RetryHelper.withRetriesAsync(exceptionalCallback(futureSupplier, errorMessage, throwOriginalOnCfe),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException, numOfRetries, executor)
                 .exceptionally(e -> {
                     Throwable t = Exceptions.unwrap(e);
                     if (t instanceof RetriesExhaustedException) {
                         throw new CompletionException(t.getCause());
                     } else {
-                        throw new CompletionException(t);
+                        Throwable unwrap = Exceptions.unwrap(e);
+                        if (unwrap instanceof WireCommandFailedException &&
+                                (((WireCommandFailedException) unwrap).getReason().equals(ConnectionDropped) ||
+                                        ((WireCommandFailedException) unwrap).getReason().equals(ConnectionFailed))) {
+                            throw new CompletionException(StoreException.create(StoreException.Type.CONNECTION_ERROR, 
+                                    errorMessage.get()));
+                        } else {
+                            throw new CompletionException(unwrap);
+                        }
                     }
                 });
     }

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -14,8 +14,10 @@ import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ModelHelper;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.tracing.RequestTracker;
+import io.pravega.controller.metrics.TransactionMetrics;
 import io.pravega.controller.mocks.SegmentHelperMock;
 import io.pravega.controller.server.ControllerService;
 import io.pravega.controller.server.SegmentHelper;
@@ -25,6 +27,7 @@ import io.pravega.controller.store.host.HostStoreFactory;
 import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
 import io.pravega.controller.store.stream.BucketStore;
 import io.pravega.controller.store.stream.OperationContext;
+import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.StreamStoreFactory;
 import io.pravega.controller.store.stream.VersionedMetadata;
@@ -32,15 +35,18 @@ import io.pravega.controller.store.stream.State;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.TaskStoreFactory;
+import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentId;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,6 +60,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Controller service implementation test.
@@ -65,7 +73,7 @@ public class ControllerServiceTest {
     private final String stream2 = "stream2";
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
 
-    private final StreamMetadataStore streamStore = StreamStoreFactory.createInMemoryStore(executor);
+    private final StreamMetadataStore streamStore = spy(StreamStoreFactory.createInMemoryStore(executor));
 
     private StreamMetadataTasks streamMetadataTasks;
     private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
@@ -168,7 +176,7 @@ public class ControllerServiceTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
 
-    @Test
+    @Test(timeout = 10000L)
     public void testMethods() throws InterruptedException, ExecutionException {
         Map<SegmentId, Long> segments;
 
@@ -193,5 +201,45 @@ public class ControllerServiceTest {
         assertEquals(Long.valueOf(0), segments.get(ModelHelper.createSegmentId(SCOPE, stream2, 0)));
         assertEquals(Long.valueOf(0), segments.get(ModelHelper.createSegmentId(SCOPE, stream2, 1)));
         assertEquals(Long.valueOf(0), segments.get(ModelHelper.createSegmentId(SCOPE, stream2, 2)));
+    }
+    
+    @Test(timeout = 10000L)
+    public void testTransactions() {
+        TransactionMetrics.initialize();
+        UUID txnId = consumer.createTransaction(SCOPE, stream1, 10000L).join().getKey();
+        doThrow(StoreException.create(StoreException.Type.WRITE_CONFLICT, "Write conflict"))
+                .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(), 
+                any(), any());
+
+        AssertExtensions.assertFutureThrows("Write conflict should have been thrown", 
+                consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L),
+                e -> Exceptions.unwrap(e) instanceof StoreException.WriteConflictException);
+
+        AssertExtensions.assertFutureThrows("Write conflict should have been thrown", 
+                consumer.abortTransaction(SCOPE, stream1, txnId),
+                e -> Exceptions.unwrap(e) instanceof StoreException.WriteConflictException);
+
+        doThrow(StoreException.create(StoreException.Type.CONNECTION_ERROR, "Connection failed"))
+                .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(), 
+                any(), any());
+
+        AssertExtensions.assertFutureThrows("Store connection exception should have been thrown",
+                consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+
+        AssertExtensions.assertFutureThrows("Store connection exception should have been thrown",
+                consumer.abortTransaction(SCOPE, stream1, txnId),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+
+        doThrow(StoreException.create(StoreException.Type.UNKNOWN, "Connection failed"))
+                .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(), 
+                any(), any());
+
+        Controller.TxnStatus status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+        
+        status = consumer.abortTransaction(SCOPE, stream1, txnId).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+        reset(streamStore);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/PravegaTablesStoreHelperTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
 public class PravegaTablesStoreHelperTest {
     private ScheduledExecutorService executor;
@@ -196,5 +196,58 @@ public class PravegaTablesStoreHelperTest {
         doAnswer(x -> connectionFailed).when(segmentHelper).createTableSegment(anyString(), anyString(), anyLong());
         AssertExtensions.assertFutureThrows("AuthFailed", storeHelper.createTable("table"),
                 e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+    }
+    
+    @Test
+    public void testNoRetriesOnUpdate() {
+        SegmentHelper segmentHelper = SegmentHelperMock.getSegmentHelperMockForTables(executor);
+        GrpcAuthHelper authHelper = GrpcAuthHelper.getDisabledAuthHelper();
+        PravegaTablesStoreHelper storeHelper = spy(new PravegaTablesStoreHelper(segmentHelper, authHelper, executor, 2));
+
+        // region connection dropped
+        CompletableFuture<Void> connectionDropped = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.ConnectionDropped));
+        doAnswer(x -> connectionDropped).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(1)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(2)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        // endregion
+        
+        // region connectionfailed
+        CompletableFuture<Void> connectionFailed = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.ConnectionFailed));
+        doAnswer(x -> connectionFailed).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(3)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(4)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        // endregion
+        
+        CompletableFuture<Void> unknownHost = Futures.failedFuture(
+                new WireCommandFailedException(WireCommandType.UPDATE_TABLE_ENTRIES, WireCommandFailedException.Reason.UnknownHost));
+        doAnswer(x -> unknownHost).when(segmentHelper).updateTableEntries(anyString(), any(), anyString(), anyLong());
+        
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.addNewEntry("table", "key", new byte[0]),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        // this should be retried. we have configured 2 retries, so 2 retries should happen hence jump from 4 to 6. 
+        verify(segmentHelper, times(6)).updateTableEntries(anyString(), any(), anyString(), anyLong());
+
+        AssertExtensions.assertFutureThrows("ConnectionDropped", storeHelper.updateEntry("table", "key", new byte[0],
+                new Version.LongVersion(0L)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.StoreConnectionException);
+        verify(segmentHelper, times(8)).updateTableEntries(anyString(), any(), anyString(), anyLong());
     }
 }

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -11,7 +11,6 @@ package io.pravega.controller.timeout;
 
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.ModelHelper;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.tracing.RequestTracker;
@@ -180,11 +179,12 @@ public abstract class TimeoutServiceTest {
     @Test(timeout = 10000)
     public void testControllerTimeout() throws InterruptedException {
         long begin = System.currentTimeMillis();
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
+                                      .thenApply(x -> x.getKey())
+                                      .join();
 
-        Optional<Throwable> result = timeoutService.getTaskCompletionQueue().poll((long) (1.3 * LEASE), TimeUnit.MILLISECONDS);
+        Optional<Throwable> result = timeoutService.getTaskCompletionQueue()
+                                                   .poll((long) (1.3 * LEASE), TimeUnit.MILLISECONDS);
         long end = System.currentTimeMillis();
         Assert.assertNotNull(result);
 
@@ -228,9 +228,9 @@ public abstract class TimeoutServiceTest {
 
     @Test(timeout = 10000)
     public void testControllerPingSuccess() throws InterruptedException {
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
+                                      .thenApply(x -> x.getKey())
+                                      .join();
 
         Optional<Throwable> result = timeoutService.getTaskCompletionQueue().poll((long) (0.75 * LEASE), TimeUnit.MILLISECONDS);
         Assert.assertNull(result);
@@ -277,11 +277,11 @@ public abstract class TimeoutServiceTest {
         ControllerService controllerService2 = new ControllerService(streamStore2, bucketStore, streamMetadataTasks2,
                 streamTransactionMetadataTasks2, helperMock, executor, null);
 
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
+                                       .thenApply(x -> x.getKey())
+                                       .join();
 
-        VersionedTransactionData txnData = streamStore.getTransactionData(SCOPE, STREAM, ModelHelper.encode(txnId), null, executor).join();
+        VersionedTransactionData txnData = streamStore.getTransactionData(SCOPE, STREAM, txnId, null, executor).join();
         Assert.assertEquals(txnData.getVersion(), getVersion(0));
 
         Optional<Throwable> result = timeoutService.getTaskCompletionQueue().poll((long) (0.75 * LEASE), TimeUnit.MILLISECONDS);
@@ -294,7 +294,7 @@ public abstract class TimeoutServiceTest {
         PingTxnStatus pingStatus = controllerService2.pingTransaction(SCOPE, STREAM, txnId, 2 * LEASE).join();
         Assert.assertEquals(PingTxnStatus.Status.OK, pingStatus.getStatus());
 
-        txnData = streamStore.getTransactionData(SCOPE, STREAM, ModelHelper.encode(txnId), null, executor).join();
+        txnData = streamStore.getTransactionData(SCOPE, STREAM, txnId, null, executor).join();
         Assert.assertEquals(txnData.getVersion(), getVersion(1));
 
         // timeoutService1 should believe that LEASE has expired and should get non empty completion tasks
@@ -339,9 +339,9 @@ public abstract class TimeoutServiceTest {
     @Test(timeout = 10000)
     public void testControllerPingLeaseTooLarge() {
         int lease = 10;
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, lease)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, lease)
+                                      .thenApply(x -> x.getKey())
+                                      .join();
 
         PingTxnStatus pingStatus = controllerService.pingTransaction(SCOPE, STREAM, txnId, Config.MAX_LEASE_VALUE + 1).join();
         Assert.assertEquals(PingTxnStatus.Status.LEASE_TOO_LARGE, pingStatus.getStatus());
@@ -353,7 +353,7 @@ public abstract class TimeoutServiceTest {
         VersionedTransactionData txData = streamStore.createTransaction(SCOPE, STREAM, txnId1, LEASE,
                 2 * LEASE, null, executor).join();
 
-        txnId = ModelHelper.decode(txData.getId());
+        txnId = txData.getId();
 
         pingStatus = controllerService.pingTransaction(SCOPE, STREAM, txnId, Config.MAX_LEASE_VALUE + 1).join();
         Assert.assertEquals(PingTxnStatus.Status.LEASE_TOO_LARGE, pingStatus.getStatus());
@@ -391,9 +391,9 @@ public abstract class TimeoutServiceTest {
     @Test(timeout = 10000)
     public void testControllerPingFailureMaxExecutionTimeExceeded() throws InterruptedException {
         int lease = 10;
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, lease)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, lease)
+                                      .thenApply(x -> x.getKey())
+                                      .join();
 
         TxnState txnState = controllerService.checkTransactionStatus(SCOPE, STREAM, txnId).join();
         Assert.assertEquals(TxnState.State.OPEN, txnState.getState());
@@ -437,9 +437,9 @@ public abstract class TimeoutServiceTest {
     @Test(timeout = 10000)
     public void testControllerPingFailureDisconnected() throws InterruptedException {
 
-        TxnId txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
-                .thenApply(x -> ModelHelper.decode(x.getKey()))
-                .join();
+        UUID txnId = controllerService.createTransaction(SCOPE, STREAM, LEASE)
+                                      .thenApply(x -> x.getKey())
+                                      .join();
 
         Optional<Throwable> result = timeoutService.getTaskCompletionQueue().poll((long) (0.75 * LEASE), TimeUnit.MILLISECONDS);
         Assert.assertNull(result);
@@ -488,7 +488,7 @@ public abstract class TimeoutServiceTest {
         UUID txId = streamStore.generateTransactionId(SCOPE, STREAM, null, executor).join();
         VersionedTransactionData txData = streamStore.createTransaction(SCOPE, STREAM, txId, LEASE,
                 10 * LEASE, null, executor).join();
-        TxnId txnId = convert(txData.getId());
+        UUID txnId = txData.getId();
 
         Controller.TxnState state = controllerService.checkTransactionStatus(SCOPE, STREAM, txnId).join();
         Assert.assertEquals(TxnState.State.OPEN, state.getState());
@@ -503,12 +503,7 @@ public abstract class TimeoutServiceTest {
         VersionedTransactionData txData = streamStore.createTransaction(SCOPE, STREAM, txnId, LEASE, 10 * LEASE,
                 null, executor).join();
 
-        TxnId tx = TxnId.newBuilder()
-                .setHighBits(txnId.getMostSignificantBits())
-                .setLowBits(txnId.getLeastSignificantBits())
-                .build();
-
-        controllerService.pingTransaction(SCOPE, STREAM, tx, LEASE);
+        controllerService.pingTransaction(SCOPE, STREAM, txnId, LEASE);
 
         TxnStatus status = streamStore.transactionStatus(SCOPE, STREAM, txData.getId(), null, executor).join();
         Assert.assertEquals(TxnStatus.OPEN, status);

--- a/controller/src/test/resources/logback.xml
+++ b/controller/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -33,3 +33,12 @@ add_system_property_ecs_config_uri() {
     echo "${name}" "${configUri}"
     add_system_property "${name}" "${configUri}"
 }
+
+# Add ECS certificates into Java truststore
+add_certs_into_truststore() {
+    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    for cert in $CERTS
+    do
+      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+    done
+}

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -36,9 +36,12 @@ add_system_property_ecs_config_uri() {
 
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
-    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    password=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD`
+    trustStore=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH`
+
+    CERTS=/etc/ssl/certs/java/ecs-certs/*.pem
     for cert in $CERTS
     do
-      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+      yes | keytool -importcert -storepass "${password}" -file "${cert}" -keystore "${trustStore}" || true
     done
 }

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -69,6 +69,7 @@ init_tier2() {
     add_system_property_ecs_config_uri "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}" "${EXTENDEDS3_ACCESS_KEY_ID}" "${EXTENDEDS3_SECRET_KEY}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
     add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
+    add_certs_into_truststore
     ;;
     esac
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.7.0
+pravegaVersion=0.7.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.7.0-SNAPSHOT
+pravegaVersion=0.7.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 

--- a/segmentstore/server/host/src/config/logback.xml
+++ b/segmentstore/server/host/src/config/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -377,7 +378,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             // Add the remainder of the buffer as a new entry (with the offset updated).
             data = data.slice(appendLength, data.getLength() - appendLength);
             offset += appendLength;
-            ReadIndexEntry lastEntry = addToCacheAndIndex(data, offset, "Append");
+            ReadIndexEntry lastEntry = addToCacheAndIndex(data, offset, this::appendSingleEntryToCacheAndIndex);
             this.lastAppendedOffset.set(lastEntry.getLastStreamSegmentOffset());
         } else {
             // The entire buffer was added as a single append.
@@ -509,7 +510,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 "The given range of bytes (Offset=%s, Length=%s) does not correspond to the StreamSegment range that is in Storage (%s).",
                 offset, data.getLength(), this.metadata.getStorageLength());
 
-        addToCacheAndIndex(data, offset, "Insert");
+        addToCacheAndIndex(data, offset, this::insertEntriesToCacheAndIndex);
     }
 
     /**
@@ -542,17 +543,17 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         return appendLength;
     }
 
-    private CacheIndexEntry addToCacheAndIndex(BufferView data, long offset, String operationName) {
+    private CacheIndexEntry addToCacheAndIndex(BufferView data, long offset, BiFunction<BufferView, Long, CacheIndexEntry> add) {
         if (data.getLength() <= this.cacheStorage.getMaxEntryLength()) {
             // The entire buffer can fit into one entry.
-            return addSingleEntryToCacheAndIndex(data, offset, operationName);
+            return add.apply(data, offset);
         } else {
             // Need to split the buffer into smaller entries and insert them individually.
             int bufferOffset = 0;
             CacheIndexEntry lastEntry = null;
             while (bufferOffset < data.getLength()) {
                 int partLength = Math.min(data.getLength() - bufferOffset, this.cacheStorage.getMaxEntryLength());
-                lastEntry = addSingleEntryToCacheAndIndex(data.slice(bufferOffset, partLength), offset + bufferOffset, operationName);
+                lastEntry = add.apply(data.slice(bufferOffset, partLength), offset + bufferOffset);
                 bufferOffset += partLength;
             }
 
@@ -560,15 +561,23 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         }
     }
 
-    private CacheIndexEntry addSingleEntryToCacheAndIndex(BufferView data, long offset, String operationName) {
+    /**
+     * Appends data at the end of the index.
+     *
+     * @param data          A {@link BufferView} representing the data to append.
+     * @param segmentOffset The segment offset that maps to the first byte in the given {@link BufferView}.
+     * @return A {@link CacheIndexEntry} representing the index entry added.
+     */
+    private CacheIndexEntry appendSingleEntryToCacheAndIndex(BufferView data, long segmentOffset) {
         int dataAddress = this.cacheStorage.insert(data);
         CacheIndexEntry newEntry;
-        ReadIndexEntry rejectedEntry;
         try {
-            newEntry = new CacheIndexEntry(offset, data.getLength(), dataAddress);
+            newEntry = new CacheIndexEntry(segmentOffset, data.getLength(), dataAddress);
             synchronized (this.lock) {
-                rejectedEntry = addToIndex(newEntry);
+                ReadIndexEntry previous = this.indexEntries.put(newEntry);
+                assert previous == null;
             }
+            newEntry.setGeneration(this.summary.addOne());
         } catch (Throwable ex) {
             if (!Exceptions.mustRethrow(ex)) {
                 // Clean up the data we inserted if we were unable to add it to the index.
@@ -577,41 +586,67 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             throw ex;
         }
 
-        if (rejectedEntry != null) {
-            deleteData(rejectedEntry);
-            if (rejectedEntry != newEntry) {
-                log.warn("{}: {} overrode existing entry (Offset = {}, OldLength = {}, NewLength = {}).",
-                        this.traceObjectId, operationName, newEntry.getStreamSegmentOffset(), rejectedEntry.getLength(), newEntry.getLength());
-            }
-        }
         return newEntry;
     }
 
     /**
-     * Attempts to add the given {@link ReadIndexEntry} to the index. No cache operations are performed.
+     * Inserts data in the index.
      *
-     * @param entry The {@link ReadIndexEntry} to add.
-     * @return A rejected {@link ReadIndexEntry}. If the given entry has overridden another that already existed in the
-     * index, the overridden one will be returned. If the given entry could not be added to the index due to another,
-     * more up-to-date one existing already, the given entry will be returned as rejected (and no modifications will
-     * be made to the index). A null value will be returned if there was no conflict.
+     * @param data          A {@link BufferView} representing the data to insert.
+     * @param segmentOffset The segment offset that maps to the first byte in the given {@link BufferView}.
+     * @return A {@link CacheIndexEntry} representing the index entry added. If the given {@link BufferView} spanned
+     * multiple entries (due to index fragmentation), only the last {@link CacheIndexEntry} is added.
      */
-    @GuardedBy("lock")
-    private ReadIndexEntry addToIndex(final ReadIndexEntry entry) {
-        Exceptions.checkNotClosed(this.closed, this);
+    private CacheIndexEntry insertEntriesToCacheAndIndex(BufferView data, long segmentOffset) {
+        CacheIndexEntry lastInsertedEntry = null;
+        synchronized (this.lock) {
+            while (data != null && data.getLength() > 0) {
+                // Figure out if the first byte in the buffer is already cached.
+                ReadIndexEntry existingEntry = this.indexEntries.getFloor(segmentOffset);
+                long overlapLength;
+                if (existingEntry != null && existingEntry.getLastStreamSegmentOffset() >= segmentOffset) {
+                    // First offset exists already. We need to skip over to the end of this entry.
+                    overlapLength = existingEntry.getStreamSegmentOffset() + existingEntry.getLength() - segmentOffset;
+                    segmentOffset += overlapLength;
+                } else {
+                    // First offset does not exist. Let's find out how much we can insert.
+                    existingEntry = this.indexEntries.getCeiling(segmentOffset);
+                    overlapLength = existingEntry == null ? data.getLength() : existingEntry.getStreamSegmentOffset() - segmentOffset;
+                    assert overlapLength > 0 : "indexEntries.getFloor(offset) == null != indexEntries.getCeiling(offset)";
 
-        // Insert the new entry and figure out if an old entry was overwritten. The vast majority of times there will
-        // be nothing to override, so we use an optimistic concurrency strategy to execute this. If we end up replacing
-        // an entry, we'll verify it and undo the insertion if appropriate.
+                    // Slice the data that we need to insert. We may be able to insert the whole buffer at once.
+                    BufferView dataToInsert = overlapLength >= data.getLength() ? data : data.slice(0, (int) overlapLength);
+                    CacheIndexEntry newEntry;
+                    int dataAddress = CacheStorage.NO_ADDRESS; // Null address pointer.
+                    try {
+                        dataAddress = this.cacheStorage.insert(dataToInsert);
+                        newEntry = new CacheIndexEntry(segmentOffset, dataToInsert.getLength(), dataAddress);
+                        ReadIndexEntry overriddenEntry = addToIndex(newEntry);
+                        assert overriddenEntry == null : "Insert overrode existing entry; " + segmentOffset + ":" + dataToInsert.getLength();
+                        lastInsertedEntry = newEntry;
+                    } catch (Throwable ex) {
+                        // Clean up the data we might have inserted if we were unable to add it to the index.
+                        this.cacheStorage.delete(dataAddress);
+                        throw ex;
+                    }
+                }
+
+                // Slice the remainder of the buffer, or set it to null if we processed everything.
+                assert overlapLength != 0 : "unable to make any progress";
+                data = overlapLength >= data.getLength() ? null : data.slice((int) overlapLength, data.getLength() - (int) overlapLength);
+            }
+        }
+
+        return lastInsertedEntry;
+    }
+
+    @GuardedBy("lock")
+    private ReadIndexEntry addToIndex(ReadIndexEntry entry) {
+        Exceptions.checkNotClosed(this.closed, this);
+        // Insert the new entry and figure out if an old entry was overwritten.
         ReadIndexEntry rejectedEntry = this.indexEntries.put(entry);
         if (entry.isDataEntry()) {
-            if (rejectedEntry != null && rejectedEntry.getLength() > entry.getLength()) {
-                // We have replaced an entry which had more up-to-date information. If we allow the existing entry to be
-                // overridden, we have potential (in-memory) data loss, so this cannot happen. Undo this.
-                this.indexEntries.put(rejectedEntry);
-                rejectedEntry.setGeneration(entry.getGeneration());
-                rejectedEntry = entry;
-            } else if (entry instanceof MergedIndexEntry) {
+            if (entry instanceof MergedIndexEntry) {
                 // This entry has already existed in the cache for a while; do not change its generation.
                 this.summary.addOne(entry.getGeneration());
             } else {
@@ -621,7 +656,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             }
         }
 
-        if (rejectedEntry != null && rejectedEntry != entry && rejectedEntry.isDataEntry()) {
+        if (rejectedEntry != null && rejectedEntry.isDataEntry()) {
             // Need to eject the old entry's data from the Cache Stats.
             this.summary.removeOne(rejectedEntry.getGeneration());
         }
@@ -1088,14 +1123,18 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     private void queueStorageRead(long offset, int length, Consumer<ReadResultEntryContents> successCallback, Consumer<Throwable> failureCallback, Duration timeout) {
         // Create a callback that inserts into the ReadIndex (and cache) and invokes the success callback.
         Consumer<StorageReadManager.Result> doneCallback = result -> {
-            ByteArraySegment data = result.getData();
+            try {
+                ByteArraySegment data = result.getData();
 
-            // Make sure we invoke our callback first, before any chance of exceptions from insert() may block it.
-            successCallback.accept(new ReadResultEntryContents(data.getReader(), data.getLength()));
-            if (!result.isDerived()) {
-                // Only insert primary results into the cache. Derived results are always sub-portions of primaries
-                // and there is no need to insert them too, as they are already contained within.
-                insert(offset, data);
+                // Make sure we invoke our callback first, before any chance of exceptions from insert() may block it.
+                successCallback.accept(new ReadResultEntryContents(data.getReader(), data.getLength()));
+                if (!result.isDerived()) {
+                    // Only insert primary results into the cache. Derived results are always sub-portions of primaries
+                    // and there is no need to insert them too, as they are already contained within.
+                    insert(offset, data);
+                }
+            } catch (Exception ex) {
+                log.error("{}: Unable to process Storage Read callback. Offset={}, Result=[{}].", this.traceObjectId, offset, result);
             }
         };
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -726,13 +726,6 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
 
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "flushPendingAppends");
 
-        if (flushArgs.getLength() == 0) {
-            // Nothing to flush.
-            WriterFlushResult result = new WriterFlushResult();
-            LoggerHelpers.traceLeave(log, this.traceObjectId, "flushPendingAppends", traceId, result);
-            return CompletableFuture.completedFuture(result);
-        }
-
         // Flush them.
         TimeoutTimer timer = new TimeoutTimer(timeout);
         CompletableFuture<Void> flush;
@@ -1562,20 +1555,24 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
      * @return A FlushResult containing statistics about the flush operation.
      */
     private WriterFlushResult updateStatePostFlush(FlushArgs flushArgs) {
-        // Update the metadata Storage Length.
-        long newLength = this.metadata.getStorageLength() + flushArgs.getLength();
-        this.metadata.setStorageLength(newLength);
+        // Update the metadata Storage Length, if necessary.
+        long newLength = this.metadata.getStorageLength();
+        if (flushArgs.getLength() > 0) {
+            newLength += flushArgs.getLength();
+            this.metadata.setStorageLength(newLength);
+        }
 
-        // Remove operations from the outstanding list as long as every single byte it contains has been committed.
+        // Remove Append Operations from the outstanding list as long as every single byte they contain have been committed.
         boolean reachedEnd = false;
         while (this.operations.size() > 0 && !reachedEnd) {
             StorageOperation first = this.operations.getFirst();
             long lastOffset = first.getLastStreamSegmentOffset();
             reachedEnd = lastOffset >= newLength;
-
-            // Verify that if we did reach the 'newLength' offset, we were on an append operation. Anything else is indicative of a bug.
-            assert reachedEnd || isAppendOperation(first) : "Flushed operation was not an Append.";
-            if (lastOffset <= newLength && isAppendOperation(first)) {
+            if (!isAppendOperation(first)) {
+                // We can only remove Append Operations.
+                reachedEnd = true;
+            } else if (lastOffset <= newLength) {
+                // Fully flushed Append Operation.
                 this.operations.removeFirst();
             }
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestCacheManager.java
@@ -11,11 +11,16 @@ package io.pravega.segmentstore.server;
 
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import lombok.Setter;
 
 /**
  * Exposes the applyCachePolicy method in the CacheManager.
  */
 public class TestCacheManager extends CacheManager {
+    @Setter
+    private Consumer<Client> unregisterInterceptor;
+
     public TestCacheManager(CachePolicy policy, CacheStorage cacheStorage, ScheduledExecutorService executorService) {
         super(policy, cacheStorage, executorService);
     }
@@ -23,5 +28,15 @@ public class TestCacheManager extends CacheManager {
     @Override
     public boolean applyCachePolicy() {
         return super.applyCachePolicy();
+    }
+
+    @Override
+    public void unregister(Client client) {
+        Consumer<Client> interceptor = this.unregisterInterceptor;
+        if (interceptor != null) {
+            interceptor.accept(client);
+        }
+
+        super.unregister(client);
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -27,15 +27,17 @@ import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.TestCacheManager;
+import io.pravega.segmentstore.server.TestStorage;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
-import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.cache.CacheState;
+import io.pravega.segmentstore.storage.cache.CacheStorage;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
-import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
+import io.pravega.segmentstore.storage.mocks.InMemoryStorage;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
@@ -764,7 +766,12 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testStorageReadsConcurrentWithOverwrite() throws Exception {
-        testConcurrentStorageReads(
+        testStorageReadsConcurrentWithOverwrite(0);
+        testStorageReadsConcurrentWithOverwrite(1);
+    }
+
+    private void testStorageReadsConcurrentWithOverwrite(int offsetDeltaBetweenReads) throws Exception {
+        testConcurrentStorageReads(offsetDeltaBetweenReads, 1,
                 (context, metadata) -> {
                     // Do nothing.
                 },
@@ -801,8 +808,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testStorageReadsConcurrentNoOverwrite() throws Exception {
+        testStorageReadsConcurrentNoOverwrite(0);
+        testStorageReadsConcurrentNoOverwrite(1);
+    }
+
+    private void testStorageReadsConcurrentNoOverwrite(int offsetDeltaBetweenReads) throws Exception {
         val appendedData = new AtomicReference<ByteArraySegment>();
-        testConcurrentStorageReads(
+        testConcurrentStorageReads(offsetDeltaBetweenReads, 0,
                 (context, metadata) -> {
                     // Now perform an append.
                     appendedData.set(getAppendData(metadata.getName(), metadata.getId(), 1, 1));
@@ -825,8 +837,12 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 });
     }
 
-    private void testConcurrentStorageReads(BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
-                                            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
+    private void testConcurrentStorageReads(
+            int offsetDeltaBetweenReads,
+            int extraAllowedStorageReads,
+            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
+            BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
+        val maxAllowedStorageReads = 2 + extraAllowedStorageReads;
         val cachePolicy = new CachePolicy(100, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
         @Cleanup
         TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
@@ -852,48 +868,55 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         Assert.assertTrue("Expected an eviction.", evicted);
 
         @Cleanup("release")
-        val firstInsertBlocker = new ReusableLatch();
+        val firstReadBlocker = new ReusableLatch();
         @Cleanup("release")
-        val firstInsertInCache = new ReusableLatch();
+        val firstRead = new ReusableLatch();
         @Cleanup("release")
-        val secondInsertBlocker = new ReusableLatch();
+        val secondReadBlocker = new ReusableLatch();
         @Cleanup("release")
-        val secondInsertInCache = new ReusableLatch();
-        val insertCount = new AtomicInteger();
+        val secondRead = new ReusableLatch();
+        val cacheInsertCount = new AtomicInteger();
         context.cacheStorage.insertCallback = address -> {
-            int insertId = insertCount.incrementAndGet();
-            if (insertId == 1) {
-                firstInsertInCache.release();
-                Exceptions.handleInterrupted(firstInsertBlocker::await);
-            } else if (insertId == 2) {
-                secondInsertInCache.release();
-                Exceptions.handleInterrupted(secondInsertBlocker::await);
-            } else {
-                Assert.fail("Too many inserts.");
+            if (cacheInsertCount.incrementAndGet() > 1) {
+                Assert.fail("Too many cache inserts.");
             }
         };
+
+        val storageReadCount = new AtomicInteger();
+        context.storage.setReadInterceptor((segment, wrappedStorage) -> {
+            int readCount = storageReadCount.incrementAndGet();
+            if (readCount == 1) {
+                firstRead.release();
+                Exceptions.handleInterrupted(firstReadBlocker::await);
+            } else if (readCount == 2) {
+                secondRead.release();
+                Exceptions.handleInterrupted(secondReadBlocker::await);
+            } else if (readCount > maxAllowedStorageReads) {
+                Assert.fail("Too many storage reads. Max allowed = " + maxAllowedStorageReads);
+            }
+        });
 
         // Initiate the first Storage Read.
         val read1Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
         val read1Data = new byte[dataInStorage.getLength()];
         val read1Future = CompletableFuture.runAsync(() -> read1Result.readRemaining(read1Data, TIMEOUT), executorService());
 
-        // Wait for it to process (the only time we can intercept it is when it's about to be entered into the cache).
-        firstInsertInCache.await();
+        // Wait for it to process.
+        firstRead.await();
 
         // Initiate the second storage read.
-        val read2Result = context.readIndex.read(segmentId, 0, dataInStorage.getLength(), TIMEOUT);
-        val read2Data = new byte[dataInStorage.getLength()];
+        val read2Length = dataInStorage.getLength() - offsetDeltaBetweenReads;
+        val read2Result = context.readIndex.read(segmentId, offsetDeltaBetweenReads, read2Length, TIMEOUT);
+        val read2Data = new byte[read2Length];
         val read2Future = CompletableFuture.runAsync(() -> read2Result.readRemaining(read2Data, TIMEOUT), executorService());
 
-        // Wait for it to process.
-        secondInsertInCache.await();
+        secondRead.await();
 
         // Unblock the first Storage Read and wait for it to complete.
-        firstInsertBlocker.release();
+        firstReadBlocker.release();
         read1Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
-        // Wait for the data to be fully added to the cache. Without this the subsequent append will not write to this entry.
+        // Wait for the data from the first read to be fully added to the cache. Without this the subsequent append will not write to this entry.
         TestUtils.await(
                 () -> {
                     try {
@@ -907,11 +930,13 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         executeBetweenReads.accept(context, metadata);
 
         // Unblock second Storage Read.
-        secondInsertBlocker.release();
+        secondReadBlocker.release();
         read2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
         // Perform final check.
         finalCheck.accept(context, metadata);
+        Assert.assertEquals("Unexpected number of storage reads.", maxAllowedStorageReads, storageReadCount.get());
+        Assert.assertEquals("Unexpected number of cache inserts.", 1, cacheInsertCount.get());
     }
 
     /**
@@ -959,6 +984,51 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                     entry.getContent().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                 },
                 ex -> ex instanceof StreamSegmentNotExistsException);
+    }
+
+    /**
+     * Tests the ability to handle Cache/Index Update failures post a successful Storage Read.
+     */
+    @Test
+    public void testStorageFailedCacheInsert() throws Exception {
+        final int segmentLength = 1024;
+        // Create a segment and write some data in Storage for it.
+        @Cleanup
+        TestContext context = new TestContext();
+        ArrayList<Long> segmentIds = createSegments(context);
+        createSegmentsInStorage(context);
+        val testSegmentId = segmentIds.get(0);
+        UpdateableSegmentMetadata sm = context.metadata.getStreamSegmentMetadata(testSegmentId);
+        sm.setStorageLength(segmentLength);
+        sm.setLength(segmentLength);
+        context.storage.openWrite(sm.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, new ByteArrayInputStream(new byte[segmentLength]), segmentLength, TIMEOUT))
+                .join();
+
+        // Keep track of inserted/deleted calls to the Cache, and "fail" the insert call.
+        val inserted = new ReusableLatch();
+        val insertedAddress = new AtomicInteger(CacheStorage.NO_ADDRESS);
+        val deletedAddress = new AtomicInteger(Integer.MAX_VALUE);
+        context.cacheStorage.insertCallback = address -> {
+            context.cacheStorage.delete(address); // Immediately delete this data (prevent leaks).
+            Assert.assertTrue(insertedAddress.compareAndSet(CacheStorage.NO_ADDRESS, address));
+            inserted.release();
+            throw new IntentionalException();
+        };
+        context.cacheStorage.deleteCallback = deletedAddress::set;
+
+        // Trigger a read. The first read call will be served with data directly from Storage, so we expect it to be successful.
+        @Cleanup
+        ReadResult readResult = context.readIndex.read(testSegmentId, 0, segmentLength, TIMEOUT);
+        ReadResultEntry entry = readResult.next();
+        Assert.assertEquals("Unexpected ReadResultEntryType.", ReadResultEntryType.Storage, entry.getType());
+        entry.requestContent(TIMEOUT);
+        entry.getContent().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS); // This should complete without issues.
+
+        // Verify that the cache insert attempt has been made
+        inserted.await();
+        Assert.assertNotEquals("Expected an insert attempt to have been made.", CacheStorage.NO_ADDRESS, insertedAddress.get());
+        AssertExtensions.assertEventuallyEquals(CacheStorage.NO_ADDRESS, deletedAddress::get, TIMEOUT.toMillis());
     }
 
     /**
@@ -1805,7 +1875,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         final ContainerReadIndex readIndex;
         final TestCacheManager cacheManager;
         final TestCacheStorage cacheStorage;
-        final Storage storage;
+        final TestStorage storage;
         final int maxExpectedStorageReadLength;
 
         TestContext() {
@@ -1815,7 +1885,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         TestContext(ReadIndexConfig readIndexConfig, CachePolicy cachePolicy) {
             this.cacheStorage = new TestCacheStorage(Integer.MAX_VALUE);
             this.metadata = new MetadataBuilder(CONTAINER_ID).build();
-            this.storage = InMemoryStorageFactory.newStorage(executorService());
+            this.storage = new TestStorage(new InMemoryStorage(), executorService());
             this.storage.initialize(1);
             this.cacheManager = new TestCacheManager(cachePolicy, this.cacheStorage, executorService());
             this.readIndex = new ContainerReadIndex(readIndexConfig, this.metadata, this.storage, this.cacheManager, executorService());

--- a/segmentstore/storage/impl/src/test/resources/logback.xml
+++ b/segmentstore/storage/impl/src/test/resources/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
@@ -19,6 +19,11 @@ import lombok.NonNull;
  */
 public interface CacheStorage extends AutoCloseable {
     /**
+     * Gets a value representing a "null" address.
+     */
+    int NO_ADDRESS = CacheLayout.NO_ADDRESS;
+
+    /**
      * Gets a value representing the size of one block. For efficiency purposes, it is highly recommended that all inserted
      * data align to this value (i.e., have a length that is a multiple of this value).
      *

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/rolling/RollingStorage.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.storage.rolling;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
+import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.CollectionHelpers;
 import io.pravega.segmentstore.contracts.BadOffsetException;
@@ -29,6 +30,7 @@ import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.SyncStorage;
 import io.pravega.shared.NameUtils;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -301,6 +303,7 @@ public class RollingStorage implements SyncStorage {
     }
 
     @Override
+    @SneakyThrows(IOException.class)
     public void write(SegmentHandle handle, long offset, InputStream data, int length) throws StreamSegmentException {
         val h = getHandle(handle);
         ensureNotDeleted(h);
@@ -321,7 +324,13 @@ public class RollingStorage implements SyncStorage {
             int writeLength = (int) Math.min(length - bytesWritten, h.getRollingPolicy().getMaxLength() - last.getLength());
             assert writeLength > 0 : "non-positive write length";
             long chunkOffset = offset + bytesWritten - last.getStartOffset();
-            this.baseStorage.write(h.getActiveChunkHandle(), chunkOffset, data, writeLength);
+
+            // Use a BoundedInputStream to ensure that the underlying storage does not try to read more (or less) data
+            // than we instructed it to. Invoking BoundedInputStream.close() will throw an IOException if baseStorage.write()
+            // has not read all the bytes it was supposed to.
+            try (BoundedInputStream bis = new BoundedInputStream(data, writeLength)) {
+                this.baseStorage.write(h.getActiveChunkHandle(), chunkOffset, bis, writeLength);
+            }
             last.increaseLength(writeLength);
             bytesWritten += writeLength;
         }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -406,8 +406,7 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
             for (int j = 0; j < APPENDS_PER_SEGMENT; j++) {
                 byte[] writeData = String.format(APPEND_FORMAT, segmentName, j).getBytes();
 
-                // Append some garbage at the end to make sure we only write as much as instructed, and not the whole InputStream.
-                val dataStream = new SequenceInputStream(new ByteArrayInputStream(writeData), new ByteArrayInputStream(extraData));
+                val dataStream = new ByteArrayInputStream(writeData);
                 s.write(writeHandle, offset, dataStream, writeData.length, TIMEOUT).join();
                 writeStream.write(writeData);
                 offset += writeData.length;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -308,75 +308,79 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     public void testConcat() throws Exception {
         final String context = createSegmentName("Concat");
         try (Storage s = createStorage()) {
-            s.initialize(DEFAULT_EPOCH);
-            HashMap<String, ByteArrayOutputStream> appendData = populate(s, context);
-
-            // Check invalid segment name.
-            val firstSegmentName = getSegmentName(0, context);
-            val firstSegmentHandle = s.openWrite(firstSegmentName).join();
-            val sealedSegmentName = createSegmentName("SealedSegment");
-            createSegment(sealedSegmentName, s);
-            val sealedSegmentHandle = s.openWrite(sealedSegmentName).join();
-            s.write(sealedSegmentHandle, 0, new ByteArrayInputStream(new byte[1]), 1, TIMEOUT).join();
-            s.seal(sealedSegmentHandle, TIMEOUT).join();
-            AtomicLong firstSegmentLength = new AtomicLong(s.getStreamSegmentInfo(firstSegmentName,
-                    TIMEOUT).join().getLength());
-            assertSuppliedFutureThrows("concat() did not throw for non-existent target segment name.",
-                    () -> s.concat(createInexistentSegmentHandle(s, false), 0, sealedSegmentName, TIMEOUT),
-                    ex -> ex instanceof StreamSegmentNotExistsException);
-
-            assertSuppliedFutureThrows("concat() did not throw for invalid source StreamSegment name.",
-                    () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), "foo2", TIMEOUT),
-                    ex -> ex instanceof StreamSegmentNotExistsException);
-
-            ArrayList<String> concatOrder = new ArrayList<>();
-            concatOrder.add(firstSegmentName);
-            for (String sourceSegment : appendData.keySet()) {
-                if (sourceSegment.equals(firstSegmentName)) {
-                    // FirstSegment is where we'll be concatenating to.
-                    continue;
-                }
-
-                assertSuppliedFutureThrows("Concat allowed when source segment is not sealed.",
-                        () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT),
-                        ex -> ex instanceof IllegalStateException);
-
-                // Seal the source segment and then re-try the concat
-                val sourceWriteHandle = s.openWrite(sourceSegment).join();
-                s.seal(sourceWriteHandle, TIMEOUT).join();
-                SegmentProperties preConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-                SegmentProperties sourceProps = s.getStreamSegmentInfo(sourceSegment, TIMEOUT).join();
-
-                s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT).join();
-                concatOrder.add(sourceSegment);
-                SegmentProperties postConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-                Assert.assertFalse("concat() did not delete source segment", s.exists(sourceSegment, TIMEOUT).join());
-
-                // Only check lengths here; we'll check the contents at the end.
-                Assert.assertEquals("Unexpected target StreamSegment.length after concatenation.",
-                        preConcatTargetProps.getLength() + sourceProps.getLength(), postConcatTargetProps.getLength());
-                firstSegmentLength.set(postConcatTargetProps.getLength());
-            }
-
-            // Check the contents of the first StreamSegment. We already validated that the length is correct.
-            SegmentProperties segmentProperties = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
-            byte[] readBuffer = new byte[(int) segmentProperties.getLength()];
-
-            // Read the entire StreamSegment.
-            int bytesRead = s.read(firstSegmentHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
-            Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
-
-            // Check, concat-by-concat, that the final data is correct.
-            int offset = 0;
-            for (String segmentName : concatOrder) {
-                byte[] concatData = appendData.get(segmentName).toByteArray();
-                AssertExtensions.assertArrayEquals("Unexpected concat data.", concatData, 0, readBuffer, offset,
-                        concatData.length);
-                offset += concatData.length;
-            }
-
-            Assert.assertEquals("Concat included more bytes than expected.", offset, readBuffer.length);
+            testConcat(context, s);
         }
+    }
+
+    protected void testConcat(String context, Storage s) throws Exception {
+        s.initialize(DEFAULT_EPOCH);
+        HashMap<String, ByteArrayOutputStream> appendData = populate(s, context);
+
+        // Check invalid segment name.
+        val firstSegmentName = getSegmentName(0, context);
+        val firstSegmentHandle = s.openWrite(firstSegmentName).join();
+        val sealedSegmentName = createSegmentName("SealedSegment");
+        createSegment(sealedSegmentName, s);
+        val sealedSegmentHandle = s.openWrite(sealedSegmentName).join();
+        s.write(sealedSegmentHandle, 0, new ByteArrayInputStream(new byte[1]), 1, TIMEOUT).join();
+        s.seal(sealedSegmentHandle, TIMEOUT).join();
+        AtomicLong firstSegmentLength = new AtomicLong(s.getStreamSegmentInfo(firstSegmentName,
+                TIMEOUT).join().getLength());
+        assertSuppliedFutureThrows("concat() did not throw for non-existent target segment name.",
+                () -> s.concat(createInexistentSegmentHandle(s, false), 0, sealedSegmentName, TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        assertSuppliedFutureThrows("concat() did not throw for invalid source StreamSegment name.",
+                () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), "foo2", TIMEOUT),
+                ex -> ex instanceof StreamSegmentNotExistsException);
+
+        ArrayList<String> concatOrder = new ArrayList<>();
+        concatOrder.add(firstSegmentName);
+        for (String sourceSegment : appendData.keySet()) {
+            if (sourceSegment.equals(firstSegmentName)) {
+                // FirstSegment is where we'll be concatenating to.
+                continue;
+            }
+
+            assertSuppliedFutureThrows("Concat allowed when source segment is not sealed.",
+                    () -> s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT),
+                    ex -> ex instanceof IllegalStateException);
+
+            // Seal the source segment and then re-try the concat
+            val sourceWriteHandle = s.openWrite(sourceSegment).join();
+            s.seal(sourceWriteHandle, TIMEOUT).join();
+            SegmentProperties preConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+            SegmentProperties sourceProps = s.getStreamSegmentInfo(sourceSegment, TIMEOUT).join();
+
+            s.concat(firstSegmentHandle, firstSegmentLength.get(), sourceSegment, TIMEOUT).join();
+            concatOrder.add(sourceSegment);
+            SegmentProperties postConcatTargetProps = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+            Assert.assertFalse("concat() did not delete source segment", s.exists(sourceSegment, TIMEOUT).join());
+
+            // Only check lengths here; we'll check the contents at the end.
+            Assert.assertEquals("Unexpected target StreamSegment.length after concatenation.",
+                    preConcatTargetProps.getLength() + sourceProps.getLength(), postConcatTargetProps.getLength());
+            firstSegmentLength.set(postConcatTargetProps.getLength());
+        }
+
+        // Check the contents of the first StreamSegment. We already validated that the length is correct.
+        SegmentProperties segmentProperties = s.getStreamSegmentInfo(firstSegmentName, TIMEOUT).join();
+        byte[] readBuffer = new byte[(int) segmentProperties.getLength()];
+
+        // Read the entire StreamSegment.
+        int bytesRead = s.read(firstSegmentHandle, 0, readBuffer, 0, readBuffer.length, TIMEOUT).join();
+        Assert.assertEquals("Unexpected number of bytes read.", readBuffer.length, bytesRead);
+
+        // Check, concat-by-concat, that the final data is correct.
+        int offset = 0;
+        for (String segmentName : concatOrder) {
+            byte[] concatData = appendData.get(segmentName).toByteArray();
+            AssertExtensions.assertArrayEquals("Unexpected concat data.", concatData, 0, readBuffer, offset,
+                    concatData.length);
+            offset += concatData.length;
+        }
+
+        Assert.assertEquals("Concat included more bytes than expected.", offset, readBuffer.length);
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/rolling/RollingStorageTestBase.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.storage.StorageTestBase;
 import io.pravega.segmentstore.storage.SyncStorage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.SequenceInputStream;
 import java.util.Random;
 import lombok.Cleanup;
 import lombok.val;
@@ -121,6 +122,51 @@ public abstract class RollingStorageTestBase extends StorageTestBase {
         // Get a read handle, which will also fetch the number of chunks for us.
         val readHandle = (RollingSegmentHandle) s.openRead(segmentName).join();
         Assert.assertEquals("Unexpected number of chunks created.", 1, readHandle.chunks().size());
+    }
+
+    @Test
+    public void testWriteOnRollOverBoundary() throws Exception {
+        final String segmentName = "Segment";
+        final int maxLength = 3; // Really small rolling length.
+
+        val seq1 = "01234";
+        val seq2 = "56789";
+        val totalWriteLength = seq1.length() + seq2.length();
+
+        @Cleanup
+        val s = createStorage();
+        s.initialize(1);
+
+        val writeHandle = s.create(segmentName, new SegmentRollingPolicy(maxLength), TIMEOUT)
+                .thenCompose(v -> s.openWrite(segmentName)).join();
+
+        val byteInputStream1 = new ByteArrayInputStream(seq1.getBytes());
+        val byteInputStream2 = new ByteArrayInputStream(seq2.getBytes());
+
+        val sequenceInputStream = new SequenceInputStream(byteInputStream1, byteInputStream2);
+
+        // This write should cause 3 rollovers.
+        s.write(writeHandle, 0, sequenceInputStream, totalWriteLength, TIMEOUT).join();
+
+        // Check rollover actually happened as expected.
+        RollingSegmentHandle checkHandle = (RollingSegmentHandle) s.openWrite(segmentName).join();
+        val chunks = checkHandle.chunks();
+        int numberOfRollovers = totalWriteLength / maxLength;
+        Assert.assertEquals(numberOfRollovers + 1, chunks.size());
+
+        for (int i = 0; i < numberOfRollovers; i++) {
+            Assert.assertEquals(maxLength * i, chunks.get(i).getStartOffset());
+            Assert.assertEquals(maxLength, chunks.get(i).getLength());
+        }
+        // Last chunk has index == numberOfRollovers, as list is 0 based.
+        Assert.assertEquals(numberOfRollovers * maxLength, chunks.get(numberOfRollovers).getStartOffset());
+        Assert.assertEquals(1, chunks.get(numberOfRollovers).getLength());
+
+        // Now validate the contents written.
+        val readHandle = s.openRead(segmentName).join();
+        byte[] output = new byte[totalWriteLength];
+        s.read(readHandle, 0, output, 0, totalWriteLength, TIMEOUT).join();
+        Assert.assertEquals(seq1 + seq2, new String(output));
     }
 
     @Override

--- a/segmentstore/storage/src/test/resources/logback.xml
+++ b/segmentstore/storage/src/test/resources/logback.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -108,6 +108,7 @@ public final class MetricsNames {
     public static final String STORAGE_CREATE_COUNT = PREFIX + "segmentstore.storage.create_count";      // Counter
     public static final String STORAGE_DELETE_COUNT = PREFIX + "segmentstore.storage.delete_count";      // Counter
     public static final String STORAGE_CONCAT_COUNT = PREFIX + "segmentstore.storage.concat_count";      // Counter
+    public static final String STORAGE_LARGE_CONCAT_COUNT = PREFIX + "segmentstore.storage.large_concat_count"; // Counter
 
 
     // Cache stats

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsTags.java
@@ -102,7 +102,7 @@ public final class MetricsTags {
         }
 
         String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
-        String[] tokens = segmentBaseName.split("[/]");
+        String[] tokens = segmentBaseName.split("/");
         int segmentIdIndex = tokens.length == 2 ? 1 : 2;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {
             String[] segmentIdTokens = tokens[segmentIdIndex].split(EPOCH_DELIMITER);

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -308,7 +308,7 @@ public final class NameUtils {
         String originalSegmentName = isTransactionSegment(qualifiedName) ? getParentStreamSegmentName(qualifiedName) : qualifiedName;
 
         List<String> retVal = new LinkedList<>();
-        String[] tokens = originalSegmentName.split("[/]");
+        String[] tokens = originalSegmentName.split("/");
         int segmentIdIndex = tokens.length == 2 ? 1 : 2;
         long segmentId;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {
@@ -369,7 +369,7 @@ public final class NameUtils {
     public static List<String> extractTableSegmentTokens(String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName);
         List<String> retVal = new LinkedList<>();
-        String[] tokens = qualifiedName.split("[/]");
+        String[] tokens = qualifiedName.split("/");
         Preconditions.checkArgument(tokens.length > 2);
         Preconditions.checkArgument(tokens[1].equals(TABLES));
         // add scope
@@ -388,7 +388,7 @@ public final class NameUtils {
      */
     public static boolean isTableSegment(String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName);
-        String[] tokens = qualifiedName.split("[/]");
+        String[] tokens = qualifiedName.split("/");
         Preconditions.checkArgument(tokens.length > 2);
 
         return tokens[1].equals(TABLES);
@@ -427,7 +427,7 @@ public final class NameUtils {
 
     private static String[] updateSegmentTags(String qualifiedSegmentName, String[] tags) {
         String segmentBaseName = getSegmentBaseName(qualifiedSegmentName);
-        String[] tokens = segmentBaseName.split("[/]");
+        String[] tokens = segmentBaseName.split("/");
 
         int segmentIdIndex = (tokens.length == 1) ? 0 : (tokens.length) == 2 ? 1 : 2;
         if (tokens[segmentIdIndex].contains(EPOCH_DELIMITER)) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/CommandEncoder.java
@@ -318,8 +318,11 @@ public class CommandEncoder extends FlushingMessageToByteEncoder<Object> {
         int blockSize = 0;
         if (blockSizeSupplier != null) {
             blockSize = blockSizeSupplier.getAppendBlockSize();
-            metricNotifier.updateSuccessMetric(CLIENT_APPEND_BLOCK_SIZE, segmentTags(append.getSegment(), append.getWriterId().toString()),
-                                               blockSize);
+            // Only publish client side metrics when there is some metrics notifier configured for efficiency.
+            if (!metricNotifier.equals(MetricNotifier.NO_OP_METRIC_NOTIFIER)) {
+                metricNotifier.updateSuccessMetric(CLIENT_APPEND_BLOCK_SIZE, segmentTags(append.getSegment(), append.getWriterId().toString()),
+                        blockSize);
+            }
         }
         segmentBeingAppendedTo = append.segment;
         writerIdPerformingAppends = append.writerId;

--- a/test/integration/src/main/resources/logback-test.xml
+++ b/test/integration/src/main/resources/logback-test.xml
@@ -9,7 +9,7 @@
       http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/test/integration/src/test/resources/logback.xml
+++ b/test/integration/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 
       http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/test/system/src/test/resources/logback-test.xml
+++ b/test/system/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-<configuration scan="true">
+<configuration scan="true" scanPeriod="30 seconds">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>


### PR DESCRIPTION
**Change log description**  
This is the cherry-pick of https://github.com/pravega/pravega/pull/4682
Instead of hard-coding, now the Java Truststore path and password get mounted from pravega manifest by pravega-operator.
This change is to start using the mounted path and password in the script to add ECS certificate into Java truststore.

**Purpose of the change**  
To include the feature into r0.7

**What the code does**  
(Detailed description of the code changes)
Inside docker/pravega/scripts/common.sh:
Retrieve password from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD
Retrieve truststore file path from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH
Then scan /etc/ssl/certs/java/ecs-certs to add all the found PEM files into Java Truststore.

**How to verify it**  
With https://... ECS configUri, Pravega segmentstore is able to write/read to/from ECS
