### PR TITLE
Issue 5008: Fix free TCP port generation logic

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SingleThreadEndToEndTest.java
@@ -36,7 +36,7 @@ public class SingleThreadEndToEndTest {
         @Cleanup
         EventStreamReader<Integer> reader = setupUtils.getIntegerReader("stream");
 
-        EventRead<Integer> event = reader.readNextEvent(100);
+        EventRead<Integer> event = reader.readNextEvent(10000);
         Assert.assertEquals(1, (int) event.getEvent());
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -30,7 +30,6 @@ import io.pravega.client.control.impl.Controller;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.common.concurrent.Futures;
-import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
@@ -39,6 +38,7 @@ import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import io.pravega.test.integration.utils.IntegerSerializer;
@@ -96,7 +96,7 @@ public class EndToEndTransactionOrderTest {
     public void setUp() throws Exception {
 
         zkTestServer = new TestingServerStarter().start();
-        int port = Config.SERVICE_PORT;
+        int port = TestUtils.getAvailableListenPort();
 
         controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), port);
         controller = controllerWrapper.getController();
@@ -116,8 +116,8 @@ public class EndToEndTransactionOrderTest {
                 internalCF,
                 AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
                                 .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0).build());
-
-        server = new PravegaConnectionListener(false, false, "localhost", 12345, store, tableStore,
+        int sssPort = TestUtils.getAvailableListenPort();
+        server = new PravegaConnectionListener(false, false, "localhost", sssPort, store, tableStore,
                 autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null,
                 true, serviceBuilder.getLowPriorityExecutor());
         server.startListening();
@@ -241,7 +241,7 @@ public class EndToEndTransactionOrderTest {
                         eventToTxnMap.put(i1, transaction.getTxnId());
                         txnToWriter.put(transaction.getTxnId(), writerId);
                     } catch (Throwable e) {
-                        log.error("test exception writing events {}", e);
+                        log.error("test exception writing events", e);
                         throw new CompletionException(e);
                     }
                 }), executor)

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -39,6 +39,7 @@ import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import io.pravega.test.integration.utils.IntegerSerializer;
@@ -75,6 +76,9 @@ public class EndToEndTransactionOrderTest {
                                                           .scalingPolicy(ScalingPolicy.fixed(1))
                                                           .build();
 
+    final int controllerPort = TestUtils.getAvailableListenPort();
+    final String serviceHost = "localhost";
+    final int servicePort = TestUtils.getAvailableListenPort();
     ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
     ConcurrentHashMap<String, List<UUID>> writersList = new ConcurrentHashMap<>();
     ConcurrentHashMap<Integer, UUID> eventToTxnMap = new ConcurrentHashMap<>();
@@ -98,7 +102,12 @@ public class EndToEndTransactionOrderTest {
         zkTestServer = new TestingServerStarter().start();
         int port = Config.SERVICE_PORT;
 
-        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), port);
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(),
+                false,
+                controllerPort,
+                serviceHost,
+                servicePort,
+                Config.HOST_STORE_CONTAINER_COUNT);
         controller = controllerWrapper.getController();
 
         connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder().build());
@@ -117,7 +126,7 @@ public class EndToEndTransactionOrderTest {
                 AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
                                 .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0).build());
 
-        server = new PravegaConnectionListener(false, false, "localhost", 12345, store, tableStore,
+        server = new PravegaConnectionListener(false, false, "localhost", servicePort, store, tableStore,
                 autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null,
                 true, serviceBuilder.getLowPriorityExecutor());
         server.startListening();

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -30,6 +30,7 @@ import io.pravega.client.control.impl.Controller;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
@@ -38,7 +39,6 @@ import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
-import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.integration.demo.ControllerWrapper;
 import io.pravega.test.integration.utils.IntegerSerializer;
@@ -96,7 +96,7 @@ public class EndToEndTransactionOrderTest {
     public void setUp() throws Exception {
 
         zkTestServer = new TestingServerStarter().start();
-        int port = TestUtils.getAvailableListenPort();
+        int port = Config.SERVICE_PORT;
 
         controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), port);
         controller = controllerWrapper.getController();
@@ -116,8 +116,8 @@ public class EndToEndTransactionOrderTest {
                 internalCF,
                 AutoScalerConfig.builder().with(AutoScalerConfig.MUTE_IN_SECONDS, 0)
                                 .with(AutoScalerConfig.COOLDOWN_IN_SECONDS, 0).build());
-        int sssPort = TestUtils.getAvailableListenPort();
-        server = new PravegaConnectionListener(false, false, "localhost", sssPort, store, tableStore,
+
+        server = new PravegaConnectionListener(false, false, "localhost", 12345, store, tableStore,
                 autoScaleMonitor.getStatsRecorder(), autoScaleMonitor.getTableSegmentStatsRecorder(), null, null, null,
                 true, serviceBuilder.getLowPriorityExecutor());
         server.startListening();

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -37,7 +37,7 @@ public class TestUtils {
     private static final AtomicInteger NEXT_PORT = new AtomicInteger(new Random().nextInt(MAX_PORT_COUNT));
 
     /**
-     * A helper method to get a random free port.
+     * A helper method to get a random free TCP port.
      *
      * @return free port.
      */
@@ -46,6 +46,9 @@ public class TestUtils {
             int candidatePort = BASE_PORT + NEXT_PORT.getAndIncrement() % MAX_PORT_COUNT;
             try {
                 ServerSocket serverSocket = new ServerSocket(candidatePort);
+                //Enabling SO_REUSEADDR prior to binding the socket using bind(SocketAddress) allows the socket
+                //to be bound even though a previous connection is in a timeout state.
+                serverSocket.setReuseAddress(true);
                 serverSocket.close();
                 return candidatePort;
             } catch (IOException e) {


### PR DESCRIPTION
**Change log description**  
Fix free TCP port generation logic

**Purpose of the change**  
Fixes #5008 

**What the code does**  
- Fixes the random free TCP port logic. This should prevent sporadic integration failures due to 
`java.net.BindException: Address already in use`
- Ensure tests uses TestUtils.getAvailableListenPort()

**How to verify it**  
All the existing tests should pass.
