### PR TITLE
Issue 4833: Add explicit JAXB dependencies in binding projects for Java 11+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,11 +329,12 @@ project ('bindings') {
         testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLogger
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
-        // Adding JAXB API and the reference implementation as dependencies here, since they are not available
-        // in newer Java SE versions (11 and newer). In the absence of these, some of transitive dependencies of 
-        // `hadoop-common` will not be found un Java SE 11 and above. 
-        compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
-        compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+        // Adding these dependencies here, since they are not available in newer Java SE versions (11 and newer). 
+        // In the absence of these, some of transitive dependencies of `hadoop-common` will not be found un Java SE 11 
+        // and above. 
+        // compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
+        // compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+        compile group: 'javax.activation', name: 'activation', version: '1.1'
 
         //For Extended S3
         compile group: 'com.emc.ecs', name: 'object-client', version: ecsObjectClientVersion, withoutLogger

--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,12 @@ project ('bindings') {
         testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion, withoutLogger
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
+        // Adding JAXB API and the reference implementation as dependencies here, since they are not available
+        // in newer Java SE versions (11 and newer). In the absence of these, some of transitive dependencies of 
+        // `hadoop-common` will not be found un Java SE 11 and above. 
+        compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
+        compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+
         //For Extended S3
         compile group: 'com.emc.ecs', name: 'object-client', version: ecsObjectClientVersion, withoutLogger
         testCompile group: 'org.gaul', name: 's3proxy', version: '1.5.5'


### PR DESCRIPTION
**Change log description**  
Add JAXB API and reference implementation dependencies to the `bindings` Gradle subproject, so that Pravega can work with HDFS binding in Java 11+. 

See [this](https://github.com/pravega/pravega/issues/4833#issuecomment-636630626) comment for additional details. 

**Purpose of the change**  
Fixes #4833 

**What the code does**  
Adds JAXB API and reference implementation dependencies to the `bindings` Gradle subproject.

**How to verify it**  
All unit, integration, and system tests must pass. In addition, the tests described in [this comment](https://github.com/pravega/pravega/issues/4833#issuecomment-636647055) must work. 
