### PR TITLE
Issue 4628: Add license copy to binary artifacts (#4675)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1036,6 +1036,8 @@ distributions {
                 exclude "logback.xml"
             }
             from (project(":standalone").installDist)
+            from 'LICENSE'
+            from 'NOTICE'
         }
     }
     client {
@@ -1045,6 +1047,8 @@ distributions {
             from { project(":shared:authplugin").configurations.runtime.allArtifacts.files }
             from { project(":client").configurations.runtime }
             from { project(":client").configurations.runtime.allArtifacts.files }
+            from 'LICENSE'
+            from 'NOTICE'
         }
     }
     javadoc {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -31,6 +31,15 @@ plugins.withId('java') {
 
     archivesBaseName = "pravega" + project.path.replace(':', '-')
 
+    // Include LICENSE and NOTICE files in every jar file 
+    jar {
+        into ('META-INF') {
+            from project.rootDir
+            include 'LICENSE'
+            include 'NOTICE'
+        }
+    }
+
     task sourceJar(type: Jar) {
         classifier = 'sources'
         from sourceSets.main.java


### PR DESCRIPTION
**Change log description**  
Cherrypick #4628 / #4675 into r0.7

**Purpose of the change**  
Fixes #4628 in Pravega  0.7.1

**What the code does**  
Copies LICENSE and NOTICE files into META-INF directory in every jar file generated. And also includes the same files in tgz and zip versions of Pravega and Pravega Client distributions

**How to verify it**  
Build should pass. The generated artifacts should have both LICENSE and NOTICE files included.
