### PR TITLE
Issue 5005: Ensure ConnectionFailedException is thrown incase the connection is closed.

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/TcpClientConnection.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/TcpClientConnection.java
@@ -264,7 +264,7 @@ public class TcpClientConnection implements ClientConnection {
 
     @Override
     public void send(WireCommand cmd) throws ConnectionFailedException {
-        Exceptions.checkNotClosed(closed.get(), this);
+        checkIfClosed();
         try {
             encoder.write(cmd);
         } catch (IOException e) {
@@ -276,13 +276,19 @@ public class TcpClientConnection implements ClientConnection {
 
     @Override
     public void send(Append append) throws ConnectionFailedException {
-        Exceptions.checkNotClosed(closed.get(), this);
+        checkIfClosed();
         try {
             encoder.write(append);
         } catch (IOException e) {
             log.warn("Error writing to connection: {}", e.toString());
             close();
             throw new ConnectionFailedException(e);
+        }
+    }
+
+    private void checkIfClosed() throws ConnectionFailedException {
+        if (closed.get()) {
+            throw new ConnectionFailedException("Connection already closed");
         }
     }
 


### PR DESCRIPTION
**Change log description**  
Ensure ConnectionFailedException is thrown incase the connection is already closed.

**Purpose of the change**  
Fixes #5005 

**What the code does**  
Ensure `ConnectionFailedException ` is thrown when the connection is dropped right before the writer sends out a `WireCommands.SetupAppend`. This will ensure the SegmentWriters attempt to reconnect by fetching the correct SSS URI from the controller.

**How to verify it**  
All the existing  tests should continue to pass. 
