### PR TITLE
Issue 4783: Timebound check for completion of workflow to avoid log flooding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ project('test:testcommon') {
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLogger
-        compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+        compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     }
     javadoc {
         dependsOn delombok
@@ -322,17 +322,6 @@ project('segmentstore:storage:impl') {
 }
 
 project ('bindings') {
-    configurations.all {
-        resolutionStrategy {
-            // We need to force this version as dependency, since ':test:testcommon' brings in a newer version of 
-            // this library which conflicts with the older version of this transitive dependency brought in by some 
-            // of the other dependences (HDFS and S3). 
-            // 
-            // Once HDFS and S3 are upgraded to a version that works with Gson version used by the ':test:testcommon' 
-            // sub-project, this configuration should be removed. 
-            force 'com.google.code.gson:gson:2.5'
-        }
-    }
     dependencies {
         // For HDFS
         compile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion, withoutLogger
@@ -349,6 +338,7 @@ project ('bindings') {
         compile project(':common')
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
+        testCompile project(':test:testcommon')
         testCompile project(path: ':segmentstore:storage', configuration: 'testRuntime')
     }
     javadoc {

--- a/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
+++ b/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
@@ -12,6 +12,9 @@ package io.pravega.common.security;
 import io.pravega.test.common.JwtBody;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -29,8 +32,9 @@ public class JwtUtilsTest {
         //        "aud": "segmentstore",
         //        "iat": 1516239022
         //     }
+        JwtBody jwtBody = JwtBody.builder().subject("1234567890").audience("segmentstore").issuedAtTime(1516239022L).build();
         String token = String.format("%s.%s.%s", "base64-encoded-header",
-                JwtBody.builder().subject("1234567890").audience("segmentstore").issuedAtTime(1516239022L).build(),
+                Base64.getEncoder().encodeToString(jwtBody.toString().getBytes(StandardCharsets.US_ASCII)),
                 "base64-encoded-signature");
 
         assertNull(JwtUtils.extractExpirationTime(token));

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -65,6 +65,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -610,6 +611,9 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
         }
         if (cause instanceof StoreException.StoreConnectionException) {
             return Status.INTERNAL;
+        }
+        if (cause instanceof TimeoutException) {
+            return Status.DEADLINE_EXCEEDED;
         }
         return Status.UNKNOWN;
     }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -1078,7 +1078,7 @@ public class StreamMetadataTasks extends TaskBase {
     }
 
     @VisibleForTesting
-    void setCompletionTimeoutMillis(long timeoutMillis) {
+    public void setCompletionTimeoutMillis(long timeoutMillis) {
         completionTimeoutMillis.set(timeoutMillis);
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/v1/PravegaTablesControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/PravegaTablesControllerServiceImplTest.java
@@ -9,6 +9,12 @@
  */
 package io.pravega.controller.server.v1;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ModelHelper;
+import io.pravega.common.Exceptions;
 import io.pravega.common.cluster.Cluster;
 import io.pravega.common.cluster.ClusterType;
 import io.pravega.common.cluster.Host;
@@ -34,19 +40,31 @@ import io.pravega.controller.server.rpc.grpc.v1.ControllerServiceImpl;
 import io.pravega.controller.store.client.StoreClient;
 import io.pravega.controller.store.client.StoreClientFactory;
 import io.pravega.controller.store.stream.BucketStore;
+import io.pravega.controller.store.stream.State;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.StreamStoreFactory;
 import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.TaskStoreFactoryForTests;
+import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Zookeeper stream store configuration.
@@ -90,14 +108,14 @@ public class PravegaTablesControllerServiceImplTest extends ControllerServiceImp
                 executorService, "host", GrpcAuthHelper.getDisabledAuthHelper(), requestTracker);
         streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, segmentHelper,
                 executorService, "host", GrpcAuthHelper.getDisabledAuthHelper());
-        this.streamRequestHandler = new StreamRequestHandler(new AutoScaleTask(streamMetadataTasks, streamStore, executorService),
+        this.streamRequestHandler = spy(new StreamRequestHandler(new AutoScaleTask(streamMetadataTasks, streamStore, executorService),
                 new ScaleOperationTask(streamMetadataTasks, streamStore, executorService),
                 new UpdateStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
                 new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executorService),
                 new DeleteStreamTask(streamMetadataTasks, streamStore, bucketStore, executorService),
                 new TruncateStreamTask(streamMetadataTasks, streamStore, executorService),
                 streamStore,
-                executorService);
+                executorService));
 
         streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executorService));
 
@@ -134,5 +152,49 @@ public class PravegaTablesControllerServiceImplTest extends ControllerServiceImp
         zkServer.close();
         StreamMetrics.reset();
         TransactionMetrics.reset();
+    }
+    
+    @Test
+    public void testTimeout() {
+        streamMetadataTasks.setCompletionTimeoutMillis(500L);
+        String stream = "timeoutStream";
+        createScopeAndStream(SCOPE1, stream, ScalingPolicy.fixed(2));
+
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(streamRequestHandler).processUpdateStream(any());
+        final StreamConfiguration configuration2 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3)).build();
+        ResultObserver<Controller.UpdateStreamStatus> result = new ResultObserver<>();
+        this.controllerService.updateStream(ModelHelper.decode(SCOPE1, stream, configuration2), result);
+        Predicate<Throwable> deadlineExceededPredicate = e -> {
+            Throwable unwrap = Exceptions.unwrap(e);
+            return unwrap instanceof StatusRuntimeException &&
+                    ((StatusRuntimeException) unwrap).getStatus().getCode().equals(Status.DEADLINE_EXCEEDED.getCode());
+        };
+        AssertExtensions.assertThrows("Timeout did not happen", result::get, deadlineExceededPredicate);
+        reset(streamRequestHandler);
+        
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(streamRequestHandler).processTruncateStream(any());
+        result = new ResultObserver<>();
+        this.controllerService.truncateStream(Controller.StreamCut.newBuilder()
+                                                                  .setStreamInfo(Controller.StreamInfo.newBuilder()
+                                                                                                      .setScope(SCOPE1)
+                                                                                                      .setStream(stream)
+                                                                                                      .build())
+                                                                  .putCut(0, 0).putCut(1, 0).build(), result);
+        AssertExtensions.assertThrows("Timeout did not happen", result::get, deadlineExceededPredicate);
+        reset(streamRequestHandler);
+        
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(streamRequestHandler).processSealStream(any());
+        result = new ResultObserver<>();
+        this.controllerService.sealStream(ModelHelper.createStreamInfo(SCOPE1, stream), result);
+        AssertExtensions.assertThrows("Timeout did not happen", result::get, deadlineExceededPredicate);
+        reset(streamRequestHandler);
+        
+        streamStore.setState(SCOPE1, stream, State.SEALED, null, executorService).join();
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(streamRequestHandler).processDeleteStream(any());
+        ResultObserver<Controller.DeleteStreamStatus> result2 = new ResultObserver<>();
+        this.controllerService.deleteStream(ModelHelper.createStreamInfo(SCOPE1, stream), result2);
+        AssertExtensions.assertThrows("Timeout did not happen", result2::get, deadlineExceededPredicate);
+        reset(streamRequestHandler);
+        streamMetadataTasks.setCompletionTimeoutMillis(Duration.ofMinutes(2).toMillis());
     }
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1508,9 +1508,9 @@ public abstract class StreamMetadataTasksTest {
     @Test(timeout = 30000)
     public void testWorkflowCompletionTimeout() {
         StreamMetadataTasks streamMetadataTask = new StreamMetadataTasks(streamStorePartialMock, bucketStore, TaskStoreFactory.createZKStore(zkClient, executor),
-                SegmentHelperMock.getSegmentHelperMock(), executor, executor, Duration.ofMillis(500).toNanos(), "host",
+                SegmentHelperMock.getSegmentHelperMock(), executor, executor, "host",
                 new GrpcAuthHelper(authEnabled, "key", 300), requestTracker);
-
+        streamMetadataTask.setCompletionTimeoutMillis(500L);
         StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
 
         String completion = "completion";

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -69,6 +69,7 @@ import io.pravega.shared.NameUtils;
 import io.pravega.shared.controller.event.AbortEvent;
 import io.pravega.shared.controller.event.CommitEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
+import io.pravega.shared.controller.event.DeleteStreamEvent;
 import io.pravega.shared.controller.event.ScaleOpEvent;
 import io.pravega.shared.controller.event.SealStreamEvent;
 import io.pravega.shared.controller.event.TruncateStreamEvent;
@@ -92,6 +93,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1503,6 +1505,66 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(createStreamFuture2.join(), Controller.CreateStreamStatus.Status.STREAM_EXISTS);
     }
 
+    @Test(timeout = 30000)
+    public void testWorkflowCompletionTimeout() {
+        StreamMetadataTasks streamMetadataTask = new StreamMetadataTasks(streamStorePartialMock, bucketStore, TaskStoreFactory.createZKStore(zkClient, executor),
+                SegmentHelperMock.getSegmentHelperMock(), executor, executor, Duration.ofMillis(500).toNanos(), "host",
+                new GrpcAuthHelper(authEnabled, "key", 300), requestTracker);
+
+        StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+
+        String completion = "completion";
+        streamStorePartialMock.createStream(SCOPE, completion, configuration, System.currentTimeMillis(), null, executor).join();
+        streamStorePartialMock.setState(SCOPE, completion, State.ACTIVE, null, executor).join();
+
+        WriterMock requestEventWriter = new WriterMock(streamMetadataTask, executor);
+        streamMetadataTask.setRequestEventWriter(requestEventWriter);
+        
+        StreamConfiguration configuration2 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3)).build();
+
+        AssertExtensions.assertFutureThrows("update timedout", 
+                streamMetadataTask.updateStream(SCOPE, completion, configuration2, null),
+                e -> Exceptions.unwrap(e) instanceof TimeoutException);
+
+        ControllerEvent event = requestEventWriter.eventQueue.poll();
+        assertTrue(event instanceof UpdateStreamEvent);
+        VersionedMetadata<StreamConfigurationRecord> configurationRecord = streamStorePartialMock
+                .getConfigurationRecord(SCOPE, completion, null, executor).join();
+        assertTrue(configurationRecord.getObject().isUpdating());
+
+        Map<Long, Long> streamCut = Collections.singletonMap(0L, 0L);
+        AssertExtensions.assertFutureThrows("truncate timedout",
+                streamMetadataTask.truncateStream(SCOPE, completion, streamCut, null),
+                e -> Exceptions.unwrap(e) instanceof TimeoutException);
+
+        event = requestEventWriter.eventQueue.poll();
+        assertTrue(event instanceof TruncateStreamEvent);
+        
+        VersionedMetadata<StreamTruncationRecord> truncationRecord = streamStorePartialMock
+                .getTruncationRecord(SCOPE, completion, null, executor).join();
+        assertTrue(truncationRecord.getObject().isUpdating());
+
+        AssertExtensions.assertFutureThrows("seal timedout",
+                streamMetadataTask.sealStream(SCOPE, completion, null),
+                e -> Exceptions.unwrap(e) instanceof TimeoutException);
+
+        event = requestEventWriter.eventQueue.poll();
+        assertTrue(event instanceof SealStreamEvent);
+        
+        VersionedMetadata<State> state = streamStorePartialMock
+                .getVersionedState(SCOPE, completion, null, executor).join();
+        assertEquals(state.getObject(), State.SEALING);
+
+        streamStorePartialMock.setState(SCOPE, completion, State.SEALED, null, executor).join();
+
+        AssertExtensions.assertFutureThrows("delete timedout",
+                streamMetadataTask.deleteStream(SCOPE, completion, null),
+                e -> Exceptions.unwrap(e) instanceof TimeoutException);
+
+        event = requestEventWriter.eventQueue.poll();
+        assertTrue(event instanceof DeleteStreamEvent);
+    }
+    
     private CompletableFuture<Void> processEvent(WriterMock requestEventWriter) throws InterruptedException {
         ControllerEvent event;
         try {

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,6 @@ swaggerJersey2JaxrsVersion=1.5.22
 slf4jApiVersion=1.7.25
 gradleGitPluginVersion=2.2.0
 k8ClientVersion=8.0.0
-gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
@@ -9,10 +9,15 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.annotations.SerializedName;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.SneakyThrows;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Represents a JWT body for serialization/deserialization purposes.
@@ -20,33 +25,46 @@ import lombok.Setter;
 @Builder
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class JwtBody {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     // See https://tools.ietf.org/html/rfc7519#page-9 for additional details about these fields.
 
     /**
      * The "sub" (for subject) claim of the JWT body.
      */
-    @SerializedName("sub")
+    @JsonProperty("sub")
     private final String subject;
 
     /**
      * The "aud" (for audience) claim of the JWT body.
      */
-    @SerializedName("aud")
+    @JsonProperty("aud")
     private final String audience;
 
     /**
      * The "iat" (for issued at) claim of the JWT body.
      */
-    @SerializedName("iat")
+    @JsonProperty("iat")
     private final Long issuedAtTime;
 
     /**
      * The "exp" (for expiration time) claim of the JWT body. It identifies the time on or after which the JWT must not
      * be accepted for processing. The value represents seconds past 1970-01-01 00:00:00Z.
      */
-    @SerializedName("exp")
+    @JsonProperty("exp")
     private final Long expirationTime;
-}
 
+    @SneakyThrows
+    @Override
+    public String toString() {
+        return MAPPER.writeValueAsString(this);
+    }
+
+    @SneakyThrows
+    public static JwtBody fromJson(String json) {
+        return MAPPER.readValue(json.getBytes(StandardCharsets.UTF_8), JwtBody.class);
+    }
+}

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
@@ -9,8 +9,7 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.Gson;
-
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 
@@ -26,8 +25,8 @@ public class JwtTestUtils {
      * @return a Base64 encoded JSON representing the specified {@code jwtBodyPart}
      */
     public static String toCompact(JwtBody jwtBodyPart) {
-        String json = new Gson().toJson(jwtBodyPart);
-        return Base64.getEncoder().encodeToString(json.getBytes());
+        String json = jwtBodyPart.toString();
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
+++ b/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
@@ -9,31 +9,31 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.Gson;
 import org.junit.Test;
 import java.time.Instant;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JwtBodyTest {
 
     @Test
     public void testSerialize() {
         JwtBody jwtBody = JwtBody.builder()
-                .subject("subject")
+                .subject("testsubject")
                 .audience("segmentstore")
                 .issuedAtTime(Instant.now().getEpochSecond())
                 .expirationTime(Instant.now().plusSeconds(50).getEpochSecond())
                 .build();
-
-        String json = new Gson().toJson(jwtBody);
-        assertNotNull(json);
+        String jwtBodyJson = jwtBody.toString();
+        assertTrue(jwtBodyJson.contains("testsubject"));
+        assertTrue(jwtBodyJson.contains("segmentstore"));
     }
 
     @Test
     public void testDeserialize() {
         String json = "{\"sub\":\"subject\",\"aud\":\"segmentstore\",\"iat\":1569837384,\"exp\":1569837434}";
-        JwtBody jwtBody = new Gson().fromJson(json, JwtBody.class);
+        JwtBody jwtBody = JwtBody.fromJson(json);
 
         assertEquals("subject", jwtBody.getSubject());
         assertEquals("segmentstore", jwtBody.getAudience());


### PR DESCRIPTION
**Change log description**  
Add timeout to workflow completion check and throw timeout exception if the workflow is not finished within that time. 

**Purpose of the change**  
Fixes #4783 

**What the code does**  
StreamMetadataTasks.java `checkDone` method was checked for in a loop indefinitely. Added timeout which will throw the timeout exception to the caller. 
ControllerServiceImpl.java will throw DEADLINE_EXCEEDED response to the client upon receiving timeout exception. 
RetryHelper.java adds a new helper method that terminates the loop if timeout elapses. 

**How to verify it**  
Unit tests added