### PR TITLE
Issue 4766: Ensure BatchClient handles partial response from SSS.

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -11,7 +11,6 @@ package io.pravega.client.batch.impl;
 
 import com.google.common.annotations.Beta;
 import io.pravega.client.batch.SegmentIterator;
-import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.segment.impl.Segment;
@@ -19,11 +18,17 @@ import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.TruncatedDataException;
+
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeoutException;
+
+import io.pravega.common.util.Retry;
 import lombok.Getter;
-import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Beta
+@Slf4j
 public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
 
     private final Segment segment;
@@ -32,6 +37,7 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
     private final long startingOffset;
     private final long endingOffset;
     private final EventSegmentReader input;
+    private final Retry.RetryWithBackoff backoffSchedule = Retry.withExpBackoff(1, 10, 9, 30000);
 
     public SegmentIteratorImpl(SegmentInputStreamFactory factory, Segment segment,
             Serializer<T> deserializer, long startingOffset, long endingOffset) {
@@ -49,16 +55,29 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
     }
 
     @Override
-    @SneakyThrows(EndOfSegmentException.class) //endingOffset should make this impossible.
     public T next() {
         if (!hasNext()) {
             throw new NoSuchElementException();
-        } 
-        try {
-            return deserializer.deserialize(input.read());
-        } catch (NoSuchSegmentException | SegmentTruncatedException e) {
-            throw new TruncatedDataException("Segment " + segment + " has been truncated.");
         }
+
+        // retry in-case of an empty ByteBuffer
+        ByteBuffer read =
+                backoffSchedule.retryWhen(t -> t instanceof TimeoutException)
+                               .run(() -> {
+                                   try {
+                                       ByteBuffer buffer = input.read();
+                                       if (buffer == null) {
+                                           log.warn("Empty buffer while reading from Segment {} at offset {}",
+                                                   input.getSegmentId(), input.getOffset());
+                                           throw new TimeoutException(input.toString());
+                                       }
+                                       return buffer;
+                                   } catch (NoSuchSegmentException | SegmentTruncatedException e) {
+                                       throw new TruncatedDataException("Segment " + segment + " has been truncated.");
+                                   }
+                               });
+
+        return deserializer.deserialize(read);
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -10,24 +10,36 @@
 package io.pravega.client.batch.impl;
 
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
+import io.pravega.client.segment.impl.EndOfSegmentException;
+import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
 import io.pravega.client.segment.impl.SegmentOutputStream;
+import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
+import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.test.common.AssertExtensions;
+
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import org.junit.Test;
+import org.mockito.internal.verification.Times;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SegmentIteratorTest {
 
@@ -112,6 +124,22 @@ public class SegmentIteratorTest {
         assertTrue(iter2.hasNext());
         assertEquals("3", iter2.next());
         assertFalse(iter.hasNext());
+    }
+
+    @Test(timeout = 5000)
+    public void testTimeoutError() throws SegmentTruncatedException, EndOfSegmentException {
+        Segment segment = new Segment("Scope", "Stream", 1);
+        int endOffset = 10;
+        SegmentInputStreamFactory factory = mock(SegmentInputStreamFactory.class);
+        EventSegmentReader input = mock(EventSegmentReader.class);
+        when(factory.createEventReaderForSegment(segment)).thenReturn(input);
+        when(input.read()).thenReturn(null).thenReturn(stringSerializer.serialize("s"));
+        @Cleanup
+        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, endOffset);
+        assertEquals("s", iter.next());
+        verify(input, times(2)).read();
+        when(input.read()).thenThrow(SegmentTruncatedException.class);
+        assertThrows(TruncatedDataException.class, () -> iter.next());
     }
 
     private void sendData(String data, SegmentOutputStream outputStream) {

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -22,15 +22,12 @@ import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
-import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.test.common.AssertExtensions;
 
-import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import org.junit.Test;
-import org.mockito.internal.verification.Times;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
**Change log description**  
Ensure the batch client retries in case a partial event is received from SegmentStore.

**Purpose of the change**  
Fixes #4766 

**What the code does**  
BatchClient reads from a Segment using `io.pravega.client.segment.impl.EventSegmentReaderImpl#read()` where the first-byte timeout is set to `Long.MAX_VALUE` .
The EventSegmentReader waits for 30seconds (`PARTIAL_DATA_TIMEOUT`) after receiving the first byte to get the remaining part of the event. In the case, the reader does not receive the complete event a newer request is sent by the EventSegmentReader.

The BatchClient client should retry in such a scenario and try to obtain the complete event before de-serializing the ByteBuffer received.

**How to verify it**  
All the existing and newly added tests should work successfully.
