### PR TITLE
Issue 4811: Replace object-json mapping library for JWT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ project('test:testcommon') {
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'io.netty', name: 'netty-all', version: nettyVersion
         compile group: 'org.apache.curator', name: 'curator-test', version: apacheCuratorVersion, withoutLogger
-        compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+        compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     }
     javadoc {
         dependsOn delombok
@@ -322,17 +322,6 @@ project('segmentstore:storage:impl') {
 }
 
 project ('bindings') {
-    configurations.all {
-        resolutionStrategy {
-            // We need to force this version as dependency, since ':test:testcommon' brings in a newer version of 
-            // this library which conflicts with the older version of this transitive dependency brought in by some 
-            // of the other dependences (HDFS and S3). 
-            // 
-            // Once HDFS and S3 are upgraded to a version that works with Gson version used by the ':test:testcommon' 
-            // sub-project, this configuration should be removed. 
-            force 'com.google.code.gson:gson:2.5'
-        }
-    }
     dependencies {
         // For HDFS
         compile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion, withoutLogger
@@ -349,6 +338,7 @@ project ('bindings') {
         compile project(':common')
         compile project(':segmentstore:storage')
         compile project(':shared:metrics')
+        testCompile project(':test:testcommon')
         testCompile project(path: ':segmentstore:storage', configuration: 'testRuntime')
     }
     javadoc {

--- a/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
+++ b/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
@@ -12,6 +12,8 @@ package io.pravega.common.security;
 import io.pravega.test.common.JwtBody;
 import org.junit.Test;
 
+import java.util.Base64;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -29,8 +31,9 @@ public class JwtUtilsTest {
         //        "aud": "segmentstore",
         //        "iat": 1516239022
         //     }
+        JwtBody jwtBody = JwtBody.builder().subject("1234567890").audience("segmentstore").issuedAtTime(1516239022L).build();
         String token = String.format("%s.%s.%s", "base64-encoded-header",
-                JwtBody.builder().subject("1234567890").audience("segmentstore").issuedAtTime(1516239022L).build(),
+                Base64.getEncoder().encodeToString(jwtBody.toString().getBytes()),
                 "base64-encoded-signature");
 
         assertNull(JwtUtils.extractExpirationTime(token));

--- a/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
+++ b/common/src/test/java/io/pravega/common/security/JwtUtilsTest.java
@@ -12,6 +12,7 @@ package io.pravega.common.security;
 import io.pravega.test.common.JwtBody;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
@@ -33,7 +34,7 @@ public class JwtUtilsTest {
         //     }
         JwtBody jwtBody = JwtBody.builder().subject("1234567890").audience("segmentstore").issuedAtTime(1516239022L).build();
         String token = String.format("%s.%s.%s", "base64-encoded-header",
-                Base64.getEncoder().encodeToString(jwtBody.toString().getBytes()),
+                Base64.getEncoder().encodeToString(jwtBody.toString().getBytes(StandardCharsets.US_ASCII)),
                 "base64-encoded-signature");
 
         assertNull(JwtUtils.extractExpirationTime(token));

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,6 @@ swaggerJersey2JaxrsVersion=1.5.22
 slf4jApiVersion=1.7.25
 gradleGitPluginVersion=2.2.0
 k8ClientVersion=8.0.0
-gsonVersion=2.8.5
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
 
-import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Represents a JWT body for serialization/deserialization purposes.
@@ -27,6 +27,8 @@ import java.io.StringReader;
 @Setter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class JwtBody {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     // See https://tools.ietf.org/html/rfc7519#page-9 for additional details about these fields.
 
@@ -58,13 +60,11 @@ public class JwtBody {
     @SneakyThrows
     @Override
     public String toString() {
-        return new ObjectMapper().writeValueAsString(this);
+        return MAPPER.writeValueAsString(this);
     }
 
     @SneakyThrows
     public static JwtBody fromJson(String json) {
-        try (StringReader jsonReader = new StringReader(json)) {
-            return new ObjectMapper().readValue(jsonReader, JwtBody.class);
-        }
+        return MAPPER.readValue(json.getBytes(StandardCharsets.UTF_8), JwtBody.class);
     }
 }

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
@@ -9,10 +9,14 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.annotations.SerializedName;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.SneakyThrows;
+
+import java.io.StringReader;
 
 /**
  * Represents a JWT body for serialization/deserialization purposes.
@@ -27,26 +31,38 @@ public class JwtBody {
     /**
      * The "sub" (for subject) claim of the JWT body.
      */
-    @SerializedName("sub")
+    @JsonProperty("sub")
     private final String subject;
 
     /**
      * The "aud" (for audience) claim of the JWT body.
      */
-    @SerializedName("aud")
+    @JsonProperty("aud")
     private final String audience;
 
     /**
      * The "iat" (for issued at) claim of the JWT body.
      */
-    @SerializedName("iat")
+    @JsonProperty("iat")
     private final Long issuedAtTime;
 
     /**
      * The "exp" (for expiration time) claim of the JWT body. It identifies the time on or after which the JWT must not
      * be accepted for processing. The value represents seconds past 1970-01-01 00:00:00Z.
      */
-    @SerializedName("exp")
+    @JsonProperty("exp")
     private final Long expirationTime;
-}
 
+    @SneakyThrows
+    @Override
+    public String toString() {
+        return new ObjectMapper().writeValueAsString(this);
+    }
+
+    @SneakyThrows
+    public static JwtBody fromJson(String json) {
+        try (StringReader jsonReader = new StringReader(json)) {
+            return new ObjectMapper().readValue(jsonReader, JwtBody.class);
+        }
+    }
+}

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtBody.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.test.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
@@ -24,6 +25,7 @@ import java.io.StringReader;
 @Builder
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class JwtBody {
 
     // See https://tools.ietf.org/html/rfc7519#page-9 for additional details about these fields.

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
@@ -9,8 +9,6 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.Gson;
-
 import java.time.Instant;
 import java.util.Base64;
 
@@ -26,7 +24,7 @@ public class JwtTestUtils {
      * @return a Base64 encoded JSON representing the specified {@code jwtBodyPart}
      */
     public static String toCompact(JwtBody jwtBodyPart) {
-        String json = new Gson().toJson(jwtBodyPart);
+        String json = jwtBodyPart.toString();
         return Base64.getEncoder().encodeToString(json.getBytes());
     }
 

--- a/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/JwtTestUtils.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.test.common;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 
@@ -25,7 +26,7 @@ public class JwtTestUtils {
      */
     public static String toCompact(JwtBody jwtBodyPart) {
         String json = jwtBodyPart.toString();
-        return Base64.getEncoder().encodeToString(json.getBytes());
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
+++ b/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
@@ -11,20 +11,23 @@ package io.pravega.test.common;
 
 import org.junit.Test;
 import java.time.Instant;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JwtBodyTest {
 
     @Test
     public void testSerialize() {
         JwtBody jwtBody = JwtBody.builder()
-                .subject("subject")
+                .subject("testsubject")
                 .audience("segmentstore")
                 .issuedAtTime(Instant.now().getEpochSecond())
                 .expirationTime(Instant.now().plusSeconds(50).getEpochSecond())
                 .build();
-        assertNotNull(jwtBody.toString());
+        String jwtBodyJson = jwtBody.toString();
+        assertTrue(jwtBodyJson.contains("testsubject"));
+        assertTrue(jwtBodyJson.contains("segmentstore"));
     }
 
     @Test

--- a/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
+++ b/test/testcommon/src/test/java/io/pravega/test/common/JwtBodyTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.test.common;
 
-import com.google.gson.Gson;
 import org.junit.Test;
 import java.time.Instant;
 import static org.junit.Assert.assertEquals;
@@ -25,15 +24,13 @@ public class JwtBodyTest {
                 .issuedAtTime(Instant.now().getEpochSecond())
                 .expirationTime(Instant.now().plusSeconds(50).getEpochSecond())
                 .build();
-
-        String json = new Gson().toJson(jwtBody);
-        assertNotNull(json);
+        assertNotNull(jwtBody.toString());
     }
 
     @Test
     public void testDeserialize() {
         String json = "{\"sub\":\"subject\",\"aud\":\"segmentstore\",\"iat\":1569837384,\"exp\":1569837434}";
-        JwtBody jwtBody = new Gson().fromJson(json, JwtBody.class);
+        JwtBody jwtBody = JwtBody.fromJson(json);
 
         assertEquals("subject", jwtBody.getSubject());
         assertEquals("segmentstore", jwtBody.getAudience());


### PR DESCRIPTION
**Change log description**  
Replaces Gson with Jackson Databind, in order to avoid mysterious version conflicts caused by explicitly added Gson dependency and implicitly brought in transitively by third-party libraries. 

**Purpose of the change**  
Fixes #4811 

**What the code does**  
Replaces usage of Gson with Jackson Databind. 

**How to verify it**  
All unit, integration, and system tests pass. 
