### PR TITLE
Issue 4875: Modify name resolution strategy of configuration properties for backward compatibility

### DIFF
--- a/common/src/main/java/io/pravega/common/util/TypedProperties.java
+++ b/common/src/main/java/io/pravega/common/util/TypedProperties.java
@@ -11,6 +11,7 @@ package io.pravega.common.util;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Properties;
 import java.util.function.Function;
@@ -29,6 +30,7 @@ import java.util.function.Function;
  * </ul>
  * Indicate that namespace "foo" has Key-Values (key1=value1, key2=value2), and namespace "bar" has (key1=value3, key3=value4).
  */
+@Slf4j
 public class TypedProperties {
     //region Members
     private static final String SEPARATOR = ".";
@@ -132,6 +134,10 @@ public class TypedProperties {
         if (property.hasLegacyName()) {
             // Value of property with old name
             propValue = this.properties.getProperty(propOldName, null);
+            if (propValue != null) {
+                log.warn("Deprecated property name '{}' used. Please use '{}' instead. Support for the old " +
+                        "property name will be removed in a future version of Pravega.", propOldName, propNewName);
+            }
         }
 
         if (propValue == null) {
@@ -139,7 +145,7 @@ public class TypedProperties {
             propValue = this.properties.getProperty(propNewName, null);
         }
 
-        // A property with neither old not new name was defined, so the property value is still null
+        // This property wasn't specified using either new or old name, so the property value is still null
         if (propValue == null) {
             if (property.hasDefaultValue()) {
                 return property.getDefaultValue();

--- a/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
+++ b/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
@@ -98,15 +98,17 @@ public class TypedPropertiesTests {
         assertEquals("configValue", config);
     }
 
+
+
     @Test
-    public void testNewPropertyTakesPrecedenceOverLegacy() {
+    public void testLegacyPropertyTakesPrecedenceOverNewOnesWhenSpecified() {
         Properties props1 = new Properties();
-        props1.setProperty("ns1.newPropertyKey", "configValue");
-        props1.setProperty("ns1.legacyPropertyKey", "configValue");
+        props1.setProperty("ns1.newPropertyKey", "new");
+        props1.setProperty("ns1.legacyPropertyKey", "old");
         TypedProperties typedProps = new TypedProperties(props1, "ns1");
         String config = typedProps.get(Property.named(
                 "newPropertyKey", "default", "legacyPropertyKey"));
-        assertEquals("configValue", config);
+        assertEquals("old", config);
     }
 
     private <T> void testData(Properties props, ExtractorFunction<T> methodToTest, Predicate<String> valueValidator) throws Exception {


### PR DESCRIPTION
**Change log description**  
Modify the name resolution strategy for configuration properties to use legacy names first, for backward compatibility.

**Purpose of the change**  
Resolves #4875. 

**What the code does**  

Previously, the properties were resolved in a way that if a property with a new name was present, it'd override any property specified using the old name. For example, if you specified both `metrics.enableStatistics=true` (old name) and `metrics.statistics.enable=false` (new name), segment store metrics would be `enabled`. These properties may be specified either via properties file (`config.properties`) or Java system properties (say, via the deployment manifest file). 

However, this behavior doesn't work in some cases. For example, Segment Store loads all the properties from `config.properties` as well as the system properties. In the `config.properties` a preconfigured property `metrics.statistics.enable=false` is already set.  So, if you specified the above property as `metrics.enableStatistics=true` in the deployment manifest, the default from `config.properties` file would still apply. That is why segment store metrics were not showing up, as described in issue #4875.  

https://github.com/pravega/pravega/blob/3a0164c0bf584d637f73aeb9991c82cb7fc348f6/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java#L256-L260

Note that this problem was limited to configuration properties that had default values specified in the configuration properties file. 

To ensure that such properties can be overridden properly using old property names, this PR changes the resolution order. So, if you specify `metrics.enableStatistics=true` in the deployment manifest, segment store metrics would be enabled. If you specified it using the new name `metrics.statistics.enable=true`, then too metrics will be enabled. 

**How to verify it**  
All tests, including system tests, must pass. 
