### PR TITLE
Issue 4702: (SegmentStore) Fixed a deadlock condition in the Read Index.

### DIFF
--- a/common/src/main/java/io/pravega/common/util/ReusableLatch.java
+++ b/common/src/main/java/io/pravega/common/util/ReusableLatch.java
@@ -111,7 +111,16 @@ public class ReusableLatch {
             }
         }
     }
-    
+
+    /**
+     * Gets the number of threads waiting.
+     *
+     * @return The number of threads waiting.
+     */
+    public int getQueueLength() {
+        return this.impl.getQueueLength();
+    }
+
     @Override
     public String toString() {
         return "LatchReleased: " + released.get();

--- a/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
+++ b/common/src/test/java/io/pravega/common/util/ReusableLatchTests.java
@@ -10,6 +10,7 @@
 package io.pravega.common.util;
 
 import io.pravega.test.common.AssertExtensions;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ReusableLatchTests {
@@ -17,6 +18,7 @@ public class ReusableLatchTests {
     @Test(timeout = 5000)
     public void testRelease() {
         ReusableLatch latch = new ReusableLatch(false);
+        Assert.assertEquals(0, latch.getQueueLength());
         AssertExtensions.assertBlocks(() -> latch.awaitUninterruptibly(), () -> latch.release());
     }
     

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -27,6 +27,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.storage.ReadOnlyStorage;
+import io.pravega.segmentstore.storage.cache.CacheFullException;
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -509,8 +510,14 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         Exceptions.checkArgument(offset + data.getLength() <= this.metadata.getStorageLength(), "entry",
                 "The given range of bytes (Offset=%s, Length=%s) does not correspond to the StreamSegment range that is in Storage (%s).",
                 offset, data.getLength(), this.metadata.getStorageLength());
-
-        addToCacheAndIndex(data, offset, this::insertEntriesToCacheAndIndex);
+        try {
+            addToCacheAndIndex(data, offset, this::insertEntriesToCacheAndIndex);
+        } catch (CacheFullException ex) {
+            // We have already ack-ed this request with the appropriate data to the upstream code, so it's not a problem
+            // if we cannot insert it into the cache due to the cache being full.
+            log.warn("{}: Unable to insert Storage Read data (Offset={}, Length={}) into the Cache. {}",
+                    this.traceObjectId, offset, data.getLength(), ex.getMessage());
+        }
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -456,7 +456,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             } else {
                 // This is the second concurrent request requesting a cleanup.
                 if (!firstCleanupBlock.isDone()) {
-                    // This has executed before the first reuqest completed.
+                    // This has executed before the first request completed.
                     concurrentRequest.set(true);
                 }
             }
@@ -475,8 +475,6 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         int length2 = length1 + 1;
         val write2Future = CompletableFuture.supplyAsync(() -> cache.insert(new ByteArraySegment(new byte[length2])), executorService());
 
-        Thread.sleep(50);
-
         // Unblock the first cleanup.
         firstCleanupBlock.complete(null);
 
@@ -486,7 +484,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
 
         // Verify that things did work as intended.
         Assert.assertFalse("Concurrent call to applyCachePolicy detected.", concurrentRequest.get());
-        Assert.assertEquals("Unexpected number of cleanup requests", 2, cleanupRequestCount.get());
+        AssertExtensions.assertGreaterThanOrEqual("Unexpected number of cleanup requests.", 1, cleanupRequestCount.get());
         Assert.assertEquals("Unexpected entry #2.", length1, cache.get(write1).getLength());
         Assert.assertEquals("Unexpected entry #3.", length2, cache.get(write2).getLength());
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -91,7 +91,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration TIMEOUT = Duration.ofSeconds(2000000);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule
@@ -1671,6 +1671,102 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         AssertExtensions.assertArrayEquals("Unexpected data read back from segment.", append2.array(), 0, allData, append1.getLength(), append2.getLength());
     }
 
+    /**
+     * Tests a deadlock-prone scenario involving multiple Storage read requests from multiple segments, all hitting a
+     * CacheFullException while trying to process.
+     *
+     * Steps:
+     * 1. Segment 1: Storage Read Complete -> Ack -> Insert in Index -> Acquire (ReadIndex1.Lock[Thread1]) -> Insert in Cache [Request1]
+     * 2. Segment 2: Storage Read Complete -> Ack -> Insert in Index -> Acquire (ReadIndex2.Lock[Thread2]) -> Insert in Cache [Request2]
+     * 3. Cache is full. Deadlock occurs if:
+     * 3.1. [Request1] invokes Cache Eviction, which wants to acquire ReadIndex2.Lock, but it is owned by Thread2.
+     * 3.2. [Request2] invokes Cache Eviction, which wants to acquire ReadIndex1.Lock, but it is owned by Thread1.
+     *
+     * This test verifies that no deadlock occurs by simulating this exact scenario. It verifies that all requests eventually
+     * complete successfully (as the deadlock victim will back off and retry).
+     */
+    @Test
+    public void testCacheFullDeadlock() throws Exception {
+        val maxCacheSize = 2 * 1024 * 1024; // This is the actual cache size, even if we set a lower value than this.
+        val append1Size = (int) (0.75 * maxCacheSize); // Fill up most of the cache - this is also a candidate for eviction.
+        val append2Size = 1; // Dummy append - need to register the read index as a cache client.
+        val segmentSize = maxCacheSize + 1;
+
+        val config = ReadIndexConfig
+                .builder()
+                .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
+                .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, maxCacheSize)
+                .build();
+        CachePolicy cachePolicy = new CachePolicy(maxCacheSize, Duration.ZERO, Duration.ofMillis(1));
+        @Cleanup
+        TestContext context = new TestContext(config, cachePolicy, maxCacheSize);
+
+        // Block the first insert (this will be from segment 1
+        val append1Address = new AtomicInteger(0);
+        context.cacheStorage.insertCallback = a -> append1Address.compareAndSet(0, a);
+        val segment1Delete = new ReusableLatch();
+        context.cacheStorage.beforeDelete = deleteAddress -> {
+            if (deleteAddress == append1Address.get()) {
+                // Block eviction of the first segment 1 data (just the first; we want the rest to go through).
+                Exceptions.handleInterrupted(segment1Delete::await);
+            }
+        };
+
+        // Create segments and make each of them slightly bigger than the cache capacity.
+        long segment1Id = createSegment(0, context);
+        long segment2Id = createSegment(1, context);
+        val segment1Metadata = context.metadata.getStreamSegmentMetadata(segment1Id);
+        val segment2Metadata = context.metadata.getStreamSegmentMetadata(segment2Id);
+        segment1Metadata.setLength(segmentSize);
+        segment1Metadata.setStorageLength(segmentSize);
+        segment2Metadata.setLength(segmentSize);
+        segment2Metadata.setStorageLength(segmentSize);
+        createSegmentsInStorage(context);
+
+        context.storage.openWrite(segment1Metadata.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, new ByteArrayInputStream(new byte[segmentSize]), segmentSize, TIMEOUT))
+                .join();
+        context.storage.openWrite(segment2Metadata.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, new ByteArrayInputStream(new byte[segmentSize]), segmentSize, TIMEOUT))
+                .join();
+
+        // Write some data into the cache. This will become a candidate for eviction at the next step.
+        context.readIndex.append(segment1Id, 0, new ByteArraySegment(new byte[append1Size]));
+
+        // Write some data into Segment 2's index. This will have no effect on the cache, but we will register it with the Cache Manager.
+        context.readIndex.append(segment2Id, 0, new ByteArraySegment(new byte[append2Size]));
+
+        // Initiate the first Storage read. This should exceed the max cache size, so it should trigger the cleanup.
+        val segment1Read = context.readIndex.read(segment1Id, append1Size, segmentSize - append1Size, TIMEOUT).next();
+        Assert.assertEquals(ReadResultEntryType.Storage, segment1Read.getType());
+        segment1Read.requestContent(TIMEOUT);
+        segment1Read.getContent().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS); // This one should complete right away.
+
+        // Wait for the delete callback to be latched.
+        TestUtils.await(() -> segment1Delete.getQueueLength() > 0, 10, TIMEOUT.toMillis());
+
+        // Initiate the second Storage read. This should also exceed the max cache size and trigger another cleanup, but
+        // (most importantly) on a different thread.
+        val segment2Read = context.readIndex.read(segment2Id, append2Size, segmentSize - append2Size, TIMEOUT).next();
+        Assert.assertEquals(ReadResultEntryType.Storage, segment2Read.getType());
+        segment2Read.requestContent(TIMEOUT);
+        segment2Read.getContent().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS); // As with the first one, this should complete right away.
+
+        // We use yet another thread to validate that no deadlock occurs. This should briefly block on Segment 2's Read index's
+        // lock, but it should be unblocked when we release that (next step).
+        val append2Future = CompletableFuture.runAsync(() -> {
+            try {
+                context.readIndex.append(segment2Id, append2Size, new ByteArraySegment(new byte[append1Size]));
+            } catch (Exception ex) {
+                throw new CompletionException(ex);
+            }
+        }, executorService());
+
+        // Release the delete blocker. If all goes well, all the other operations should be unblocked at this point.
+        segment1Delete.release();
+        append2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
     //endregion
 
     //region Helpers
@@ -1970,7 +2066,11 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         }
 
         TestContext(ReadIndexConfig readIndexConfig, CachePolicy cachePolicy) {
-            this.cacheStorage = new TestCacheStorage(Integer.MAX_VALUE);
+            this(readIndexConfig, cachePolicy, Integer.MAX_VALUE);
+        }
+
+        TestContext(ReadIndexConfig readIndexConfig, CachePolicy cachePolicy, int actualCacheSize) {
+            this.cacheStorage = new TestCacheStorage(Math.min(Integer.MAX_VALUE, actualCacheSize));
             this.metadata = new MetadataBuilder(CONTAINER_ID).build();
             this.storage = new TestStorage(new InMemoryStorage(), executorService());
             this.storage.initialize(1);
@@ -2002,6 +2102,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     //region TestCacheStorage
 
     private static class TestCacheStorage extends DirectMemoryCache {
+        Consumer<Integer> beforeDelete;
         Consumer<Integer> insertCallback;
         Consumer<Integer> deleteCallback;
         boolean disableAppends;
@@ -2024,9 +2125,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         @Override
         public int insert(BufferView data) {
             int r = super.insert(data);
-            Consumer<Integer> callback = this.insertCallback;
-            if (callback != null) {
-                callback.accept(r);
+            Consumer<Integer> afterInsert = this.insertCallback;
+            if (afterInsert != null) {
+                afterInsert.accept(r);
             }
 
             return r;
@@ -2056,6 +2157,11 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
         @Override
         public void delete(int address) {
+            Consumer<Integer> beforeDelete = this.beforeDelete;
+            if (beforeDelete != null) {
+                beforeDelete.accept(address);
+            }
+
             super.delete(address);
             Consumer<Integer> callback = this.deleteCallback;
             if (callback != null) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -91,7 +91,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, 0) // Default: Off (we have a special test for this).
             .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024)
             .build();
-    private static final Duration TIMEOUT = Duration.ofSeconds(2000000);
+    private static final Duration TIMEOUT = Duration.ofSeconds(20);
     private static final Duration SHORT_TIMEOUT = Duration.ofMillis(20);
 
     @Rule

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheStorage.java
@@ -114,10 +114,11 @@ public interface CacheStorage extends AutoCloseable {
     /**
      * Sets a callback that will be invoked during {@link #insert} if there is insufficient capacity to add more entries.
      *
-     * @param cacheFullCallback The callback to invoke. This should return `true` if a cache cleanup was performed, and
-     *                          `false` otherwise.
+     * @param cacheFullCallback    The callback to invoke. This should return `true` if a cache cleanup was performed, and
+     *                             `false` otherwise.
+     * @param retryDelayBaseMillis The amount of time to wait between retries if cacheFullCallback returns `false`.
      */
-    void setCacheFullCallback(@NonNull Supplier<Boolean> cacheFullCallback);
+    void setCacheFullCallback(@NonNull Supplier<Boolean> cacheFullCallback, int retryDelayBaseMillis);
 
     /**
      * Closes this {@link CacheStorage} instance and releases all resources used by it.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/NoOpCache.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/NoOpCache.java
@@ -72,7 +72,7 @@ public class NoOpCache implements CacheStorage {
     }
 
     @Override
-    public void setCacheFullCallback(Supplier<Boolean> cacheFullCallback) {
+    public void setCacheFullCallback(Supplier<Boolean> cacheFullCallback, int millis) {
 
     }
 }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/cache/DirectMemoryCacheTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/cache/DirectMemoryCacheTests.java
@@ -230,7 +230,7 @@ public class DirectMemoryCacheTests {
      */
     @Test
     public void testCacheFull() {
-        final int cleanAfterInvocations = DirectMemoryCache.MAX_CLEANUP_ATTEMPTS;
+        final int cleanAfterInvocations = DirectMemoryCache.MAX_CLEANUP_ATTEMPTS - 1;
         final int maxSize = LAYOUT.bufferSize();
         final int maxStoredSize = maxSize - LAYOUT.blockSize();
         final BufferView toInsert = new ByteArraySegment(new byte[1]);
@@ -256,9 +256,9 @@ public class DirectMemoryCacheTests {
             }
 
             return reportClean.get();
-        });
+        }, 1);
 
-        // 1. No cleanup, no error, reporting the truth. We should only try once.
+        // 1. No cleanup, no error, reporting the truth. We should try as many times as possible.
         reportClean.set(false);
         actualClean.set(false);
         throwError.set(false);
@@ -267,7 +267,8 @@ public class DirectMemoryCacheTests {
                 "Expected CacheFullException when no cleanup and no error.",
                 () -> c.insert(toInsert),
                 ex -> ex instanceof CacheFullException);
-        Assert.assertEquals("Unexpected number of invocations when no cleanup and no error.", 1, invocationCount.get());
+        Assert.assertEquals("Unexpected number of invocations when no cleanup and no error.",
+                DirectMemoryCache.MAX_CLEANUP_ATTEMPTS, invocationCount.get());
 
         // 2. No cleanup, no error, reporting that we did clean up. We should try as many times as possible.
         reportClean.set(true);


### PR DESCRIPTION
Signed-off-by: Andrei Paduroiu <andrei.paduroiu@emc.com>

**Change log description**  
- Changed the `CacheManager` to reject additional concurrent cache cleanup requests if one is ongoing (as opposed from using a mutex to serialize them).
- Changed the `DirectMemoryCache` to use an exp backoff retry if it cannot clean up the cache after it detected the cache was full.

**Purpose of the change**  
Fixes #4702.

**What the code does**  
See #4702 for a description of a scenario that leads to this. 
The problem arises if 2 concurrent Storage reads complete at about the same time, and both want to insert into a full cache at the same time. Each callback would execute on its own thread, acquire the Read Index lock associated with their segment, then acquire the Cache Manager eviction lock (whomever does it first), and the Cache Manager would attempt to clean up the index by accessing the other Read Indices (leading to a deadlock).

This has been fixed in 2 steps:
1. Removed the Cache Manager lock altogether. If another request comes in while a cache eviction is in progress, the second request will be rejected. 
2. Changed the Streaming Cache (`DirectMemoryCache`) to use an exp backoff retry in case it is unable to trigger a cache eviction
    - Previously it would retry immediately and give up as soon as the CM said nothing could be done.
    - Now it will try up to 5 times, waiting 50-250ms in between requests. 
    - If after 5 attempts it is not able to do anything, then it will throw up a `CacheFullException`
        - This is the same as before, except that now it adds the extra delays in between checks.
    - On the append path, a `CacheFullException` will shut down the container (this has not changed)
    - On the Storage Read Path, a `CacheFullException` has no effect on the request. The original request has already been ack-ed/sent to the client before the attempt to write to the cache. If we cannot write to the cache due to cache full, we will log a warning now so we can trace this in the logs.

**How to verify it**  
New, specific unit test added that verifies this exact situation. The unit test would not complete if there were a deadlock.
