### PR TITLE
Issue 4962: (SegmentStore) Enabling Netty Paranoid Leak Detection if needed

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -168,6 +168,11 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 # information to clients, which may raise security concerns.
 #pravegaservice.request.replyWithStackTraceOnError.enable=false
 
+# Whether to enable PARANOID Netty ByteBuf Leak detection.
+# Recommended values: false for production environments.
+# WARNING: Setting to 'true' may have server performance effects. Only enable for debugging purposes only.
+#pravegaservice.netty.leakDetection.enable=false
+
 ##endregion
 
 ##region AutoScaler Settings

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ServiceStarterTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ServiceStarterTest.java
@@ -9,9 +9,12 @@
  */
 package io.pravega.segmentstore.server.host;
 
+import io.netty.util.ResourceLeakDetector;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
 import io.pravega.test.common.TestingServerStarter;
+import lombok.Cleanup;
+import lombok.val;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
@@ -22,37 +25,62 @@ import org.junit.Test;
 import java.io.IOException;
 
 public class ServiceStarterTest {
-
+    private ServiceBuilderConfig.Builder defaultConfigBuilder;
     private String zkUrl;
     private TestingServer zkTestServer;
+    private ResourceLeakDetector.Level originalLevel;
 
     @Before
-    public void startZookeeper() throws Exception {
+    public void setUp() throws Exception {
+        originalLevel = ResourceLeakDetector.getLevel();
         zkTestServer = new TestingServerStarter().start();
         zkUrl = zkTestServer.getConnectString();
+        defaultConfigBuilder = ServiceBuilderConfig
+                .builder()
+                .include(ServiceConfig.builder()
+                        .with(ServiceConfig.CONTAINER_COUNT, 1)
+                        .with(ServiceConfig.ZK_URL, zkUrl));
     }
 
     @After
-    public void stopZookeeper() throws IOException {
+    public void tearDown() throws IOException {
+        ResourceLeakDetector.setLevel(originalLevel);
         zkTestServer.close();
+    }
+
+    private ServiceBuilderConfig.Builder getDefaultConfigBuilder() {
+        return this.defaultConfigBuilder.makeCopy();
     }
 
     /**
      * Check that the client created by ServiceStarter can correctly connect to a Zookeeper server using the custom
      * Zookeeper client factory.
-     *
-     * @throws Exception
      */
     @Test
     public void testCuratorClientCreation() throws Exception {
-        ServiceBuilderConfig.Builder configBuilder = ServiceBuilderConfig
-                .builder()
-                .include(ServiceConfig.builder()
-                        .with(ServiceConfig.CONTAINER_COUNT, 1)
-                        .with(ServiceConfig.ZK_URL, zkUrl));
-        ServiceStarter serviceStarter = new ServiceStarter(configBuilder.build());
+        ServiceStarter serviceStarter = new ServiceStarter(getDefaultConfigBuilder().build());
         CuratorFramework zkClient = serviceStarter.createZKClient();
         zkClient.blockUntilConnected();
         Assert.assertTrue(zkClient.getZookeeperClient().isConnected());
+    }
+
+    /**
+     * Tests {@link ServiceStarter#start()} and {@link ServiceStarter#shutdown()}.
+     */
+    @Test
+    public void testStartShutdown() throws Exception {
+        val config = getDefaultConfigBuilder()
+                .include(ServiceConfig.builder().with(ServiceConfig.NETTY_LEAK_DETECTION_ENABLED, true))
+                .build();
+
+        @Cleanup("shutdown")
+        ServiceStarter serviceStarter = new ServiceStarter(config);
+        serviceStarter.start();
+        val levelStarted = ResourceLeakDetector.getLevel();
+        Assert.assertEquals("Unexpected ResourceLeakDetector.Level when running.", ResourceLeakDetector.Level.PARANOID, levelStarted);
+
+        serviceStarter.shutdown();
+        val levelShutdown = ResourceLeakDetector.getLevel();
+        Assert.assertEquals("Unexpected ResourceLeakDetector.Level when shutdown.", originalLevel, levelShutdown);
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -59,6 +59,7 @@ public class ServiceConfig {
     public static final Property<Integer> CACHE_POLICY_MAX_TIME = Property.named("cache.time.seconds.max", 30 * 60, "cacheMaxTimeSeconds");
     public static final Property<Integer> CACHE_POLICY_GENERATION_TIME = Property.named("cache.generation.duration.seconds", 1, "cacheGenerationTimeSeconds");
     public static final Property<Boolean> REPLY_WITH_STACK_TRACE_ON_ERROR = Property.named("request.replyWithStackTraceOnError.enable", false, "replyWithStackTraceOnError");
+    public static final Property<Boolean> NETTY_LEAK_DETECTION_ENABLED = Property.named("netty.leakDetection.enable", false);
     public static final Property<String> INSTANCE_ID = Property.named("instance.id", "");
 
     // TLS-related config for the service
@@ -278,6 +279,12 @@ public class ServiceConfig {
     private final boolean replyWithStackTraceOnError;
 
     /**
+     * Whether to enable {@link io.netty.util.ResourceLeakDetector}.
+     */
+    @Getter
+    private final boolean nettyLeakDetectionEnabled;
+
+    /**
      * Gets a value that uniquely identifies the Service. This is useful if multiple Service Instances share the same
      * log files or during testing, when multiple Service Instances run in the same process. This value will be prefixed
      * to the names of all Threads used by this Service Instance, which should make log parsing easier.
@@ -347,6 +354,7 @@ public class ServiceConfig {
         this.cachePolicy = new CachePolicy(cachePolicyMaxSize, cachePolicyTargetUtilization, cachePolicyMaxUtilization,
                 Duration.ofSeconds(cachePolicyMaxTime), Duration.ofSeconds(cachePolicyGenerationTime));
         this.replyWithStackTraceOnError = properties.getBoolean(REPLY_WITH_STACK_TRACE_ON_ERROR);
+        this.nettyLeakDetectionEnabled = properties.getBoolean(NETTY_LEAK_DETECTION_ENABLED);
         this.instanceId = properties.get(INSTANCE_ID);
     }
 


### PR DESCRIPTION
**Change log description**  
Added a setting to enable Netty Paranoid Leak Detection. Disabled by default.

**Purpose of the change**  
Fixes #4962.

**What the code does**  
Added `pravegaservice.netty.leakDetection.enable` config value that enables aggressive Netty ByteBuf leak detection. If enabled, sets the mode to PARANOID.

**How to verify it**  
Build must pass. If any leak detections do occur as a result of this, they should be addressed in a separate PR.
