### PR TITLE
Issue 4792: API stubs for supporting offset/version based TableSegment reads.

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -403,7 +403,7 @@ public class SegmentHelper implements AutoCloseable {
         RawClient connection = new RawClient(ModelHelper.encode(uri), connectionFactory);
         final long requestId = connection.getFlow().asLong();
         WireCommands.UpdateTableEntries request = new WireCommands.UpdateTableEntries(requestId, tableName, delegationToken,
-                new WireCommands.TableEntries(wireCommandEntries));
+                new WireCommands.TableEntries(wireCommandEntries), 0L);
 
         return sendRequest(connection, requestId, request)
                 .thenApply(rpl -> {
@@ -444,7 +444,7 @@ public class SegmentHelper implements AutoCloseable {
         RawClient connection = new RawClient(ModelHelper.encode(uri), connectionFactory);
         final long requestId = connection.getFlow().asLong();
 
-        WireCommands.RemoveTableKeys request = new WireCommands.RemoveTableKeys(requestId, tableName, delegationToken, keyList);
+        WireCommands.RemoveTableKeys request = new WireCommands.RemoveTableKeys(requestId, tableName, delegationToken, keyList, 0L);
 
         return sendRequest(connection, requestId, request)
                 .thenAccept(rpl -> handleReply(clientRequestId, rpl, connection, tableName, WireCommands.RemoveTableKeys.class, type))

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -403,7 +403,7 @@ public class SegmentHelper implements AutoCloseable {
         RawClient connection = new RawClient(ModelHelper.encode(uri), connectionFactory);
         final long requestId = connection.getFlow().asLong();
         WireCommands.UpdateTableEntries request = new WireCommands.UpdateTableEntries(requestId, tableName, delegationToken,
-                new WireCommands.TableEntries(wireCommandEntries), 0L);
+                new WireCommands.TableEntries(wireCommandEntries), WireCommands.NULL_TABLE_SEGMENT_OFFSET);
 
         return sendRequest(connection, requestId, request)
                 .thenApply(rpl -> {
@@ -444,7 +444,8 @@ public class SegmentHelper implements AutoCloseable {
         RawClient connection = new RawClient(ModelHelper.encode(uri), connectionFactory);
         final long requestId = connection.getFlow().asLong();
 
-        WireCommands.RemoveTableKeys request = new WireCommands.RemoveTableKeys(requestId, tableName, delegationToken, keyList, 0L);
+        WireCommands.RemoveTableKeys request = new WireCommands.RemoveTableKeys(
+                requestId, tableName, delegationToken, keyList, WireCommands.NULL_TABLE_SEGMENT_OFFSET);
 
         return sendRequest(connection, requestId, request)
                 .thenAccept(rpl -> handleReply(clientRequestId, rpl, connection, tableName, WireCommands.RemoveTableKeys.class, type))

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -651,26 +651,26 @@ public class PravegaRequestProcessorTest {
         // Test with unversioned data.
         TableEntry e1 = TableEntry.unversioned(keys.get(0), generateValue(rnd));
         WireCommands.TableEntries cmd = getTableEntries(singletonList(e1));
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", cmd));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", cmd, 0L));
         order.verify(connection).send(new WireCommands.TableEntriesUpdated(2, singletonList(0L)));
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(1), eq(false), any());
 
         // Test with versioned data.
         e1 = TableEntry.versioned(keys.get(0), generateValue(rnd), 0L);
         cmd = getTableEntries(singletonList(e1));
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(3, tableSegmentName, "", cmd));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(3, tableSegmentName, "", cmd, 0L));
         order.verify(connection).send(any());
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(1), eq(true), any());
 
         // Test with key not present. The table store throws KeyNotExistsException.
         TableEntry e2 = TableEntry.versioned(keys.get(1), generateValue(rnd), 0L);
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(4, tableSegmentName, "", getTableEntries(singletonList(e2))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(4, tableSegmentName, "", getTableEntries(singletonList(e2)), 0L));
         order.verify(connection).send(new WireCommands.TableKeyDoesNotExist(4, tableSegmentName, ""));
         verifyNoMoreInteractions(recorderMock);
 
         // Test with invalid key version. The table store throws BadKeyVersionException.
         TableEntry e3 = TableEntry.versioned(keys.get(0), generateValue(rnd), 10L);
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(5, tableSegmentName, "", getTableEntries(singletonList(e3))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(5, tableSegmentName, "", getTableEntries(singletonList(e3)), 0L));
         order.verify(connection).send(new WireCommands.TableKeyBadVersion(5, tableSegmentName, ""));
         verifyNoMoreInteractions(recorderMock);
     }
@@ -698,20 +698,20 @@ public class PravegaRequestProcessorTest {
         processor.createTableSegment(new WireCommands.CreateTableSegment(1, tableSegmentName, ""));
         order.verify(connection).send(new WireCommands.SegmentCreated(1, tableSegmentName));
         TableEntry e1 = TableEntry.unversioned(keys.get(0), generateValue(rnd));
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(singletonList(e1))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(singletonList(e1)), 0L));
         order.verify(connection).send(new WireCommands.TableEntriesUpdated(2, singletonList(0L)));
         verify(recorderMock).createTableSegment(eq(tableSegmentName), any());
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(1), eq(false), any());
 
         // Remove a Table Key
         WireCommands.TableKey key = new WireCommands.TableKey(wrappedBuffer(e1.getKey().getKey().array()), 0L);
-        processor.removeTableKeys(new WireCommands.RemoveTableKeys(3, tableSegmentName, "", singletonList(key)));
+        processor.removeTableKeys(new WireCommands.RemoveTableKeys(3, tableSegmentName, "", singletonList(key), 0L));
         order.verify(connection).send(new WireCommands.TableKeysRemoved(3, tableSegmentName));
         verify(recorderMock).removeKeys(eq(tableSegmentName), eq(1), eq(true), any());
 
         // Test with non-existent key.
         key = new WireCommands.TableKey(wrappedBuffer(e1.getKey().getKey().array()), 0L);
-        processor.removeTableKeys(new WireCommands.RemoveTableKeys(4, tableSegmentName, "", singletonList(key)));
+        processor.removeTableKeys(new WireCommands.RemoveTableKeys(4, tableSegmentName, "", singletonList(key), 0L));
         order.verify(connection).send(new WireCommands.TableKeyBadVersion(4, tableSegmentName, ""));
         verifyNoMoreInteractions(recorderMock);
     }
@@ -766,7 +766,7 @@ public class PravegaRequestProcessorTest {
         verify(recorderMock).createTableSegment(eq(tableSegmentName), any());
 
         TableEntry e1 = TableEntry.unversioned(keys.get(0), generateValue(rnd));
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(4, tableSegmentName, "", getTableEntries(singletonList(e1))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(4, tableSegmentName, "", getTableEntries(singletonList(e1)), 0L));
         order.verify(connection).send(new WireCommands.TableEntriesUpdated(4, singletonList(0L)));
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(1), eq(false), any());
 
@@ -815,7 +815,7 @@ public class PravegaRequestProcessorTest {
         recorderMockOrder.verify(recorderMock).getKeys(eq(tableSegmentName), eq(1), any());
 
         // Update a value to a key.
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(3, tableSegmentName, "", getTableEntries(singletonList(entry))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(3, tableSegmentName, "", getTableEntries(singletonList(entry)), 0L));
         order.verify(connection).send(new WireCommands.TableEntriesUpdated(3, singletonList(0L)));
         recorderMockOrder.verify(recorderMock).updateEntries(eq(tableSegmentName), eq(1), eq(false), any());
 
@@ -854,7 +854,7 @@ public class PravegaRequestProcessorTest {
         processor.createTableSegment(new WireCommands.CreateTableSegment(1, tableSegmentName, ""));
         order.verify(connection).send(new WireCommands.SegmentCreated(1, tableSegmentName));
         verify(recorderMock).createTableSegment(eq(tableSegmentName), any());
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(asList(e1, e2, e3))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(asList(e1, e2, e3)), 0L));
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(3), eq(false), any());
 
         // 1. Now read the table keys where suggestedKeyCount is equal to number of entries in the Table Store.
@@ -925,7 +925,7 @@ public class PravegaRequestProcessorTest {
         processor.createTableSegment(new WireCommands.CreateTableSegment(1, tableSegmentName, ""));
         order.verify(connection).send(new WireCommands.SegmentCreated(1, tableSegmentName));
         verify(recorderMock).createTableSegment(eq(tableSegmentName), any());
-        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(asList(e1, e2, e3))));
+        processor.updateTableEntries(new WireCommands.UpdateTableEntries(2, tableSegmentName, "", getTableEntries(asList(e1, e2, e3)), 0L));
         verify(recorderMock).updateEntries(eq(tableSegmentName), eq(3), eq(false), any());
 
         // 1. Now read the table entries where suggestedEntryCount is equal to number of entries in the Table Store.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -102,6 +102,9 @@ public enum WireCommandType {
     READ_TABLE_ENTRIES(85, WireCommands.ReadTableEntries::readFrom),
     TABLE_ENTRIES_READ(86, WireCommands.TableEntriesRead::readFrom),
 
+    TABLE_ENTRIES_DELTA_READ(87, WireCommands.TableEntriesDeltaRead::readFrom),
+    READ_TABLE_ENTRIES_DELTA(88, WireCommands.ReadTableEntriesDelta::readFrom),
+
     KEEP_ALIVE(100, WireCommands.KeepAlive::readFrom);
 
     private final int code;

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1650,10 +1650,10 @@ public final class WireCommands {
         @Override
         public void writeFields(DataOutput out) throws IOException {
             out.writeLong(requestId);
-            out.writeLong(tableSegmentOffset);
             out.writeUTF(segment);
             out.writeUTF(delegationToken == null ? "" : delegationToken);
             tableEntries.writeFields(out);
+            out.writeLong(tableSegmentOffset);
         }
 
         public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
@@ -1723,6 +1723,7 @@ public final class WireCommands {
             for (TableKey key : keys) {
                 key.writeFields(out);
             }
+            out.writeLong(tableSegmentOffset);
         }
 
         public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -60,9 +60,10 @@ public final class WireCommands {
     public static final int TYPE_SIZE = 4;
     public static final int TYPE_PLUS_LENGTH_SIZE = 8;
     public static final int MAX_WIRECOMMAND_SIZE = 0x00FFFFFF; // 16MB-1
-    
+
     public static final long NULL_ATTRIBUTE_VALUE = Long.MIN_VALUE; //This is the same as Attributes.NULL_ATTRIBUTE_VALUE
-    
+    public static final long NULL_TABLE_SEGMENT_OFFSET = -1;
+
     private static final Map<Integer, WireCommandType> MAPPING;
     private static final String EMPTY_STACK_TRACE = "";
     static {
@@ -109,7 +110,7 @@ public final class WireCommands {
             int lowVersion = in.readInt();
             return new Hello(highVersion, lowVersion);
         }
-        
+
         @Override
         public long getRequestId() {
             return 0;
@@ -144,7 +145,7 @@ public final class WireCommands {
             String serverStackTrace = (in.available() > 0) ? in.readUTF() : EMPTY_STACK_TRACE;
             return new WrongHost(requestId, segment, correctHost, serverStackTrace);
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -182,7 +183,7 @@ public final class WireCommands {
             long offset = (in.available() >= Long.BYTES) ? in.readLong() : -1L;
             return new SegmentIsSealed(requestId, segment, serverStackTrace, offset);
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -223,7 +224,7 @@ public final class WireCommands {
             long offset = (in.available() >= Long.BYTES) ? in.readLong() : -1L;
             return new SegmentIsTruncated(requestId, segment, startOffset, serverStackTrace, offset);
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -260,7 +261,7 @@ public final class WireCommands {
         public String toString() {
             return "Segment already exists: " + segment;
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -303,7 +304,7 @@ public final class WireCommands {
         public String toString() {
             return "No such segment: " + segment;
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -378,7 +379,7 @@ public final class WireCommands {
         public String toString() {
             return "Invalid event number: " + eventNumber + " for writer: " + writerId;
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -415,7 +416,7 @@ public final class WireCommands {
             String serverStackTrace = (in.available() > 0) ? in.readUTF() : EMPTY_STACK_TRACE;
             return new OperationUnsupported(requestId, operationName, serverStackTrace);
         }
-        
+
         @Override
         public boolean isFailure() {
             return true;
@@ -735,7 +736,7 @@ public final class WireCommands {
             long currentSegmentWriteOffset = in.available() >= Long.BYTES ? in.readLong() : -1L;
             return new DataAppended(requestId, writerId, eventNumber, previousEventNumber, currentSegmentWriteOffset);
         }
-        
+
         @Override
         public long getRequestId() {
             return requestId;
@@ -901,7 +902,7 @@ public final class WireCommands {
             return new GetSegmentAttribute(requestId, segment, attributeId, delegationToken);
         }
     }
-    
+
     @Data
     public static final class SegmentAttribute implements Reply, WireCommand {
         final WireCommandType type = WireCommandType.SEGMENT_ATTRIBUTE;
@@ -921,11 +922,11 @@ public final class WireCommands {
 
         public static WireCommand readFrom(DataInput in, int length) throws IOException {
             long requestId = in.readLong();
-            long value = in.readLong();                
+            long value = in.readLong();
             return new SegmentAttribute(requestId, value);
         }
     }
-    
+
     @Data
     public static final class UpdateSegmentAttribute implements Request, WireCommand {
         final WireCommandType type = WireCommandType.UPDATE_SEGMENT_ATTRIBUTE;
@@ -957,13 +958,13 @@ public final class WireCommands {
             long requestId = in.readLong();
             String segment = in.readUTF();
             UUID attributeId = new UUID(in.readLong(), in.readLong());
-            long newValue = in.readLong();                
+            long newValue = in.readLong();
             long excpecteValue = in.readLong();
             String delegationToken = in.readUTF();
             return new UpdateSegmentAttribute(requestId, segment, attributeId, newValue, excpecteValue, delegationToken);
         }
     }
-    
+
     @Data
     public static final class SegmentAttributeUpdated implements Reply, WireCommand {
         final WireCommandType type = WireCommandType.SEGMENT_ATTRIBUTE_UPDATED;
@@ -987,7 +988,7 @@ public final class WireCommands {
             return new SegmentAttributeUpdated(requestId, success);
         }
     }
-    
+
     @Data
     public static final class GetStreamSegmentInfo implements Request, WireCommand {
         final WireCommandType type = WireCommandType.GET_STREAM_SEGMENT_INFO;
@@ -1661,7 +1662,7 @@ public final class WireCommands {
             String segment = in.readUTF();
             String delegationToken = in.readUTF();
             TableEntries entries = (TableEntries) TableEntries.readFrom(in, in.available());
-            long tableSegmentOffset = in.readLong();
+            long tableSegmentOffset = (in.available() > 0 ) ? in.readLong() : NULL_TABLE_SEGMENT_OFFSET;
 
             return new UpdateTableEntries(requestId, segment, delegationToken, entries, tableSegmentOffset);
         }
@@ -1735,7 +1736,7 @@ public final class WireCommands {
             for (int i = 0; i < numberOfKeys; i++) {
                 keys.add((TableKey) TableKey.readFrom(in, in.available()));
             }
-            long tableSegmentOffset = in.readLong();
+            long tableSegmentOffset = (in.available() > 0 ) ? in.readLong() : NULL_TABLE_SEGMENT_OFFSET;
 
             return new RemoveTableKeys(requestId, segment, delegationToken, keys, tableSegmentOffset);
         }
@@ -2234,8 +2235,9 @@ public final class WireCommands {
         final boolean reachedEnd;
         final long lastVersion;
 
+        // TODO: Will be implemented as apart of: https://github.com/pravega/pravega/issues/4677
         @Override
-        public void process(ReplyProcessor cp) {
+        public void process(ReplyProcessor cp) throws UnsupportedOperationException {
 
         }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -817,7 +817,7 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
     public void testtableEntriesDeltaRead() throws IOException {
         List<Map.Entry<WireCommands.TableKey, WireCommands.TableValue>> entries = Arrays.asList(
                 new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), new WireCommands.TableValue(buf)),
-                new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), new WireCommands.TableValue(buf)));
+                new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l + 1), new WireCommands.TableValue(buf)));
         WireCommands.TableEntries tableEntries = new WireCommands.TableEntries(entries);
 
         WireCommands.TableEntriesDeltaRead cmd = new WireCommands.TableEntriesDeltaRead(

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -719,7 +719,7 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
                 new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), new WireCommands.TableValue(buf)),
                 new SimpleImmutableEntry<>(WireCommands.TableKey.EMPTY, WireCommands.TableValue.EMPTY),
                 new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), WireCommands.TableValue.EMPTY));
-        testCommand(new WireCommands.UpdateTableEntries(l, testString1, "", new WireCommands.TableEntries(entries)));
+        testCommand(new WireCommands.UpdateTableEntries(l, testString1, "", new WireCommands.TableEntries(entries), 0L));
     }
 
     @Test
@@ -730,7 +730,7 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
     @Test
     public void testRemoveTableKeys() throws IOException {
         testCommand(new WireCommands.RemoveTableKeys(l, testString1, "", Arrays.asList(new WireCommands.TableKey(buf, 1L),
-                                                                                       new WireCommands.TableKey(buf, 2L))));
+                                                                                       new WireCommands.TableKey(buf, 2L)), 0L));
     }
 
     @Test

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -807,6 +807,24 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
         testCommand(cmd);
     }
 
+    @Test
+    public void testReadTableEntriesDelta() throws IOException {
+        WireCommands.ReadTableEntriesDelta cmd = new WireCommands.ReadTableEntriesDelta(l, testString1, "", 1L, 100);
+        testCommand(cmd);
+    }
+
+    @Test
+    public void testtableEntriesDeltaRead() throws IOException {
+        List<Map.Entry<WireCommands.TableKey, WireCommands.TableValue>> entries = Arrays.asList(
+                new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), new WireCommands.TableValue(buf)),
+                new SimpleImmutableEntry<>(new WireCommands.TableKey(buf, l), new WireCommands.TableValue(buf)));
+        WireCommands.TableEntries tableEntries = new WireCommands.TableEntries(entries);
+
+        WireCommands.TableEntriesDeltaRead cmd = new WireCommands.TableEntriesDeltaRead(
+                l, testString1, tableEntries, false, false,  WireCommands.TableKey.NO_VERSION);
+        testCommand(cmd);
+    }
+
     @SuppressWarnings("unchecked")
     private <T extends WireCommands.ReleasableCommand> void testReleasableCommand(
             Supplier<T> fromBuf, WireCommands.Constructor fromStream, Function<T, Integer> getRefCnt) throws IOException {


### PR DESCRIPTION
**Change log description**  
* Stub out new APIs.

**Purpose of the change**  
Addresses #4792 .

**What the code does**  
(Detailed description of the code changes)

This code defines new (and refactors old) APIs that will allow the various teams to begin work on supporting offset/version based TableSegment reads.

**How to verify it**  
* Run WireCommandTests.
