### PR TITLE
Issue 4721: Auto-reconciliation of BookKeeperLog Metadata.

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -840,34 +840,60 @@ class BookKeeperLog implements DurableDataLog {
     private void persistMetadata(LogMetadata metadata, boolean create) throws DurableDataLogException {
         try {
             byte[] serializedMetadata = LogMetadata.SERIALIZER.serialize(metadata).getCopy();
-            Stat result;
-            if (create) {
-                result = new Stat();
-                this.zkClient.create()
-                             .creatingParentsIfNeeded()
-                             .storingStatIn(result)
-                             .forPath(this.logNodePath, serializedMetadata);
-            } else {
-                result = this.zkClient.setData()
-                                      .withVersion(metadata.getUpdateVersion())
-                                      .forPath(this.logNodePath, serializedMetadata);
-
-            }
-
+            Stat result = create
+                    ? createZkMetadata(serializedMetadata)
+                    : updateZkMetadata(serializedMetadata, metadata.getUpdateVersion());
             metadata.withUpdateVersion(result.getVersion());
         } catch (KeeperException.NodeExistsException | KeeperException.BadVersionException keeperEx) {
-            // We were fenced out. Clean up and throw appropriate exception.
-            throw new DataLogWriterNotPrimaryException(
-                    String.format("Unable to acquire exclusive write lock for log (path = '%s%s').", this.zkClient.getNamespace(), this.logNodePath),
-                    keeperEx);
+            if (reconcileMetadata(metadata)) {
+                log.info("{}: Received '{}' from ZooKeeper while persisting metadata (path = '{}{}'), however metadata has been persisted correctly. Not rethrowing.",
+                        this.traceObjectId, keeperEx.toString(), this.zkClient.getNamespace(), this.logNodePath);
+            } else {
+                // We were fenced out. Convert to an appropriate exception.
+                throw new DataLogWriterNotPrimaryException(
+                        String.format("Unable to acquire exclusive write lock for log (path = '%s%s').", this.zkClient.getNamespace(), this.logNodePath),
+                        keeperEx);
+            }
         } catch (Exception generalEx) {
-            // General exception. Clean up and rethrow appropriate exception.
+            // General exception. Convert to an appropriate exception.
             throw new DataLogInitializationException(
                     String.format("Unable to update ZNode for path '%s%s'.", this.zkClient.getNamespace(), this.logNodePath),
                     generalEx);
         }
 
         log.info("{} Metadata persisted ({}).", this.traceObjectId, metadata);
+    }
+
+    @VisibleForTesting
+    protected Stat createZkMetadata(byte[] serializedMetadata) throws Exception {
+        val result = new Stat();
+        this.zkClient.create().creatingParentsIfNeeded().storingStatIn(result).forPath(this.logNodePath, serializedMetadata);
+        return result;
+    }
+
+    @VisibleForTesting
+    protected Stat updateZkMetadata(byte[] serializedMetadata, int version) throws Exception {
+        return this.zkClient.setData().withVersion(version).forPath(this.logNodePath, serializedMetadata);
+    }
+
+    /**
+     * Verifies the given {@link LogMetadata} against the actual one stored in ZooKeeper.
+     *
+     * @param metadata The Metadata to check.
+     * @return True if the metadata stored in ZooKeeper is an identical match to the given one, false otherwise. If true,
+     * {@link LogMetadata#getUpdateVersion()} will also be updated with the one stored in ZooKeeper.
+     */
+    private boolean reconcileMetadata(LogMetadata metadata) {
+        try {
+            val actualMetadata = loadMetadata();
+            if (metadata.equals(actualMetadata)) {
+                metadata.withUpdateVersion(actualMetadata.getUpdateVersion());
+                return true;
+            }
+        } catch (DataLogInitializationException ex) {
+            log.warn("{}: Unable to verify persisted metadata (path = '{}{}').", this.traceObjectId, this.zkClient.getNamespace(), this.logNodePath, ex);
+        }
+        return false;
     }
 
     /**
@@ -890,6 +916,7 @@ class BookKeeperLog implements DurableDataLog {
 
         persistMetadata(metadata, create);
     }
+
 
     //endregion
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/LedgerMetadata.java
@@ -10,6 +10,7 @@
 package io.pravega.segmentstore.storage.impl.bookkeeper;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class LedgerMetadata {
     /**
      * The BookKeeper-assigned Ledger Id.

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ReadOnlyLogMetadata.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ReadOnlyLogMetadata.java
@@ -52,4 +52,35 @@ public interface ReadOnlyLogMetadata {
      * @return The Truncation Address.
      */
     LedgerAddress getTruncationAddress();
+
+    /**
+     * Determines whether this {@link ReadOnlyLogMetadata} is equivalent to the other one.
+     *
+     * @param other The other instance.
+     * @return True if equivalent, false otherwise.
+     */
+    default boolean equals(ReadOnlyLogMetadata other) {
+        if (other == null) {
+            return false;
+        }
+
+        List<LedgerMetadata> ledgers = getLedgers();
+        List<LedgerMetadata> otherLedgers = other.getLedgers();
+        if (this.isEnabled() != other.isEnabled()
+                || this.getEpoch() != other.getEpoch()
+                || !this.getTruncationAddress().equals(other.getTruncationAddress())
+                || ledgers.size() != otherLedgers.size()) {
+            return false;
+        }
+
+        // Check each ledger.
+        for (int i = 0; i < ledgers.size(); i++) {
+            if (!ledgers.get(i).equals(otherLedgers.get(i))) {
+                return false;
+            }
+        }
+
+        // All tests have passed.
+        return true;
+    }
 }

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -388,6 +388,10 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
 
     @Test
     public void testReconcileMetadata() throws Exception {
+        @Cleanup
+        BookKeeperAdmin a = new BookKeeperAdmin(this.factory.get().getBookKeeperClient());
+        val initialLedgers = Sets.newHashSet(a.listLedgers());
+
         // Test initialization (node creation).
         try (val log = new TestBookKeeperLog()) {
             // Data not persisted and we throw an error - this is a real fencing event.
@@ -425,9 +429,8 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
         }
 
         // Verify ledger cleanup.
-        @Cleanup
-        BookKeeperAdmin a = new BookKeeperAdmin(this.factory.get().getBookKeeperClient());
         val allLedgers = Sets.newHashSet(a.listLedgers());
+        allLedgers.removeAll(initialLedgers);
         Assert.assertEquals("Unexpected ledgers in BK.", expectedLedgerIds, allLedgers);
     }
 


### PR DESCRIPTION
**Change log description**  
- BookKeeperLog.persistMetadata will auto-reconcile the metadata if it gets a `NodeExistsException` or `BadVersionException` from ZooKeeper while doing a CAS update. 

**Purpose of the change**  
Fixes #4721.

**What the code does**  
- See #4721 for why this is needed.
- The `BookKeeperLog` will attempt to read the metadata from ZK and compare it to what it wanted to persist in the first place. If identical (except for versions), it will consider the update to have gone through, otherwise it will rethrow the original exception.

**How to verify it**  
New unit test added.
