### PR TITLE
Issue 4933: (Key-Value Tables) Enforcing Key and Value serialization limits

### DIFF
--- a/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
+++ b/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
@@ -10,6 +10,7 @@
 package io.pravega.client.tables;
 
 import com.google.common.annotations.Beta;
+import io.pravega.client.tables.impl.TableSegment;
 import io.pravega.common.util.AsyncIterator;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +98,16 @@ import lombok.NonNull;
  */
 @Beta
 public interface KeyValueTable<KeyT, ValueT> extends AutoCloseable {
+    /**
+     * The maximum serialization length of a Table Segment Key.
+     */
+    int MAXIMUM_SERIALIZED_KEY_LENGTH = TableSegment.MAXIMUM_KEY_LENGTH / 2;
+
+    /**
+     * The maximum serialized length of a Table Segment Value.
+     */
+    int MAXIMUM_SERIALIZED_VALUE_LENGTH = TableSegment.MAXIMUM_VALUE_LENGTH;
+
     /**
      * Unconditionally inserts a new or updates an existing Entry in the {@link KeyValueTable}.
      *

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyFamilySerializer.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyFamilySerializer.java
@@ -24,8 +24,17 @@ import org.apache.commons.lang3.SerializationException;
  * Serializer for Key-Value Table Key Families.
  */
 class KeyFamilySerializer {
+    /**
+     * Maximum length for a Key Family serialization using {@link #ENCODING}.
+     * If this value is changed, care must be taken such that the sum of it, {@link #PREFIX_LENGTH} and
+     * {@link TableSegment#MAXIMUM_KEY_LENGTH} do not exceed the server-side limits.
+     */
     @VisibleForTesting
-    static final int MAX_KEY_FAMILY_LENGTH = 1024; // It can't be longer than TableSegment.MAX_KEY_LENGTH
+    static final int MAX_KEY_FAMILY_LENGTH = 2096;
+    /**
+     * A prefix added to every Key Family serialization. This is encoded in the key itself. See
+     * {@link #MAX_KEY_FAMILY_LENGTH} for constraints.
+     */
     @VisibleForTesting
     static final int PREFIX_LENGTH = 2; // [0, 65535]. First 6 bits will be empty.
     @VisibleForTesting

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyFamilySerializer.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyFamilySerializer.java
@@ -30,7 +30,7 @@ class KeyFamilySerializer {
      * {@link TableSegment#MAXIMUM_KEY_LENGTH} do not exceed the server-side limits.
      */
     @VisibleForTesting
-    static final int MAX_KEY_FAMILY_LENGTH = 2096;
+    static final int MAX_KEY_FAMILY_LENGTH = 2048;
     /**
      * A prefix added to every Key Family serialization. This is encoded in the key itself. See
      * {@link #MAX_KEY_FAMILY_LENGTH} for constraints.

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
@@ -371,6 +371,8 @@ public class KeyValueTableImpl<KeyT, ValueT> implements KeyValueTable<KeyT, Valu
     private ByteBuf serializeKey(String keyFamily, KeyT k) {
         ByteBuf keyFamilySerialization = KEY_FAMILY_SERIALIZER.serialize(keyFamily);
         ByteBuf keySerialization = Unpooled.wrappedBuffer(this.keySerializer.serialize(k));
+        Preconditions.checkArgument(keySerialization.readableBytes() <= KeyValueTable.MAXIMUM_SERIALIZED_KEY_LENGTH,
+                "Key Too Long. Expected at most %s, actual %s.", KeyValueTable.MAXIMUM_SERIALIZED_KEY_LENGTH, keySerialization.readableBytes());
         return Unpooled.wrappedBuffer(keyFamilySerialization, keySerialization);
     }
 
@@ -382,7 +384,10 @@ public class KeyValueTableImpl<KeyT, ValueT> implements KeyValueTable<KeyT, Valu
     }
 
     private ByteBuf serializeValue(ValueT v) {
-        return Unpooled.wrappedBuffer(this.valueSerializer.serialize(v));
+        ByteBuf valueSerialization = Unpooled.wrappedBuffer(this.valueSerializer.serialize(v));
+        Preconditions.checkArgument(valueSerialization.readableBytes() <= KeyValueTable.MAXIMUM_SERIALIZED_VALUE_LENGTH,
+                "Value Too Long. Expected at most %s, actual %s.", KeyValueTable.MAXIMUM_SERIALIZED_VALUE_LENGTH, valueSerialization.readableBytes());
+        return valueSerialization;
     }
 
     private ValueT deserializeValue(ByteBuf s) {

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -16,6 +16,7 @@ import io.pravega.client.tables.IteratorItem;
 import io.pravega.client.tables.TableEntry;
 import io.pravega.client.tables.TableKey;
 import io.pravega.common.util.AsyncIterator;
+import io.pravega.shared.protocol.netty.WireCommands;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -56,9 +57,17 @@ public interface TableSegment extends AutoCloseable {
 
     /**
      * The maximum length of a Table Segment Value.
-     * Synchronized with io.pravega.segmentstore.contracts.tables.TableStore.MAXIMUM_VALUE_LENGTH().
+     * Synchronized with io.pravega.segmentstore.contracts.tables.TableStore.MAXIMUM_VALUE_LENGTH.
      */
     int MAXIMUM_VALUE_LENGTH = 1024 * 1024 - MAXIMUM_KEY_LENGTH;
+    /**
+     * Maximum number of Entries that can be updated, removed or retrieved with a single request.
+     */
+    int MAXIMUM_BATCH_KEY_COUNT = 256;
+    /**
+     * Maximum total serialization length of all keys and values for any given request.
+     */
+    int MAXIMUM_BATCH_LENGTH = WireCommands.MAX_WIRECOMMAND_SIZE - 8192;
 
     /**
      * Inserts a new or updates an existing Table Entry into this Table Segment.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -66,6 +66,8 @@ public interface TableSegment extends AutoCloseable {
     int MAXIMUM_BATCH_KEY_COUNT = 256;
     /**
      * Maximum total serialization length of all keys and values for any given request.
+     * See io.pravega.segmentstore.server.host.handler.PravegaRequestProcessor.MAX_TABLE_RESPONSE_SIZE for the server-side
+     * equivalent.
      */
     int MAXIMUM_BATCH_LENGTH = WireCommands.MAX_WIRECOMMAND_SIZE - 8192;
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -66,8 +66,6 @@ public interface TableSegment extends AutoCloseable {
     int MAXIMUM_BATCH_KEY_COUNT = 256;
     /**
      * Maximum total serialization length of all keys and values for any given request.
-     * See io.pravega.segmentstore.server.host.handler.PravegaRequestProcessor.MAX_TABLE_RESPONSE_SIZE for the server-side
-     * equivalent.
      */
     int MAXIMUM_BATCH_LENGTH = WireCommands.MAX_WIRECOMMAND_SIZE - 8192;
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
@@ -159,7 +159,6 @@ class TableSegmentImpl implements TableSegment {
                 final int sliceStart = index;
                 final int sliceLength = Math.min(MAX_GET_KEY_BATCH_SIZE, wireKeys.size() - sliceStart);
                 futures.add(processor.execute(() -> fetchSlice(resultBuilder.slice(sliceStart, sliceStart + sliceLength))));
-                //futures.add(fetchSlice(resultBuilder.slice(index, index + sliceLength)));
                 index += sliceLength;
             }
 

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
@@ -147,6 +147,7 @@ class TableSegmentImpl implements TableSegment {
         // between the client and server dictates that we issue subsequent requests for the remaining keys. This is the
         // only way we can handle such a case since we do not know the size of the entries that are about to be returned
         // and therefore we cannot pre-partition the keys.
+        // TODO: consider optimizing (https://github.com/pravega/pravega/issues/4936).
         return Futures.loop(
                 () -> result.size() < wireKeys.size(),
                 () -> execute((state, requestId) -> {

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
@@ -146,7 +146,7 @@ class TableSegmentImpl implements TableSegment {
         // The server-side will truncate the result if it exceeds the maximum response size. In that case, the contract
         // between the client and server dictates that we issue subsequent requests for the remaining keys. This is the
         // only way we can handle such a case since we do not know the size of the entries that are about to be returned
-        // we we cannot pre-partition the keys.
+        // and therefore we cannot pre-partition the keys.
         return Futures.loop(
                 () -> result.size() < wireKeys.size(),
                 () -> execute((state, requestId) -> {

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableImplTests.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableImplTests.java
@@ -10,6 +10,7 @@
 package io.pravega.client.tables.impl;
 
 import io.pravega.client.admin.KeyValueTableInfo;
+import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.tables.KeyValueTable;
@@ -46,16 +47,22 @@ public class KeyValueTableImplTests extends KeyValueTableTestBase {
         return this.keyValueTable;
     }
 
+    @Override
+    protected <K, V> KeyValueTable<K, V> createKeyValueTable(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+        return new KeyValueTableImpl<>(KVT, this.segmentFactory, this.controller, keySerializer, valueSerializer);
+    }
+
     @Before
     public void setup() throws Exception {
         super.setup();
         this.connectionFactory = new MockConnectionFactoryImpl();
         this.controller = new MockController("localhost", 0, this.connectionFactory, false);
-        this.isScopeCreated = this.controller.createScope(KVT.getScope()).get().booleanValue();
+        boolean isScopeCreated = this.controller.createScope(KVT.getScope()).get().booleanValue();
+        Assert.assertTrue(isScopeCreated);
         this.controller.createKeyValueTable(KVT.getScope(), KVT.getKeyValueTableName(),
                 KeyValueTableConfiguration.builder().partitionCount(getSegmentCount()).build());
         this.segmentFactory = new MockTableSegmentFactory(getSegmentCount(), executorService());
-        this.keyValueTable = new KeyValueTableImpl<>(KVT, this.segmentFactory, this.controller, KEY_SERIALIZER, VALUE_SERIALIZER);
+        this.keyValueTable = createKeyValueTable(KEY_SERIALIZER, VALUE_SERIALIZER);
     }
 
     @After

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableMapImplTests.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableMapImplTests.java
@@ -11,6 +11,7 @@ package io.pravega.client.tables.impl;
 
 import com.google.common.util.concurrent.Runnables;
 import io.pravega.client.admin.KeyValueTableInfo;
+import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.tables.KeyValueTable;
@@ -60,6 +61,11 @@ public class KeyValueTableMapImplTests extends KeyValueTableTestSetup {
         return this.keyValueTable;
     }
 
+    @Override
+    protected <K, V> KeyValueTable<K, V> createKeyValueTable(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+        return new KeyValueTableImpl<>(KVT, this.segmentFactory, this.controller, keySerializer, valueSerializer);
+    }
+
     @Before
     public void setup() throws Exception {
         super.setup();
@@ -69,7 +75,7 @@ public class KeyValueTableMapImplTests extends KeyValueTableTestSetup {
         this.controller.createKeyValueTable(KVT.getScope(), KVT.getKeyValueTableName(),
                 KeyValueTableConfiguration.builder().partitionCount(getSegmentCount()).build());
         this.segmentFactory = new MockTableSegmentFactory(getSegmentCount(), executorService());
-        this.keyValueTable = new KeyValueTableImpl<>(KVT, this.segmentFactory, this.controller, KEY_SERIALIZER, VALUE_SERIALIZER);
+        this.keyValueTable = createKeyValueTable(KEY_SERIALIZER, VALUE_SERIALIZER);
     }
 
     @After

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
@@ -394,7 +394,7 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testLargeEntryBatchRetrieval() {
-        val maxSize = TableSegment.MAXIMUM_BATCH_LENGTH * 8; // Sufficiently large to require multiple requests and throttling.
+        val maxSize = TableSegment.MAXIMUM_BATCH_LENGTH * 5; // Sufficiently large to require multiple requests and throttling.
         val keyFamily = "a";
 
         Function<Integer, byte[]> getValue = keyId -> {

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.tables.impl;
 
+import io.pravega.client.stream.impl.ByteArraySerializer;
 import io.pravega.client.tables.BadKeyVersionException;
 import io.pravega.client.tables.IteratorItem;
 import io.pravega.client.tables.IteratorState;
@@ -18,12 +19,16 @@ import io.pravega.client.tables.TableKey;
 import io.pravega.client.tables.Version;
 import io.pravega.common.util.AsyncIterator;
 import io.pravega.test.common.AssertExtensions;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
@@ -35,8 +40,6 @@ import org.junit.Test;
  * `io.pravega.test.integration.KeyValueTableImplTests` (using real Segment Store and Wire Protocol).
  */
 public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
-    protected boolean isScopeCreated;
-
     /**
      * Tests the ability to perform single-key conditional insertions. These methods are exercised:
      * - {@link KeyValueTable#putIfAbsent}
@@ -44,7 +47,6 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testSingleKeyConditionalInserts() {
-        Assert.assertTrue(isScopeCreated);
         val versions = new Versions();
         @Cleanup
         val kvt = createKeyValueTable();
@@ -77,7 +79,6 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testSingleKeyUpdates() {
-        Assert.assertTrue(isScopeCreated);
         val versions = new Versions();
         @Cleanup
         val kvt = createKeyValueTable();
@@ -124,7 +125,6 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testSingleKeyUnconditionalRemovals() {
-        Assert.assertTrue(isScopeCreated);
         val versions = new Versions();
         @Cleanup
         val kvt = createKeyValueTable();
@@ -189,7 +189,6 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testMultiKeyOperations() {
-        Assert.assertTrue(isScopeCreated);
         val versions = new Versions();
         @Cleanup
         val kvt = createKeyValueTable();
@@ -301,9 +300,105 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
         checkValues(iteration.get(), versions, kvt);
     }
 
+    /**
+     * Verifies that overflowing (larger than limit) {@link TableEntry} instances are rejected.
+     */
+    @Test
+    public void testLargeKeyValueUpdates() {
+        val rnd = new Random(0);
+        val limitKey = new byte[KeyValueTable.MAXIMUM_SERIALIZED_KEY_LENGTH];
+        val limitValue = new byte[KeyValueTable.MAXIMUM_SERIALIZED_VALUE_LENGTH];
+        rnd.nextBytes(limitKey);
+        rnd.nextBytes(limitValue);
+        @Cleanup
+        val kvt = createKeyValueTable(new ByteArraySerializer(), new ByteArraySerializer());
+        kvt.put(null, limitKey, limitValue).join();
+        val resultValue = kvt.get(null, limitKey).join().getValue();
+        Assert.assertArrayEquals("Unexpected value returned (no key family).", limitValue, resultValue);
+
+        kvt.put("abc", limitKey, limitValue).join();
+        val resultValue2 = kvt.get("abc", limitKey).join().getValue();
+        Assert.assertArrayEquals("Unexpected value returned (with key family).", limitValue, resultValue);
+
+        // Max Key Length exceeded.
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expected a rejection of a key that is too long.",
+                () -> kvt.put(null, new byte[limitKey.length + 1], limitValue),
+                ex -> ex instanceof IllegalArgumentException);
+
+        // Max Value Length exceeded.
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expected a rejection of a value that is too long.",
+                () -> kvt.put(null, limitKey, new byte[limitValue.length + 1]),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    /**
+     * Verifies that overflowing a single {@link TableSegment} limits are rejected. No batch updates, removals or retrievals
+     * may exceed the {@link TableSegment#MAXIMUM_BATCH_KEY_COUNT} or {@link TableSegment#MAXIMUM_BATCH_LENGTH} limits.
+     */
+    @Test
+    public void testLargeBatchUpdates() {
+        val rnd = new Random(0);
+
+        @Cleanup
+        val kvt = createKeyValueTable(new ByteArraySerializer(), new ByteArraySerializer());
+
+        // Exceeding by batch count.
+        val getBatchCountExceeded = IntStream.range(0, TableSegment.MAXIMUM_BATCH_KEY_COUNT + 1)
+                .mapToObj(i -> new byte[]{(byte) i})
+                .collect(Collectors.toList());
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Get batch exceeded max count.",
+                () -> kvt.getAll("a", getBatchCountExceeded),
+                ex -> ex instanceof IllegalArgumentException);
+
+        val putBatchCountExceeded = getBatchCountExceeded.stream()
+                .map(a -> (Map.Entry<byte[], byte[]>) new AbstractMap.SimpleImmutableEntry<>(a, a))
+                .collect(Collectors.toList());
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Put batch exceeded max count.",
+                () -> kvt.putAll("a", putBatchCountExceeded),
+                ex -> ex instanceof IllegalArgumentException);
+
+        val removeBatchCountExceeded = getBatchCountExceeded.stream().map(TableKey::unversioned).collect(Collectors.toList());
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Remove batch exceeded max count.",
+                () -> kvt.removeAll("a", removeBatchCountExceeded),
+                ex -> ex instanceof IllegalArgumentException);
+
+        // Exceed by serialization size.
+        // It is impossible to exceed the serialization size for retrievals or removals (due to the max key constraint),
+        // so the only request we can verify is the update one.
+        val limitValue = new byte[KeyValueTable.MAXIMUM_SERIALIZED_VALUE_LENGTH];
+        rnd.nextBytes(limitValue);
+        val putBatchSizeExceeded = new ArrayList<Map.Entry<byte[], byte[]>>();
+        int estimatedSize = 0;
+        while (estimatedSize < TableSegment.MAXIMUM_BATCH_LENGTH) {
+            val k = new byte[KeyValueTable.MAXIMUM_SERIALIZED_KEY_LENGTH];
+            rnd.nextBytes(k);
+            val e = new AbstractMap.SimpleImmutableEntry<>(k, limitValue);
+            putBatchSizeExceeded.add(e);
+            estimatedSize += e.getKey().length + e.getValue().length;
+        }
+
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Put batch exceeded max size.",
+                () -> kvt.putAll("a", putBatchSizeExceeded),
+                ex -> ex instanceof IllegalArgumentException);
+    }
+
+    /**
+     * Verify that multi-get retrieval from a single segment of keys totalling more than the limit(s) works correctly.
+     */
+    @Test
+    public void testLargeEntryBatchRetrieval() {
+        // TODO
+
+    }
+
     @Test
     public void testIterators() {
-        Assert.assertTrue(isScopeCreated);
         @Cleanup
         val kvt = createKeyValueTable();
         val iteration = new AtomicInteger(0);

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
@@ -394,7 +394,7 @@ public abstract class KeyValueTableTestBase extends KeyValueTableTestSetup {
      */
     @Test
     public void testLargeEntryBatchRetrieval() {
-        val maxSize = TableSegment.MAXIMUM_BATCH_LENGTH * 4; // Sufficiently large to require multiple requests.
+        val maxSize = TableSegment.MAXIMUM_BATCH_LENGTH * 8; // Sufficiently large to require multiple requests and throttling.
         val keyFamily = "a";
 
         Function<Integer, byte[]> getValue = keyId -> {

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestSetup.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestSetup.java
@@ -60,6 +60,8 @@ abstract class KeyValueTableTestSetup extends LeakDetectorTestSuite {
 
     protected abstract KeyValueTable<Integer, String> createKeyValueTable();
 
+    protected abstract <K, V> KeyValueTable<K, V> createKeyValueTable(Serializer<K> keySerializer, Serializer<V> valueSerializer);
+
     protected int getKeyFamilyCount() {
         return DEFAULT_KEY_FAMILY_COUNT;
     }
@@ -73,7 +75,7 @@ abstract class KeyValueTableTestSetup extends LeakDetectorTestSuite {
     }
 
     private int getKeysWithoutKeyFamily() {
-        return getKeyFamilyCount() * getKeysPerKeyFamily();
+        return Math.min(TableSegment.MAXIMUM_BATCH_KEY_COUNT, getKeyFamilyCount() * getKeysPerKeyFamily());
     }
 
     protected void forEveryKey(BiConsumer<String, Integer> handler) {

--- a/client/src/test/java/io/pravega/client/tables/impl/MockTableSegmentFactory.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/MockTableSegmentFactory.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.tables.impl;
 
+import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.tables.BadKeyVersionException;
@@ -119,12 +120,16 @@ class MockTableSegmentFactory implements TableSegmentFactory {
                     Exceptions.checkNotClosed(this.closed, this);
                     val result = new ArrayList<TableSegmentKeyVersion>();
                     val toUpdate = new HashMap<ByteBuf, EntryValue>();
+                    AtomicInteger serializationLength = new AtomicInteger();
                     entries.forEachRemaining(e -> {
                         checkVersion(e.getKey());
+                        checkLengths(e);
+                        serializationLength.addAndGet(e.getKey().getKey().readableBytes() + e.getValue().readableBytes());
                         long version = this.nextVersion.getAndIncrement();
                         toUpdate.put(e.getKey().getKey().copy(), new EntryValue(e.getValue().copy(), version));
                         result.add(TableSegmentKeyVersion.from(version));
                     });
+                    checkBatchSize(result.size(), serializationLength.get());
                     this.data.putAll(toUpdate);
                     return result;
                 }
@@ -137,10 +142,13 @@ class MockTableSegmentFactory implements TableSegmentFactory {
                 synchronized (this.data) {
                     Exceptions.checkNotClosed(this.closed, this);
                     val toRemove = new ArrayList<ByteBuf>();
+                    AtomicInteger serializationLength = new AtomicInteger();
                     keys.forEachRemaining(k -> {
                         checkVersion(k);
+                        serializationLength.addAndGet(k.getKey().readableBytes());
                         toRemove.add(k.getKey());
                     });
+                    checkBatchSize(toRemove.size(), serializationLength.get());
                     toRemove.forEach(this.data::remove);
                 }
             }, this.executorService);
@@ -152,13 +160,16 @@ class MockTableSegmentFactory implements TableSegmentFactory {
                 synchronized (this.data) {
                     Exceptions.checkNotClosed(this.closed, this);
                     val result = new ArrayList<TableSegmentEntry>();
+                    AtomicInteger serializationLength = new AtomicInteger();
                     keys.forEachRemaining(k -> {
+                        serializationLength.addAndGet(k.readableBytes());
                         EntryValue ev = this.data.getOrDefault(k, null);
                         TableSegmentEntry e = ev == null
                                 ? null
                                 : TableSegmentEntry.versioned(k.copy(), ev.value.copy(), ev.version);
                         result.add(e);
                     });
+                    checkBatchSize(result.size(), serializationLength.get());
                     return result;
                 }
             }, this.executorService);
@@ -233,6 +244,18 @@ class MockTableSegmentFactory implements TableSegmentFactory {
                     }
                 }
             }
+        }
+
+        private void checkLengths(TableSegmentEntry e) {
+            Preconditions.checkArgument(e.getKey().getKey().readableBytes() <= TableSegment.MAXIMUM_KEY_LENGTH, "Key too long.");
+            Preconditions.checkArgument(e.getValue().readableBytes() <= TableSegment.MAXIMUM_VALUE_LENGTH, "Value too long.");
+        }
+
+        private void checkBatchSize(int count, int serializationLength) {
+            Preconditions.checkArgument(count <= TableSegment.MAXIMUM_BATCH_KEY_COUNT,
+                    "Too many items. Expected at most %s, actual %s.", TableSegment.MAXIMUM_BATCH_KEY_COUNT, count);
+            Preconditions.checkArgument(serializationLength <= TableSegment.MAXIMUM_BATCH_LENGTH,
+                    "Batch serialization too big. Expected at most %s, actual %s.", TableSegment.MAXIMUM_BATCH_LENGTH, serializationLength);
         }
 
         @RequiredArgsConstructor

--- a/client/src/test/java/io/pravega/client/tables/impl/TableSegmentImplTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/TableSegmentImplTest.java
@@ -11,6 +11,7 @@ package io.pravega.client.tables.impl;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.pravega.auth.AuthenticationException;
@@ -37,9 +38,11 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -55,6 +58,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -168,32 +172,48 @@ public class TableSegmentImplTest extends ThreadPooledTestSuite {
      * Connection reset failures are not tested here; they're checked in {@link #testReconnect()}.
      */
     @Test
-    public void testGetTruncated() throws Exception {
-        val requestKeys = Arrays.asList(100L, 200L, 300L, 400L, 500L);
-        val expectedEntries = Arrays.asList(
-                versionedEntry(requestKeys.get(0), "one hundred", 1L),
-                versionedEntry(requestKeys.get(1), "two hundred", 2L),
-                versionedEntry(requestKeys.get(2), "three hundred", 3L),
-                versionedEntry(requestKeys.get(3), "four hundred", 3L),
-                null); // This key does not exist.
+    public void testGetALotOfKeys() throws Exception {
+        val expectedBatchKeyLength = 15; // Manual calculation of TableSegmentImpl.MAX_GET_KEY_BATCH_SIZE.
+        val requestKeys = LongStream.range(0, 61).mapToObj(l -> l * 100).collect(Collectors.toList());
+        val expectedEntries = requestKeys.stream().map(key -> versionedEntry(key, key.toString(), key)).collect(Collectors.toList());
+        expectedEntries.set(expectedEntries.size() - 1, null); // This key does not exist.
         val expectedWireKeys = toWireKeys(requestKeys.stream().map(this::buf).map(TableSegmentKey::unversioned).collect(Collectors.toList()));
+
+        // Calculate the expected sent/receive ranges.
+        val expectedRanges = new ArrayList<Map.Entry<Integer, Integer>>(); // Key: Start Index, Value: End Index.
+        int idx = 0;
+        while (idx < expectedEntries.size()) {
+            val expectedLength = Math.min(expectedBatchKeyLength, expectedEntries.size() - idx);
+            expectedRanges.add(new AbstractMap.SimpleImmutableEntry<>(idx, idx + expectedLength));
+            idx += expectedLength;
+        }
 
         @Cleanup
         val context = new TestContext();
 
-        // Successful operation.
+        // Initiate a get request.
         val getResult = context.segment.get(requestKeys.stream().map(this::buf).iterator());
-        for (int i = 0; i < expectedEntries.size(); i++) {
-            val expectedSentKeys = expectedWireKeys.subList(i, expectedWireKeys.size());
-            val wireCommand = (WireCommands.ReadTable) context.getConnection().getLastSentWireCommand();
+
+        // Capture all the requests sent over the wire and verify that we've sent as many as we expected to.
+        val sentWireCommands = context.getConnection().getLastSentWireCommands(expectedRanges.size());
+        Assert.assertEquals(expectedRanges.size(), sentWireCommands.size());
+
+        // Validate the sent keys and send appropriate responses.
+        for (int i = 0; i < expectedRanges.size(); i++) {
+            int rangeStart = expectedRanges.get(i).getKey();
+            int rangeEnd = expectedRanges.get(i).getValue();
+
+            val expectedSentKeys = expectedWireKeys.subList(rangeStart, rangeEnd);
+            val wireCommand = (WireCommands.ReadTable) sentWireCommands.get(i);
             checkWireCommand(expectedSentKeys, wireCommand.getKeys());
 
-            val returnedKeys = Collections.singletonList(requestKeys.get(i));
-            val returnedEntries = Collections.singletonList(expectedEntries.get(i));
+            val returnedKeys = requestKeys.subList(rangeStart, rangeEnd);
+            val returnedEntries = expectedEntries.subList(rangeStart, rangeEnd);
             val replyWireEntries = toWireEntries(returnedEntries, returnedKeys);
-            context.sendReply(new WireCommands.TableRead(context.getConnection().getLastRequestId(), SEGMENT.getScopedName(), replyWireEntries));
+            context.sendReply(new WireCommands.TableRead(wireCommand.getRequestId(), SEGMENT.getScopedName(), replyWireEntries));
         }
 
+        // Validate final result.
         val actualEntries = getResult.get(SHORT_TIMEOUT, TimeUnit.MILLISECONDS);
         AssertExtensions.assertListEquals("Unexpected return value", expectedEntries, actualEntries, this::entryEquals);
     }
@@ -631,12 +651,24 @@ public class TableSegmentImplTest extends ThreadPooledTestSuite {
         private final Runnable onClose;
         @Getter
         private long lastRequestId;
-        @Getter
-        private WireCommand lastSentWireCommand;
+        private final Deque<WireCommand> lastSentWireCommands = new ArrayDeque<>();
         @Setter
         private boolean failed = false;
         @Getter
         private boolean closed = false;
+
+        public WireCommand getLastSentWireCommand() {
+            return this.lastSentWireCommands.isEmpty() ? null : this.lastSentWireCommands.peekLast();
+        }
+
+        public List<WireCommand> getLastSentWireCommands(int count) {
+            val result = new ArrayList<WireCommand>();
+            val it = this.lastSentWireCommands.descendingIterator();
+            while (count > 0 && it.hasNext()) {
+                result.add(it.next());
+            }
+            return Lists.reverse(result);
+        }
 
         @Override
         public void close() {
@@ -653,7 +685,7 @@ public class TableSegmentImplTest extends ThreadPooledTestSuite {
             }
 
             this.lastRequestId = ((Request) cmd).getRequestId();
-            this.lastSentWireCommand = cmd;
+            this.lastSentWireCommands.addLast(cmd);
             if (this.failed) {
                 callback.complete(new ConnectionFailedException());
             }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -191,13 +191,13 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         final int readSize = min(MAX_READ_SIZE, max(TYPE_PLUS_LENGTH_SIZE, readSegment.getSuggestedLength()));
         long trace = LoggerHelpers.traceEnter(log, operation, readSegment);
         segmentStore.read(segment, readSegment.getOffset(), readSize, TIMEOUT)
-                .thenAccept(readResult -> {
-                    LoggerHelpers.traceLeave(log, operation, trace, readResult);
-                    handleReadResult(readSegment, readResult);
-                    this.statsRecorder.readComplete(timer.getElapsed());
-                })
-                .exceptionally(ex -> handleException(readSegment.getRequestId(), segment, readSegment.getOffset(), operation,
-                        wrapCancellationException(ex)));
+                    .thenAccept(readResult -> {
+                        LoggerHelpers.traceLeave(log, operation, trace, readResult);
+                        handleReadResult(readSegment, readResult);
+                        this.statsRecorder.readComplete(timer.getElapsed());
+                    })
+                    .exceptionally(ex -> handleException(readSegment.getRequestId(), segment, readSegment.getOffset(), operation,
+                                                         wrapCancellationException(ex)));
     }
 
     private boolean verifyToken(String segment, long requestId, String delegationToken, String operation) {
@@ -240,9 +240,9 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             segmentStore.getStreamSegmentInfo(segment, TIMEOUT)
                     .thenAccept(info ->
                             connection.send(new SegmentIsTruncated(request.getRequestId(), segment,
-                                    info.getStartOffset(), EMPTY_STACK_TRACE, nonCachedEntry.getStreamSegmentOffset())))
+                                                                   info.getStartOffset(), EMPTY_STACK_TRACE, nonCachedEntry.getStreamSegmentOffset())))
                     .exceptionally(e -> handleException(request.getRequestId(), segment, nonCachedEntry.getStreamSegmentOffset(), operation,
-                            wrapCancellationException(e)));
+                                                        wrapCancellationException(e)));
         } else {
             Preconditions.checkState(nonCachedEntry != null, "No ReadResultEntries returned from read!?");
             nonCachedEntry.requestContent(TIMEOUT);
@@ -261,16 +261,16 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                             // to make a read. In that case, send the appropriate error back.
                             final String clientReplyStackTrace = replyWithStackTraceOnError ? e.getMessage() : EMPTY_STACK_TRACE;
                             connection.send(new SegmentIsTruncated(request.getRequestId(), segment,
-                                    nonCachedEntry.getStreamSegmentOffset(), clientReplyStackTrace,
-                                    nonCachedEntry.getStreamSegmentOffset()));
+                                                                   nonCachedEntry.getStreamSegmentOffset(), clientReplyStackTrace,
+                                                                   nonCachedEntry.getStreamSegmentOffset()));
                         } else {
                             handleException(request.getRequestId(), segment, nonCachedEntry.getStreamSegmentOffset(), operation,
-                                    wrapCancellationException(e));
+                                            wrapCancellationException(e));
                         }
                         return null;
                     })
                     .exceptionally(e -> handleException(request.getRequestId(), segment, nonCachedEntry.getStreamSegmentOffset(), operation,
-                            wrapCancellationException(e)));
+                                                        wrapCancellationException(e)));
         }
     }
 
@@ -341,23 +341,23 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         long trace = LoggerHelpers.traceEnter(log, operation, updateSegmentAttribute);
         val update = new AttributeUpdate(attributeId, AttributeUpdateType.ReplaceIfEquals, newValue, expectedValue);
         segmentStore.updateAttributes(segmentName, Collections.singletonList(update), TIMEOUT)
-                .whenComplete((v, e) -> {
-                    LoggerHelpers.traceLeave(log, operation, trace, e);
-                    final Consumer<Throwable> failureHandler = t -> {
-                        log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segmentName, "handling result of " + operation, t);
-                        connection.close();
-                    };
-                    if (e == null) {
-                        invokeSafely(connection::send, new SegmentAttributeUpdated(requestId, true), failureHandler);
-                    } else {
-                        if (Exceptions.unwrap(e) instanceof BadAttributeUpdateException) {
-                            log.debug("Updating segment attribute {} failed due to: {}", update, e.getMessage());
-                            invokeSafely(connection::send, new SegmentAttributeUpdated(requestId, false), failureHandler);
+                    .whenComplete((v, e) -> {
+                        LoggerHelpers.traceLeave(log, operation, trace, e);
+                        final Consumer<Throwable> failureHandler = t -> {
+                            log.error(requestId, "Error (Segment = '{}', Operation = '{}')", segmentName, "handling result of " + operation, t);
+                            connection.close();
+                        };
+                        if (e == null) {
+                            invokeSafely(connection::send, new SegmentAttributeUpdated(requestId, true), failureHandler);
                         } else {
-                            handleException(requestId, segmentName, operation, e);
+                            if (Exceptions.unwrap(e) instanceof BadAttributeUpdateException) {
+                                log.debug("Updating segment attribute {} failed due to: {}", update, e.getMessage());
+                                invokeSafely(connection::send, new SegmentAttributeUpdated(requestId, false), failureHandler);
+                            } else {
+                                handleException(requestId, segmentName, operation, e);
+                            }
                         }
-                    }
-                });
+                    });
     }
 
     @Override
@@ -425,14 +425,14 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 new AttributeUpdate(CREATION_TIME, AttributeUpdateType.None, System.currentTimeMillis())
         );
 
-        if (!verifyToken(createStreamSegment.getSegment(), createStreamSegment.getRequestId(), createStreamSegment.getDelegationToken(), operation)) {
+       if (!verifyToken(createStreamSegment.getSegment(), createStreamSegment.getRequestId(), createStreamSegment.getDelegationToken(), operation)) {
             return;
-        }
+       }
 
-        log.info(createStreamSegment.getRequestId(), "Creating stream segment {}.", createStreamSegment);
-        segmentStore.createStreamSegment(createStreamSegment.getSegment(), attributes, TIMEOUT)
-                .thenAccept(v -> connection.send(new SegmentCreated(createStreamSegment.getRequestId(), createStreamSegment.getSegment())))
-                .whenComplete((res, e) -> {
+       log.info(createStreamSegment.getRequestId(), "Creating stream segment {}.", createStreamSegment);
+       segmentStore.createStreamSegment(createStreamSegment.getSegment(), attributes, TIMEOUT)
+                   .thenAccept(v -> connection.send(new SegmentCreated(createStreamSegment.getRequestId(), createStreamSegment.getSegment())))
+                   .whenComplete((res, e) -> {
                     if (e == null) {
                         statsRecorder.createSegment(createStreamSegment.getSegment(),
                                 createStreamSegment.getScaleType(), createStreamSegment.getTargetRate(), timer.getElapsed());
@@ -452,29 +452,29 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         log.info(mergeSegments.getRequestId(), "Merging Segments {} ", mergeSegments);
         segmentStore.mergeStreamSegment(mergeSegments.getTarget(), mergeSegments.getSource(), TIMEOUT)
-                .thenAccept(mergeResult -> {
-                    recordStatForTransaction(mergeResult, mergeSegments.getTarget());
-                    connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
-                            mergeSegments.getTarget(),
-                            mergeSegments.getSource(),
-                            mergeResult.getTargetSegmentLength()));
-                })
-                .exceptionally(e -> {
-                    if (Exceptions.unwrap(e) instanceof StreamSegmentMergedException) {
-                        log.info(mergeSegments.getRequestId(), "Stream segment is already merged '{}'.",
-                                mergeSegments.getSource());
-                        segmentStore.getStreamSegmentInfo(mergeSegments.getTarget(), TIMEOUT)
-                                .thenAccept(properties -> {
-                                    connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
-                                            mergeSegments.getTarget(),
-                                            mergeSegments.getSource(),
-                                            properties.getLength()));
-                                });
-                        return null;
-                    } else {
-                        return handleException(mergeSegments.getRequestId(), mergeSegments.getSource(), operation, e);
-                    }
-                });
+                    .thenAccept(mergeResult -> {
+                        recordStatForTransaction(mergeResult, mergeSegments.getTarget());
+                        connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
+                                                                        mergeSegments.getTarget(),
+                                                                        mergeSegments.getSource(),
+                                                                        mergeResult.getTargetSegmentLength()));
+                    })
+                    .exceptionally(e -> {
+                        if (Exceptions.unwrap(e) instanceof StreamSegmentMergedException) {
+                            log.info(mergeSegments.getRequestId(), "Stream segment is already merged '{}'.",
+                                    mergeSegments.getSource());
+                            segmentStore.getStreamSegmentInfo(mergeSegments.getTarget(), TIMEOUT)
+                                        .thenAccept(properties -> {
+                                            connection.send(new WireCommands.SegmentsMerged(mergeSegments.getRequestId(),
+                                                                                            mergeSegments.getTarget(),
+                                                                                            mergeSegments.getSource(),
+                                                                                            properties.getLength()));
+                                        });
+                            return null;
+                        } else {
+                            return handleException(mergeSegments.getRequestId(), mergeSegments.getSource(), operation, e);
+                        }
+                    });
     }
 
     @Override
@@ -570,11 +570,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         log.info(createTableSegment.getRequestId(), "Creating table segment {}.", createTableSegment);
         val timer = new Timer();
         tableStore.createSegment(createTableSegment.getSegment(), createTableSegment.isSorted(), TIMEOUT)
-                .thenAccept(v -> {
-                    connection.send(new SegmentCreated(createTableSegment.getRequestId(), createTableSegment.getSegment()));
-                    this.tableStatsRecorder.createTableSegment(createTableSegment.getSegment(), timer.getElapsed());
-                })
-                .exceptionally(e -> handleException(createTableSegment.getRequestId(), createTableSegment.getSegment(), operation, e));
+                  .thenAccept(v -> {
+                      connection.send(new SegmentCreated(createTableSegment.getRequestId(), createTableSegment.getSegment()));
+                      this.tableStatsRecorder.createTableSegment(createTableSegment.getSegment(), timer.getElapsed());
+                  })
+                  .exceptionally(e -> handleException(createTableSegment.getRequestId(), createTableSegment.getSegment(), operation, e));
     }
 
     @Override
@@ -589,11 +589,11 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         log.info(deleteTableSegment.getRequestId(), "Deleting table segment {}.", deleteTableSegment);
         val timer = new Timer();
         tableStore.deleteSegment(segment, deleteTableSegment.isMustBeEmpty(), TIMEOUT)
-                .thenRun(() -> {
-                    connection.send(new SegmentDeleted(deleteTableSegment.getRequestId(), segment));
-                    this.tableStatsRecorder.deleteTableSegment(segment, timer.getElapsed());
-                })
-                .exceptionally(e -> handleException(deleteTableSegment.getRequestId(), segment, operation, e));
+                  .thenRun(() -> {
+                      connection.send(new SegmentDeleted(deleteTableSegment.getRequestId(), segment));
+                      this.tableStatsRecorder.deleteTableSegment(segment, timer.getElapsed());
+                  })
+                  .exceptionally(e -> handleException(deleteTableSegment.getRequestId(), segment, operation, e));
     }
 
     @Override
@@ -606,10 +606,10 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         log.info(mergeTableSegments.getRequestId(), "Merging table segments {}.", mergeTableSegments);
         tableStore.merge(mergeTableSegments.getTarget(), mergeTableSegments.getSource(), TIMEOUT)
-                .thenRun(() -> connection.send(new WireCommands.SegmentsMerged(mergeTableSegments.getRequestId(),
-                        mergeTableSegments.getTarget(),
-                        mergeTableSegments.getSource(), -1)))
-                .exceptionally(e -> handleException(mergeTableSegments.getRequestId(), mergeTableSegments.getSource(), operation, e));
+                  .thenRun(() -> connection.send(new WireCommands.SegmentsMerged(mergeTableSegments.getRequestId(),
+                                                                                 mergeTableSegments.getTarget(),
+                                                                                 mergeTableSegments.getSource(), -1)))
+                  .exceptionally(e -> handleException(mergeTableSegments.getRequestId(), mergeTableSegments.getSource(), operation, e));
     }
 
     @Override
@@ -623,8 +623,8 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         log.info(sealTableSegment.getRequestId(), "Sealing table segment {}.", sealTableSegment);
         tableStore.seal(segment, TIMEOUT)
-                .thenRun(() -> connection.send(new SegmentSealed(sealTableSegment.getRequestId(), segment)))
-                .exceptionally(e -> handleException(sealTableSegment.getRequestId(), segment, operation, e));
+                  .thenRun(() -> connection.send(new SegmentSealed(sealTableSegment.getRequestId(), segment)))
+                  .exceptionally(e -> handleException(sealTableSegment.getRequestId(), segment, operation, e));
     }
 
     @Override
@@ -817,21 +817,21 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         Preconditions.checkArgument(resultEntries.size() == inputKeys.size(), "Number of input keys should match result entry count.");
         final List<Map.Entry<WireCommands.TableKey, WireCommands.TableValue>> entries =
                 IntStream.range(0, resultEntries.size())
-                        .mapToObj(i -> {
-                            TableEntry resultTableEntry = resultEntries.get(i);
-                            if (resultTableEntry == null) { // no entry for key at index i.
-                                BufferView k = inputKeys.get(i); // key for which the read result was null.
-                                val keyWireCommand = new WireCommands.TableKey(toByteBuf(k), TableKey.NOT_EXISTS);
-                                return new AbstractMap.SimpleImmutableEntry<>(keyWireCommand, WireCommands.TableValue.EMPTY);
-                            } else {
-                                TableEntry te = resultEntries.get(i);
-                                TableKey k = te.getKey();
-                                val keyWireCommand = new WireCommands.TableKey(toByteBuf(k.getKey()), k.getVersion());
-                                val valueWireCommand = new WireCommands.TableValue(toByteBuf(te.getValue()));
-                                return new AbstractMap.SimpleImmutableEntry<>(keyWireCommand, valueWireCommand);
+                         .mapToObj(i -> {
+                             TableEntry resultTableEntry = resultEntries.get(i);
+                             if (resultTableEntry == null) { // no entry for key at index i.
+                                 BufferView k = inputKeys.get(i); // key for which the read result was null.
+                                 val keyWireCommand = new WireCommands.TableKey(toByteBuf(k), TableKey.NOT_EXISTS);
+                                 return new AbstractMap.SimpleImmutableEntry<>(keyWireCommand, WireCommands.TableValue.EMPTY);
+                             } else {
+                                 TableEntry te = resultEntries.get(i);
+                                 TableKey k = te.getKey();
+                                 val keyWireCommand = new WireCommands.TableKey(toByteBuf(k.getKey()), k.getVersion());
+                                 val valueWireCommand = new WireCommands.TableValue(toByteBuf(te.getValue()));
+                                 return new AbstractMap.SimpleImmutableEntry<>(keyWireCommand, valueWireCommand);
 
-                            }
-                        }).collect(toList());
+                             }
+                         }).collect(toList());
 
         return new WireCommands.TableEntries(entries);
     }
@@ -859,21 +859,21 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
 
         if (u instanceof StreamSegmentExistsException) {
             log.info(requestId, "Segment '{}' already exists and cannot perform operation '{}'.",
-                    segment, operation);
+                     segment, operation);
             invokeSafely(connection::send, new SegmentAlreadyExists(requestId, segment, clientReplyStackTrace), failureHandler);
 
         } else if (u instanceof StreamSegmentNotExistsException) {
             log.warn(requestId, "Segment '{}' does not exist and cannot perform operation '{}'.",
-                    segment, operation);
+                     segment, operation);
             invokeSafely(connection::send, new NoSuchSegment(requestId, segment, clientReplyStackTrace, offset), failureHandler);
         } else if (u instanceof StreamSegmentSealedException) {
             log.info(requestId, "Segment '{}' is sealed and cannot perform operation '{}'.",
-                    segment, operation);
+                     segment, operation);
             invokeSafely(connection::send, new SegmentIsSealed(requestId, segment, clientReplyStackTrace, offset), failureHandler);
         } else if (u instanceof ContainerNotFoundException) {
             int containerId = ((ContainerNotFoundException) u).getContainerId();
             log.warn(requestId, "Wrong host. Segment = '{}' (Container {}) is not owned. Operation = '{}').",
-                    segment, containerId, operation);
+                     segment, containerId, operation);
             invokeSafely(connection::send, new WrongHost(requestId, segment, "", clientReplyStackTrace), failureHandler);
         } else if (u instanceof ReadCancellationException) {
             log.info(requestId, "Sending empty response on connection {} while reading segment {} due to CancellationException.",
@@ -898,7 +898,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             BadOffsetException badOffset = (BadOffsetException) u;
             log.info(requestId, "Segment '{}' is truncated and cannot perform operation '{}' at offset '{}'", segment, operation, offset);
             invokeSafely(connection::send, new SegmentIsTruncated(requestId, segment, badOffset.getExpectedOffset(),
-                    clientReplyStackTrace, offset), failureHandler);
+                                                                  clientReplyStackTrace, offset), failureHandler);
         } else if (u instanceof TableSegmentNotEmptyException) {
             log.warn(requestId, "Table segment '{}' is not empty to perform '{}'.", segment, operation);
             invokeSafely(connection::send, new TableSegmentNotEmpty(requestId, segment, clientReplyStackTrace), failureHandler);
@@ -929,7 +929,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         try {
             if (mergeResult != null &&
                     mergeResult.getAttributes().containsKey(Attributes.CREATION_TIME) &&
-                    mergeResult.getAttributes().containsKey(Attributes.EVENT_COUNT)) {
+                            mergeResult.getAttributes().containsKey(Attributes.EVENT_COUNT)) {
                 long creationTime = mergeResult.getAttributes().get(Attributes.CREATION_TIME);
                 int numOfEvents = mergeResult.getAttributes().get(Attributes.EVENT_COUNT).intValue();
                 long len = mergeResult.getMergedDataLength();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -718,7 +718,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         tableStore.get(segment, keys, TIMEOUT)
                 .thenAccept(values -> {
                     // NOTE: getTableEntriesCommand will truncate the result to prevent it from exceeding MAX_TABLE_RESPONSE_SIZE.
-                    // In such a situation, not all requested will be returned to the caller; only the head of the list will.
+                    // In such a situation, not all requested items will be returned to the caller; only the head of the list will.
                     WireCommands.TableEntries response = getTableEntriesCommand(readTable.getRequestId(), keys, values);
                     connection.send(new WireCommands.TableRead(readTable.getRequestId(), segment, response));
                     this.tableStatsRecorder.getKeys(readTable.getSegment(), response.getEntries().size(), timer.getElapsed());

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -719,6 +719,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                 .thenAccept(values -> {
                     // NOTE: getTableEntriesCommand will truncate the result to prevent it from exceeding MAX_TABLE_RESPONSE_SIZE.
                     // In such a situation, not all requested items will be returned to the caller; only the head of the list will.
+                    // TODO: consider optimizing (https://github.com/pravega/pravega/issues/4936).
                     WireCommands.TableEntries response = getTableEntriesCommand(readTable.getRequestId(), keys, values);
                     connection.send(new WireCommands.TableRead(readTable.getRequestId(), segment, response));
                     this.tableStatsRecorder.getKeys(readTable.getSegment(), response.getEntries().size(), timer.getElapsed());

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -411,7 +411,7 @@ public class PravegaRequestProcessorTest {
         processor.mergeSegments(new WireCommands.MergeSegments(requestId, streamSegmentName, transactionName, ""));
 
         order.verify(connection).send(new WireCommands.NoSuchSegment(requestId, NameUtils.getTransactionNameFromId(streamSegmentName,
-                txnid), "", -1L));
+                                                                                                                       txnid), "", -1L));
     }
 
     @Test(timeout = 20000)
@@ -617,11 +617,11 @@ public class PravegaRequestProcessorTest {
         PravegaRequestProcessor processor = new PravegaRequestProcessor(store, tableStore, connection);
 
         assertThrows("seal() is implemented.",
-                () -> processor.sealTableSegment(new WireCommands.SealTableSegment(1, streamSegmentName, "")),
-                ex -> ex instanceof UnsupportedOperationException);
+                     () -> processor.sealTableSegment(new WireCommands.SealTableSegment(1, streamSegmentName, "")),
+                     ex -> ex instanceof UnsupportedOperationException);
         assertThrows("merge() is implemented.",
-                () -> processor.mergeTableSegments(new WireCommands.MergeTableSegments(1, streamSegmentName, streamSegmentName, "")),
-                ex -> ex instanceof UnsupportedOperationException);
+                     () -> processor.mergeTableSegments(new WireCommands.MergeTableSegments(1, streamSegmentName, streamSegmentName, "")),
+                     ex -> ex instanceof UnsupportedOperationException);
     }
 
     @Test(timeout = 20000)
@@ -810,8 +810,8 @@ public class PravegaRequestProcessorTest {
         WireCommands.TableKey keyResponse = new WireCommands.TableKey(toByteBuf(entry.getKey().getKey()),
                 WireCommands.TableKey.NOT_EXISTS);
         order.verify(connection).send(new WireCommands.TableRead(2, tableSegmentName,
-                new WireCommands.TableEntries(
-                        singletonList(new AbstractMap.SimpleImmutableEntry<>(keyResponse, WireCommands.TableValue.EMPTY)))));
+                                                                 new WireCommands.TableEntries(
+                                                                         singletonList(new AbstractMap.SimpleImmutableEntry<>(keyResponse, WireCommands.TableValue.EMPTY)))));
         recorderMockOrder.verify(recorderMock).getKeys(eq(tableSegmentName), eq(1), any());
 
         // Update a value to a key.
@@ -824,7 +824,7 @@ public class PravegaRequestProcessorTest {
         TableEntry expectedEntry = TableEntry.versioned(entry.getKey().getKey(), entry.getValue(), 0L);
         processor.readTable(new WireCommands.ReadTable(4, tableSegmentName, "", singletonList(key)));
         order.verify(connection).send(new WireCommands.TableRead(4, tableSegmentName,
-                getTableEntries(singletonList(expectedEntry))));
+                                                                 getTableEntries(singletonList(expectedEntry))));
         recorderMockOrder.verify(recorderMock).getKeys(eq(tableSegmentName), eq(1), any());
     }
 


### PR DESCRIPTION
**Change log description**  
- Enforcing the maximum Key Length, maximum Value Length and maximum Key Family Length for all KeyValueTable operations.
    - Max Key Length is 4KB, Max Value Length is 1MB-1KB, Max Key Family Length is 2KB.
- Ensuring no KeyValueTable wire command exceeds the maximum wire command size.

**Purpose of the change**  
Fixes #4933.

**What the code does**  
- KeyValueTable
    - Exposed constants that define the maximum key length and maximum value length
    - Exposed a constant that defines the maximum number of items that can be updated, removed or retrieved at any given time.
    - Exposed a constant that defines the maximum serialization size for any multi-key operations (even though each key and value are subject to their own constraints, we enforce that a batch of these will not exceed pre-set limits).
        - This value is required so that we do not exceed the maximum Wire Command size and inherently the Netty frame size.
- TableSegment
    - If a Get request exceeds a predefined number of keys (calculated to around 15, which ensures that no response exceeds the max wire command size), then that get request is split into non-overlapping sub-requests (of at most 15 keys) and issued in parallel to the Segment Store.
    - The requests are "throttled" on the client side by ensuring no more than 5 concurrent calls per request can execute at any given time. 
    - The response is compiled and returned to the upstream code as if no split happened.
- OrderedProcessor
    - Renamed from OrderedItemProcessor and moved to a new package (where it belongs)
    - Since this was no longer used by anything else, I repurposed it to the needs of the TableSegmentImpl, by simplifying its behavior.
    - It now acts as a simple "capacity limiter" that only allows a certain number of tasks to execute concurrently and queues the rest.

**How to verify it**  
All unit and integration tests must pass. New tests have been added to verify these limits and new TableSegmentImpl.get behavior.
