### PR TITLE
Issue 4670: SegmentContainer in recovery mode

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server;
+import java.util.concurrent.CompletableFuture;
+
+public interface DebugSegmentContainer extends SegmentContainer{
+    CompletableFuture<Void> createStreamSegment(String streamSegmentName, int length, boolean isSealed);
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainerFactory.java
@@ -24,6 +24,14 @@ public interface SegmentContainerFactory {
      */
     SegmentContainer createStreamSegmentContainer(int containerId);
 
+    /**
+     * Creates a new instance of a DebugSegmentContainer.
+     *
+     * @param containerId The Id of the container to create.
+     * @return The DebugSegmentContainer instance.
+     */
+    DebugSegmentContainer createDebugStreamSegmentContainer(int containerId);
+
     @FunctionalInterface
     interface CreateExtensions {
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.server.containers;
+
+import io.pravega.common.TimeoutTimer;
+import io.pravega.common.util.ArrayView;
+import io.pravega.segmentstore.contracts.StreamSegmentInformation;
+import io.pravega.segmentstore.server.*;
+import io.pravega.segmentstore.server.attributes.AttributeIndexFactory;
+import io.pravega.segmentstore.storage.StorageFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Slf4j
+public class DebugStreamSegmentContainer extends StreamSegmentContainer implements DebugSegmentContainer {
+    private static final Duration TIMEOUT = Duration.ofMinutes(1);
+    private final ContainerConfig config;
+
+    /**
+     * Creates a new instance of the StreamSegmentContainer class.
+     *
+     * @param streamSegmentContainerId The Id of the StreamSegmentContainer.
+     * @param config                   The ContainerConfig to use for this StreamSegmentContainer.
+     * @param durableLogFactory        The DurableLogFactory to use to create DurableLogs.
+     * @param readIndexFactory         The ReadIndexFactory to use to create Read Indices.
+     * @param attributeIndexFactory    The AttributeIndexFactory to use to create Attribute Indices.
+     * @param writerFactory            The WriterFactory to use to create Writers.
+     * @param storageFactory           The StorageFactory to use to create Storage Adapters.
+     * @param createExtensions         A Function that, given an instance of this class, will create the set of
+     *                                 {@link SegmentContainerExtension}s to be associated with that instance.
+     * @param executor                 An Executor that can be used to run async tasks.
+     */
+    DebugStreamSegmentContainer(int streamSegmentContainerId, ContainerConfig config, OperationLogFactory durableLogFactory, ReadIndexFactory readIndexFactory, AttributeIndexFactory attributeIndexFactory, WriterFactory writerFactory, StorageFactory storageFactory, SegmentContainerFactory.CreateExtensions createExtensions, ScheduledExecutorService executor) {
+        super(streamSegmentContainerId, config, durableLogFactory, readIndexFactory, attributeIndexFactory, writerFactory, storageFactory, createExtensions, executor);
+        this.config = config;
+    }
+
+    /**
+     * Creates a stream segment.
+     * @param streamSegmentName A string.
+     * @param length An integer.
+     * @param isSealed A boolean.
+     * @return A created stream segment.
+     */
+    @Override
+    public CompletableFuture<Void> createStreamSegment(String streamSegmentName, int length, boolean isSealed /*TODO: pass in generic params */) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("createStreamSegment called for {}", streamSegmentName);
+        }
+        StreamSegmentInformation segmentProp = StreamSegmentInformation.builder()
+                .name(streamSegmentName)
+                .length(length)
+                .sealed(isSealed)
+                .build();
+        ArrayView segmentInfo = MetadataStore.SegmentInfo.serialize(MetadataStore.SegmentInfo.builder().properties(segmentProp).build());
+        return metadataStore.createSegment(streamSegmentName, segmentInfo, new TimeoutTimer(TIMEOUT));
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -684,7 +684,7 @@ public abstract class MetadataStore implements AutoCloseable {
 
     @Data
     @Builder
-    protected static class SegmentInfo {
+    public static class SegmentInfo {
         private static final SegmentInfoSerializer SERIALIZER = new SegmentInfoSerializer();
         private final long segmentId;
         private final SegmentProperties properties;
@@ -704,12 +704,12 @@ public abstract class MetadataStore implements AutoCloseable {
         }
 
         @SneakyThrows(IOException.class)
-        static ArrayView serialize(SegmentInfo state) {
+        public static ArrayView serialize(SegmentInfo state) {
             return SERIALIZER.serialize(state);
         }
 
         @SneakyThrows(IOException.class)
-        static SegmentInfo deserialize(ArrayView contents) {
+        public static SegmentInfo deserialize(ArrayView contents) {
             try {
                 return SERIALIZER.deserialize(contents);
             } catch (EOFException | SerializationException ex) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainerFactory.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.server.containers;
 
 import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.server.DebugSegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.storage.StorageFactory;
@@ -40,5 +41,10 @@ public class ReadOnlySegmentContainerFactory implements SegmentContainerFactory 
         Preconditions.checkArgument(containerId == READONLY_CONTAINER_ID,
                 "ReadOnly Containers can only have Id %s.", READONLY_CONTAINER_ID);
         return new ReadOnlySegmentContainer(this.storageFactory, this.executor);
+    }
+
+    @Override
+    public DebugSegmentContainer createDebugStreamSegmentContainer(int containerId) {
+        return null;
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -101,7 +101,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     private final ContainerAttributeIndex attributeIndex;
     private final Writer writer;
     private final Storage storage;
-    private final MetadataStore metadataStore;
+    protected final MetadataStore metadataStore;
     private final ScheduledExecutorService executor;
     private final MetadataCleaner metadataCleaner;
     private final AtomicBoolean closed;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerFactory.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerFactory.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
 import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.server.WriterFactory;
+import io.pravega.segmentstore.server.DebugSegmentContainer;
 import io.pravega.segmentstore.server.attributes.AttributeIndexFactory;
 import io.pravega.segmentstore.storage.StorageFactory;
 import java.util.concurrent.ScheduledExecutorService;
@@ -58,6 +59,12 @@ public class StreamSegmentContainerFactory implements SegmentContainerFactory {
         this.storageFactory = Preconditions.checkNotNull(storageFactory, "storageFactory");
         this.createExtensions = Preconditions.checkNotNull(createExtensions, "createExtensions");
         this.executor = Preconditions.checkNotNull(executor, "executor");
+    }
+
+    @Override
+    public DebugSegmentContainer createDebugStreamSegmentContainer(int containerId) {
+        return new DebugStreamSegmentContainer(containerId, config, this.operationLogFactory, this.readIndexFactory,
+                this.attributeIndexFactory, this.writerFactory, this.storageFactory, this.createExtensions, this.executor);
     }
 
     @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -18,6 +18,7 @@ import io.pravega.common.util.ReusableLatch;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.ContainerNotFoundException;
 import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
+import io.pravega.segmentstore.server.DebugSegmentContainer;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.SegmentProperties;
@@ -247,6 +248,11 @@ public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
         TestContainerFactory(Exception startException, ReusableLatch startReleaseSignal) {
             this.startException = startException;
             this.startReleaseSignal = startReleaseSignal;
+        }
+
+        @Override
+        public DebugSegmentContainer createDebugStreamSegmentContainer(int containerId) {
+            return null;
         }
 
         @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -193,6 +193,16 @@ public final class NameUtils {
     }
 
     /**
+     * Checks whether given name is an Attribute Segment.
+     *
+     * @param segmentName The name of the segment.
+     * @return true if the name is Attribute Segment. False otherwise
+     */
+    public static boolean isAttributeSegment(String segmentName) {
+        return segmentName.endsWith(ATTRIBUTE_SUFFIX);
+    }
+
+    /**
      * Gets the name of the Segment name from its Header Segment Name.
      *
      * @param headerSegmentName The name of the Header Segment.


### PR DESCRIPTION
**Change log description**  
Exposes `CreateStreamSegment` API to take in length and `isSealed` status

**Purpose of the change**  
Fixes #4670 

**What the code does**  
Added `DebugStreamSegmentContainer `implementing `StreamSegmentContainer `to expose an API for `createStreamSegment `to accept length and `isSealed `status from the user

**How to verify it**  
Build shall pass.