### PR TITLE
Issue 4893: Add Scopes Metrics

### DIFF
--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -308,6 +308,8 @@ public final class StreamMetrics extends AbstractControllerMetrics {
             INSTANCE.get().sealStreamLatency.close();
             INSTANCE.get().updateStreamLatency.close();
             INSTANCE.get().truncateStreamLatency.close();
+            INSTANCE.get().createScopeLatency.close();
+            INSTANCE.get().deleteScopeLatency.close();
             INSTANCE.set(null);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -105,13 +105,11 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     }
 
     /**
-     * This method increments the global and Scope-specific counters of Scope creations and reports the latency of the
-     * operation.
+     * This method increments the global counter of Scope creations and reports the latency of the operation.
      *
-     * @param scope             Scope.
      * @param latency           Latency of the createStream operation.
      */
-    public void createScope(String scope, Duration latency) {
+    public void createScope(Duration latency) {
         DYNAMIC_LOGGER.incCounterValue(CREATE_SCOPE, 1);
         createScopeLatency.reportSuccessValue(latency.toMillis());
     }
@@ -153,13 +151,11 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     }
 
     /**
-     * This method increments the global and Scope-specific counters of Stream deletions and reports the latency of
-     * the operation.
+     * This method increments the global counter of Scope deletions and reports the latency of the operation.
      *
-     * @param scope         Scope.
      * @param latency       Latency of the deleteStream operation.
      */
-    public void deleteScope(String scope, Duration latency) {
+    public void deleteScope(Duration latency) {
         DYNAMIC_LOGGER.incCounterValue(DELETE_SCOPE, 1);
         deleteScopeLatency.reportSuccessValue(latency.toMillis());
     }

--- a/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
+++ b/controller/src/main/java/io/pravega/controller/metrics/StreamMetrics.java
@@ -14,9 +14,15 @@ import io.pravega.shared.metrics.OpStatsLogger;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.pravega.shared.MetricsNames.CREATE_SCOPE;
+import static io.pravega.shared.MetricsNames.CREATE_SCOPE_FAILED;
+import static io.pravega.shared.MetricsNames.CREATE_SCOPE_LATENCY;
 import static io.pravega.shared.MetricsNames.CREATE_STREAM;
 import static io.pravega.shared.MetricsNames.CREATE_STREAM_FAILED;
 import static io.pravega.shared.MetricsNames.CREATE_STREAM_LATENCY;
+import static io.pravega.shared.MetricsNames.DELETE_SCOPE;
+import static io.pravega.shared.MetricsNames.DELETE_SCOPE_FAILED;
+import static io.pravega.shared.MetricsNames.DELETE_SCOPE_LATENCY;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM_FAILED;
 import static io.pravega.shared.MetricsNames.DELETE_STREAM_LATENCY;
@@ -50,12 +56,17 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     private final OpStatsLogger updateStreamLatency;
     private final OpStatsLogger truncateStreamLatency;
 
+    private final OpStatsLogger createScopeLatency;
+    private final OpStatsLogger deleteScopeLatency;
+
     private StreamMetrics() {
         createStreamLatency = STATS_LOGGER.createStats(CREATE_STREAM_LATENCY);
         deleteStreamLatency = STATS_LOGGER.createStats(DELETE_STREAM_LATENCY);
         sealStreamLatency = STATS_LOGGER.createStats(SEAL_STREAM_LATENCY);
         updateStreamLatency = STATS_LOGGER.createStats(UPDATE_STREAM_LATENCY);
         truncateStreamLatency = STATS_LOGGER.createStats(TRUNCATE_STREAM_LATENCY);
+        createScopeLatency = STATS_LOGGER.createStats(CREATE_SCOPE_LATENCY);
+        deleteScopeLatency = STATS_LOGGER.createStats(DELETE_SCOPE_LATENCY);
     }
 
     /**
@@ -94,6 +105,18 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     }
 
     /**
+     * This method increments the global and Scope-specific counters of Scope creations and reports the latency of the
+     * operation.
+     *
+     * @param scope             Scope.
+     * @param latency           Latency of the createStream operation.
+     */
+    public void createScope(String scope, Duration latency) {
+        DYNAMIC_LOGGER.incCounterValue(CREATE_SCOPE, 1);
+        createScopeLatency.reportSuccessValue(latency.toMillis());
+    }
+
+    /**
      * This method increments the global counter of failed Stream creations in the system as well as the failed creation
      * attempts for this specific Stream.
      *
@@ -103,6 +126,17 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     public void createStreamFailed(String scope, String streamName) {
         DYNAMIC_LOGGER.incCounterValue(globalMetricName(CREATE_STREAM_FAILED), 1);
         DYNAMIC_LOGGER.incCounterValue(CREATE_STREAM_FAILED, 1, streamTags(scope, streamName));
+    }
+
+    /**
+     * This method increments the global counter of failed Scope creations in the system as well as the failed creation
+     * attempts for this specific Scope.
+     *
+     * @param scope         Scope.
+     */
+    public void createScopeFailed(String scope) {
+        DYNAMIC_LOGGER.incCounterValue(globalMetricName(CREATE_SCOPE_FAILED), 1);
+        DYNAMIC_LOGGER.incCounterValue(CREATE_SCOPE_FAILED, 1, streamTags(scope, ""));
     }
 
     /**
@@ -119,6 +153,18 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     }
 
     /**
+     * This method increments the global and Scope-specific counters of Stream deletions and reports the latency of
+     * the operation.
+     *
+     * @param scope         Scope.
+     * @param latency       Latency of the deleteStream operation.
+     */
+    public void deleteScope(String scope, Duration latency) {
+        DYNAMIC_LOGGER.incCounterValue(DELETE_SCOPE, 1);
+        deleteScopeLatency.reportSuccessValue(latency.toMillis());
+    }
+
+    /**
      * This method increments the counter of failed Stream deletions in the system as well as the failed deletion
      * attempts for this specific Stream.
      *
@@ -128,6 +174,17 @@ public final class StreamMetrics extends AbstractControllerMetrics {
     public void deleteStreamFailed(String scope, String streamName) {
         DYNAMIC_LOGGER.incCounterValue(globalMetricName(DELETE_STREAM_FAILED), 1);
         DYNAMIC_LOGGER.incCounterValue(DELETE_STREAM_FAILED, 1, streamTags(scope, streamName));
+    }
+
+    /**
+     * This method increments the counter of failed Stream deletions in the system as well as the failed deletion
+     * attempts for this specific Stream.
+     *
+     * @param scope         Scope.
+     */
+    public void deleteScopeFailed(String scope) {
+        DYNAMIC_LOGGER.incCounterValue(globalMetricName(DELETE_SCOPE_FAILED), 1);
+        DYNAMIC_LOGGER.incCounterValue(DELETE_SCOPE_FAILED, 1, streamTags(scope, ""));
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -506,7 +506,7 @@ public class ControllerService {
 
     private CreateScopeStatus reportCreateScopeMetrics(String scope, CreateScopeStatus status, Duration latency) {
         if (status.getStatus().equals(CreateScopeStatus.Status.SUCCESS)) {
-            StreamMetrics.getInstance().createScope(scope, latency);
+            StreamMetrics.getInstance().createScope(latency);
         } else if (status.getStatus().equals(CreateScopeStatus.Status.FAILURE)) {
             StreamMetrics.getInstance().createScopeFailed(scope);
         }
@@ -547,7 +547,7 @@ public class ControllerService {
 
     private DeleteScopeStatus reportDeleteScopeMetrics(String scope, DeleteScopeStatus status, Duration latency) {
         if (status.getStatus().equals(DeleteScopeStatus.Status.SUCCESS)) {
-            StreamMetrics.getInstance().deleteScope(scope, latency);
+            StreamMetrics.getInstance().deleteScope(latency);
         } else if (status.getStatus().equals(DeleteScopeStatus.Status.FAILURE)) {
             StreamMetrics.getInstance().deleteScopeFailed(scope);
         }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
@@ -19,6 +19,7 @@ import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTracker;
 import io.pravega.common.util.Retry;
+import io.pravega.controller.metrics.StreamMetrics;
 import io.pravega.controller.server.ControllerService;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.rpc.auth.GrpcAuthHelper;
@@ -104,7 +105,7 @@ public class IntermittentCnxnFailureTest {
 
         controllerService = new ControllerService(streamStore, bucketStore, streamMetadataTasks,
                 streamTransactionMetadataTasks, segmentHelperMock, executor, null);
-
+        StreamMetrics.initialize();
         controllerService.createScope(SCOPE).get();
     }
 
@@ -116,6 +117,7 @@ public class IntermittentCnxnFailureTest {
         zkClient.close();
         zkServer.close();
         connectionFactory.close();
+        StreamMetrics.reset();
         ExecutorServiceHelpers.shutdown(executor);
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -172,6 +172,14 @@ public final class MetricsNames {
     public static final String THREAD_POOL_ACTIVE_THREADS = PREFIX + "segmentstore.thread_pool.active_threads";  // Histogram
 
     // Metrics in Controller
+    // Scope request counts
+    public static final String CREATE_SCOPE = PREFIX + "controller.scope.created";                           // Counter
+    public static final String CREATE_SCOPE_LATENCY = PREFIX + "controller.scope.created_latency_ms";        // Histogram
+    public static final String CREATE_SCOPE_FAILED = PREFIX + "controller.scope.create_failed";              // Counter and Per-scope Counter
+    public static final String DELETE_SCOPE = PREFIX + "controller.scope.deleted";                           // Counter
+    public static final String DELETE_SCOPE_LATENCY = PREFIX + "controller.scope.deleted_latency_ms";        // Histogram
+    public static final String DELETE_SCOPE_FAILED = PREFIX + "controller.scope.delete_failed";              // Counter and Per-scope Counter
+
     // Stream request counts
     public static final String CREATE_STREAM = PREFIX + "controller.stream.created";                         // Counter
     public static final String CREATE_STREAM_LATENCY = PREFIX + "controller.stream.created_latency_ms";      // Histogram

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -184,10 +184,16 @@ public class StreamMetricsTest {
         StreamMetrics.getInstance().createStreamFailed("failedScope", "failedStream");
         StreamMetrics.getInstance().deleteScopeFailed("failedScope");
         StreamMetrics.getInstance().deleteStreamFailed("failedScope", "failedStream");
+        StreamMetrics.getInstance().updateStreamFailed("failedScope", "failedStream");
+        StreamMetrics.getInstance().truncateStreamFailed("failedScope", "failedStream");
+        StreamMetrics.getInstance().sealStreamFailed("failedScope", "failedStream");
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE_FAILED).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM_FAILED).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.TRUNCATE_STREAM_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.SEAL_STREAM_FAILED).count());
     }
 
     @Test(timeout = 30000)

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -169,6 +169,10 @@ public class StreamMetricsTest {
         assertEquals(2, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE).count());
         assertEquals(7, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM).count());
 
+        // Update the Stream.
+        controllerWrapper.getControllerService().updateStream(scopeName, streamName, StreamConfiguration.builder().build()).get();
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM).count());
+
         // Seal the Stream.
         controllerWrapper.getControllerService().sealStream(scopeName, streamName).get();
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.SEAL_STREAM).count());

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -21,6 +21,7 @@ import io.pravega.client.stream.impl.Controller;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.controller.metrics.StreamMetrics;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
@@ -177,6 +178,16 @@ public class StreamMetricsTest {
         controllerWrapper.getControllerService().deleteScope(scopeName).get();
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE).count());
+
+        // Exercise the metrics for failed stream and scope creation/deletion.
+        StreamMetrics.getInstance().createScopeFailed("failedScope");
+        StreamMetrics.getInstance().createStreamFailed("failedScope", "failedStream");
+        StreamMetrics.getInstance().deleteScopeFailed("failedScope");
+        StreamMetrics.getInstance().deleteStreamFailed("failedScope", "failedStream");
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED).count());
     }
 
     @Test(timeout = 30000)

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -170,8 +170,8 @@ public class StreamMetricsTest {
         assertEquals(7, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM).count());
 
         // Update the Stream.
-        controllerWrapper.getControllerService().updateStream(scopeName, streamName, StreamConfiguration.builder().build()).get();
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM).count());
+        controllerWrapper.getControllerService().updateStream(scopeName, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(10)).build()).get();
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.globalMetricName(MetricsNames.UPDATE_STREAM)).count());
 
         // Seal the Stream.
         controllerWrapper.getControllerService().sealStream(scopeName, streamName).get();


### PR DESCRIPTION
**Change log description**  
Adds metrics for created and deleted scopes.

**Purpose of the change**  
Fixes #4893.

**What the code does**  
This PR extends `StreamMetrics` class to also take care of reporting a couple of new metrics related to scopes creation and deletion.

**How to verify it**  
New test checking that the new metrics (and some former ones) are reported.