### PR TITLE
Revert "Issue 4642 - cherry-pick into r0.7 for ECS TLS support (#4684)"

### DIFF
--- a/docker/pravega/scripts/common.sh
+++ b/docker/pravega/scripts/common.sh
@@ -33,24 +33,3 @@ add_system_property_ecs_config_uri() {
     echo "${name}" "${configUri}"
     add_system_property "${name}" "${configUri}"
 }
-
-# Add ECS certificates into Java truststore
-add_certs_into_truststore() {
-    password="changeit"
-    trust="/etc/ssl/certs/java/cacerts"
-    certificate="ecs-certificate.pem"
-
-    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD"; then
-        password=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PASSWORD`
-    fi
-    if test -f "/etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH"; then
-        trustStore=`cat /etc/secret-volume/ECS_JAVA_TRUST_STORE_PATH`
-    fi
-    if test -f "/etc/secret-volume/ECS_CERTIFICATE_NAME"; then
-        certificate=`cat /etc/secret-volume/ECS_CERTIFICATE_NAME`
-    fi
-
-    if test -f "/etc/secret-volume/${certificate}"; then
-        yes | keytool -importcert -storepass "${password}" -file "/etc/secret-volume/${certificate}" -keystore "${trustStore}" || true
-    fi
-}

--- a/docker/pravega/scripts/init_tier2.sh
+++ b/docker/pravega/scripts/init_tier2.sh
@@ -69,7 +69,6 @@ init_tier2() {
     add_system_property_ecs_config_uri "extendeds3.configUri" "${EXTENDEDS3_CONFIGURI}" "${EXTENDEDS3_ACCESS_KEY_ID}" "${EXTENDEDS3_SECRET_KEY}"
     add_system_property "extendeds3.bucket" "${EXTENDEDS3_BUCKET}"
     add_system_property "extendeds3.prefix" "${EXTENDEDS3_PREFIX}"
-    add_certs_into_truststore
     ;;
     esac
 }


### PR DESCRIPTION
This reverts commit 8f3dc1c8b1688112480fde0976ace568eb3b52c3.

**Change log description**  
This reverts commit 8f3dc1c8b1688112480fde0976ace568eb3b52c3.
Decision made that no ECS TLS changes go to r0.7 and operator 0.4.4

**Purpose of the change**  
Fixes #4642 

**What the code does**  
(Detailed description of the code changes)
This reverts commit 8f3dc1c8b1688112480fde0976ace568eb3b52c3.
It removes the changes made into common.sh and init_tier2.sh

**How to verify it**  
The changes should be removed.
