### PR TITLE
Issue 4919: Use delomboked source code in javadoc distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1021,12 +1021,14 @@ task javadocs(type: Javadoc) {
     ext.projects = [':client']
     title = "Pravega API"
     destinationDir = file("${buildDir}/javadocs")
-    source = files(projects.collect {
-        project(it).sourceSets.main.allJava
-    })
-    classpath = files(projects.collect {
-        project(it).sourceSets.main.output + project(it).sourceSets.main.compileClasspath
-    })
+
+    projects.collect {
+        dependsOn project(it).delombok
+
+        source += project(it).delombok.outputDir
+        classpath += project(it).sourceSets.main.output + project(it).sourceSets.main.compileClasspath
+    }
+
     failOnError = true
     exclude "**/impl/**"
     options.addBooleanOption("Xdoclint:all,-reference", true)


### PR DESCRIPTION
Signed-off-by: Igor Medvedev <medvedevigorek@gmail.com>

**Change log description**  
Javadoc task for all projects operates on delomboked source code and produces the complete javadoc including methods generated by Lombok. However the same is not true for javadoc distribution, it works on the source code as-is that includes Lombok annotations and produces incomplete javadoc bundle. 

The change is to ensure the javadoc distribution uses delomboked source code. 


**Purpose of the change**  
Fixes #4919 

**What the code does**  
Javadoc distribution task is updated to use delomboked source code for javadoc generation.

**How to verify it**  
Running `javadocDistZip` or `javadocDistTar` tasks would produce a javadoc bundle which would have method generated by Lombok included as well 
