### PR TITLE
Issue 4743: (SegmentStore) Infinite loop in StorageWriter if deleting a segment while flushing.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -644,6 +644,10 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
      * Determines whether flushFully can continue given the current state of this SegmentAggregator.
      */
     private boolean canContinueFlushingFully() {
+        if (this.metadata.isDeleted()) {
+            return false; // No point in flushing if the segment has been deleted in the meantime.
+        }
+
         StorageOperation next = this.operations.getFirst();
         return isAppendOperation(next) || isTruncateOperation(next);
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1584,6 +1584,32 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof DataCorruptionException);
     }
 
+    /**
+     * Tests a scenario where the Segment has been deleted (in the metadata) while it was actively flushing. This verifies
+     * that an ongoing flush operation will abort (i.e., eventually complete) so that the next iteration of the StorageWriter
+     * may properly delete the segment.
+     */
+    @Test
+    public void testSegmentDeletedWhileFlushing() throws Exception {
+        final WriterConfig config = DEFAULT_CONFIG;
+
+        @Cleanup
+        TestContext context = new TestContext(config);
+        context.segmentAggregator.initialize(TIMEOUT).join();
+
+        // Add one append, followed by a Seal.
+        StorageOperation appendOp = generateAppendAndUpdateMetadata(SEGMENT_ID, new byte[config.getFlushThresholdBytes() - 1], context);
+        context.segmentAggregator.add(appendOp);
+        context.segmentAggregator.add(generateSealAndUpdateMetadata(SEGMENT_ID, context));
+        Assert.assertTrue("Unexpected value returned by mustFlush().", context.segmentAggregator.mustFlush());
+
+        // Meanwhile, delete the segment (but do not notify the StorageWriter yet).
+        val sm = (UpdateableSegmentMetadata) context.segmentAggregator.getMetadata();
+        sm.markDeleted();
+        val flushResult = context.segmentAggregator.flush(TIMEOUT).join();
+        Assert.assertEquals("Unexpected number of bytes flushed.", 0, flushResult.getFlushedBytes());
+    }
+
     //endregion
 
     //region Unknown outcome operation reconciliation

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/TestWriterDataSource.java
@@ -381,6 +381,11 @@ class TestWriterDataSource implements WriterDataSource, AutoCloseable {
 
             // Perform the same validation checks as the ReadIndex would do.
             SegmentMetadata sm = this.metadata.getStreamSegmentMetadata(streamSegmentId);
+            if (sm.isDeleted()) {
+                // StorageWriterFactory.WriterDataSource returns null for inexistent segments.
+                return null;
+            }
+
             Preconditions.checkArgument(length >= 0, "length must be a non-negative number");
             Preconditions.checkArgument(startOffset >= sm.getStorageLength(),
                     "startOffset (%s) must refer to an offset beyond the Segment's StorageLength offset(%s).", startOffset, sm.getStorageLength());


### PR DESCRIPTION
**Change log description**  
Fixed a bug in SegmentAggregator where it was possible to enter an infinite loop if deleting a segment while flushing.

**Purpose of the change**  
Fixes #4743.

**What the code does**  
Exiting the flush loop if a segment deletion is detected.

**How to verify it**  
New unit test added. The unit test would have never finished (timed out) if the fix hadn't been there.
