### PR TITLE
Issue 4088: Failing all tests that leak Netty resources

### DIFF
--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -11,8 +11,6 @@ package io.pravega.client.segment.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
 import io.pravega.client.netty.impl.ClientConnection;
 import io.pravega.client.netty.impl.ClientConnection.CompletedCallback;
 import io.pravega.client.netty.impl.ConnectionFactory;
@@ -33,7 +31,7 @@ import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.AppendSetup;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
 import io.pravega.test.common.AssertExtensions;
-import io.pravega.test.common.ThreadPooledTestSuite;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -48,8 +46,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.List;
 import lombok.Cleanup;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
@@ -74,26 +70,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class SegmentOutputStreamTest extends ThreadPooledTestSuite {
+public class SegmentOutputStreamTest extends LeakDetectorTestSuite {
 
     private static final String SEGMENT = "test/0";
     private static final String TXN_SEGMENT = "scope/stream/0.#epoch.0#transaction.00000000000000000000000000000001";
     private static final int SERVICE_PORT = 12345;
     private static final RetryWithBackoff RETRY_SCHEDULE = Retry.withExpBackoff(1, 1, 2);
     private final Consumer<Segment> segmentSealedCallback = segment -> { };
-    private Level originalLevel;
-    
-    @Before
-    public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-    }
 
-    @After
-    public void teardown() {
-        ResourceLeakDetector.setLevel(originalLevel);
-    }
-    
     private static ByteBuffer getBuffer(String s) {
         return ByteBuffer.wrap(s.getBytes());
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -10,8 +10,6 @@
 package io.pravega.client.stream.impl;
 
 import com.google.common.collect.ImmutableMap;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentOutputStream;
@@ -26,7 +24,7 @@ import io.pravega.common.util.ReusableLatch;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.CollectingExecutor;
-import io.pravega.test.common.ThreadPooledTestSuite;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,8 +38,6 @@ import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -52,21 +48,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-public class EventStreamWriterTest extends ThreadPooledTestSuite {
-    
-    private Level originalLevel;
-    
-    @Before
-    public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-    }
-
-    @After
-    public void teardown() {
-        ResourceLeakDetector.setLevel(originalLevel);
-    }
-    
+public class EventStreamWriterTest extends LeakDetectorTestSuite {
     @Test
     public void testWrite() {
         String scope = "scope";

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -17,8 +17,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
@@ -28,6 +26,7 @@ import io.netty.util.concurrent.ScheduledFuture;
 import io.pravega.shared.protocol.netty.WireCommands.Event;
 import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,7 +43,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AppendEncodeDecodeTest {
+public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     private final int appendBlockSize = 1024;  
     private final UUID writerId = new UUID(1, 2);
@@ -67,7 +65,6 @@ public class AppendEncodeDecodeTest {
     private final CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
     private final FakeLengthDecoder lengthDecoder = new FakeLengthDecoder();
     private final AppendDecoder appendDecoder = new AppendDecoder();
-    private Level origionalLogLevel;
 
     private EventExecutor executor = new EventExecutor() {
         private final ScheduledExecutorService scheduler  = Executors.newSingleThreadScheduledExecutor();
@@ -234,13 +231,6 @@ public class AppendEncodeDecodeTest {
         Mockito.when(ctx.executor()).thenReturn(executor);
         idBatchSizeTrackerMap.put(0L, new FixedBatchSizeTracker(appendBlockSize));
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
-        origionalLogLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-    }
-
-    @After
-    public void teardown() {
-        ResourceLeakDetector.setLevel(origionalLogLevel);
     }
 
     @RequiredArgsConstructor

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendReconnectTest.java
@@ -10,10 +10,6 @@
 package io.pravega.test.integration;
 
 import io.netty.channel.Channel;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.netty.impl.ConnectionPoolImpl;
@@ -37,6 +33,7 @@ import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.protocol.netty.WireCommands;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -51,16 +48,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AppendReconnectTest {
-    private Level originalLevel;
+public class AppendReconnectTest extends LeakDetectorTestSuite {
     private ServiceBuilder serviceBuilder;
     private final Consumer<Segment> segmentSealedCallback = segment -> { };
 
     @Before
     public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
         this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
         this.serviceBuilder.initialize();
     }
@@ -68,7 +61,6 @@ public class AppendReconnectTest {
     @After
     public void teardown() {
         this.serviceBuilder.close();
-        ResourceLeakDetector.setLevel(originalLevel);
     }
 
     @Test(timeout = 30000)

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -13,10 +13,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
@@ -61,6 +57,7 @@ import io.pravega.shared.protocol.netty.WireCommands.Event;
 import io.pravega.shared.protocol.netty.WireCommands.NoSuchSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentCreated;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.nio.ByteBuffer;
 import java.util.UUID;
@@ -81,16 +78,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AppendTest {
-    private Level originalLevel;
+public class AppendTest extends LeakDetectorTestSuite {
     private ServiceBuilder serviceBuilder;
     private final Consumer<Segment> segmentSealedCallback = segment -> { };
 
     @Before
     public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
         this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
         this.serviceBuilder.initialize();
     }
@@ -98,7 +91,6 @@ public class AppendTest {
     @After
     public void teardown() {
         this.serviceBuilder.close();
-        ResourceLeakDetector.setLevel(originalLevel);
     }
 
     @Test(timeout = 10000)

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -11,10 +11,6 @@ package io.pravega.test.integration;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.netty.impl.ConnectionFactoryImpl;
@@ -59,6 +55,7 @@ import io.pravega.shared.protocol.netty.ByteBufWrapper;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.ReadSegment;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentRead;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -79,10 +76,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ReadTest {
+public class ReadTest extends LeakDetectorTestSuite {
 
     private static final int TIMEOUT_MILLIS = 30000;
-    private Level originalLevel;
     private ServiceBuilder serviceBuilder;
     private final Consumer<Segment> segmentSealedCallback = segment -> { };
     @Rule
@@ -90,9 +86,6 @@ public class ReadTest {
 
     @Before
     public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
         this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
         this.serviceBuilder.initialize();
     }
@@ -100,7 +93,6 @@ public class ReadTest {
     @After
     public void teardown() {
         this.serviceBuilder.close();
-        ResourceLeakDetector.setLevel(originalLevel);
     }
 
     @Test(timeout = 10000)

--- a/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StateSynchronizerTest.java
@@ -9,10 +9,6 @@
  */
 package io.pravega.test.integration;
 
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.Revision;
 import io.pravega.client.state.Revisioned;
@@ -27,6 +23,7 @@ import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,16 +38,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class StateSynchronizerTest {
+public class StateSynchronizerTest extends LeakDetectorTestSuite {
 
-    private Level originalLevel;
     private ServiceBuilder serviceBuilder;
 
     @Before
     public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
         this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
         this.serviceBuilder.initialize();
     }
@@ -58,7 +51,6 @@ public class StateSynchronizerTest {
     @After
     public void teardown() {
         this.serviceBuilder.close();
-        ResourceLeakDetector.setLevel(originalLevel);
     }
     
     @Data

--- a/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/TransactionTest.java
@@ -9,22 +9,13 @@
  */
 package io.pravega.test.integration;
 
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetector.Level;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Slf4JLoggerFactory;
-import io.pravega.client.stream.Stream;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
-import io.pravega.segmentstore.contracts.tables.TableStore;
-import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.store.ServiceBuilder;
-import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
@@ -32,7 +23,13 @@ import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.client.stream.mock.MockStreamManager;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.io.Serializable;
 import lombok.Cleanup;
@@ -42,15 +39,11 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class TransactionTest {
-    private Level originalLevel;
+public class TransactionTest extends LeakDetectorTestSuite {
     private ServiceBuilder serviceBuilder;
 
     @Before
     public void setup() throws Exception {
-        originalLevel = ResourceLeakDetector.getLevel();
-        ResourceLeakDetector.setLevel(Level.PARANOID);
-        InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
         this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
         this.serviceBuilder.initialize();
     }
@@ -58,7 +51,6 @@ public class TransactionTest {
     @After
     public void teardown() {
         this.serviceBuilder.close();
-        ResourceLeakDetector.setLevel(originalLevel);
     }
 
     @Test(timeout = 10000)

--- a/test/testcommon/src/main/java/io/pravega/test/common/LeakDetectorTestSuite.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/LeakDetectorTestSuite.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.common;
+
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.internal.logging.InternalLogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.Slf4JLoggerFactory;
+import lombok.RequiredArgsConstructor;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+/**
+ * Base class for a unit test that wants to check for Netty (ByteBuf) resource leaks. Automatically fails any tests
+ * for which {@link ResourceLeakDetector} reports a leak.
+ *
+ * This works by attaching a specialized {@link Slf4JLoggerFactory} to the {@link ResourceLeakDetector} and invokes
+ * {@link Assert#fail} when {@link InternalLogger#error} is invoked.
+ */
+public abstract class LeakDetectorTestSuite extends ThreadPooledTestSuite {
+    private ResourceLeakDetector.Level originalLevel;
+
+    @Before
+    public void before() {
+        super.before();
+        InternalLoggerFactory.setDefaultFactory(new ResourceLeakLoggerFactory());
+        this.originalLevel = ResourceLeakDetector.getLevel();
+        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+    }
+
+    @After
+    public void after() throws InterruptedException {
+        super.after();
+        ResourceLeakDetector.setLevel(this.originalLevel);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class ResourceLeakLoggerFactory extends Slf4JLoggerFactory {
+        @Override
+        public InternalLogger newInstance(String name) {
+            InternalLogger baseLogger = ((Slf4JLoggerFactory) Slf4JLoggerFactory.INSTANCE).newInstance(name);
+            if (name.equals(ResourceLeakDetector.class.getName())) {
+                return new ResourceLeakAssertionLogger(baseLogger);
+            } else {
+                return baseLogger;
+            }
+        }
+
+        @RequiredArgsConstructor
+        private static class ResourceLeakAssertionLogger implements InternalLogger {
+            private final InternalLogger wrappedLogger;
+
+            @Override
+            public String name() {
+                return this.wrappedLogger.name();
+            }
+
+            @Override
+            public boolean isTraceEnabled() {
+                return this.wrappedLogger.isTraceEnabled();
+            }
+
+            @Override
+            public void trace(String msg) {
+                this.wrappedLogger.trace(msg);
+            }
+
+            @Override
+            public void trace(String format, Object arg) {
+                this.wrappedLogger.trace(format, arg);
+            }
+
+            @Override
+            public void trace(String format, Object argA, Object argB) {
+                this.wrappedLogger.trace(format, argA, argB);
+            }
+
+            @Override
+            public void trace(String format, Object... arguments) {
+                this.wrappedLogger.trace(format, arguments);
+            }
+
+            @Override
+            public void trace(String msg, Throwable t) {
+                this.wrappedLogger.trace(msg, t);
+            }
+
+            @Override
+            public void trace(Throwable t) {
+                this.wrappedLogger.trace(t);
+            }
+
+            @Override
+            public boolean isDebugEnabled() {
+                return this.wrappedLogger.isDebugEnabled();
+            }
+
+            @Override
+            public void debug(String msg) {
+                this.wrappedLogger.debug(msg);
+            }
+
+            @Override
+            public void debug(String format, Object arg) {
+                this.wrappedLogger.debug(format, arg);
+            }
+
+            @Override
+            public void debug(String format, Object argA, Object argB) {
+                this.wrappedLogger.debug(format, argA, argB);
+            }
+
+            @Override
+            public void debug(String format, Object... arguments) {
+                this.wrappedLogger.debug(format, arguments);
+            }
+
+            @Override
+            public void debug(String msg, Throwable t) {
+                this.wrappedLogger.debug(msg, t);
+            }
+
+            @Override
+            public void debug(Throwable t) {
+                this.wrappedLogger.debug(t);
+            }
+
+            @Override
+            public boolean isInfoEnabled() {
+                return this.wrappedLogger.isInfoEnabled();
+            }
+
+            @Override
+            public void info(String msg) {
+                this.wrappedLogger.info(msg);
+            }
+
+            @Override
+            public void info(String format, Object arg) {
+                this.wrappedLogger.info(format, arg);
+            }
+
+            @Override
+            public void info(String format, Object argA, Object argB) {
+                this.wrappedLogger.info(format, argA, argB);
+            }
+
+            @Override
+            public void info(String format, Object... arguments) {
+                this.wrappedLogger.info(format, arguments);
+            }
+
+            @Override
+            public void info(String msg, Throwable t) {
+                this.wrappedLogger.info(msg, t);
+            }
+
+            @Override
+            public void info(Throwable t) {
+                this.wrappedLogger.info(t);
+            }
+
+            @Override
+            public boolean isWarnEnabled() {
+                return this.wrappedLogger.isWarnEnabled();
+            }
+
+            @Override
+            public void warn(String msg) {
+                this.wrappedLogger.warn(msg);
+            }
+
+            @Override
+            public void warn(String format, Object arg) {
+                this.wrappedLogger.warn(format, arg);
+            }
+
+            @Override
+            public void warn(String format, Object... arguments) {
+                this.wrappedLogger.warn(format, arguments);
+            }
+
+            @Override
+            public void warn(String format, Object argA, Object argB) {
+                this.wrappedLogger.warn(format, argA, argB);
+            }
+
+            @Override
+            public void warn(String msg, Throwable t) {
+                this.wrappedLogger.warn(msg, t);
+            }
+
+            @Override
+            public void warn(Throwable t) {
+                this.wrappedLogger.warn(t);
+            }
+
+            @Override
+            public boolean isErrorEnabled() {
+                return this.wrappedLogger.isErrorEnabled();
+            }
+
+            @Override
+            public void error(String msg) {
+                error(msg, new Object[0]);
+            }
+
+            @Override
+            public void error(String format, Object arg) {
+                error(format, new Object[]{arg});
+            }
+
+            @Override
+            public void error(String format, Object argA, Object argB) {
+                error(format, new Object[]{argA, argB});
+            }
+
+            @Override
+            public void error(String format, Object... arguments) {
+                this.wrappedLogger.error(format, arguments);
+                Assert.fail("RESOURCE LEAK: " + String.format(format, arguments));
+            }
+
+            @Override
+            public void error(String msg, Throwable t) {
+                this.wrappedLogger.error(msg, t);
+                Assert.fail(String.format("RESOURCE LEAK: %s (%s)", msg, t));
+            }
+
+            @Override
+            public void error(Throwable t) {
+                error("", t);
+            }
+
+            @Override
+            public boolean isEnabled(InternalLogLevel level) {
+                return this.wrappedLogger.isEnabled(level);
+            }
+
+            @Override
+            public void log(InternalLogLevel level, String msg) {
+                log(level, msg, new Object[0]);
+            }
+
+            @Override
+            public void log(InternalLogLevel level, String format, Object arg) {
+                log(level, format, new Object[]{arg});
+            }
+
+            @Override
+            public void log(InternalLogLevel level, String format, Object argA, Object argB) {
+                log(level, format, new Object[]{argA, argB});
+            }
+
+            @Override
+            public void log(InternalLogLevel level, String format, Object... arguments) {
+                this.wrappedLogger.log(level, format, arguments);
+                if (level == InternalLogLevel.ERROR) {
+                    Assert.fail("RESOURCE LEAK: " + String.format(format, arguments));
+                }
+            }
+
+            @Override
+            public void log(InternalLogLevel level, String msg, Throwable t) {
+                this.wrappedLogger.log(level, msg, t);
+                if (level == InternalLogLevel.ERROR) {
+                    Assert.fail(String.format("RESOURCE LEAK: %s (%s)", msg, t));
+                }
+            }
+
+            @Override
+            public void log(InternalLogLevel level, Throwable t) {
+                log(level, "", t);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
**Change log description**  
- Created `LeakDetectorTestSuite`, a base class that hooks into Netty's ResourceLeakDetector and fails any test for which a resource leak is detected.
- Wired up all existing tests that make use of `ResourceLeakDetector` to inherit from this base class.

**Purpose of the change**  
Fixes #4088.

**What the code does**  
No functional code changes.

**How to verify it**  
Build must complete successfully.
