### PR TITLE
Issue 4977: Add Actions CI for Gradle, Codecov, DCO, Java 8/11

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,11 +11,10 @@ coverage:
   status:
     project:
       default:
-        against: parent
-        target: auto
         threshold: 0.5%
-        branches:
-          - master
+    patch:
+      default:
+        threshold: 0.5%
   ignore:
     - "**/generated/**"
     - "standalone"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,21 @@
+# This is a basic workflow to help you get started with Actions
+
+name: DCO
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: DCO-Check
+      uses: tim-actions/dco@v1.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,46 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+
+    name: Java ${{ matrix.java }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Restore local Gradle & Maven cache
+      uses: actions/cache@v2.1.0
+      with:
+        path: |
+          .gradle
+          ~/.gradle
+          ~/.m2
+        key: gradle-m2-java-${{ matrix.java }}
+        restore-keys: |
+          gradle-m2-java-
+          gradle-m2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Assemble with Gradle
+      run: ./gradlew assemble
+    - name: Check with Gradle
+      run: ./gradlew check
+    - name: Codecov
+      if: ${{ matrix.java == 8 }}
+      uses: codecov/codecov-action@v1.0.12
+    - name: Javadoc with Gradle
+      run: ./gradlew javadocs


### PR DESCRIPTION
**Change log description**  
Adds a Gradle build/test/coverage workflow & a DCO workflow that run in parallel.

**Purpose of the change**  
To enforce Developer Certificate of Origin signoffs. To test the Gradle build against Java 8 & 11. To upload coverage reports to Codecov.
Fixes #4977

**What the code does**  
Adds two parallel workflows, one to run Gradle and coverage against Java 8 & 11, and another that checks git commits for Signed-off-by.

**How to verify it**  
I'm not sure whether this PR will run the Actions CI (and use my secrets). It runs in my fork here: https://github.com/derekm/pravega/pull/4

**Open questions**
1. ~Should coverage reports be uploaded for only one version of Java?~
   * Coverage is only uploaded for the Java 8 build.
2. How should this incorporate release or system test stages from the Travis build?