### PR TITLE
Issue 4901: Fix not null check on target param in StreamHelpers#readAll

### DIFF
--- a/common/src/main/java/io/pravega/common/io/StreamHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/StreamHelpers.java
@@ -37,7 +37,7 @@ public final class StreamHelpers {
         Preconditions.checkNotNull(stream, "stream");
         Preconditions.checkNotNull(target, "target");
         Preconditions.checkElementIndex(startOffset, target.length, "startOffset");
-        Exceptions.checkArgument(maxLength >= 0, "maxLength", "maxLength must be a non-negative number.");
+        Exceptions.checkArgument(maxLength >= 0, "maxLength", "must be a non-negative number.");
 
         int totalBytesRead = 0;
         while (totalBytesRead < maxLength) {

--- a/common/src/main/java/io/pravega/common/io/StreamHelpers.java
+++ b/common/src/main/java/io/pravega/common/io/StreamHelpers.java
@@ -35,7 +35,7 @@ public final class StreamHelpers {
      */
     public static int readAll(InputStream stream, byte[] target, int startOffset, int maxLength) throws IOException {
         Preconditions.checkNotNull(stream, "stream");
-        Preconditions.checkNotNull(stream, "target");
+        Preconditions.checkNotNull(target, "target");
         Preconditions.checkElementIndex(startOffset, target.length, "startOffset");
         Exceptions.checkArgument(maxLength >= 0, "maxLength", "maxLength must be a non-negative number.");
 

--- a/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/io/StreamHelpersTests.java
@@ -10,6 +10,7 @@
 package io.pravega.common.io;
 
 import io.pravega.test.common.AssertExtensions;
+import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,6 +67,46 @@ public class StreamHelpersTests {
                 "readAll accepted a length higher than the given input stream length.",
                 () -> StreamHelpers.readAll(new TestInputStream(buffer), buffer.length + 1),
                 ex -> ex instanceof EOFException);
+    }
+
+    /**
+     * Confirm StreamHelpers#readAll throws on null input stream
+     */
+    @Test
+    public void readAllThrowsOnNullInputStream() {
+        AssertExtensions.assertThrows("stream parameter cannot be null",
+                () -> StreamHelpers.readAll(null, null, 0, 0),
+                e -> e instanceof NullPointerException && e.getMessage().equals("stream"));
+    }
+
+    /**
+     * Confirm StreamHelpers#readAll throws on null target byte array
+     */
+    @Test
+    public void readAllThrowsOnNullTargetBuffer() {
+        AssertExtensions.assertThrows("target parameter cannot be null",
+                () -> StreamHelpers.readAll(new ByteArrayInputStream(new byte[0]), null, 0, 0),
+                e -> e instanceof NullPointerException && e.getMessage().equals("target"));
+    }
+
+    /**
+     * Confirm StreamHelpers#readAll throws on illegal offset
+     */
+    @Test
+    public void readAllThrowsOnIllegalOffset() {
+        AssertExtensions.assertThrows("start offset must be less than target buffer length",
+                () -> StreamHelpers.readAll(new ByteArrayInputStream(new byte[0]), new byte[0], 0, 0),
+                e -> e instanceof IndexOutOfBoundsException && e.getMessage().equals("startOffset (0) must be less than size (0)"));
+    }
+
+    /**
+     * Confirm StreamHelpers#readAll throws on illegal max length
+     */
+    @Test
+    public void readAllThrowsOnIllegalMaxLength() throws Exception {
+        AssertExtensions.assertThrows("max length must be non-negative",
+                () -> StreamHelpers.readAll(new ByteArrayInputStream(new byte[0]), new byte[1], 0, -1),
+                e -> e instanceof IllegalArgumentException && e.getMessage().equals("maxLength: must be a non-negative number."));
     }
 
     private static class TestInputStream extends InputStream {

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -120,11 +120,11 @@ public class AssertExtensions {
             Assert.fail(message + " No exception has been thrown.");
         } catch (CompletionException | ExecutionException ex) {
             if (!tester.test(ex.getCause())) {
-                throw new AssertionError(message + " Exception thrown was of unexpected type: " + ex.getCause(), ex);
+                throw new AssertionError(message + " Exception thrown failed tester: " + ex.getCause(), ex);
             }
         } catch (Throwable ex) {
             if (!tester.test(ex)) {
-                throw new AssertionError(message + " Exception thrown was of unexpected type: " + ex, ex);
+                throw new AssertionError(message + " Exception thrown failed tester: " + ex, ex);
             }
         }
     }


### PR DESCRIPTION
**Change log description**  
Not null precondition checks in `StreamHelpers#readAll` were testing the `stream` param twice.

**Purpose of the change**  
To fix a bug where the NPE for null `target` param would be thrown 1 line late with the wrong error message.
Fixes #4901

**What the code does**  
Makes second not null precondition check match its error message. Makes null `target` throw NPE with a better error message.

**How to verify it**  
Negative tests in `StreamHelpers` unit tests were added to confirm the correct exception is thrown when `target` param is left null. Negative tests were implemented for the other preconditions, which resulting in improving exception text for `maxLength` parameter and for `assertThrows` failures.