### PR TITLE
Issue 4642 - cherry-pick into r0.7 for ECS TLS support

### DIFF
--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -36,12 +36,21 @@ add_system_property_ecs_config_uri() {
 
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
-    password=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD`
-    trustStore=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH`
+    password="changeit"
+    trust="/etc/ssl/certs/java/cacerts"
+    certificate="ecs-certificate.pem"
 
-    CERTS=/etc/ssl/certs/java/ecs-certs/*.pem
-    for cert in $CERTS
-    do
-      yes | keytool -importcert -storepass "${password}" -file "${cert}" -keystore "${trustStore}" || true
-    done
+    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD"; then
+        password=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD`
+    fi
+    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH"; then
+        trustStore=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH`
+    fi
+    if test -f "/etc/secret-volume/ECS_CERTIFICATE_NAME"; then
+        certificate=`cat /etc/secret-volume/ECS_CERTIFICATE_NAME`
+    fi
+
+    if test -f "/etc/secret-volume/${certificate}"; then
+        yes | keytool -importcert -storepass "${password}" -file "/etc/secret-volume/${certificate}" -keystore "${trustStore}" || true
+    fi
 }

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -33,3 +33,12 @@ add_system_property_ecs_config_uri() {
     echo "${name}" "${configUri}"
     add_system_property "${name}" "${configUri}"
 }
+
+# Add ECS certificates into Java truststore
+add_certs_into_truststore() {
+    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    for cert in $CERTS
+    do
+      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+    done
+}

--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -36,9 +36,12 @@ add_system_property_ecs_config_uri() {
 
 # Add ECS certificates into Java truststore
 add_certs_into_truststore() {
-    CERTS=/etc/ssl/certs/java/ecs-certs/*
+    password=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD`
+    trustStore=`cat /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH`
+
+    CERTS=/etc/ssl/certs/java/ecs-certs/*.pem
     for cert in $CERTS
     do
-      yes | keytool -importcert -storepass changeit -file "${cert}" -keystore /etc/ssl/certs/java/cacerts || true
+      yes | keytool -importcert -storepass "${password}" -file "${cert}" -keystore "${trustStore}" || true
     done
 }

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -69,6 +69,7 @@ init_tier2() {
     add_system_property_ecs_config_uri "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}" "${EXTENDEDS3_ACCESS_KEY_ID}" "${EXTENDEDS3_SECRET_KEY}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
     add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
+    add_certs_into_truststore
     ;;
     esac
 }


### PR DESCRIPTION
**Change log description**  
This is the cherry-pick of https://github.com/pravega/pravega/pull/4682
Instead of hard-coding, now the Java Truststore path and password get mounted from pravega manifest by pravega-operator.
This change is to start using the mounted path and password in the script to add ECS certificate into Java truststore.

**Purpose of the change**  
To include the feature into r0.7

**What the code does**  
(Detailed description of the code changes)
Inside docker/pravega/scripts/common.sh:
Retrieve password from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PASSWORD
Retrieve truststore file path from /etc/ssl/certs/java/ecs-certs/JAVA_TRUST_STORE_PATH
Then scan /etc/ssl/certs/java/ecs-certs to add all the found PEM files into Java Truststore.

**How to verify it**  
With https://... ECS configUri, Pravega segmentstore is able to write/read to/from ECS
