### PR TITLE
Issue 4977: Add Actions CI for Gradle, Codecov, Java 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,12 +13,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    #strategy:
-    #  matrix:
-    #    #java: [8, 11, 14]
-    #    java: [8]
+    strategy:
+      matrix:
+        java: [8, 11, 14]
 
-    name: Java 8 #${{ matrix.java }}
+    name: Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -28,20 +27,43 @@ jobs:
           .gradle
           ~/.gradle
           ~/.m2
-        key: gradle-m2-java-8 #${{ matrix.java }}
+        key: gradle-m2-java-${{ matrix.java }}
         restore-keys: |
           gradle-m2-java-
           gradle-m2
-    - name: Set up JDK 8 #${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
-        java-version: 8 #${{ matrix.java }}
+        java-version: ${{ matrix.java }}
     - name: Assemble with Gradle
       run: ./gradlew assemble
+    - name: Javadoc with Gradle
+      run: ./gradlew javadocs
+
+  test:
+
+    needs: build
+    runs-on: ubuntu-latest
+
+    name: Test on Java 8
+    steps:
+    - uses: actions/checkout@v1
+    - name: Restore local Gradle & Maven cache
+      uses: actions/cache@v2.1.0
+      with:
+        path: |
+          .gradle
+          ~/.gradle
+          ~/.m2
+        key: gradle-m2-java-8
+        restore-keys: |
+          gradle-m2-java-
+          gradle-m2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
     - name: Check with Gradle
       run: ./gradlew check
     - name: Codecov
-      #if: ${{ matrix.java == 8 }}
       uses: codecov/codecov-action@v1.0.12
-    - name: Javadoc with Gradle
-      run: ./gradlew javadocs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Java 11
     steps:
@@ -42,7 +42,7 @@ jobs:
   test:
 
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Tests on Java 11
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 14]
+        java: [11, 14]
 
     name: Java ${{ matrix.java }}
     steps:
@@ -45,7 +45,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
-    name: Test on Java 8
+    name: Test on Java 11
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -55,14 +55,14 @@ jobs:
           .gradle
           ~/.gradle
           ~/.m2
-        key: gradle-m2-java-8
+        key: gradle-m2-java-11
         restore-keys: |
           gradle-m2-java-
           gradle-m2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - name: Check with Gradle
       run: ./gradlew check
     - name: Codecov

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,8 +34,6 @@ jobs:
 #        java-version: 11
     - name: Assemble with Gradle
       run: ./gradlew assemble --parallel
-    - name: Javadoc with Gradle
-      run: ./gradlew javadocs
     - name: Rat, Checkstyle & Spotbugs with Gradle
       run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,10 +28,10 @@ jobs:
         restore-keys: |
           gradle-m2-java-
           gradle-m2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
+#    - name: Set up JDK 11
+#      uses: actions/setup-java@v1
+#      with:
+#        java-version: 11
     - name: Assemble with Gradle
       run: ./gradlew assemble
     - name: Javadoc with Gradle
@@ -58,10 +58,10 @@ jobs:
         restore-keys: |
           gradle-m2-java-
           gradle-m2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
+#    - name: Set up JDK 11
+#      uses: actions/setup-java@v1
+#      with:
+#        java-version: 11
     - name: Unit tests with Gradle
       run: ./gradlew test --exclude-task test:integration:test
     - name: Codecov

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,13 +39,15 @@ jobs:
       run: ./gradlew assemble
     - name: Javadoc with Gradle
       run: ./gradlew javadocs
+    - name: Rat, Checkstyle & Spotbugs with Gradle
+      run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest
 
-  test:
+  unit:
 
     needs: build
     runs-on: ubuntu-latest
 
-    name: Test on Java 11
+    name: Unit Tests on Java 11
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -63,7 +65,35 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Check with Gradle
-      run: ./gradlew check
+    - name: Unit tests with Gradle
+      run: ./gradlew test --exclude-task test:integration:test
     - name: Codecov
-      uses: codecov/codecov-action@v1.0.12
+      uses: codecov/codecov-action@v1.0.15
+
+  integration:
+
+    needs: build
+    runs-on: ubuntu-latest
+
+    name: Integration Tests on Java 11
+    steps:
+    - uses: actions/checkout@v1
+    - name: Restore local Gradle & Maven cache
+      uses: actions/cache@v2.1.0
+      with:
+        path: |
+          .gradle
+          ~/.gradle
+          ~/.m2
+        key: gradle-m2-java-11
+        restore-keys: |
+          gradle-m2-java-
+          gradle-m2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Integration tests with Gradle
+      run: ./gradlew test:integration:test
+    - name: Codecov
+      uses: codecov/codecov-action@v1.0.15

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,11 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [11]
 
-    name: Java ${{ matrix.java }}
+    name: Java 11
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -27,14 +24,14 @@ jobs:
           .gradle
           ~/.gradle
           ~/.m2
-        key: gradle-m2-java-${{ matrix.java }}
+        key: gradle-m2-java-11
         restore-keys: |
           gradle-m2-java-
           gradle-m2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: ${{ matrix.java }}
+        java-version: 11
     - name: Assemble with Gradle
       run: ./gradlew assemble
     - name: Javadoc with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,47 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    #strategy:
+    #  matrix:
+    #    #java: [8, 11, 14]
+    #    java: [8]
+
+    name: Java 8 #${{ matrix.java }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Restore local Gradle & Maven cache
+      uses: actions/cache@v2.1.0
+      with:
+        path: |
+          .gradle
+          ~/.gradle
+          ~/.m2
+        key: gradle-m2-java-8 #${{ matrix.java }}
+        restore-keys: |
+          gradle-m2-java-
+          gradle-m2
+    - name: Set up JDK 8 #${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8 #${{ matrix.java }}
+    - name: Assemble with Gradle
+      run: ./gradlew assemble
+    - name: Check with Gradle
+      run: ./gradlew check
+    - name: Codecov
+      #if: ${{ matrix.java == 8 }}
+      uses: codecov/codecov-action@v1.0.12
+    - name: Javadoc with Gradle
+      run: ./gradlew javadocs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,11 +33,11 @@ jobs:
 #      with:
 #        java-version: 11
     - name: Assemble with Gradle
-      run: ./gradlew assemble
+      run: ./gradlew assemble --parallel
     - name: Javadoc with Gradle
       run: ./gradlew javadocs
     - name: Rat, Checkstyle & Spotbugs with Gradle
-      run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest
+      run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel
 
   test:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,12 +42,12 @@ jobs:
     - name: Rat, Checkstyle & Spotbugs with Gradle
       run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest
 
-  unit:
+  test:
 
     needs: build
     runs-on: ubuntu-latest
 
-    name: Unit Tests on Java 11
+    name: Tests on Java 11
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -69,31 +69,5 @@ jobs:
       run: ./gradlew test --exclude-task test:integration:test
     - name: Codecov
       uses: codecov/codecov-action@v1.0.15
-
-  integration:
-
-    needs: build
-    runs-on: ubuntu-latest
-
-    name: Integration Tests on Java 11
-    steps:
-    - uses: actions/checkout@v1
-    - name: Restore local Gradle & Maven cache
-      uses: actions/cache@v2.1.0
-      with:
-        path: |
-          .gradle
-          ~/.gradle
-          ~/.m2
-        key: gradle-m2-java-11
-        restore-keys: |
-          gradle-m2-java-
-          gradle-m2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
     - name: Integration tests with Gradle
       run: ./gradlew test:integration:test
-    - name: Codecov
-      uses: codecov/codecov-action@v1.0.15

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11]
 
     name: Java ${{ matrix.java }}
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,10 @@ allprojects {
             }
         }
     }
+
+    tasks.withType(Test) {
+        jvmArgs = ["-Xmx2g"]
+    }
 }
 
 project('common') {

--- a/cli/admin/src/test/java/io/pravega/cli/admin/utils/ConfigUtilsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/utils/ConfigUtilsTest.java
@@ -21,7 +21,7 @@ public class ConfigUtilsTest {
     public void testConfigUtils() throws IOException {
         @Cleanup
         AdminCommandState commandState = new AdminCommandState();
-        System.setProperty("pravega.configurationFile", "../../config/admin-cli.properties");
+        System.setProperty("pravega.configurationFile", "../resources/admin-cli.properties");
         System.setProperty("pravegaservice", "pravegaservice");
         ConfigUtils.loadProperties(commandState);
     }

--- a/cli/admin/src/test/resources/admin-cli.properties
+++ b/cli/admin/src/test/resources/admin-cli.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Test configuration file to exercise loading properties without interfering with other tests.
+
+# Config for CLI Controller REST/GRPC endpoints.
+cli.store.metadata.backend=segmentstore
+
+# General configuration for the Pravega cluster at hand.
+pravegaservice.container.count=4
+
+# Config for Data recovery commands
+# Valid values: HDFS, FILESYSTEM, EXTENDEDS3, INMEMORY.
+pravegaservice.storage.impl.name=FILESYSTEM

--- a/cli/user/src/test/java/io/pravega/cli/user/stream/StreamCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/stream/StreamCommandTest.java
@@ -98,7 +98,7 @@ public class StreamCommandTest {
         Assert.assertNotNull(StreamCommand.List.descriptor());
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     @SneakyThrows
     public void testAppendAndReadStream() {
         String scope = "appendAndReadStreamScope";


### PR DESCRIPTION
**Change log description**  
Adds build and test/coverage for Java 11. Runs Rat, Checkstyle and SpotBugs before tests.

**Purpose of the change**  
To test the Gradle build against Java 11. To more reliably upload coverage reports to Codecov. To transition off of Travis CI. To run source checks prior to tests.
Fixes #4977

**What the code does**  
Adds a workflow to run compilation against a matrix of Java versions (currently only 11) and tests against a single Java version (11) on a simulated merge.

**How to verify it**  
Actions CI is running in this PR. It also runs in my fork here: https://github.com/derekm/pravega/pull/4

**Open questions**
1. Should this incorporate release or system test stages from the Travis build?