### PR TITLE
Issue 4688: Handling znode deletion

### DIFF
--- a/deployment/aws/installer/roles/install-bk/files/install-bk.sh
+++ b/deployment/aws/installer/roles/install-bk/files/install-bk.sh
@@ -18,7 +18,7 @@ PRAVEGA_CLUSTER_NAME=${PRAVEGA_CLUSTER_NAME:-"pravega-cluster"}
 BK_CLUSTER_NAME=${BK_CLUSTER_NAME:-"bookkeeper"}
 BK_AUTORECOVERY=${BK_AUTORECOVERY:-"false"}
 
-BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}/ledgers"
+BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${BK_CLUSTER_NAME}/ledgers"
 
 if [ $USE_MOUNT -eq 0 ]; then
     BK_DIR="/bk"
@@ -48,8 +48,7 @@ until /opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL ls /; do sleep 
 
 echo "create the zk root"
 /opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}
-/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}
-/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}
+/opt/zk/zookeeper-3.5.1-alpha/bin/zkCli.sh -server $ZK_URL create /${PRAVEGA_PATH}/${BK_CLUSTER_NAME}
 
 echo "format the bookie"
 # format bookie

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -27,7 +27,7 @@ ZK_URL=$(echo "${ZK_URL:-127.0.0.1:2181}" | sed -r 's/,/;/g')
 PRAVEGA_PATH=${PRAVEGA_PATH:-"pravega"}
 PRAVEGA_CLUSTER_NAME=${PRAVEGA_CLUSTER_NAME:-"pravega-cluster"}
 BK_CLUSTER_NAME=${BK_CLUSTER_NAME:-"bookkeeper"}
-BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}/ledgers"
+BK_LEDGERS_PATH="/${PRAVEGA_PATH}/${BK_CLUSTER_NAME}/ledgers"
 BK_DIR="/bk"
 BK_zkLedgersRootPath=${BK_LEDGERS_PATH}
 BK_HOME=/opt/bookkeeper
@@ -46,7 +46,7 @@ export BK_metadataServiceUri=zk://${ZK_URL}${BK_LEDGERS_PATH}
 export BK_journalDirectories=${BK_journalDirectories:-${BK_DIR}/journal}
 export BK_ledgerDirectories=${BK_ledgerDirectories:-${BK_DIR}/ledgers}
 export BK_indexDirectories=${BK_DIR}/index
-export BK_CLUSTER_ROOT_PATH=/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}
+export BK_CLUSTER_ROOT_PATH=/${PRAVEGA_PATH}/${BK_CLUSTER_NAME}
 
 export BK_tlsProvider=OpenSSL
 export BK_tlsKeyStoreType=JKS


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

**Change log description**  
The values of *BK_LEDGERS_PATH* and *BK_CLUSTER_ROOT_PATH* are modified to appropriate values so that znode deletion can be handled as expected.

**Purpose of the change**  
Fixes #4688 

**What the code does**  
Modifies the *BK_LEDGERS_PATH* and *BK_CLUSTER_ROOT_PATH* to `"/${PRAVEGA_PATH}/${BK_CLUSTER_NAME}/ledgers"` instead of the previous value which was dependent on the Pravega Cluster name as well i.e. `"/${PRAVEGA_PATH}/${PRAVEGA_CLUSTER_NAME}/${BK_CLUSTER_NAME}/ledgers"`

**How to verify it**  
After the bookkeeper cluster is up and running, you can exec into a zookeeper pod and find the znodes created in the new path instead of the old one.
