### PR TITLE
Issue 4695: Improved batch size calculation algorithm.

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -330,12 +330,12 @@ public class AppendTest {
         streamManager.createStream("Scope", streamName, null);
         @Cleanup
         EventStreamWriter<String> producer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(), EventWriterConfig.builder().build());
-        long blockingTime = timeWrites(testString, 200, producer, true);
-        long nonBlockingTime = timeWrites(testString, 10000, producer, false);
+        long blockingTime = timeWrites(testString, 3000, producer, true);
+        long nonBlockingTime = timeWrites(testString, 600000, producer, false);
         System.out.println("Blocking took: " + blockingTime + "ms.");
         System.out.println("Non blocking took: " + nonBlockingTime + "ms.");        
-        assertTrue(blockingTime < 5000);
-        assertTrue(nonBlockingTime < 5000);
+        assertTrue(blockingTime < 10000);
+        assertTrue(nonBlockingTime < 10000);
     }
 
     private long timeWrites(String testString, int number, EventStreamWriter<String> producer, boolean synchronous)


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Tune the Append batch size tracker's algorithm for calculating batch size.

**Purpose of the change**  
Fixes #4695 

**What the code does**  
Averages two different algorithms. One is based on time with a target of 7ms, and the other is based on the appends outstanding (as it did before). Accuracy is also improved through measuring in nanos rather than millis, and samples are weighted exponentially. The averages are also calculated over a longer period of time to avoid oscillations.

**How to verify it**
We will need several rounds of experimental tests to verify the new parameters.
