### PR TITLE
Issue 4813: Rate computation in SegmentAggregates should account for silent period 

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentAggregates.java
@@ -127,7 +127,15 @@ abstract class SegmentAggregates {
                 lastTick = newTick;
                 final long count = currentCount;
                 currentCount = 0;
-                computeDecay(count, (double) Duration.ofMillis(age).toMillis() / 1000.0);
+                long iterations = age / TICK_INTERVAL;
+                // If the age is greater than tick interval, then account for silent periods between last 
+                // reported update and current update by calling the decay function for all silent tick intervals
+                // with event count as 0 for them.
+                for (long i = 0; i < iterations - 1; i++) {
+                    computeDecay(0, (double) TICK_INTERVAL / 1000.0);
+                }
+                double duration = (age - ((iterations - 1) * TICK_INTERVAL)) / 1000.0;
+                computeDecay(count, duration);
             }
 
             return true;


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Calls the delay function for each silent period between two update notifications on segmentaggregates.  

**Purpose of the change**  
#4813 

**What the code does**  
The weighted average rate computation takes the instant rate as events / time between two subsequent update calls. If there is a long delay between the two calls, then it calls the decay function with a small instant rate which effectively decays the rate by a very small factor without accounting for additional decays for silent periods.
So what we do now instead is to take the instant rate as the rate in the latest tick. And all ticks between current update call and the last update call are treated as silent periods and rate is decayed for each of those ticks before applying the current instant rate. 

**How to verify it**  
Unit test added. 