### PR TITLE
Issue 4995: fix test readonly

### DIFF
--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
@@ -513,13 +513,15 @@ public abstract class ChunkStorageTests extends ThreadPooledTestSuite {
                 " delete should throw IllegalArgumentException.",
                 () -> chunkStorage.delete(ChunkHandle.readHandle(chunkName)),
                 ex -> ex instanceof IllegalArgumentException);
-
+        // Make readonly and open.
         chunkStorage.setReadOnly(hWrite, true);
+        chunkStorage.openWrite(chunkName);
 
-        ChunkHandle hWrite2 = chunkStorage.openWrite(chunkName);
-        assertTrue(hWrite2.isReadOnly());
-
+        // Make writable and open again.
         chunkStorage.setReadOnly(hWrite, false);
+        ChunkHandle hWrite2 = chunkStorage.openWrite(chunkName);
+        assertFalse(hWrite2.isReadOnly());
+
         bytesWritten = chunkStorage.write(hWrite, 1, 1, new ByteArrayInputStream(new byte[1]));
         assertEquals(1, bytesWritten);
         chunkStorage.delete(hWrite);


### PR DESCRIPTION
**Change log description**  
Fix ChunkStorageTests.testReadonly test to be more robust . 

**Purpose of the change**  
Fixes #4995 


**What the code does**  
The issue seems to be that inside jenkins job set up the effective permissions are such that Files.isWritable returns true. This causes test to fail. (note that this test does not fail locally or in travis.)
Code fixes the assert that may depend on env.

**How to verify it**  
all unit tests in Jenkins, travis pass
