### PR TITLE
Issue 4925: Unit Test fix for TableMetadataTasksTest in Controller

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -175,15 +175,7 @@ public class TableMetadataTasks implements AutoCloseable {
                                     .thenCompose(x -> eventHelper.checkDone(() -> isDeleted(scope, kvtName)))
                                     .thenApply(y -> DeleteKVTableStatus.Status.SUCCESS);
                         });
-            }), e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor).
-            handle((result, ex) -> {
-                    if (ex != null) {
-                        log.warn(requestId, "Delete kvtable failed due to ", ex);
-                        return DeleteKVTableStatus.Status.FAILURE;
-                    } else {
-                        return result;
-                    }
-                });
+            }), e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor);
     }
 
     public CompletableFuture<Void> deleteSegments(String scope, String kvt, Set<Long> segmentsToDelete,

--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -143,15 +143,7 @@ public class TableMetadataTasks implements AutoCloseable {
                                        return isCreateProcessed(scope, kvtName, kvtConfig, createTimestamp, executor);
                                  });
                             });
-               }, e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor)
-                .handle((result, ex) -> {
-                    if (ex != null) {
-                        log.warn(requestId, "Create kvtable failed due to ", ex);
-                        return CreateKeyValueTableStatus.Status.FAILURE;
-                    } else {
-                        return result;
-                    }
-                });
+               }, e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor);
     }
 
 
@@ -205,7 +197,7 @@ public class TableMetadataTasks implements AutoCloseable {
     }
 
     private CompletableFuture<Boolean> isDeleted(String scope, String kvtName, KVTOperationContext context) {
-        return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, false, null, executor),
+        return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, false, context, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, KVTableState.UNKNOWN)
                 .thenCompose(state -> {
                     if (state.equals(KVTableState.UNKNOWN)) {

--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -143,15 +143,7 @@ public class TableMetadataTasks implements AutoCloseable {
                                        return isCreateProcessed(scope, kvtName, kvtConfig, createTimestamp, executor);
                                  });
                             });
-               }, e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor)
-                .handle((result, ex) -> {
-                    if (ex != null) {
-                        log.warn(requestId, "Create kvtable failed due to ", ex);
-                        return CreateKeyValueTableStatus.Status.FAILURE;
-                    } else {
-                        return result;
-                    }
-                });
+               }, e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor);
     }
 
 
@@ -183,15 +175,7 @@ public class TableMetadataTasks implements AutoCloseable {
                                     .thenCompose(x -> eventHelper.checkDone(() -> isDeleted(scope, kvtName)))
                                     .thenApply(y -> DeleteKVTableStatus.Status.SUCCESS);
                         });
-            }), e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor)
-                .handle((result, ex) -> {
-                    if (ex != null) {
-                        log.warn(requestId, "Delete kvtable failed due to ", ex);
-                        return DeleteKVTableStatus.Status.FAILURE;
-                    } else {
-                        return result;
-                    }
-                });
+            }), e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor);
     }
 
     public CompletableFuture<Void> deleteSegments(String scope, String kvt, Set<Long> segmentsToDelete,
@@ -212,8 +196,7 @@ public class TableMetadataTasks implements AutoCloseable {
                                                 false, delegationToken, requestId), executor));
     }
 
-    @VisibleForTesting
-    protected CompletableFuture<Boolean> isDeleted(String scope, String kvtName) {
+    private CompletableFuture<Boolean> isDeleted(String scope, String kvtName) {
         return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, false, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, KVTableState.UNKNOWN)
                 .thenCompose(state -> {
@@ -240,8 +223,7 @@ public class TableMetadataTasks implements AutoCloseable {
                 });
     }
 
-    @VisibleForTesting
-    protected CompletableFuture<Boolean> isCreated(String scope, String kvtName, Executor executor) {
+    private CompletableFuture<Boolean> isCreated(String scope, String kvtName, Executor executor) {
        return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, true, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, KVTableState.UNKNOWN)
                .thenApply(state -> {

--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -146,7 +146,6 @@ public class TableMetadataTasks implements AutoCloseable {
                }, e -> Exceptions.unwrap(e) instanceof RetryableException, NUM_RETRIES, executor);
     }
 
-
     /**
      * Delete a KeyValueTable.
      *
@@ -268,7 +267,7 @@ public class TableMetadataTasks implements AutoCloseable {
     private CompletableFuture<Void> createNewSegment(String scope, String kvt, long segmentId, String controllerToken,
                                                      long requestId) {
         final String qualifiedTableSegmentName = getQualifiedTableSegmentName(scope, kvt, segmentId);
-        log.info("Creating segment {}", qualifiedTableSegmentName);
+        log.debug("Creating segment {}", qualifiedTableSegmentName);
         return Futures.toVoid(withRetries(() -> segmentHelper.createTableSegment(qualifiedTableSegmentName, controllerToken, requestId, true), executor));
     }
 

--- a/controller/src/test/java/io/pravega/controller/mocks/EventHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventHelperMock.java
@@ -9,14 +9,27 @@
  */
 package io.pravega.controller.mocks;
 
+import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.index.HostIndex;
 import io.pravega.controller.task.EventHelper;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 public class EventHelperMock {
 
     public static EventHelper getEventHelperMock(ScheduledExecutorService executor, String hostId, HostIndex hostIndex) {
         return new EventHelper(executor, hostId, hostIndex);
+    }
+
+    public static EventHelper getFailingEventHelperMock() {
+        EventHelper mockHelper = mock(EventHelper.class);
+        doReturn(Futures.failedFuture(new CompletionException(new RuntimeException()))).when(mockHelper)
+                .addIndexAndSubmitTask(any(), any());
+        return mockHelper;
     }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventHelperMock.java
@@ -9,27 +9,14 @@
  */
 package io.pravega.controller.mocks;
 
-import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.index.HostIndex;
 import io.pravega.controller.task.EventHelper;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 public class EventHelperMock {
 
     public static EventHelper getEventHelperMock(ScheduledExecutorService executor, String hostId, HostIndex hostIndex) {
         return new EventHelper(executor, hostId, hostIndex);
-    }
-
-    public static EventHelper getFailingEventHelperMock() {
-        EventHelper mockHelper = mock(EventHelper.class);
-        doReturn(Futures.failedFuture(new CompletionException(new RuntimeException()))).when(mockHelper)
-                .addIndexAndSubmitTask(any(), any());
-        return mockHelper;
     }
 }

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -178,13 +178,18 @@ public abstract class TableMetadataTasksTest {
                 requestTracker, helper));
 
         creationTime = System.currentTimeMillis();
+        createOperationFuture = kvtTasks.createKeyValueTable(SCOPE, kvtable1, kvtConfig, creationTime);
+        assertEquals(CreateKeyValueTableStatus.Status.FAILURE, createOperationFuture.join());
         AssertExtensions.assertFutureThrows("create timedout",
-                kvtTasks.createKeyValueTable(SCOPE, kvtable1, kvtConfig, creationTime),
+                helper.checkDone(() -> kvtTasks.isCreated(SCOPE, kvtable1, executor)),
                 e -> Exceptions.unwrap(e) instanceof TimeoutException);
 
         // delete KVTable times out
+        CompletableFuture<Controller.DeleteKVTableStatus.Status> deleteOperation =
+        kvtTasks.deleteKeyValueTable(SCOPE, tableName, null);
+        assertEquals(DeleteKVTableStatus.Status.FAILURE, deleteOperation.join());
         AssertExtensions.assertFutureThrows("delete timedout",
-                kvtTasks.deleteKeyValueTable(SCOPE, tableName, null),
+                helper.checkDone(() -> kvtTasks.isDeleted(SCOPE, tableName)),
                 e -> Exceptions.unwrap(e) instanceof TimeoutException);
     }
 

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -15,7 +15,6 @@ import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTracker;
 import io.pravega.controller.metrics.StreamMetrics;
-import io.pravega.controller.mocks.EventHelperMock;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.eventProcessor.requesthandlers.kvtable.CreateTableTask;
 import io.pravega.controller.server.eventProcessor.requesthandlers.kvtable.DeleteTableTask;
@@ -43,7 +42,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-//import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Executors;
@@ -123,14 +121,6 @@ public abstract class TableMetadataTasksTest {
 
         KeyValueTableConfiguration storedConfig = kvtStore.getConfiguration(SCOPE, kvtable1, null, executor).get();
         assertEquals(storedConfig.getPartitionCount(), kvtConfig.getPartitionCount());
-
-        // check retry failures...
-        EventHelper mockHelper = EventHelperMock.getFailingEventHelperMock();
-        TableMetadataTasks kvtFailingMetaTasks = spy(new TableMetadataTasks(kvtStore, segmentHelperMock, executor, executor,
-                "host", GrpcAuthHelper.getDisabledAuthHelper(),
-                requestTracker, mockHelper));
-        CreateKeyValueTableStatus.Status status = kvtFailingMetaTasks.createKeyValueTable(SCOPE, kvtable1, kvtConfig, creationTime).get();
-        assertEquals(CreateKeyValueTableStatus.Status.FAILURE, status);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -10,6 +10,7 @@
 package io.pravega.controller.task.KeyValueTable;
 
 import io.pravega.client.tables.KeyValueTableConfiguration;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTracker;
@@ -33,6 +34,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
 import io.pravega.controller.task.EventHelper;
 import io.pravega.shared.controller.event.ControllerEvent;
 
+import io.pravega.test.common.AssertExtensions;
 import lombok.Data;
 import lombok.Getter;
 
@@ -41,6 +43,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+//import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Executors;
@@ -48,6 +51,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.spy;
@@ -164,68 +168,34 @@ public abstract class TableMetadataTasksTest {
     }
 
     @Test(timeout = 30000)
-    public void testWorkflowCompletionTimeout() {
-        /*
-        EventHelper helper = EventHelperMock.getEventHelperMock(executor, "host", ((AbstractStreamMetadataStore) kvtStorePartialMock).getHostTaskIndex());
+    public void testWorkflowCompletionTimeout() throws Exception {
+        // Create a new KVTable
+        String tableName = "kvtable2";
+        long creationTime = System.currentTimeMillis();
+        KeyValueTableConfiguration kvtConfig = KeyValueTableConfiguration.builder().partitionCount(2).build();
+        CompletableFuture<Controller.CreateKeyValueTableStatus.Status> createOperationFuture
+                = kvtMetadataTasks.createKeyValueTable(SCOPE, tableName, kvtConfig, creationTime);
+        assertTrue(Futures.await(processEvent((TableMetadataTasksTest.WriterMock) requestEventWriter)));
+        assertEquals(CreateKeyValueTableStatus.Status.SUCCESS, createOperationFuture.join());
 
-        StreamMetadataTasks streamMetadataTask = new StreamMetadataTasks(kvtStorePartialMock, bucketStore,
-                TaskStoreFactory.createZKStore(zkClient, executor),
-                SegmentHelperMock.getSegmentHelperMock(), executor, "host",
-                new GrpcAuthHelper(authEnabled, "key", 300), requestTracker, helper);
-        streamMetadataTask.setCompletionTimeoutMillis(500L);
-        StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+        //CreateKVTable times out
+        EventHelper helper = new EventHelper(executor, "host", ((AbstractKVTableMetadataStore) kvtStore).getHostTaskIndex());
+        helper.setCompletionTimeoutMillis(50L);
+        EventStreamWriter<ControllerEvent> eventWriter = new WriterMock();
+        helper.setRequestEventWriter(eventWriter);
+        TableMetadataTasks kvtTasks = spy(new TableMetadataTasks(kvtStore, segmentHelperMock, executor, executor,
+                "host", GrpcAuthHelper.getDisabledAuthHelper(),
+                requestTracker, helper));
 
-        String completion = "completion";
-        kvtStorePartialMock.createStream(SCOPE, completion, configuration, System.currentTimeMillis(), null, executor).join();
-        kvtStorePartialMock.setState(SCOPE, completion, State.ACTIVE, null, executor).join();
-
-        WriterMock requestEventWriter = new WriterMock(streamMetadataTask, executor);
-        streamMetadataTask.setRequestEventWriter(requestEventWriter);
-        
-        StreamConfiguration configuration2 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3)).build();
-
-        AssertExtensions.assertFutureThrows("update timedout", 
-                streamMetadataTask.updateStream(SCOPE, completion, configuration2, null),
+        creationTime = System.currentTimeMillis();
+        AssertExtensions.assertFutureThrows("create timedout",
+                kvtTasks.createKeyValueTable(SCOPE, kvtable1, kvtConfig, creationTime),
                 e -> Exceptions.unwrap(e) instanceof TimeoutException);
 
-        ControllerEvent event = requestEventWriter.eventQueue.poll();
-        assertTrue(event instanceof UpdateStreamEvent);
-        VersionedMetadata<StreamConfigurationRecord> configurationRecord = kvtStorePartialMock
-                .getConfigurationRecord(SCOPE, completion, null, executor).join();
-        assertTrue(configurationRecord.getObject().isUpdating());
-
-        Map<Long, Long> streamCut = Collections.singletonMap(0L, 0L);
-        AssertExtensions.assertFutureThrows("truncate timedout",
-                streamMetadataTask.truncateStream(SCOPE, completion, streamCut, null),
-                e -> Exceptions.unwrap(e) instanceof TimeoutException);
-
-        event = requestEventWriter.eventQueue.poll();
-        assertTrue(event instanceof TruncateStreamEvent);
-        
-        VersionedMetadata<StreamTruncationRecord> truncationRecord = kvtStorePartialMock
-                .getTruncationRecord(SCOPE, completion, null, executor).join();
-        assertTrue(truncationRecord.getObject().isUpdating());
-
-        AssertExtensions.assertFutureThrows("seal timedout",
-                streamMetadataTask.sealStream(SCOPE, completion, null),
-                e -> Exceptions.unwrap(e) instanceof TimeoutException);
-
-        event = requestEventWriter.eventQueue.poll();
-        assertTrue(event instanceof SealStreamEvent);
-        
-        VersionedMetadata<State> state = kvtStorePartialMock
-                .getVersionedState(SCOPE, completion, null, executor).join();
-        assertEquals(state.getObject(), State.SEALING);
-
-        kvtStorePartialMock.setState(SCOPE, completion, State.SEALED, null, executor).join();
-
+        // delete KVTable times out
         AssertExtensions.assertFutureThrows("delete timedout",
-                streamMetadataTask.deleteStream(SCOPE, completion, null),
+                kvtTasks.deleteKeyValueTable(SCOPE, tableName, null),
                 e -> Exceptions.unwrap(e) instanceof TimeoutException);
-
-        event = requestEventWriter.eventQueue.poll();
-        assertTrue(event instanceof DeleteStreamEvent);
-         */
     }
 
     @Data


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
1. Added implementation for test testWorkflowCompletionTimeout() in class "controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java"
which tests the usecase where Create and DeleteAPI events timeout and never complete.

2. Changed the handling for event timeout in CreateAPI to throw the timeout exception so it can be retried till DEADLINE_EXCEEDED. This makes Create and Delete APIs consistent with respect to their event timeout behavior.
Changed necessary tests for this change.

**Purpose of the change**  
Fixes #4925
