### PR TITLE
Issue 4817: Improve sealed stream handling of EventStreamWriter and ByteStreamWriter.

### DIFF
--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
@@ -75,8 +75,8 @@ public class ByteStreamClientImpl implements ByteStreamClientFactory {
     @Override
     public ByteStreamWriter createByteStreamWriter(String streamName) {
         StreamSegments segments = Futures.getThrowingException(controller.getCurrentSegments(scope, streamName));
-        Preconditions.checkArgument(segments.getNumberOfSegments() == 0, "Stream is sealed");
-        Preconditions.checkArgument(segments.getNumberOfSegments() == 1, "Stream is configured with more than one segment");
+        Preconditions.checkState(segments.getNumberOfSegments() > 0, "Stream is sealed");
+        Preconditions.checkState(segments.getNumberOfSegments() == 1, "Stream is configured with more than one segment");
         Segment segment = segments.getSegments().iterator().next();
         EventWriterConfig config = EventWriterConfig.builder().build();
         String delegationToken = segments.getDelegationToken();

--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
@@ -75,7 +75,8 @@ public class ByteStreamClientImpl implements ByteStreamClientFactory {
     @Override
     public ByteStreamWriter createByteStreamWriter(String streamName) {
         StreamSegments segments = Futures.getThrowingException(controller.getCurrentSegments(scope, streamName));
-        Preconditions.checkArgument(segments.getSegments().size() == 1, "Stream is configured with more than one segment");
+        Preconditions.checkArgument(segments.getNumberOfSegments() == 0, "Stream is sealed");
+        Preconditions.checkArgument(segments.getNumberOfSegments() == 1, "Stream is configured with more than one segment");
         Segment segment = segments.getSegments().iterator().next();
         EventWriterConfig config = EventWriterConfig.builder().build();
         String delegationToken = segments.getDelegationToken();

--- a/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ControllerImpl.java
@@ -757,7 +757,7 @@ public class ControllerImpl implements Controller {
     public CompletableFuture<StreamSegmentSuccessors> getSuccessors(final StreamCut from) {
         Exceptions.checkNotClosed(closed.get(), this);
         Stream stream = from.asImpl().getStream();
-        long traceId = LoggerHelpers.traceEnter(log, "getSuccessorsFromCut", stream);
+        long traceId = LoggerHelpers.traceEnter(log, "getSuccessors", stream);
 
         return getSegmentsBetweenStreamCuts(from, StreamCut.UNBOUNDED).whenComplete((x, e) -> {
             if (e != null) {
@@ -782,7 +782,7 @@ public class ControllerImpl implements Controller {
             if (e != null) {
                 log.warn("getSegments for {} failed: ", stream.getStreamName(), e);
             }
-            LoggerHelpers.traceLeave(log, "getSuccessors", traceId);
+            LoggerHelpers.traceLeave(log, "getSegments", traceId);
         });
     }
 
@@ -832,6 +832,9 @@ public class ControllerImpl implements Controller {
                      .whenComplete((x, e) -> {
                          if (e != null) {
                              log.warn("getCurrentSegments for {}/{} failed: ", scope, stream, e);
+                         }
+                         if (x.getNumberOfSegments() == 0 ) {
+                             log.warn("getCurrentSegments for {}/{} returned zero segments since the Stream is sealed", scope, stream);
                          }
                          LoggerHelpers.traceLeave(log, "getCurrentSegments", traceId);
                      });

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.stream.impl;
 
+import com.google.common.base.Preconditions;
 import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.segment.impl.Segment;
@@ -102,7 +103,14 @@ public class SegmentSelector {
 
         if (successors == null) {
             return Collections.emptyList();
-        } else {
+        } else if  (successors.getSegmentToPredecessor().isEmpty()) {
+            log.warn("Stream {} is sealed since no successor segments found for segment {} ", sealedSegment.getStream(), sealedSegment);
+            Exception e = new IllegalStateException("Writes cannot proceed since the stream is sealed");
+            removeAllWriters().forEach(pendingEvent -> pendingEvent.getAckFuture()
+                                                                   .completeExceptionally(e));
+            return Collections.emptyList();
+        }
+        else {
             return updateSegmentsUponSealed(successors, sealedSegment, segmentSealedCallback);
         }
     }
@@ -131,9 +139,11 @@ public class SegmentSelector {
     }
 
     @Synchronized
-    private List<PendingEvent> updateSegments(StreamSegments newSteamSegments, Consumer<Segment>
+    private List<PendingEvent> updateSegments(StreamSegments newStreamSegments, Consumer<Segment>
             segmentSealedCallBack) {
-        currentSegments = newSteamSegments;
+        Preconditions.checkState(newStreamSegments.getNumberOfSegments() > 0,
+                "Writers cannot proceed writing since the stream %s is sealed", stream);
+        currentSegments = newStreamSegments;
         createMissingWriters(segmentSealedCallBack);
 
         List<PendingEvent> toResend = new ArrayList<>();

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -103,14 +103,13 @@ public class SegmentSelector {
 
         if (successors == null) {
             return Collections.emptyList();
-        } else if  (successors.getSegmentToPredecessor().isEmpty()) {
+        } else if (successors.getSegmentToPredecessor().isEmpty()) {
             log.warn("Stream {} is sealed since no successor segments found for segment {} ", sealedSegment.getStream(), sealedSegment);
             Exception e = new IllegalStateException("Writes cannot proceed since the stream is sealed");
             removeAllWriters().forEach(pendingEvent -> pendingEvent.getAckFuture()
                                                                    .completeExceptionally(e));
             return Collections.emptyList();
-        }
-        else {
+        } else {
             return updateSegmentsUponSealed(successors, sealedSegment, segmentSealedCallback);
         }
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamSegments.java
@@ -84,6 +84,10 @@ public class StreamSegments {
         }
         return result;
     }
+
+    public int getNumberOfSegments() {
+        return segments.size();
+    }
     
     public StreamSegments withReplacementRange(Segment segment, StreamSegmentsWithPredecessors replacementRanges) {
         SegmentWithRange replacedSegment = findReplacedSegment(segment);

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -95,7 +95,6 @@ public class ClientFactoryTest {
         // setup mocks
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controllerClient, connectionFactory, inFactory, outFactory, condFactory, metaFactory);
         StreamSegments currentSegments = new StreamSegments(new TreeMap<>(), "");
-        SegmentOutputStream outStream = mock(SegmentOutputStream.class);
         when(controllerClient.getCurrentSegments(scope, stream))
                 .thenReturn(CompletableFuture.completedFuture(currentSegments));
 

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -103,7 +103,7 @@ public class ClientFactoryTest {
         EventStreamWriter<String> writer = clientFactory.createEventWriter(stream, new JavaSerializer<String>(), writerConfig);
         assertEquals(writerConfig, writer.getConfig());
     }
-    
+
     @Test
     public void testTxnWriter() {
         ClientFactoryImpl clientFactory = new ClientFactoryImpl("scope", controllerClient, connectionFactory);

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -11,8 +11,16 @@ package io.pravega.client.stream.impl;
 
 
 import io.pravega.client.netty.impl.ConnectionFactory;
+import io.pravega.client.segment.impl.ConditionalOutputStreamFactory;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentInputStreamFactory;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
+import io.pravega.client.segment.impl.SegmentOutputStream;
+import io.pravega.client.segment.impl.SegmentOutputStreamFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
+
+import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import lombok.val;
@@ -22,6 +30,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +44,14 @@ public class ClientFactoryTest {
     private ConnectionFactory connectionFactory;
     @Mock
     private Controller controllerClient;
+    @Mock
+    private SegmentInputStreamFactory inFactory;
+    @Mock
+    private SegmentOutputStreamFactory outFactory;
+    @Mock
+    private ConditionalOutputStreamFactory condFactory;
+    @Mock
+    private SegmentMetadataClientFactory metaFactory;
 
     @Test
     public void testCloseWithExternalController() {
@@ -54,8 +73,29 @@ public class ClientFactoryTest {
         String scope = "scope";
         String stream = "stream1";
         // setup mocks
-        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controllerClient, connectionFactory);
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controllerClient, connectionFactory, inFactory, outFactory, condFactory, metaFactory);
+        NavigableMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        Segment segment = new Segment(scope, stream, 0L);
+        segments.put(1.0, new SegmentWithRange(segment, 0.0, 1.0));
+        StreamSegments currentSegments = new StreamSegments(segments, "");
+        SegmentOutputStream outStream = mock(SegmentOutputStream.class);
+        when(controllerClient.getCurrentSegments(scope, stream))
+                .thenReturn(CompletableFuture.completedFuture(currentSegments));
+        when(outFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outStream);
+
+        EventWriterConfig writerConfig = EventWriterConfig.builder().build();
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(stream, new JavaSerializer<String>(), writerConfig);
+        assertEquals(writerConfig, writer.getConfig());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testEventWriterSealedStream() {
+        String scope = "scope";
+        String stream = "stream1";
+        // setup mocks
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scope, controllerClient, connectionFactory, inFactory, outFactory, condFactory, metaFactory);
         StreamSegments currentSegments = new StreamSegments(new TreeMap<>(), "");
+        SegmentOutputStream outStream = mock(SegmentOutputStream.class);
         when(controllerClient.getCurrentSegments(scope, stream))
                 .thenReturn(CompletableFuture.completedFuture(currentSegments));
 
@@ -63,7 +103,7 @@ public class ClientFactoryTest {
         EventStreamWriter<String> writer = clientFactory.createEventWriter(stream, new JavaSerializer<String>(), writerConfig);
         assertEquals(writerConfig, writer.getConfig());
     }
-
+    
     @Test
     public void testTxnWriter() {
         ClientFactoryImpl clientFactory = new ClientFactoryImpl("scope", controllerClient, connectionFactory);
@@ -73,4 +113,5 @@ public class ClientFactoryTest {
         val txnWriter2 = clientFactory.createTransactionalEventWriter( "stream1", new JavaSerializer<String>(), writerConfig);
         assertEquals(writerConfig, txnWriter2.getConfig());
     }
+    
 }

--- a/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ControllerImplTest.java
@@ -387,6 +387,10 @@ public class ControllerImplTest {
                     responseObserver.onCompleted();
                 } else if (request.getStream().equals("deadline")) {
                     // dont send any response
+                } else if (request.getStream().equals("sealedStream")) {
+                    // empty response if the Stream is sealed.
+                    responseObserver.onNext( SegmentRanges.newBuilder().build());
+                    responseObserver.onCompleted();
                 } else {
                     responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
                 }
@@ -1181,6 +1185,9 @@ public class ControllerImplTest {
 
         streamSegments = controllerClient.getCurrentSegments("scope1", "stream2");
         AssertExtensions.assertFutureThrows("Should throw Exception", streamSegments, throwable -> true);
+
+        streamSegments = controllerClient.getCurrentSegments("scope1", "sealedStream");
+        assertTrue(streamSegments.get().getNumberOfSegments() == 0);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SegmentSelectorTest.java
@@ -228,6 +228,45 @@ public class SegmentSelectorTest {
     }
 
     @Test
+    public void testSealedStream() {
+        final Segment segment0 = new Segment(scope, streamName, 0);
+        final Segment segment1 = new Segment(scope, streamName, 1);
+        final CompletableFuture<Void> writerFuture = new CompletableFuture<>();
+
+        // Setup Mock.
+        SegmentOutputStream s0Writer = Mockito.mock(SegmentOutputStream.class);
+        SegmentOutputStream s1Writer = Mockito.mock(SegmentOutputStream.class);
+        when(s0Writer.getUnackedEventsOnSeal())
+                .thenReturn(ImmutableList.of(PendingEvent.withHeader("0", ByteBuffer.wrap("e".getBytes()), writerFuture)));
+
+        SegmentOutputStreamFactory factory = Mockito.mock(SegmentOutputStreamFactory.class);
+        when(factory.createOutputStreamForSegment(eq(segment0), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), any(DelegationTokenProvider.class)))
+                .thenReturn(s0Writer);
+        when(factory.createOutputStreamForSegment(eq(segment1), ArgumentMatchers.<Consumer<Segment>>any(), any(EventWriterConfig.class), any(DelegationTokenProvider.class)))
+                .thenReturn(s1Writer);
+
+        Controller controller = Mockito.mock(Controller.class);
+        SegmentSelector selector = new SegmentSelector(new StreamImpl(scope, streamName), controller, factory, config,
+                DelegationTokenProviderFactory.createWithEmptyToken());
+        TreeMap<Double, SegmentWithRange> segments = new TreeMap<>();
+        addNewSegment(segments, 0, 0.0, 0.5);
+        addNewSegment(segments, 1, 0.5, 1.0);
+        StreamSegments streamSegments = new StreamSegments(segments, "");
+
+        when(controller.getCurrentSegments(scope, streamName))
+                .thenReturn(CompletableFuture.completedFuture(streamSegments));
+        //trigger refresh.
+        selector.refreshSegmentEventWriters(segmentSealedCallback);
+
+        //simulate controller returning empty result since the stream is sealed..
+        when(controller.getSuccessors(segment0))
+                .thenReturn(CompletableFuture.completedFuture(new StreamSegmentsWithPredecessors(Collections.emptyMap(), "")));
+
+        assertEquals(Collections.emptyList(), selector.refreshSegmentEventWritersUponSealed(segment0, segmentSealedCallback));
+        assertFutureThrows("Writer Future", writerFuture, t -> t instanceof IllegalStateException);
+    }
+
+    @Test
     public void testSegmentRefreshOnSealed() {
         final Segment segment0 = new Segment(scope, streamName, 0);
         final Segment segment1 = new Segment(scope, streamName, computeSegmentId(1, 1));


### PR DESCRIPTION
**Change log description**  
Improve sealed stream handling for EventStreamWriter and ByteStreamWriter.

**Purpose of the change**  
Fixes #4817 

**What the code does**  
- Ensure EventStreamWriter does not attempt to send inflight events if the Controller returns an empty successor segments since the stream is sealed.
- Ensure writes via EventStreamWriter on a sealed stream throws an exception.
- Ensure the creating a ByteStreamWriter and EventStreamWriter on a sealed stream throws an exception.

**How to verify it**  
All the existing and newly added tests should pass