### PR TITLE
Issue 4730: Temporarily revert control rate of parallel Segment Container recoveries (#4655)

### DIFF
--- a/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
+++ b/common/src/main/java/io/pravega/common/util/OrderedItemProcessor.java
@@ -24,14 +24,12 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 /**
  * Processes items in order, subject to capacity constraints.
  */
 @ThreadSafe
-@Slf4j
 public class OrderedItemProcessor<ItemType, ResultType> implements AutoCloseable {
     //region members
 
@@ -41,7 +39,6 @@ public class OrderedItemProcessor<ItemType, ResultType> implements AutoCloseable
     private final Function<ItemType, CompletableFuture<ResultType>> processor;
     @GuardedBy("stateLock")
     private final Deque<QueueItem> pendingItems;
-    private final boolean closeOnException;
     private final Executor executor;
 
     /**
@@ -70,23 +67,15 @@ public class OrderedItemProcessor<ItemType, ResultType> implements AutoCloseable
      * @param capacity  The maximum number of concurrent executions.
      * @param processor A Function that, given an Item, returns a CompletableFuture that indicates when the item has been
      *                  processed (successfully or not).
-     * @param closeOnException Whether or not the OrderedItemProcessor should shut down when it throws an exception
-     *                         processing an item. The default behavior is to close the processor on exception.
      * @param executor  An Executor for async invocations.
      */
-    public OrderedItemProcessor(int capacity, Function<ItemType, CompletableFuture<ResultType>> processor,
-                                boolean closeOnException, Executor executor) {
+    public OrderedItemProcessor(int capacity, Function<ItemType, CompletableFuture<ResultType>> processor, Executor executor) {
         Preconditions.checkArgument(capacity > 0, "capacity must be a non-negative number.");
         this.capacity = capacity;
         this.processor = Preconditions.checkNotNull(processor, "processor");
         this.executor = Preconditions.checkNotNull(executor, "executor");
         this.pendingItems = new ArrayDeque<>();
         this.activeCount = 0;
-        this.closeOnException = closeOnException;
-    }
-
-    public OrderedItemProcessor(int capacity, Function<ItemType, CompletableFuture<ResultType>> processor, Executor executor) {
-        this(capacity, processor, true, executor);
     }
 
     //endregion
@@ -177,16 +166,12 @@ public class OrderedItemProcessor<ItemType, ResultType> implements AutoCloseable
         synchronized (this.stateLock) {
             // Release the spot occupied by this item's execution.
             this.activeCount--;
-            if (exception != null) {
-                log.warn("Exception thrown while processing item: ", exception);
-                // Only close the processor and cancel pending items if exceptions from processed items are not allowed.
-                if (!this.closed && this.closeOnException) {
-                    // Need to fail all future items and close to prevent new items from being processed.
-                    failEx = new ProcessingException("A previous item failed to commit. Cannot process new items.", exception);
-                    toFail = new ArrayList<>(this.pendingItems);
-                    this.pendingItems.clear();
-                    this.closed = true;
-                }
+            if (exception != null && !this.closed) {
+                // Need to fail all future items and close to prevent new items from being processed.
+                failEx = new ProcessingException("A previous item failed to commit. Cannot process new items.", exception);
+                toFail = new ArrayList<>(this.pendingItems);
+                this.pendingItems.clear();
+                this.closed = true;
             }
 
             if (this.emptyNotifier != null && this.activeCount == 0 && this.pendingItems.isEmpty()) {

--- a/config/config.properties
+++ b/config/config.properties
@@ -54,11 +54,6 @@ pravegaservice.containerCount=4
 # Valid values: Positive integer in the valid TCP port ranges.
 pravegaservice.listeningPort=12345
 
-# Number of Segment Containers that a Segment Store will start (and recover) in parallel. The main objective of this
-# parameter is to prevent multiple Segment Container recoveries in parallel to overload the cache. A higher value may
-# speed up recoveries, but sufficient cache size should be configured for safety.
-#pravegaservice.parallelContainerStarts=1
-
 # Full URL (host:port) where to find a ZooKeeper that can be used for coordinating this Pravega Cluster.
 # Required.
 pravegaservice.zkURL=localhost:2181

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -183,7 +183,6 @@ public final class ServiceStarter {
                         this.zkClient,
                         new Host(this.serviceConfig.getPublishedIPAddress(),
                                 this.serviceConfig.getPublishedPort(), null),
-                        this.serviceConfig.getParallelContainerStarts(),
                         setup.getCoreExecutor()));
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManager.java
@@ -37,20 +37,18 @@ class ZKSegmentContainerManager implements SegmentContainerManager {
     /**
      * Creates a new instance of the ZKSegmentContainerManager class.
      *
-     * @param containerRegistry       The SegmentContainerRegistry to manage.
-     * @param zkClient                ZooKeeper client.
-     * @param pravegaServiceEndpoint  Pravega service endpoint details.
-     * @param parallelContainerStarts Defines the number of containers to start in parallel.
-     * @param executor                Executor service for running async operations.
+     * @param containerRegistry      The SegmentContainerRegistry to manage.
+     * @param zkClient               ZooKeeper client.
+     * @param pravegaServiceEndpoint Pravega service endpoint details.
+     * @param executor               Executor service for running async operations.
      */
     ZKSegmentContainerManager(SegmentContainerRegistry containerRegistry, CuratorFramework zkClient,
-                              Host pravegaServiceEndpoint, int parallelContainerStarts, ScheduledExecutorService executor) {
+                              Host pravegaServiceEndpoint, ScheduledExecutorService executor) {
         Preconditions.checkNotNull(containerRegistry, "containerRegistry");
         Preconditions.checkNotNull(zkClient, "zkClient");
         this.host = Preconditions.checkNotNull(pravegaServiceEndpoint, "pravegaServiceEndpoint");
         this.cluster = new ClusterZKImpl(zkClient, ClusterType.HOST);
-        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint,
-                parallelContainerStarts, executor);
+        this.containerMonitor = new ZKSegmentContainerMonitor(containerRegistry, zkClient, pravegaServiceEndpoint, executor);
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -17,7 +17,6 @@ import io.pravega.common.cluster.Host;
 import io.pravega.common.cluster.HostContainerMap;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.CollectionHelpers;
-import io.pravega.common.util.OrderedItemProcessor;
 import io.pravega.segmentstore.server.ContainerHandle;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
 import java.io.IOException;
@@ -78,9 +77,6 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
     private final ScheduledExecutorService executor;
     private AtomicReference<ScheduledFuture<?>> assigmentTask;
     private final AtomicLong lastReportTime;
-    // We start Segment Containers sequentially, given that starting them in parallel may lead to the cache being full
-    // if there is too much data to recover.
-    private final OrderedItemProcessor<Integer, ContainerHandle> startContainerOrderedProcessor;
 
     /**
      * Creates an instance of ZKSegmentContainerMonitor.
@@ -90,7 +86,7 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
      * @param pravegaServiceEndpoint The pravega endpoint for which we need to fetch the container assignment.
      */
     ZKSegmentContainerMonitor(SegmentContainerRegistry containerRegistry, CuratorFramework zkClient,
-                              Host pravegaServiceEndpoint, int parallelContainerStarts, ScheduledExecutorService executor) {
+                              Host pravegaServiceEndpoint, ScheduledExecutorService executor) {
         Preconditions.checkNotNull(zkClient, "zkClient");
 
         this.registry = Preconditions.checkNotNull(containerRegistry, "containerRegistry");
@@ -102,9 +98,6 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
         this.hostContainerMapNode = new NodeCache(zkClient, clusterPath);
         this.assigmentTask = new AtomicReference<>();
         this.lastReportTime = new AtomicLong(CURRENT_TIME_MILLIS.get());
-        // Allow OrderedItemProcessor to throw exceptions, as they may happen while starting containers. But we want to
-        // continue processing subsequent container starts irrespective of such failures.
-        this.startContainerOrderedProcessor = new OrderedItemProcessor<>(parallelContainerStarts, this::startContainer, false, this.executor);
     }
 
     /**
@@ -155,7 +148,6 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
 
         // Wait for all the containers to be closed.
         Futures.await(Futures.allOf(results), CLOSE_TIMEOUT_PER_CONTAINER.toMillis());
-        this.startContainerOrderedProcessor.close();
     }
 
     @VisibleForTesting
@@ -197,10 +189,8 @@ public class ZKSegmentContainerMonitor implements AutoCloseable {
                     this.lastReportTime.set(CURRENT_TIME_MILLIS.get());
                 }
 
-                // We start segment containers sequentially to ensure that we do not overload the cache with parallel
-                // container recoveries.
-                containersToBeStarted.forEach(startContainerOrderedProcessor::process);
                 // Initiate the start and stop tasks asynchronously.
+                containersToBeStarted.forEach(this::startContainer);
                 containersToBeStopped.forEach(this::stopContainer);
             } else {
                 log.warn("No segment container assignments found");

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerManagerTest.java
@@ -51,7 +51,6 @@ public class ZKSegmentContainerManagerTest extends ThreadPooledTestSuite {
     private final static int TEST_TIMEOUT = 60000;
     private final static int RETRY_SLEEP_MS = 100;
     private final static int MAX_RETRY = 5;
-    private final static int MAX_PARALLEL_CONTAINER_STARTS = 1;
     private static final int PORT = TestUtils.getAvailableListenPort();
     private final static Host PRAVEGA_SERVICE_ENDPOINT = new Host(getHostAddress(), PORT, null);
     private final static String PATH = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
@@ -159,7 +158,7 @@ public class ZKSegmentContainerManagerTest extends ThreadPooledTestSuite {
     }
 
     private ZKSegmentContainerManager createContainerManager(SegmentContainerRegistry registry, CuratorFramework zkClient) {
-        return new ZKSegmentContainerManager(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, MAX_PARALLEL_CONTAINER_STARTS, executorService());
+        return new ZKSegmentContainerManager(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, executorService());
     }
 
     private void initializeHostContainerMapping(CuratorFramework zkClient) throws Exception {

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitorTest.java
@@ -56,7 +56,6 @@ public class ZKSegmentContainerMonitorTest extends ThreadPooledTestSuite {
     private final static int TEST_TIMEOUT = 60000;
     private final static int RETRY_SLEEP_MS = 100;
     private final static int MAX_RETRY = 5;
-    private final static int MAX_PARALLEL_CONTAINER_STARTS = 1;
     private static final int PORT = TestUtils.getAvailableListenPort();
     private final static Host PRAVEGA_SERVICE_ENDPOINT = new Host(getHostAddress(), PORT, null);
     private final static String PATH = ZKPaths.makePath("cluster", "segmentContainerHostMapping");
@@ -316,7 +315,7 @@ public class ZKSegmentContainerMonitorTest extends ThreadPooledTestSuite {
 
     private ZKSegmentContainerMonitor createContainerMonitor(
             SegmentContainerRegistry registry, CuratorFramework zkClient) {
-        return new ZKSegmentContainerMonitor(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, MAX_PARALLEL_CONTAINER_STARTS, executorService());
+        return new ZKSegmentContainerMonitor(registry, zkClient, PRAVEGA_SERVICE_ENDPOINT, executorService());
     }
 
     private void initializeHostContainerMapping(CuratorFramework zkClient) throws Exception {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -34,7 +34,6 @@ public class ServiceConfig {
     public static final Property<Integer> PUBLISHED_PORT = Property.named("publishedPort");
     public static final Property<String> LISTENING_IP_ADDRESS = Property.named("listeningIPAddress", "");
     public static final Property<String> PUBLISHED_IP_ADDRESS = Property.named("publishedIPAddress", "");
-    public static final Property<Integer> PARALLEL_CONTAINER_STARTS = Property.named("parallelContainerStarts", 1);
     public static final Property<String> ZK_URL = Property.named("zkURL", "localhost:2181");
     public static final Property<Integer> ZK_RETRY_SLEEP_MS = Property.named("zkRetrySleepMs", 5000);
     public static final Property<Integer> ZK_RETRY_COUNT = Property.named("zkRetryCount", 5);
@@ -153,12 +152,6 @@ public class ServiceConfig {
      */
     @Getter
     private final String publishedIPAddress;
-
-    /**
-     * Number of segment containers that a Segment Store will start (and recover) in parallel.
-     */
-    @Getter
-    private final int parallelContainerStarts;
 
     /**
      * The Zookeeper URL.
@@ -309,7 +302,6 @@ public class ServiceConfig {
         } else {
             this.publishedIPAddress = publishedIPAddress;
         }
-        this.parallelContainerStarts = properties.getInt(PARALLEL_CONTAINER_STARTS);
         this.zkURL = properties.get(ZK_URL);
         this.zkRetrySleepMs = properties.getInt(ZK_RETRY_SLEEP_MS);
         this.zkRetryCount = properties.getInt(ZK_RETRY_COUNT);
@@ -360,7 +352,6 @@ public class ServiceConfig {
                 .append(String.format("listeningIPAddress: %s, ", listeningIPAddress))
                 .append(String.format("publishedPort: %d, ", publishedPort))
                 .append(String.format("publishedIPAddress: %s, ", publishedIPAddress))
-                .append(String.format("parallelContainerStarts: %d, ", parallelContainerStarts))
                 .append(String.format("zkURL: %s, ", zkURL))
                 .append(String.format("zkRetrySleepMs: %d, ", zkRetrySleepMs))
                 .append(String.format("zkSessionTimeoutMs: %d, ", zkSessionTimeoutMs))


### PR DESCRIPTION
**Change log description**  
This PR temporarily reverts PR #4655, as it shows sporadic instability in system tests.

**Purpose of the change**  
Fixes #4730.

**What the code does**  
Temporarily reverts changes in #4655.

**How to verify it**  
System tests should pass consistently.
