### PR TITLE
Issue 4815: (Bugfix) Ensure TxnFailedException is thrown only if Transaction is not in an open state

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -25,9 +25,9 @@ import io.pravega.client.stream.TxnFailedException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import io.pravega.common.concurrent.Futures;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -126,9 +126,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
             for (SegmentTransaction<Type> tx : inner.values()) {
                 tx.close();
             }
-            final CompletableFuture<Void> future = controller.commitTransaction(stream, writerId, timestamp, txId);
-            getAndHandleExceptions(future, TxnFailedException::new);
-            pinger.stopPing(txId);
+            Futures.getThrowingException(controller.commitTransaction(stream, writerId, timestamp, txId));
             closed.set(true);
         }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -127,6 +127,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
                 tx.close();
             }
             Futures.getThrowingException(controller.commitTransaction(stream, writerId, timestamp, txId));
+            pinger.stopPing(txId);
             closed.set(true);
         }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -246,7 +246,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
             txn.commit();
         } catch (Exception e) {
             assertTrue(e instanceof RetriesExhaustedException && e.getCause() instanceof StatusRuntimeException);
-            // the user retries the commit.
+            // the user retries the commit since the TxnFailedException is not thrown.
             txn.commit();
         }
 


### PR DESCRIPTION
**Change log description**  
Ensure TxnFailedException is thrown only if the Transaction is not in an open state

**Purpose of the change**  
Fixes #4815 

**What the code does**  
Ensure TxnFailedException is thrown only if the Transaction is not in an open state

**How to verify it**  
All the existing and newly added tests should pass
