### PR TITLE
Issue 4764: Optimized AppendDecoder to make fewer buffer copies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,8 @@ project('shared:protocol') {
         compile group: 'io.netty', name: 'netty-handler', version: nettyVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
-     
+        testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
+        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
     }
 }
 

--- a/common/src/main/java/io/pravega/common/io/BufferViewSink.java
+++ b/common/src/main/java/io/pravega/common/io/BufferViewSink.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.common.io;
+
+import io.pravega.common.util.BufferView;
+import java.io.IOException;
+
+/**
+ * Defines an object that can accept {@link BufferView}s. This can be applied to various {@link java.io.OutputStream}s
+ * in order to more efficiently make memory-to-memory buffer transfers without the need for extra buffer allocations or
+ * byte-by-byte copies.
+ */
+public interface BufferViewSink {
+    /**
+     * Includes the given {@link BufferView}.
+     *
+     * @param buffer The {@link BufferView} to include.
+     * @throws IOException If an IO Exception occurred.
+     */
+    void writeBuffer(BufferView buffer) throws IOException;
+}

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutput.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.common.io.serialization;
 
+import io.pravega.common.io.BufferViewSink;
 import io.pravega.common.util.BufferView;
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -26,7 +27,7 @@ import java.util.function.ToIntFunction;
  *
  * This interface is designed to serialize data that can be consumed using {@link RevisionDataInput}.
  */
-public interface RevisionDataOutput extends DataOutput {
+public interface RevisionDataOutput extends DataOutput, BufferViewSink {
     /**
      * Maximum value that can be encoded using {@link #writeCompactLong}.
      */
@@ -271,6 +272,7 @@ public interface RevisionDataOutput extends DataOutput {
      *               by {@link RevisionDataInput#readArray})).
      * @throws IOException If an IO Exception occurred.
      */
+    @Override
     void writeBuffer(BufferView buffer) throws IOException;
 
     /**

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataOutputStream.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.common.io.serialization;
 
+import io.pravega.common.io.BufferViewSink;
 import io.pravega.common.io.SerializationException;
 import io.pravega.common.util.BitConverter;
 import io.pravega.common.util.BufferView;
@@ -310,7 +311,12 @@ abstract class RevisionDataOutputStream extends DataOutputStream implements Revi
         writeCompactInt(buf.getLength());
 
         // Copy the buffer contents to this OutputStream. This will write all its bytes.
-        buf.copyTo(this);
+        if (this.out instanceof BufferViewSink) {
+            ((BufferViewSink) this.out).writeBuffer(buf);
+            super.written += buf.getLength();
+        } else {
+            buf.copyTo(this);
+        }
     }
 
     @Override

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -115,6 +115,11 @@ public class ByteArraySegment implements ArrayView {
     }
 
     @Override
+    public Reader getBufferViewReader() {
+        return new Reader();
+    }
+
+    @Override
     public InputStream getReader() {
         return new ByteArrayInputStream(this.array, this.startOffset, this.length);
     }
@@ -256,21 +261,6 @@ public class ByteArraySegment implements ArrayView {
         return new ByteArraySegment(this.array, this.startOffset + offset, length, readOnly || this.readOnly);
     }
 
-    /**
-     * Returns a new ByteArraySegment that wraps the same underlying array that this ByteSegmentDoes, except that the
-     * new instance is marked as Read-Only.
-     * If this instance is already Read-Only, this instance is returned instead.
-     *
-     * @return  A new read-only ByteArraySegment.
-     */
-    public ByteArraySegment asReadOnly() {
-        if (isReadOnly()) {
-            return this;
-        } else {
-            return new ByteArraySegment(this.array, this.startOffset, this.length, true);
-        }
-    }
-
     @Override
     public String toString() {
         if (getLength() > 128) {
@@ -279,6 +269,27 @@ public class ByteArraySegment implements ArrayView {
             return String.format("{%s}", IntStream.range(arrayOffset(), arrayOffset() + getLength()).boxed()
                     .map(i -> Byte.toString(this.array[i]))
                     .collect(Collectors.joining(",")));
+        }
+    }
+
+    //endregion
+
+    //region Reader
+
+    private class Reader implements BufferView.Reader {
+        private int position = 0;
+
+        @Override
+        public int available() {
+            return ByteArraySegment.this.length - this.position;
+        }
+
+        @Override
+        public int readBytes(ByteArraySegment segment) {
+            int len = Math.min(available(), segment.getLength());
+            System.arraycopy(array(), arrayOffset() + this.position, segment.array(), segment.arrayOffset(), len);
+            this.position += len;
+            return len;
         }
     }
 

--- a/common/src/main/java/io/pravega/common/util/CompositeArrayView.java
+++ b/common/src/main/java/io/pravega/common/util/CompositeArrayView.java
@@ -36,14 +36,14 @@ public interface CompositeArrayView extends BufferView {
     void set(int index, byte value);
 
     /**
-     * Copies a specified number of bytes from the given {@link ArrayView} into this {@link CompositeArrayView}.
+     * Copies a specified number of bytes from the given {@link BufferView.Reader} into this {@link CompositeArrayView}.
      *
-     * @param source       The {@link ArrayView} to copy bytes from.
+     * @param reader       The {@link BufferView.Reader} to copy bytes from.
      * @param targetOffset The offset within this {@link CompositeArrayView} to start copying at.
      * @param length       The number of bytes to copy.
      * @throws ArrayIndexOutOfBoundsException If targetOffset or length are invalid.
      */
-    void copyFrom(ArrayView source, int targetOffset, int length);
+    void copyFrom(BufferView.Reader reader, int targetOffset, int length);
 
     /**
      * Creates a new {@link CompositeArrayView} that represents a sub-range of this {@link CompositeArrayView} instance.

--- a/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
+++ b/common/src/test/java/io/pravega/common/util/ByteArraySegmentTests.java
@@ -159,6 +159,25 @@ public class ByteArraySegmentTests {
     }
 
     /**
+     * Tests the functionality of getBufferViewReader.
+     */
+    @Test
+    public void testGetBufferViewReader() {
+        final byte[] buffer = createFormattedBuffer();
+        ByteArraySegment segment = new ByteArraySegment(buffer);
+
+        for (int offset = 0; offset < buffer.length / 2; offset++) {
+            int length = buffer.length - offset * 2;
+            BufferView.Reader reader = segment.slice(offset, length).getBufferViewReader();
+            ByteArraySegment readBuffer = reader.readFully(2);
+            for (int i = 0; i < length; i++) {
+                Assert.assertEquals("Unexpected value at index " + i + " after reading from offset " + offset, segment.get(i + offset), readBuffer.get(i));
+            }
+            Assert.assertEquals(0, reader.readBytes(new ByteArraySegment(new byte[1])));
+        }
+    }
+
+    /**
      * Tests the functionality of getReader (the ability to return an InputStream from a sub-segment of the main buffer).
      */
     @Test

--- a/common/src/test/java/io/pravega/common/util/CompositeBufferViewTests.java
+++ b/common/src/test/java/io/pravega/common/util/CompositeBufferViewTests.java
@@ -80,6 +80,22 @@ public class CompositeBufferViewTests {
      * Tests {@link CompositeBufferView#getReader()}.
      */
     @Test
+    public void testGetBufferViewReader() throws IOException {
+        val components = createComponents();
+        val cb = BufferView.wrap(components);
+        val expectedSize = components.stream().mapToInt(BufferView::getLength).sum();
+        val asInputStream = new SequenceInputStream(Iterators.asEnumeration(components.stream().map(BufferView::getReader).iterator()));
+        val expected = StreamHelpers.readAll(asInputStream, expectedSize);
+        val reader = cb.getBufferViewReader();
+        val actual = reader.readFully(3);
+        AssertExtensions.assertArrayEquals("", expected, 0, actual.array(), actual.arrayOffset(), expectedSize);
+        Assert.assertEquals(0, reader.readBytes(new ByteArraySegment(new byte[1])));
+    }
+
+    /**
+     * Tests {@link CompositeBufferView#getReader()}.
+     */
+    @Test
     public void testGetReader() throws IOException {
         val components = createComponents();
         val cb = BufferView.wrap(components);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DataFrame.java
@@ -14,8 +14,8 @@ import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.io.SerializationException;
-import io.pravega.common.util.ArrayView;
 import io.pravega.common.util.BitConverter;
+import io.pravega.common.util.BufferView;
 import io.pravega.common.util.CloseableIterator;
 import io.pravega.common.util.CompositeArrayView;
 import io.pravega.common.util.CompositeByteArraySegment;
@@ -220,17 +220,17 @@ public class DataFrame {
     }
 
     /**
-     * Appends the contents of the ByteArraySegment to the DataFrame.
+     * Appends the contents of the {@link BufferView.Reader} to the DataFrame.
      *
-     * @param data The ByteArraySegment to append.
-     * @return The number of bytes written. If less than the length of the ByteArraySegment, the frame is full and cannot
+     * @param data The {@link BufferView.Reader} to append.
+     * @return The number of bytes written. If less than {@link BufferView.Reader#available()}, the frame is full and cannot
      * write anything anymore. The remaining bytes will need to be written to a new frame.
      * @throws IllegalStateException If the frame is sealed or no entry has been started.
      */
-    int append(ArrayView data) {
+    int append(BufferView.Reader data) {
         ensureAppendConditions();
 
-        int actualLength = Math.min(data.getLength(), getAvailableLength());
+        int actualLength = Math.min(data.available(), getAvailableLength());
         if (actualLength > 0) {
             this.contents.copyFrom(data, writePosition, actualLength);
             writePosition += actualLength;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DataFrameTests.java
@@ -67,7 +67,7 @@ public class DataFrameTests {
 
         AssertExtensions.assertThrows(
                 "append(ByteArraySegment) worked even though no entry started.",
-                () -> df.append(new ByteArraySegment(new byte[1])),
+                () -> df.append(new ByteArraySegment(new byte[1]).getBufferViewReader()),
                 ex -> ex instanceof IllegalStateException);
 
         // Start a new entry.
@@ -154,7 +154,7 @@ public class DataFrameTests {
             // Append the first half of the record as one DataFrame Entry.
             dataFrame.startNewEntry(true); // true - this is the first entry for the record.
             int firstHalfLength = record.getLength() / 2;
-            int bytesAppended = dataFrame.append(record.slice(0, firstHalfLength));
+            int bytesAppended = dataFrame.append(record.slice(0, firstHalfLength).getBufferViewReader());
             dataFrame.endEntry(false); // false - we did not finish the record.
             if (bytesAppended < firstHalfLength) {
                 // We filled out the frame.
@@ -165,7 +165,7 @@ public class DataFrameTests {
             // Append the second half of the record as one DataFrame Entry.
             dataFrame.startNewEntry(false); // false - this is not the first entry for the record.
             int secondHalfLength = record.getLength() - firstHalfLength;
-            bytesAppended = dataFrame.append(record.slice(firstHalfLength, secondHalfLength));
+            bytesAppended = dataFrame.append(record.slice(firstHalfLength, secondHalfLength).getBufferViewReader());
             fullRecordsAppended += bytesAppended;
             if (bytesAppended < secondHalfLength) {
                 // We filled out the frame.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/Append.java
@@ -13,8 +13,10 @@ import io.netty.buffer.ByteBuf;
 import io.pravega.shared.protocol.netty.WireCommands.Event;
 import java.util.UUID;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 @Data
+@RequiredArgsConstructor
 public class Append implements Request, Comparable<Append> {
     final String segment;
     final UUID writerId;
@@ -31,17 +33,7 @@ public class Append implements Request, Comparable<Append> {
     public Append(String segment, UUID writerId, long eventNumber, Event event, long expectedLength, long flowId) {
         this(segment, writerId, eventNumber, 1, event.getAsByteBuf(), expectedLength, flowId);
     }
-    
-    public Append(String segment, UUID writerId, long eventNumber, int eventCount, ByteBuf data, Long expectedLength, long flowId) {
-        this.segment = segment;
-        this.writerId = writerId;
-        this.eventNumber = eventNumber;
-        this.eventCount = eventCount;
-        this.data = data;
-        this.expectedLength = expectedLength;
-        this.flowId = flowId;
-    }
-    
+
     public int getDataLength() {
         return data.readableBytes();
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -203,7 +203,6 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
                 // Work around a bug in netty:
                 // See https://github.com/netty/netty/issues/5597
                 if (appendDataBuf.readableBytes() == 0) {
-                    assert currentBlock.getData().readableBytes() == 0;
                     currentBlock.release();
                     appendDataBuf = wrappedBuffer(((WireCommands.PartialEvent) cmd).getData(), blockEnd.getData());
                 } else {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AppendDecoder.java
@@ -193,11 +193,6 @@ public class AppendDecoder extends MessageToMessageDecoder<WireCommand> {
             }
         }
 
-        // Make a copy of the ByteBuf as the readable bytes of the result may be significantly less than the total allocated
-        // memory for this buffer. This problem is exacerbated with connection pooling where we may have a good amount of
-        // padding around each append. Since this Append ByteBuf is expected to live for as long as the Segment Store
-        // needs to process it, we need to compact this so that we don't use an excessive amount of heap memory which could
-        // lead to out-of-memory situations.
         return appendDataBuf;
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
@@ -13,6 +13,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.pravega.common.Exceptions;
 import io.pravega.common.util.BufferView;
+import io.pravega.common.util.ByteArraySegment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -21,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * {@link BufferView} wrapper for {@link ByteBuf} instances.
@@ -84,6 +86,11 @@ public class ByteBufWrapper implements BufferView {
     }
 
     @Override
+    public Reader getBufferViewReader() {
+        return new ByteBufReader(this.buf.duplicate());
+    }
+
+    @Override
     public InputStream getReader() {
         Exceptions.checkNotClosed(this.buf.refCnt() == 0, this);
         return new ByteBufInputStream(this.buf.duplicate(), false);
@@ -137,6 +144,32 @@ public class ByteBufWrapper implements BufferView {
     @Override
     public String toString() {
         return this.buf.toString();
+    }
+
+    //endregion
+
+    //region Reader Implementation
+
+    /**
+     * {@link BufferView.Reader} implementation.
+     */
+    @RequiredArgsConstructor
+    private static class ByteBufReader implements Reader {
+        private final ByteBuf buf;
+
+        @Override
+        public int available() {
+            return this.buf.readableBytes();
+        }
+
+        @Override
+        public int readBytes(ByteArraySegment segment) {
+            int len = Math.min(segment.getLength(), this.buf.readableBytes());
+            if (len > 0) {
+                this.buf.readBytes(segment.array(), segment.arrayOffset(), len);
+            }
+            return len;
+        }
     }
 
     //endregion

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -2189,18 +2189,31 @@ public final class WireCommands {
         @Getter
         private boolean released = true;
 
-        abstract void releaseInternal();
-
+        /**
+         * Marks the fact that this instance requires {@link #release()} to be invoked in order to free up resources.
+         *
+         * @return This instance.
+         */
         WireCommand requireRelease() {
             this.released = false;
             return this;
         }
 
+        /**
+         * Releases any resources used by this command, if needed ({@link #isReleased()} is false. This method has no
+         * effect if invoked multiple times or if no resource release is required.
+         */
         public void release() {
             if (!this.released) {
                 releaseInternal();
                 this.released = true;
             }
         }
+
+        /**
+         * Internal implementation of {@link #release()}. Do not invoke directly as this method offers no protection
+         * against multiple invocations.
+         */
+        abstract void releaseInternal();
     }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
-import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -457,7 +456,8 @@ public final class WireCommands {
     }
 
     @Data
-    public static final class PartialEvent implements WireCommand {
+    @EqualsAndHashCode(callSuper = false)
+    public static final class PartialEvent extends ReleasableCommand {
         final WireCommandType type = WireCommandType.PARTIAL_EVENT;
         final ByteBuf data;
 
@@ -466,10 +466,13 @@ public final class WireCommands {
             data.getBytes(data.readerIndex(), (OutputStream) out, data.readableBytes());
         }
 
-        public static WireCommand readFrom(DataInput in, int length) throws IOException {
-            byte[] msg = new byte[length];
-            in.readFully(msg);
-            return new PartialEvent(wrappedBuffer(msg));
+        public static WireCommand readFrom(EnhancedByteBufInputStream in, int length) throws IOException {
+            return new PartialEvent(in.readFully(length).retain()).requireRelease();
+        }
+
+        @Override
+        void releaseInternal() {
+            this.data.release();
         }
     }
 
@@ -526,7 +529,8 @@ public final class WireCommands {
     }
 
     @Data
-    public static final class AppendBlock implements WireCommand {
+    @EqualsAndHashCode(callSuper = false)
+    public static final class AppendBlock extends ReleasableCommand {
         final WireCommandType type = WireCommandType.APPEND_BLOCK;
         final UUID writerId;
         final ByteBuf data;
@@ -548,16 +552,21 @@ public final class WireCommands {
             // Data not written, as it should be null.
         }
 
-        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+        public static WireCommand readFrom(EnhancedByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
-            byte[] data = new byte[length - Long.BYTES * 2];
-            in.readFully(data);
-            return new AppendBlock(writerId, wrappedBuffer(data));
+            ByteBuf data = in.readFully(length - Long.BYTES * 2).retain();
+            return new AppendBlock(writerId, data).requireRelease();
+        }
+
+        @Override
+        void releaseInternal() {
+            this.data.release();
         }
     }
 
     @Data
-    public static final class AppendBlockEnd implements WireCommand {
+    @EqualsAndHashCode(callSuper = false)
+    public static final class AppendBlockEnd extends ReleasableCommand {
         final WireCommandType type = WireCommandType.APPEND_BLOCK_END;
         final UUID writerId;
         final int sizeOfWholeEvents;
@@ -582,26 +591,32 @@ public final class WireCommands {
             out.writeLong(requestId);
         }
 
-        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+        public static WireCommand readFrom(EnhancedByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
             int sizeOfHeaderlessAppends = in.readInt();
             int dataLength = in.readInt();
-            byte[] data;
+            ByteBuf data;
             if (dataLength > 0) {
-                data = new byte[dataLength];
-                in.readFully(data);
+                data = in.readFully(dataLength);
             } else {
-                data = new byte[0];
+                data = EMPTY_BUFFER;
             }
             int numEvents = in.readInt();
             long lastEventNumber = in.readLong();
             long requestId = in.available() >= Long.BYTES ? in.readLong() : -1L;
-            return new AppendBlockEnd(writerId, sizeOfHeaderlessAppends, wrappedBuffer(data), numEvents, lastEventNumber, requestId);
+            return new AppendBlockEnd(writerId, sizeOfHeaderlessAppends, data.retain(), numEvents, lastEventNumber, requestId)
+                    .requireRelease();
+        }
+
+        @Override
+        void releaseInternal() {
+            this.data.release();
         }
     }
 
     @Data
-    public static final class ConditionalAppend implements WireCommand, Request {
+    @EqualsAndHashCode(callSuper = false)
+    public static final class ConditionalAppend extends ReleasableCommand implements Request {
         final WireCommandType type = WireCommandType.CONDITIONAL_APPEND;
         final UUID writerId;
         final long eventNumber;
@@ -619,16 +634,16 @@ public final class WireCommands {
             out.writeLong(requestId);
         }
 
-        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+        public static WireCommand readFrom(EnhancedByteBufInputStream in, int length) throws IOException {
             UUID writerId = new UUID(in.readLong(), in.readLong());
             long eventNumber = in.readLong();
             long expectedOffset = in.readLong();
             Event event = readEvent(in, length);
             long requestId = (in.available() >= Long.BYTES) ? in.readLong() : -1L;
-            return new ConditionalAppend(writerId, eventNumber, expectedOffset, event, requestId);
+            return new ConditionalAppend(writerId, eventNumber, expectedOffset, event, requestId).requireRelease();
         }
 
-        private static Event readEvent(ByteBufInputStream in, int length) throws IOException {
+        private static Event readEvent(EnhancedByteBufInputStream in, int length) throws IOException {
             int typeCode = in.readInt();
             if (typeCode != WireCommandType.EVENT.getCode()) {
                 throw new InvalidMessageException("Was expecting EVENT but found: " + typeCode);
@@ -637,9 +652,7 @@ public final class WireCommands {
             if (eventLength > length - TYPE_PLUS_LENGTH_SIZE) {
                 throw new InvalidMessageException("Was expecting length: " + length + " but found: " + eventLength);
             }
-            byte[] msg = new byte[eventLength];
-            in.readFully(msg);
-            return new Event(wrappedBuffer(msg));
+            return new Event(in.readFully(eventLength).retain());
         }
 
         @Override
@@ -651,6 +664,11 @@ public final class WireCommands {
         public void process(RequestProcessor cp) {
             //Unreachable. This should be handled in AppendDecoder.
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        void releaseInternal() {
+            this.event.data.release();
         }
     }
 
@@ -786,7 +804,7 @@ public final class WireCommands {
             long offset = in.readLong();
             int suggestedLength = in.readInt();
             String delegationToken = in.readUTF();
-            long requestId = in.available()  >= Long.BYTES ? in.readLong() : -1L;
+            long requestId = in.available() >= Long.BYTES ? in.readLong() : -1L;
             return new ReadSegment(segment, offset, suggestedLength, delegationToken, requestId);
         }
 
@@ -796,12 +814,12 @@ public final class WireCommands {
         }
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @RequiredArgsConstructor
     @Getter
     @ToString
-    @EqualsAndHashCode(exclude = {"mustRelease", "released"})
+    @EqualsAndHashCode(callSuper = false)
     @NotThreadSafe
-    public static final class SegmentRead implements Reply, WireCommand {
+    public static final class SegmentRead extends ReleasableCommand implements Reply {
         final WireCommandType type = WireCommandType.SEGMENT_READ;
         final String segment;
         final long offset;
@@ -809,12 +827,6 @@ public final class WireCommands {
         final boolean endOfSegment;
         final ByteBuf data;
         final long requestId;
-        private final boolean mustRelease;
-        private boolean released = false;
-
-        public SegmentRead(String segment, long offset, boolean atTail, boolean endOfSegment, ByteBuf data, long requestId) {
-            this(segment, offset, atTail, endOfSegment, data, requestId, false);
-        }
 
         @Override
         public void process(ReplyProcessor cp) {
@@ -844,15 +856,12 @@ public final class WireCommands {
             }
             ByteBuf data = in.readFully(dataLength).retain();
             long requestId = in.available() >= Long.BYTES ? in.readLong() : -1L;
-            return new SegmentRead(segment, offset, atTail, endOfSegment, data, requestId, true);
+            return new SegmentRead(segment, offset, atTail, endOfSegment, data, requestId).requireRelease();
         }
 
-        public void release() {
-            if (this.mustRelease && !this.released) {
-                this.data.release();
-            }
-
-            this.released = true;
+        @Override
+        void releaseInternal() {
+            this.data.release();
         }
 
         @Override
@@ -2173,4 +2182,25 @@ public final class WireCommands {
         }
     }
 
+    /**
+     * Base class for any command that may require releasing resources.
+     */
+    static abstract class ReleasableCommand implements WireCommand {
+        @Getter
+        private boolean released = true;
+
+        abstract void releaseInternal();
+
+        WireCommand requireRelease() {
+            this.released = false;
+            return this;
+        }
+
+        public void release() {
+            if (!this.released) {
+                releaseInternal();
+                this.released = true;
+            }
+        }
+    }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -804,7 +804,7 @@ public final class WireCommands {
             long offset = in.readLong();
             int suggestedLength = in.readInt();
             String delegationToken = in.readUTF();
-            long requestId = in.available() >= Long.BYTES ? in.readLong() : -1L;
+            long requestId = in.available()  >= Long.BYTES ? in.readLong() : -1L;
             return new ReadSegment(segment, offset, suggestedLength, delegationToken, requestId);
         }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.shared.protocol.netty;
 
-import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
@@ -26,6 +25,7 @@ import io.netty.util.concurrent.ScheduledFuture;
 import io.pravega.shared.protocol.netty.WireCommands.Event;
 import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.LeakDetectorTestSuite;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,13 +36,15 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(MockitoJUnitRunner.class)
 public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
-    private final int appendBlockSize = 1024;  
+    private final int appendBlockSize = 1024;
     private final UUID writerId = new UUID(1, 2);
     private final String streamName = "Test Stream Name";
     private final ConcurrentHashMap<Long, AppendBatchSizeTracker> idBatchSizeTrackerMap = new ConcurrentHashMap<>();
@@ -66,8 +68,11 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     private final FakeLengthDecoder lengthDecoder = new FakeLengthDecoder();
     private final AppendDecoder appendDecoder = new AppendDecoder();
 
-    private EventExecutor executor = new EventExecutor() {
-        private final ScheduledExecutorService scheduler  = Executors.newSingleThreadScheduledExecutor();
+    protected int getThreadPoolSize() {
+        return 1;
+    }
+
+    private final EventExecutor executor = new EventExecutor() {
         @Override
         public EventExecutor next() {
             return null;
@@ -160,7 +165,7 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
         @Override
         public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-            scheduler.schedule(command, delay, unit);
+            executorService().schedule(command, delay, unit);
             return null;
         }
 
@@ -224,6 +229,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     private ChannelHandlerContext ctx;
     @Mock
     private Channel ch;
+    private ByteBuf fakeNetwork;
+    private BufferReleaseVerifier releaseVerifier;
 
     @Before
     public void setup() {
@@ -231,11 +238,20 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         Mockito.when(ctx.executor()).thenReturn(executor);
         idBatchSizeTrackerMap.put(0L, new FixedBatchSizeTracker(appendBlockSize));
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
+        fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
+        releaseVerifier = new BufferReleaseVerifier();
+    }
+
+    @After
+    public void tearDown() {
+        releaseVerifier.close(); // This will check that all included buffers have been properly released.
+        fakeNetwork.release();
+        Assert.assertEquals(0, fakeNetwork.refCnt());
     }
 
     @RequiredArgsConstructor
     private static final class FixedBatchSizeTracker implements AppendBatchSizeTracker {
-        private final int appendBlockSize;  
+        private final int appendBlockSize;
 
         @Override
         public int getAppendBlockSize() {
@@ -273,8 +289,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     @Test(expected = InvalidMessageException.class)
     public void testAppendWithoutSetup() throws Exception {
         int size = 10;
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         append(streamName, writerId, 0, 1, size, fakeNetwork);
     }
 
@@ -289,9 +303,9 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         // Simulate Setup append
         appendDecoder.processCommand(setupAppend);
         // Simulate receiving an appendBlock
-        appendDecoder.processCommand((WireCommand) appendBlock);
+        appendDecoder.processCommand(appendBlock);
         // Simulate a missing appendBlockEnd by sending an appendBlock
-        appendDecoder.processCommand((WireCommand) appendBlock);
+        appendDecoder.processCommand(appendBlock);
     }
 
     @Test(expected = InvalidMessageException.class)
@@ -305,7 +319,7 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         // Simulate Setup append
         appendDecoder.processCommand(setupAppend);
         // Simulate an error by directly sending AppendBlockEnd.
-        appendDecoder.processCommand((WireCommand) appendBlock);
+        appendDecoder.processCommand(appendBlock);
     }
 
     @Test(expected = InvalidMessageException.class)
@@ -320,7 +334,7 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         // Simulate Setup append
         appendDecoder.processCommand(setupAppend);
         // Simulate an error by directly sending AppendBlockEnd.
-        appendDecoder.processCommand((WireCommand) appendBlock);
+        appendDecoder.processCommand(appendBlock);
     }
 
     @Test(expected = InvalidMessageException.class)
@@ -330,13 +344,16 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         ByteBuf data = Unpooled.wrappedBuffer(content);
 
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
-        WireCommands.AppendBlockEnd appendBlock = new WireCommands.AppendBlockEnd(writerId, 1024, data,  1, 2, 123L);
+        WireCommands.AppendBlockEnd blockEnd = new WireCommands.AppendBlockEnd(writerId, 1024, data, 1, 2, 123L);
+        ByteBuf data2 = Unpooled.wrappedBuffer(content);
+        val blockEnd2 = new WireCommands.AppendBlockEnd(writerId, 1024, data2, 1, 1, 123L);
+        this.releaseVerifier.include(blockEnd, data).include(blockEnd2, data2);
 
         // Simulate Setup append
         appendDecoder.processCommand(setupAppend);
-        appendDecoder.processCommand((WireCommand) appendBlock);
-        appendBlock = new WireCommands.AppendBlockEnd(writerId, 1024, data,  1, 1, 123L);
-        appendDecoder.processCommand((WireCommand) appendBlock);
+        Append append = (Append) appendDecoder.processCommand(blockEnd);
+        append.getData().release(); // This append is successful and has been consumed; dispose of it.
+        appendDecoder.processCommand(blockEnd2);
     }
 
     @Test(expected = InvalidMessageException.class)
@@ -347,12 +364,15 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         WireCommands.AppendBlock appendBlock = new WireCommands.AppendBlock(writerId, data);
-        WireCommands.AppendBlockEnd appendBlockEnd = new WireCommands.AppendBlockEnd(writerId, 1024, null,  2, 2, 123L);
+
+        ByteBuf data2 = Unpooled.wrappedBuffer(content);
+        WireCommands.AppendBlockEnd appendBlockEnd = new WireCommands.AppendBlockEnd(writerId, 1024, data2, 2, 2, 123L);
+        this.releaseVerifier.include(appendBlock, data).include(appendBlockEnd, data2);
 
         // Simulate Setup append
         appendDecoder.processCommand(setupAppend);
-        appendDecoder.processCommand((WireCommand) appendBlock);
-        appendDecoder.processCommand((WireCommand) appendBlockEnd);
+        appendDecoder.processCommand(appendBlock);
+        appendDecoder.processCommand(appendBlockEnd);
     }
 
     @Test(expected = InvalidMessageException.class)
@@ -363,34 +383,34 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
         SetupAppend setupAppend1 = new SetupAppend(1, writerId, "segment", "");
         SetupAppend setupAppend2 = new SetupAppend(2, writerId2, "segment2", "");
-        WireCommands.AppendBlock appendBlock = new WireCommands.AppendBlock(writerId, Unpooled.wrappedBuffer(content));
-        WireCommands.AppendBlockEnd appendBlockEnd = new WireCommands.AppendBlockEnd( writerId2, 1024, Unpooled.wrappedBuffer(content),  1, 1, 123L);
+        val data1 = Unpooled.wrappedBuffer(content);
+        WireCommands.AppendBlock appendBlock = new WireCommands.AppendBlock(writerId, data1);
+        val data2 = Unpooled.wrappedBuffer(content);
+        WireCommands.AppendBlockEnd appendBlockEnd = new WireCommands.AppendBlockEnd(writerId2, 1024, data2, 1, 1, 123L);
+        this.releaseVerifier.include(appendBlock, data1).include(appendBlockEnd, data2);
 
         appendDecoder.processCommand(setupAppend1);
         appendDecoder.processCommand(setupAppend2);
-        appendDecoder.processCommand((WireCommand) appendBlock);
-        appendDecoder.processCommand((WireCommand) appendBlockEnd);
+        appendDecoder.processCommand(appendBlock);
+        appendDecoder.processCommand(appendBlockEnd);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIllegalWireCommand() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         CommandEncoder commandEncoder = new CommandEncoder(null);
         commandEncoder.encode(ctx, null, fakeNetwork);
     }
 
     @Test(expected = InvalidMessageException.class)
     public void testAppendInvalidCount() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[10];
         Arrays.fill(content, (byte) 1);
         ByteBuf data = Unpooled.wrappedBuffer(content);
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
         CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
@@ -400,8 +420,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     @Test
     public void testVerySmallBlockSize() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
@@ -412,8 +430,9 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
-        
-        ArrayList<Object> received = new ArrayList<>();
+
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         commandEncoder.encode(ctx, msg, fakeNetwork);
         read(fakeNetwork, received);
         assertEquals(2, received.size());
@@ -439,8 +458,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     private void sendAndVerifyEvents(String segment, UUID writerId, int numEvents, int eventSize,
                                      int expectedMessages) throws Exception {
         @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
-        ArrayList<Object> received = setupAppend(segment, writerId, fakeNetwork);
+        val received = new ReceivedCommands();
+        setupAppend(segment, writerId, fakeNetwork);
         for (int i = 0; i < numEvents; i++) {
             append(segment, writerId, eventSize * (i + 1L), i, eventSize, fakeNetwork);
             read(fakeNetwork, received);
@@ -451,10 +470,9 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
         assertEquals(expectedMessages + 1, received.size());
         assertEquals(received.get(received.size() - 1), keepAlive);
-        received.remove(received.size() - 1);
-        verify(received, numEvents, eventSize);
+        received.results.remove(received.size() - 1);
+        verify(received.results, numEvents, eventSize);
     }
-
 
     @Test
     public void testFlushBeforeEndOfBlock() throws Exception {
@@ -468,8 +486,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     private void testFlush(int size) throws Exception {
         @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
-        ArrayList<Object> received = setupAppend(streamName, writerId, fakeNetwork);
+        val received = new ReceivedCommands();
+        setupAppend(streamName, writerId, fakeNetwork);
 
         append(streamName, writerId, 0, 0, size, fakeNetwork);
         read(fakeNetwork, received);
@@ -486,11 +504,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         assertEquals(keepAlive, two);
     }
 
-
     @Test
     public void testAppendWithoutBatchTracker() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
@@ -499,7 +514,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         commandEncoder.encode(ctx, msg, fakeNetwork);
         read(fakeNetwork, received);
         assertEquals(2, received.size());
@@ -510,8 +526,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     @Test
     public void testBlockTimeout() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
@@ -522,10 +536,11 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         Mockito.when(ch.writeAndFlush(Mockito.any())).thenAnswer(i -> {
-           commandEncoder.encode(ctx, i.getArgument(0), fakeNetwork);
-           return null;
+            commandEncoder.encode(ctx, i.getArgument(0), fakeNetwork);
+            return null;
         });
         commandEncoder.encode(ctx, msg, fakeNetwork);
         Thread.sleep(idBatchSizeTrackerMap.get(1L).getBatchTimeout() + 100);
@@ -539,15 +554,14 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     @Test
     public void testAppendComplete() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[256];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
         CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
@@ -560,20 +574,20 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         Append readAppend = (Append) received.get(1);
         assertEquals((256  + TYPE_PLUS_LENGTH_SIZE) * 4L, readAppend.data.readableBytes());
         assertEquals((content.length + TYPE_PLUS_LENGTH_SIZE) * 4L, readAppend.data.readableBytes());
+        System.out.println();
     }
 
     @Test
     public void testSessionFlush() throws Exception {
         final UUID writerId2 = new UUID(1, 3);
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
         CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         SetupAppend setupAppend = new SetupAppend(1, writerId, "segment", "");
         commandEncoder.encode(ctx, setupAppend, fakeNetwork);
         appendDecoder.processCommand(setupAppend);
@@ -602,15 +616,14 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         final UUID writerId4 = new UUID(1, 5);
         final UUID writerId5 = new UUID(1, 6);
         final UUID writerId6 = new UUID(1, 7);
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(appendBlockSize));
         CommandEncoder commandEncoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        ArrayList<Object> received = new ArrayList<>();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         Mockito.when(ch.writeAndFlush(Mockito.any())).thenAnswer(i -> {
             commandEncoder.encode(ctx, i.getArgument(0), fakeNetwork);
             return null;
@@ -654,8 +667,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     @Test(expected = InvalidMessageException.class)
     public void testInvalidAppendEventNumber() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
@@ -672,8 +683,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidAppendConditional() throws Exception {
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         byte[] content = new byte[100];
         Arrays.fill(content, (byte) 1);
         Event event = new Event(Unpooled.wrappedBuffer(content));
@@ -743,8 +752,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
 
         CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writer1, streamName, "");
         encoder.encode(ctx, setupAppend, fakeNetwork);
         setupAppend = new SetupAppend(1, writer2, streamName, "");
@@ -761,8 +768,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
         CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writerId, streamName, "");
         encoder.encode(ctx, setupAppend, fakeNetwork);
         Append msg = new Append(streamName, writerId, 1, 1, Unpooled.EMPTY_BUFFER, null, 1);
@@ -772,7 +777,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         Append msg3 = new Append(streamName, writerId, 3, 1, Unpooled.EMPTY_BUFFER, null, 1);
         encoder.encode(ctx, msg2, fakeNetwork);
         encoder.encode(ctx, msg3, fakeNetwork);
-        ArrayList<Object> received = Lists.newArrayList();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         read(fakeNetwork, received);
         assertEquals(4, received.size());
         assertEquals(setupAppend, received.get(0));
@@ -787,8 +793,6 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         idBatchSizeTrackerMap.remove(1L);
         idBatchSizeTrackerMap.put(1L, new FixedBatchSizeTracker(size));
         CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
-        @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
         SetupAppend setupAppend = new SetupAppend(1, writerId, streamName, "");
         encoder.encode(ctx, setupAppend, fakeNetwork);
         Append msg = new Append(streamName, writerId, 1, 1, Unpooled.EMPTY_BUFFER, null, 1);
@@ -799,7 +803,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         encoder.encode(ctx, msg2, fakeNetwork);
         encoder.encode(ctx, msg3, fakeNetwork);
         encoder.encode(ctx, new KeepAlive(), fakeNetwork);
-        ArrayList<Object> received = Lists.newArrayList();
+        @Cleanup("release")
+        val received = new ReceivedCommands();
         read(fakeNetwork, received);
         assertEquals(3, received.size());
         assertEquals(setupAppend, received.get(0));
@@ -812,8 +817,8 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     public void testAppendAtBlockBound() throws Exception {
         int size = appendBlockSize;
         @Cleanup("release")
-        ByteBuf fakeNetwork = ByteBufAllocator.DEFAULT.buffer();
-        ArrayList<Object> received = setupAppend(streamName, writerId, fakeNetwork);
+        val received = new ReceivedCommands();
+        setupAppend(streamName, writerId, fakeNetwork);
 
         append(streamName, writerId, size, 1, size, fakeNetwork);
         read(fakeNetwork, received);
@@ -844,14 +849,12 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         sendAndVerifyEvents(streamName, writerId, 2, size, 2);
     }
 
-    private ArrayList<Object> setupAppend(String testStream, UUID writerId, ByteBuf fakeNetwork) throws Exception {
+    private void setupAppend(String testStream, UUID writerId, ByteBuf fakeNetwork) throws Exception {
         SetupAppend setupAppend = new SetupAppend(1, writerId, testStream, "");
         encoder.encode(ctx, setupAppend, fakeNetwork);
-        ArrayList<Object> received = new ArrayList<>();
         WireCommand command = CommandDecoder.parseCommand(fakeNetwork);
         assertTrue(appendDecoder.acceptInboundMessage(command));
         assertEquals(setupAppend, appendDecoder.processCommand(command));
-        return received;
     }
 
     private long append(String segment, UUID writerId, long offset, int messageNumber, int length, ByteBuf out)
@@ -866,20 +869,20 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         return offset + length;
     }
 
-    private void read(ByteBuf in, List<Object> results) throws Exception {
+    private void read(ByteBuf in, ReceivedCommands received) throws Exception {
         ByteBuf segmented = (ByteBuf) lengthDecoder.decode(null, in);
         while (segmented != null) {
-            int before = results.size();
+            int before = received.results.size();
             WireCommand command = CommandDecoder.parseCommand(segmented);
             if (appendDecoder.acceptInboundMessage(command)) {
                 Request request = appendDecoder.processCommand(command);
                 if (request != null) {
-                    results.add(request);
+                    received.results.add(request);
                 }
             } else {
-                results.add(command);
+                received.results.add(command);
             }
-            assertTrue(results.size() == before || results.size() == before + 1);
+            assertTrue(received.results.size() == before || received.results.size() == before + 1);
             segmented.release();
             segmented = (ByteBuf) lengthDecoder.decode(null, in);
         }
@@ -928,6 +931,58 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         } else {
             // Other type of buffer (direct?). Our best guess is invoking capacity() which should return the right value.
             return buf.capacity();
+        }
+    }
+
+    private static class BufferReleaseVerifier implements AutoCloseable {
+        private final ArrayList<Supplier<Integer>> getRefCounts;
+
+        BufferReleaseVerifier() {
+            this.getRefCounts = new ArrayList<>();
+        }
+
+        BufferReleaseVerifier include(WireCommands.ReleasableCommand cmd, ByteBuf buf) {
+            cmd.requireRelease();
+            Supplier<Integer> s = buf::refCnt;
+            AssertExtensions.assertGreaterThan("Expecting a referenced buffer.", 0, s.get());
+            this.getRefCounts.add(s);
+            return this;
+        }
+
+
+        @Override
+        public void close() {
+            for (int i = 0; i < this.getRefCounts.size(); i++) {
+                Assert.assertEquals("Referenced buffer found at position " + i, 0, (int) this.getRefCounts.get(i).get());
+            }
+        }
+    }
+
+    private static class ReceivedCommands {
+        final List<Object> results = new ArrayList<>();
+
+        int size() {
+            return this.results.size();
+        }
+
+        Object get(int index) {
+            return this.results.get(index);
+        }
+
+        /**
+         * Releases all appends. This is consistent with the Append Processor behavior in the Segment Store: once it
+         * is done processing the append, it will release it. We need to simulate the same behavior so that we may validate
+         * the following cases:
+         * - No reference undercounts (trying to use a {@link ByteBuf} that has {@link ByteBuf#refCnt()} 0.
+         * - No leaked {@link ByteBuf}s. In combination with {@link LeakDetectorTestSuite}, this verifies that at the end
+         * the test(s), {@link ByteBuf#refCnt()} is 0 when the {@link ByteBuf}s are garbage collected.
+         */
+        void release() {
+            for (Object o : results) {
+                if (o instanceof Append) {
+                    ((Append) o).getData().release();
+                }
+            }
         }
     }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -67,12 +67,7 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
     private final CommandEncoder encoder = new CommandEncoder(idBatchSizeTrackerMap::get);
     private final FakeLengthDecoder lengthDecoder = new FakeLengthDecoder();
     private final AppendDecoder appendDecoder = new AppendDecoder();
-
-    protected int getThreadPoolSize() {
-        return 1;
-    }
-
-    private final EventExecutor executor = new EventExecutor() {
+    private EventExecutor executor = new EventExecutor() {
         @Override
         public EventExecutor next() {
             return null;
@@ -224,13 +219,16 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
 
         }
     };
-
     @Mock
     private ChannelHandlerContext ctx;
     @Mock
     private Channel ch;
     private ByteBuf fakeNetwork;
     private BufferReleaseVerifier releaseVerifier;
+
+    protected int getThreadPoolSize() {
+        return 1;
+    }
 
     @Before
     public void setup() {

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
@@ -108,11 +108,17 @@ public class ByteBufWrapperTests {
         val copy = wrap.getCopy();
         Assert.assertArrayEquals("Unexpected result from getCopy.", expectedData, copy);
 
+        // Get BufferView Reader.
+        val bufferViewReader = wrap.getBufferViewReader();
+        val bufferViewReaderData = bufferViewReader.readFully(2);
+        AssertExtensions.assertArrayEquals("Unexpected result from getReader.", expectedData, 0,
+                bufferViewReaderData.array(), bufferViewReaderData.arrayOffset(), expectedData.length);
+
         // Get Reader.
         @Cleanup
         val reader = wrap.getReader();
         val readerData = IOUtils.readFully(reader, wrap.getLength());
-        Assert.assertArrayEquals("Unexpected result from getReader.", expectedData, copy);
+        Assert.assertArrayEquals("Unexpected result from getReader.", expectedData, readerData);
 
         // Copy To OutputStream.
         @Cleanup

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import lombok.Data;
 import org.junit.Test;
 
@@ -70,11 +72,23 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
     @Test
     public void testAppendBlock() throws IOException {
         testCommand(new WireCommands.AppendBlock(uuid));
+
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.AppendBlock(uuid, buf),
+                WireCommands.AppendBlock::readFrom,
+                ab -> ab.getData().refCnt());
     }
 
     @Test
     public void testAppendBlockEnd() throws IOException {
         testCommand(new WireCommands.AppendBlockEnd(uuid, i, buf, i, i, l));
+
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.AppendBlockEnd(uuid, i, buf, i, i, l),
+                WireCommands.AppendBlockEnd::readFrom,
+                abe -> abe.getData().refCnt());
     }
 
     @Data
@@ -115,6 +129,12 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
         ConditionalAppendV7 commandV7 = new ConditionalAppendV7(uuid, l, l, new Event(buf));
         commandV7.writeFields(new DataOutputStream(bout));
         testCommandFromByteArray(bout.toByteArray(), new WireCommands.ConditionalAppend(uuid, l, l, new Event(buf), -1));
+
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.ConditionalAppend(uuid, l, l, new Event(buf), -1),
+                WireCommands.ConditionalAppend::readFrom,
+                ce -> ce.getEvent().getData().refCnt());
     }
 
     @Test
@@ -518,34 +538,13 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
     @Test
     public void testSegmentRead() throws IOException {
         testCommand(new WireCommands.SegmentRead(testString1, l, true, false, buf, l));
-    }
 
-    @Test
-    public void testSegmentReadRelease() throws IOException {
-        // If we pass in the buffer ourselves, there should be no need to release.
-        int originalRefCnt = buf.refCnt();
-        WireCommands.SegmentRead sr = new WireCommands.SegmentRead(testString1, l, true, false, buf, l);
-        assertTrue(sr.isReleased());
-        sr.release();
-        assertEquals(originalRefCnt, buf.refCnt());
-        assertTrue(sr.isReleased());
-        sr.release(); // Do this again. The second time should have no effect.
-        assertEquals(originalRefCnt, buf.refCnt());
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.SegmentRead(testString1, l, true, false, buf, l),
+                WireCommands.SegmentRead::readFrom,
+                sr -> sr.getData().refCnt());
 
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        sr.writeFields(new DataOutputStream(bout));
-        ByteBuf buffer = Unpooled.wrappedBuffer(bout.toByteArray());
-        WireCommands.SegmentRead read = (WireCommands.SegmentRead) WireCommands.SegmentRead.readFrom(new EnhancedByteBufInputStream(buffer), bout.size());
-        assertEquals(2, read.getData().refCnt());
-        assertEquals(2, buffer.refCnt());
-        buffer.release();
-        assertEquals(1, read.getData().refCnt());
-        assertEquals(1, buffer.refCnt());
-        read.release();
-        assertEquals(0, read.getData().refCnt());
-        assertEquals(0, buffer.refCnt());
-        read.release(); // Do this again. The second time should have no effect.
-        assertEquals(0, buffer.refCnt());
     }
 
     @Test
@@ -797,7 +796,34 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
         testCommand(cmd);
     }
 
+    @SuppressWarnings("unchecked")
+    private <T extends WireCommands.ReleasableCommand> void testReleasableCommand(
+            Supplier<T> fromBuf, WireCommands.Constructor fromStream, Function<T, Integer> getRefCnt) throws IOException {
+        // If we pass in the buffer ourselves, there should be no need to release.
+        int originalRefCnt = buf.refCnt();
+        T command = fromBuf.get();
+        assertTrue(command.isReleased());
+        command.release();
+        assertEquals(originalRefCnt, buf.refCnt());
+        assertTrue(command.isReleased());
+        command.release(); // Do this again. The second time should have no effect.
+        assertEquals(originalRefCnt, buf.refCnt());
 
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        command.writeFields(new DataOutputStream(bout));
+        ByteBuf buffer = Unpooled.wrappedBuffer(bout.toByteArray());
+        T command2 = (T) fromStream.readFrom(new EnhancedByteBufInputStream(buffer), bout.size());
+        assertEquals(2, (int) getRefCnt.apply(command2));
+        assertEquals(2, buffer.refCnt());
+        buffer.release();
+        assertEquals(1, (int) getRefCnt.apply(command2));
+        assertEquals(1, buffer.refCnt());
+        command2.release();
+        assertEquals(0, (int) getRefCnt.apply(command2));
+        assertEquals(0, buffer.refCnt());
+        command2.release(); // Do this again. The second time should have no effect.
+        assertEquals(0, buffer.refCnt());
+    }
 
     private void testCommand(WireCommand command) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -153,8 +153,19 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
                 () -> WireCommands.ConditionalAppend.readFrom(new EnhancedByteBufInputStream(buf), buf.capacity()),
                 t -> t instanceof EOFException);
         assertThrows("Unsupported operation",
-                     () -> cmd.process(mock(RequestProcessor.class)),
-                     t -> t instanceof UnsupportedOperationException);
+                () -> cmd.process(mock(RequestProcessor.class)),
+                t -> t instanceof UnsupportedOperationException);
+    }
+
+    @Test
+    public void testPartialEvent() throws IOException {
+        testCommand(new WireCommands.PartialEvent(buf));
+
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.PartialEvent(buf),
+                WireCommands.PartialEvent::readFrom,
+                pe -> pe.getData().refCnt());
     }
 
     @Test

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
@@ -132,6 +132,11 @@ public class TruncateableArray implements ArrayView {
     }
 
     @Override
+    public Reader getBufferViewReader() {
+        throw new UnsupportedOperationException("getBufferViewReader() not supported.");
+    }
+
+    @Override
     public BufferView slice(int offset, int length) {
         throw new UnsupportedOperationException("slice() not supported.");
     }
@@ -147,11 +152,6 @@ public class TruncateableArray implements ArrayView {
     }
 
     @Override
-    public Reader getBufferViewReader() {
-        throw new UnsupportedOperationException("getBufferViewReader() not supported.");
-    }
-
-    @Override
     public void copyTo(byte[] target, int targetOffset, int length) {
         throw new UnsupportedOperationException("copyTo() not supported.");
     }
@@ -160,8 +160,7 @@ public class TruncateableArray implements ArrayView {
     public byte[] getCopy() {
         throw new UnsupportedOperationException("getCopy() not supported.");
     }
-
-
+    
     //endregion
 
     //region Operations

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
@@ -147,6 +147,11 @@ public class TruncateableArray implements ArrayView {
     }
 
     @Override
+    public Reader getBufferViewReader() {
+        throw new UnsupportedOperationException("getBufferViewReader() not supported.");
+    }
+
+    @Override
     public void copyTo(byte[] target, int targetOffset, int length) {
         throw new UnsupportedOperationException("copyTo() not supported.");
     }

--- a/test/testcommon/src/main/java/io/pravega/test/common/LeakDetectorTestSuite.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/LeakDetectorTestSuite.java
@@ -22,9 +22,18 @@ import org.junit.Before;
 /**
  * Base class for a unit test that wants to check for Netty (ByteBuf) resource leaks. Automatically fails any tests
  * for which {@link ResourceLeakDetector} reports a leak.
- *
+ * <p>
  * This works by attaching a specialized {@link Slf4JLoggerFactory} to the {@link ResourceLeakDetector} and invokes
  * {@link Assert#fail} when {@link InternalLogger#error} is invoked.
+ * <p>
+ * NOTE:
+ * Ensure that Log4j is properly configured in the (Test) Project where this is used. If you get a `WARN` when running
+ * your test saying that Log4j is not properly configured (no appenders set up), the Leak Detector WILL NOT WORK. At the
+ * very least, verify the following are included as dependencies in your Test Project:
+ * <pre><code>
+ * testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
+ * testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+ * </code></pre>
  */
 public abstract class LeakDetectorTestSuite extends ThreadPooledTestSuite {
     private ResourceLeakDetector.Level originalLevel;


### PR DESCRIPTION
**Change log description**  
- Optimized AppendDecoder to make fewer buffer copies from Netty to the Segment Store.
- Optimized the ingestion path in the Segment Store to choose the most efficient method of copying data based on the source and target buffer types.

**Purpose of the change**  
Fixes #4764.

**What the code does**  
`AppendDecoder`, in conjunction with `WireCommands.AppendBlock/AppendBlockEnd/ConditionalAppend/Event/PartialEvent`, is responsible for translating between Wire Commands and an `Append` that can be processed by the Segment Store it's sitting on top of.

However all these classes make numerous buffer allocations and copies for data to get from Netty's network bufs to the Segment Store:
- Netty -> AppendBlockEnd -> Append
- Netty -> AppendBlock/AppendBlockEnd -> Append
- Netty -> ConditionalAppend -> Event -> Append

This PR changes these classes to not execute those copies anymore but rely on ByteBuf slicing and retaining for this:
- The Wire Commands listed above use `EnhancedByteBufInputStream` to fetch a `ByteBuf` slice out of Netty's network bufs (direct memory buffers)
- These are `retain`-ed and sent out to `AppendDecoder`
- `AppendDecoder` stitches them into one or more `Append` instances which exposes those bufs as a composite `ByteBuf`. This `Append is then passed on to the underlying Segment Store via `AppendProcessor`.

AppendProcessor and Segment Store already manage the lifecycle of these buffers by invoking `retain`/`release` in `StreamSegmentAppendOperation` and `release` in `AppendProcessor` after the append is complete. 

Additionally, inside the ingestion pipeline in the Segment Store, the following modifications have been made:
- `DataFrameOutputStream` implements the new `BufferViewSink`. This allows using direct buffer copies (from Netty via `StreamSegmentAppendOperation` to the `DataFrame` that ends up getting sent to BK). Previously we were using the `OutputStream.write(...)` methods which were less efficient.

**How to verify it**  
Unit tests, integration tests and system tests must pass.
Unit tests for these classes have been updated to check for memory leaks and under-referenced buffers.
