### PR TITLE
Issue 4652: (SegmentStore) Fixed Reconciliation of partially-flushed Storage append

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -757,7 +757,8 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         Exceptions.checkNotClosed(this.closed, this);
         Preconditions.checkState(!this.recoveryMode, "StreamSegmentReadIndex is in Recovery Mode.");
         Preconditions.checkArgument(length >= 0, "length must be a non-negative number");
-        Preconditions.checkArgument(startOffset >= this.metadata.getStorageLength(), "startOffset must refer to an offset beyond the Segment's StorageLength offset.");
+        Preconditions.checkArgument(startOffset >= this.metadata.getStorageLength(),
+                "[%s]: startOffset (%s) must refer to an offset beyond the Segment's StorageLength offset(%s).", this.traceObjectId, startOffset, this.metadata.getStorageLength());
         Preconditions.checkArgument(startOffset + length <= this.metadata.getLength(), "startOffset+length must be less than the length of the Segment.");
         Preconditions.checkArgument(startOffset >= Math.min(this.metadata.getStartOffset(), this.metadata.getStorageLength()),
                 "startOffset is before the Segment's StartOffset.");

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1308,8 +1308,8 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
             op.reconcileComplete(reconciledBytes); // Reflect the reconciliation result in the operation.
             if (op.getLength() == 0) {
                 // Operation has been completely validated; pop it off the list.
-                StorageOperation firstOp = this.operations.removeFirst();
-                assert op == firstOp && op.getLastStreamSegmentOffset() <= storageInfo.getLength();
+                StorageOperation removedOp = this.operations.removeFirst();
+                assert op == removedOp : "Reconciled operation is not the same as removed operation";
             }
 
             return new WriterFlushResult().withFlushedBytes(reconciledBytes);
@@ -1731,8 +1731,6 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         }
 
         void reconcileComplete(int reconciledBytes) {
-            Preconditions.checkArgument(reconciledBytes <= this.length.get(),
-                    "Attempted to reconcile more bytes than stored in this operation.");
             this.streamSegmentOffset.addAndGet(reconciledBytes);
             this.length.addAndGet(-reconciledBytes);
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -1303,28 +1303,28 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
      * if the operation cannot be reconciled, based on the in-memory metadata or the current state of the Segment in Storage.
      */
     private CompletableFuture<WriterFlushResult> reconcileAppendOperation(AggregatedAppendOperation op, SegmentProperties storageInfo, TimeoutTimer timer) {
-        CompletableFuture<Boolean> reconcileResult;
+        CompletableFuture<Integer> reconcileResult;
         WriterFlushResult flushResult = new WriterFlushResult();
         if (op.getLength() > 0) {
             // This operation has data. Reconcile that first.
-            reconcileResult = reconcileData(op, storageInfo, timer)
-                    .thenApply(reconciledBytes -> {
-                        flushResult.withFlushedBytes(reconciledBytes);
-                        return reconciledBytes >= op.getLength() && op.getLastStreamSegmentOffset() <= storageInfo.getLength();
-                    });
+            reconcileResult = reconcileData(op, storageInfo, timer);
         } else {
             // No data to reconcile, so we consider this part done.
-            reconcileResult = CompletableFuture.completedFuture(true);
+            reconcileResult = CompletableFuture.completedFuture(0);
         }
 
-        return reconcileResult.thenApplyAsync(fullyReconciled -> {
-            if (fullyReconciled) {
+        return reconcileResult.thenApplyAsync(reconciledBytes -> {
+            StorageOperation firstOp = this.operations.getFirst();
+            assert op == firstOp : "Reconciled operation is not the same as removed operation";
+            op.reconcileComplete(reconciledBytes); // Reflect the reconciliation result in the operation.
+            if (op.getLength() == 0) {
                 // Operation has been completely validated; pop it off the list.
-                StorageOperation removedOp = this.operations.removeFirst();
-                assert op == removedOp : "Reconciled operation is not the same as removed operation";
+                assert op.getLastStreamSegmentOffset() <= storageInfo.getLength() : "Fully reconciled operation is not entirely in Storage.";
+                this.operations.removeFirst();
             }
-            return flushResult;
-        });
+
+            return flushResult.withFlushedBytes(reconciledBytes);
+        }, this.executor);
     }
 
     /**
@@ -1739,6 +1739,13 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
 
         boolean isSealed() {
             return this.sealed.get();
+        }
+
+        void reconcileComplete(int reconciledBytes) {
+            Preconditions.checkArgument(reconciledBytes <= this.length.get(),
+                    "Attempted to reconcile more bytes than stored in this operation.");
+            this.streamSegmentOffset.addAndGet(reconciledBytes);
+            this.length.addAndGet(-reconciledBytes);
         }
 
         // region StorageOperation Implementation

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
@@ -383,7 +383,7 @@ class TestWriterDataSource implements WriterDataSource, AutoCloseable {
             SegmentMetadata sm = this.metadata.getStreamSegmentMetadata(streamSegmentId);
             Preconditions.checkArgument(length >= 0, "length must be a non-negative number");
             Preconditions.checkArgument(startOffset >= sm.getStorageLength(),
-                    "startOffset must be larger than refer to an offset beyond the Segment's StorageLength offset.");
+                    "startOffset (%s) must refer to an offset beyond the Segment's StorageLength offset(%s).", startOffset, sm.getStorageLength());
             Preconditions.checkArgument(startOffset + length <= sm.getLength(),
                     "startOffset+length must be less than the length of the Segment.");
             Preconditions.checkArgument(startOffset >= Math.min(sm.getStartOffset(), sm.getStorageLength()),


### PR DESCRIPTION
**Change log description**  
Fixed a bug in SegmentAggregator where it would be unable to resume flush operations after reconciling a partially flushed append.

**Purpose of the change**  
Fixes #4652.

**What the code does**  
- Upon successfully reconciling an append operation, the `SegmentAggregator` would correctly update the Segment's metadata to reflect the Storage offset, however it would not trim the reconciled operation's that has been reconciled. After this, when resuming normal operations, the SegmentAggregator would ask the Read Index to provide data for the reconciled offsets, but the Read Index would correctly reject the request since the StorageWriter is not allowed to request data that has already been moved to Storage.
- This fix changes the SegmentAggregator to update its internal state by trimming the "head" of the pending Append which overlaps the reconciled data. 

**How to verify it**  
There already exist unit tests for reconciliation; I have updated one of them to simulate partially flushed appends which would help test this scenario.
