### PR TITLE
Issue 4989: Add integration and system test for size based retention policy

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceConfig.java
@@ -16,6 +16,7 @@ import io.pravega.controller.store.client.StoreClientConfig;
 import io.pravega.controller.store.host.HostMonitorConfig;
 import io.pravega.controller.timeout.TimeoutServiceConfig;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -96,4 +97,10 @@ public interface ControllerServiceConfig {
      * @return Whether REST server is enabled, and its configuration if it is enabled.
      */
     Optional<RESTServerConfig> getRestServerConfig();
+
+    /**
+     * Frequency at which periodic retention jobs should be performed for each stream. 
+     * @return Duration for retention frequency.
+     */
+    Duration getRetentionFrequency();
 }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -240,12 +240,13 @@ public class ControllerServiceStarter extends AbstractIdleService {
             streamStore = streamMetadataStoreRef.orElse(StreamStoreFactory.createStore(storeClient, segmentHelper, authHelper, controllerExecutor));
 
             streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, taskMetadataStore,
-                    segmentHelper, controllerExecutor, eventExecutor, host.getHostId(), authHelper, requestTracker);
+                    segmentHelper, controllerExecutor, eventExecutor, host.getHostId(), authHelper, requestTracker, 
+                    serviceConfig.getRetentionFrequency().toMillis());
             streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore,
                     segmentHelper, controllerExecutor, eventExecutor, host.getHostId(), serviceConfig.getTimeoutServiceConfig(), authHelper);
 
             BucketServiceFactory bucketServiceFactory = new BucketServiceFactory(host.getHostId(), bucketStore, 1000);
-            Duration executionDurationRetention = Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES);
+            Duration executionDurationRetention = serviceConfig.getRetentionFrequency();
 
             PeriodicRetention retentionWork = new PeriodicRetention(streamStore, streamMetadataTasks, retentionExecutor, requestTracker);
             retentionService = bucketServiceFactory.createRetentionService(executionDurationRetention, retentionWork::retention, retentionExecutor);

--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -29,7 +29,6 @@ import io.pravega.shared.metrics.StatsProvider;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -102,7 +101,6 @@ public class Main {
                     .grpcServerConfig(Optional.of(grpcServerConfig))
                     .restServerConfig(Optional.of(restServerConfig))
                     .tlsEnabledForSegmentStore(Config.TLS_ENABLED_FOR_SEGMENT_STORE)
-                    .retentionFrequency(Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES))
                     .build();
 
             setUncaughtExceptionHandler(Main::logUncaughtException);

--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -29,6 +29,7 @@ import io.pravega.shared.metrics.StatsProvider;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -101,6 +102,7 @@ public class Main {
                     .grpcServerConfig(Optional.of(grpcServerConfig))
                     .restServerConfig(Optional.of(restServerConfig))
                     .tlsEnabledForSegmentStore(Config.TLS_ENABLED_FOR_SEGMENT_STORE)
+                    .retentionFrequency(Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES))
                     .build();
 
             setUncaughtExceptionHandler(Main::logUncaughtException);

--- a/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/impl/ControllerServiceConfigImpl.java
@@ -19,10 +19,12 @@ import io.pravega.controller.store.client.StoreType;
 import io.pravega.controller.store.host.HostMonitorConfig;
 import io.pravega.controller.timeout.TimeoutServiceConfig;
 import com.google.common.base.Preconditions;
+import io.pravega.controller.util.Config;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -45,7 +47,9 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
     private final Optional<GRPCServerConfig> gRPCServerConfig;
 
     private final Optional<RESTServerConfig> restServerConfig;
-
+    
+    private final Duration retentionFrequency;
+    
     @Builder
     ControllerServiceConfigImpl(final int threadPoolSize,
                                 final StoreClientConfig storeClientConfig,
@@ -55,7 +59,8 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
                                 final TimeoutServiceConfig timeoutServiceConfig,
                                 final Optional<ControllerEventProcessorConfig> eventProcessorConfig,
                                 final Optional<GRPCServerConfig> grpcServerConfig,
-                                final Optional<RESTServerConfig> restServerConfig) {
+                                final Optional<RESTServerConfig> restServerConfig,
+                                final Duration retentionFrequency) {
         Exceptions.checkArgument(threadPoolSize > 0, "threadPoolSize", "Should be positive integer");
         Preconditions.checkNotNull(storeClientConfig, "storeClientConfig");
         Preconditions.checkNotNull(hostMonitorConfig, "hostMonitorConfig");
@@ -86,5 +91,7 @@ public class ControllerServiceConfigImpl implements ControllerServiceConfig {
         this.eventProcessorConfig = eventProcessorConfig;
         this.gRPCServerConfig = grpcServerConfig;
         this.restServerConfig = restServerConfig;
+        this.retentionFrequency = retentionFrequency == null ? Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES)
+                : retentionFrequency;
     }
 }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -84,9 +84,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import lombok.Synchronized;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.LoggerFactory;
@@ -102,9 +104,9 @@ import static io.pravega.controller.task.Stream.TaskStepsRetryHelper.withRetries
  */
 public class StreamMetadataTasks extends TaskBase {
     private static final TagLogger log = new TagLogger(LoggerFactory.getLogger(StreamMetadataTasks.class));
-    private static final long RETENTION_FREQUENCY_IN_MINUTES = Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES).toMillis();
 
-
+    private final AtomicLong retentionFrequencyMillis;
+    
     private final StreamMetadataStore streamMetadataStore;
     private final BucketStore bucketStore;
     private final SegmentHelper segmentHelper;
@@ -114,14 +116,14 @@ public class StreamMetadataTasks extends TaskBase {
     private final ScheduledExecutorService eventExecutor;
     private EventHelper eventHelper;
 
-
     public StreamMetadataTasks(final StreamMetadataStore streamMetadataStore,
                                BucketStore bucketStore, final TaskMetadataStore taskMetadataStore,
                                final SegmentHelper segmentHelper, final ScheduledExecutorService executor,
                                final ScheduledExecutorService eventExecutor, final String hostId,
-                               GrpcAuthHelper authHelper, RequestTracker requestTracker) {
+                               GrpcAuthHelper authHelper, RequestTracker requestTracker, final long retentionFrequencyMillis) {
         this(streamMetadataStore, bucketStore, taskMetadataStore, segmentHelper, executor, eventExecutor, new Context(hostId),
                 authHelper, requestTracker);
+        this.retentionFrequencyMillis.set(retentionFrequencyMillis);
     }
 
     @VisibleForTesting
@@ -156,6 +158,7 @@ public class StreamMetadataTasks extends TaskBase {
         this.segmentHelper = segmentHelper;
         this.authHelper = authHelper;
         this.requestTracker = requestTracker;
+        this.retentionFrequencyMillis = new AtomicLong(Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES).toMillis());
         this.setReady();
     }
 
@@ -303,7 +306,7 @@ public class StreamMetadataTasks extends TaskBase {
     private CompletableFuture<StreamCutRecord> generateStreamCutIfRequired(String scope, String stream,
                                                                            StreamCutReferenceRecord previous, long recordingTime,
                                                                            OperationContext context, String delegationToken) {
-        if (previous == null || recordingTime - previous.getRecordingTime() > RETENTION_FREQUENCY_IN_MINUTES) {
+        if (previous == null || recordingTime - previous.getRecordingTime() > retentionFrequencyMillis.get()) {
             return Futures.exceptionallyComposeExpecting(
                     previous == null ? CompletableFuture.completedFuture(null) :
                             streamMetadataStore.getStreamCutRecord(scope, stream, previous, context, executor),

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
@@ -32,6 +32,7 @@ import io.pravega.controller.util.Config;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.control.impl.Controller;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -158,6 +159,7 @@ public class ControllerWrapper implements AutoCloseable {
                 .eventProcessorConfig(eventProcessorConfig)
                 .grpcServerConfig(Optional.of(grpcServerConfig))
                 .restServerConfig(restServerConfig)
+                .retentionFrequency(Duration.ofSeconds(1))
                 .build();
 
         controllerServiceMain = new ControllerServiceMain(serviceConfig);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/RetentionTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/RetentionTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.test.integration.endtoendtest;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.connection.impl.ConnectionFactory;
+import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.RetentionPolicy;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.controller.server.eventProcessor.LocalController;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class RetentionTest {
+
+    private final String serviceHost = "localhost";
+    private final int containerCount = 4;
+    private int controllerPort;
+    private URI controllerURI; 
+    private TestingServer zkTestServer;
+    private PravegaConnectionListener server;
+    private ControllerWrapper controllerWrapper;
+    private ServiceBuilder serviceBuilder;
+    private ScheduledExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+        TableStore tableStore = serviceBuilder.createTableStoreService();
+        controllerPort = TestUtils.getAvailableListenPort();
+        controllerURI = URI.create("tcp://" + serviceHost + ":" + controllerPort);
+        int servicePort = TestUtils.getAvailableListenPort();
+        server = new PravegaConnectionListener(false, servicePort, store, tableStore, this.serviceBuilder.getLowPriorityExecutor());
+        server.startListening();
+
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                containerCount);
+        controllerWrapper.awaitRunning();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ExecutorServiceHelpers.shutdown(executor);
+        controllerWrapper.close();
+        server.close();
+        serviceBuilder.close();
+        zkTestServer.close();
+    }
+    
+    @Test(timeout = 30000)
+    public void testRetentionTime() throws Exception {
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scalingPolicy(ScalingPolicy.fixed(2))
+                                                        .retentionPolicy(RetentionPolicy.byTime(Duration.ofSeconds(1)))
+                                                        .build();
+        LocalController controller = (LocalController) controllerWrapper.getController();
+        String name = "testtime";
+        Stream stream = new StreamImpl(name, name);
+        controllerWrapper.getControllerService().createScope(name).get();
+        controller.createStream(name, name, config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder()
+                                                                                          .controllerURI(controllerURI)
+                                                                                          .build());
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(name, controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(name, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+
+        Map<Segment, Long> x = controller.getSegmentsAtTime(stream, 0L).join();
+        assertTrue(x.values().stream().allMatch(a -> a == 0));
+        AtomicBoolean continueLoop = new AtomicBoolean(true);
+        Futures.loop(continueLoop::get, () -> writer.writeEvent("a"), executor);
+        
+        AssertExtensions.assertEventuallyEquals(true, () -> controller
+                .getSegmentsAtTime(stream, 0L).join().values().stream().anyMatch(a -> a > 0), 30 * 1000L);
+        continueLoop.set(false);
+    }
+    
+    @Test(timeout = 30000)
+    public void testRetentionSize() throws Exception {
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scalingPolicy(ScalingPolicy.fixed(2))
+                                                        .retentionPolicy(RetentionPolicy.bySizeBytes(10))
+                                                        .build();
+        LocalController controller = (LocalController) controllerWrapper.getController();
+        String name = "testsize";
+        Stream stream = new StreamImpl(name, name);
+        controllerWrapper.getControllerService().createScope(name).get();
+        controller.createStream(name, name, config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder()
+                                                                                          .controllerURI(controllerURI)
+                                                                                          .build());
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(name, controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(name, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+
+        Map<Segment, Long> x = controller.getSegmentsAtTime(stream, 0L).join();
+        assertTrue(x.values().stream().allMatch(a -> a == 0));
+        AtomicBoolean continueLoop = new AtomicBoolean(true);
+        Futures.loop(continueLoop::get, () -> writer.writeEvent("a"), executor);
+        
+        AssertExtensions.assertEventuallyEquals(true, () -> controller
+                .getSegmentsAtTime(stream, 0L).join().values().stream().anyMatch(a -> a > 0), 30 * 1000L);
+        continueLoop.set(false);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Adds system and integration tests for size based retention policy

**Purpose of the change**  
Fixes #4989 

**What the code does**  
Makes retention frequency part of ControllerServiceConfig instead of the static value in Config.java. This allows integration tests to set much smaller value than the default of 30 minutes. 

Adds new integration and system test which test size and time based retentions. 

**How to verify it**  
All tests should pass
