### PR TITLE
Issue 4910: Added new metrics to report the distribution of client appends and reads

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -74,6 +74,8 @@ public final class MetricsNames {
     public static final String SEGMENT_DELETE_LATENCY = PREFIX + "segmentstore.segment.delete_latency_ms";              // Histogram
     public static final String SEGMENT_READ_LATENCY = PREFIX + "segmentstore.segment.read_latency_ms";                  // Histogram
     public static final String SEGMENT_WRITE_LATENCY = PREFIX + "segmentstore.segment.write_latency_ms";                // Histogram
+    public static final String SEGMENT_APPEND_SIZE = PREFIX + "segmentstore.segment.append_size";                       // Histogram
+    public static final String SEGMENT_READ_SIZE = PREFIX + "segmentstore.segment.read_size";                           // Histogram
     public static final String SEGMENT_READ_BYTES = PREFIX + "segmentstore.segment.read_bytes";                         // Counter and Per-segment Counter
     public static final String SEGMENT_WRITE_BYTES = PREFIX + "segmentstore.segment.write_bytes";                       // Counter and Per-segment Counter
     public static final String SEGMENT_WRITE_EVENTS = PREFIX + "segmentstore.segment.write_events";                     // Counter and Per-segment Counter


### PR DESCRIPTION
**Change log description**  
Adds two new metrics to report the size distribution of appends and reads.

**Purpose of the change**  
Fixes #4910.

**What the code does**  
This PR adds a couple of `OpStatsLogger` metrics in `SegmentStatsRecorderImpl` to report the size distribution of appends and reads. This information can give us important insights about the kind of writes and reads that Pravega is serving.

**How to verify it**  
All tests should be working as before.
