### PR TITLE
Issues 3373, 4003, 2985: Remove javadoc and compile warnings

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -20,7 +20,10 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -20,10 +20,7 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -42,31 +39,46 @@ public class ClientConfig implements Serializable {
 
 
     /** controllerURI The controller rpc URI. This can be of 2 types
-     1. tcp://ip1:port1,ip2:port2,...
-        This is used if the controller endpoints are static and can be directly accessed.
-     2. pravega://ip1:port1,ip2:port2,...
-        This is used to autodiscovery the controller endpoints from an initial controller list.
+     * 1. tcp://ip1:port1,ip2:port2,...
+     *    This is used if the controller endpoints are static and can be directly accessed.
+     * 2. pravega://ip1:port1,ip2:port2,...
+     *   This is used to autodiscovery the controller endpoints from an initial controller list.
+     *
+     * @param controllerURI The controller RPC URI.
+     * @return The controller RPC URI.
     */
     private final URI controllerURI;
 
     /**
      * Credentials to be passed on to the Pravega controller for authentication and authorization.
+     *
+     * @param credentials Pravega controller credentials for authentication and authorization.
+     * @return Pravega controller credentials for authentication and authorization.
      */
     private final Credentials credentials;
 
     /**
      * Path to an optional truststore. If this is null or empty, the default JVM trust store is used.
      * This is currently expected to be a signing certificate for the certification authority.
+     *
+     * @param trustStore Path to an optional truststore.
+     * @return Path to an optional truststore.
      */
     private final String trustStore;
 
     /**
-     * If the flag {@link #isEnableTls()}  is set, this flag decides whether to enable host name validation or not.
+     * If the flag {@link #isEnableTls()} is set, this flag decides whether to enable host name validation or not.
+     *
+     * @param validateHostName Flag to decide whether to enable host name validation or not.
+     * @return Flag to decide whether to enable host name validation or not.
      */
     private final boolean validateHostName;
 
     /**
      * Maximum number of connections per Segment store to be used by connection pooling.
+     *
+     * @param maxConnectionsPerSegmentStore Maximum number of connections per Segment Store for connection pooling.
+     * @return Maximum number of connections per Segment Store for connection pooling.
      */
     private final int maxConnectionsPerSegmentStore;
 
@@ -105,6 +117,9 @@ public class ClientConfig implements Serializable {
     /**
      * An optional listener which can be used to get performance metrics from the client. The user
      * can implement this interface to obtain performance metrics of the client.
+     *
+     * @param metricListener Listener to collect client performance metrics.
+     * @return Listener to collect client performance metrics.
      */
     private final MetricListener metricListener;
 

--- a/client/src/main/java/io/pravega/client/admin/KeyValueTableInfo.java
+++ b/client/src/main/java/io/pravega/client/admin/KeyValueTableInfo.java
@@ -21,11 +21,17 @@ import lombok.Data;
 public class KeyValueTableInfo {
     /**
      * Scope name of the Key-Value Table.
+     *
+     * @param scope Scope name of the Key-Value Table.
+     * @return Scope name of the Key-Value Table.
      */
     private final String scope;
 
     /**
      * Key-Value Table name.
+     *
+     * @param keyValueTableName Key-Value Table name.
+     * @return Key-Value Table name.
      */
     private final String keyValueTableName;
 

--- a/client/src/main/java/io/pravega/client/admin/StreamInfo.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamInfo.java
@@ -29,27 +29,42 @@ import lombok.Data;
 public class StreamInfo {
     /**
      * Scope name of the stream.
+     *
+     * @param scope Scope name of the stream.
+     * @return Scope name of the stream.
      */
     private final String scope;
 
     /**
      * Stream name.
+     *
+     * @param streamName Stream name.
+     * @return Stream name.
      */
     private final String streamName;
 
     /**
      * {@link StreamCut} representing the current TAIL of the stream.
+     *
+     * @param tailStreamCut {@link StreamCut} representing the current TAIL of the stream.
+     * @return {@link StreamCut} representing the current TAIL of the stream.
      */
     private final StreamCut tailStreamCut;
 
     /**
      * {@link StreamCut} representing the current HEAD of the stream.
+     *
+     * @param headStreamCut {@link StreamCut} representing the current HEAD of the stream.
+     * @return {@link StreamCut} representing the current HEAD of the stream.
      */
     private final StreamCut headStreamCut;
 
     /**
      * Indicates whether the Stream is sealed (true) or not (false). If a stream is sealed, then no further Events
      * can be written to it.
+     *
+     * @param sealed Indicates whether the Stream is sealed (true) or not (false).
+     * @return Indicates whether the Stream is sealed (true) or not (false).
      */
     private final boolean sealed;
 }

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
@@ -30,7 +30,7 @@ public class ConditionalOutputStreamFactoryImpl implements ConditionalOutputStre
     }
 
     private RetryWithBackoff getRetryFromConfig(EventWriterConfig config) {
-        return Retry.withExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+        return Retry.withExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                     config.getRetryAttempts(), config.getMaxBackoffMillis());
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -65,7 +65,7 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     }
 
     private RetryWithBackoff getRetryFromConfig(EventWriterConfig config) {
-        return Retry.withExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+        return Retry.withExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                     config.getRetryAttempts(), config.getMaxBackoffMillis());
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -59,7 +59,7 @@ public class EventWriterConfig implements Serializable {
 
     public static final class EventWriterConfigBuilder {
         private static final long MIN_TRANSACTION_TIMEOUT_TIME_MILLIS = 10000;
-        private int initalBackoffMillis = 1;
+        private int initialBackoffMillis = 1;
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
@@ -70,11 +70,11 @@ public class EventWriterConfig implements Serializable {
         
         public EventWriterConfig build() {
             Preconditions.checkArgument(transactionTimeoutTime >= MIN_TRANSACTION_TIMEOUT_TIME_MILLIS, "Transaction time must be at least 10 seconds.");
-            Preconditions.checkArgument(initalBackoffMillis >= 0, "Backoff times must be positive numbers");
+            Preconditions.checkArgument(initialBackoffMillis >= 0, "Backoff times must be positive numbers");
             Preconditions.checkArgument(backoffMultiple >= 0, "Backoff multiple must be positive numbers");
             Preconditions.checkArgument(maxBackoffMillis >= 0, "Backoff times must be positive numbers");
             Preconditions.checkArgument(retryAttempts >= 0, "Retry attempts must be a positive number");
-            return new EventWriterConfig(initalBackoffMillis, maxBackoffMillis, retryAttempts, backoffMultiple,
+            return new EventWriterConfig(initialBackoffMillis, maxBackoffMillis, retryAttempts, backoffMultiple,
                                          enableConnectionPooling,
                                          transactionTimeoutTime,
                                          automaticallyNoteTime);

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -20,7 +20,7 @@ import lombok.Data;
 public class EventWriterConfig implements Serializable {
     
     private static final long serialVersionUID = 1L;
-    private final int initalBackoffMillis;
+    private final int initialBackoffMillis;
     private final int maxBackoffMillis;
     private final int retryAttempts;
     private final int backoffMultiple;
@@ -51,6 +51,9 @@ public class EventWriterConfig implements Serializable {
     /**
      * Automatically invoke {@link EventStreamWriter#noteTime(long)} passing
      * {@link System#currentTimeMillis()} on a regular interval.
+     *
+     * @param automaticallyNoteTime Interval to regularly invoke {@link EventStreamWriter#noteTime(long)}.
+     * @return Interval to regularly invoke {@link EventStreamWriter#noteTime(long)}.
      */
     private final boolean automaticallyNoteTime;
 

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -26,12 +26,16 @@ public class StreamConfiguration implements Serializable {
     /**
      * API to return scaling policy.
      *
+     * @param scalingPolicy The Stream Scaling policy.
+     * @return Scaling Policy for the Stream.
      */
     private final ScalingPolicy scalingPolicy;
 
     /**
      * API to return retention policy.
      *
+     * @param retentionPolicy The Stream Retention policy.
+     * @return Retention Policy for the Stream.
      */
     private final RetentionPolicy retentionPolicy;
     
@@ -41,6 +45,11 @@ public class StreamConfiguration implements Serializable {
      * not calling {@link EventStreamWriter#noteTime(long)} the writer will be forgotten.
      * If there are no known writers, readers that call {@link EventStreamReader#getCurrentTimeWindow(Stream)}
      * will receive a `null` when they are at the corresponding position in the stream.
+     *
+     * @param timestampAggregationTimeout The duration after the last call to {@link EventStreamWriter#noteTime(long)}
+     *                                    which the timestamp should be considered valid before it is forgotten.
+     * @return The duration after the last call to {@link EventStreamWriter#noteTime(long)} which the timestamp should
+     * be considered valid before it is forgotten.
      */
     private final long timestampAggregationTimeout;
 

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -143,7 +143,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     private void handleLogSealed(Segment segment) {
         sealedSegmentQueue.add(segment);
         retransmitPool.execute(() -> {
-            Retry.indefinitelyWithExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+            Retry.indefinitelyWithExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                              config.getMaxBackoffMillis(),
                                              t -> log.error("Encountered exception when handling a sealed segment: ", t))
                  .run(() -> {

--- a/client/src/main/java/io/pravega/client/tables/IteratorItem.java
+++ b/client/src/main/java/io/pravega/client/tables/IteratorItem.java
@@ -25,10 +25,18 @@ public class IteratorItem<T> {
      * Gets an {@link IteratorState} that can be used to reinvoke {@link KeyValueTable#entryIterator} or
      * {@link KeyValueTable#keyIterator} if a previous iteration has been interrupted (by losing the pointer to the
      * {@link AsyncIterator}), system restart, etc.
+     *
+     * @param state {@link IteratorState} that can be used to reinvoke {@link KeyValueTable#entryIterator} or
+     * {@link KeyValueTable#keyIterator} if a previous iteration has been interrupted.
+     * @return {@link IteratorState} that can be used to reinvoke {@link KeyValueTable#entryIterator} or
+     * {@link KeyValueTable#keyIterator} if a previous iteration has been interrupted
      */
     private final IteratorState state;
     /**
      * A List of items that are contained in this instance.
+     *
+     * @param items List of items that are contained in this instance.
+     * @return List of items that are contained in this instance.
      */
     private final List<T> items;
 }

--- a/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
+++ b/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
@@ -55,16 +55,16 @@ import lombok.NonNull;
  * <ul>
  * <li> Unconditional Updates will insert and/or overwrite any existing values for the given Key, regardless of whether
  * that Key previously existed or not, and regardless of what that Key's version is. Such updates can be performed using
- * {@link #put(String, KeyT, ValueT)} or {@link #putAll(String, Iterable)}.
+ * {@link #put(String, Object, Object)} or {@link #putAll(String, Iterable)}.
  * <li> Conditional Updates will only overwrite an existing value if the specified {@link Version} matches the one that
- * is currently present on the server. Conditional inserts can be performed using {@link #putIfAbsent(String, KeyT, ValueT)}
+ * is currently present on the server. Conditional inserts can be performed using {@link #putIfAbsent(String, Object, Object)}
  * and will only succeed if the given Key does not already exist in the given Key Family. Conditional updates can be
- * performed using {@link #replace(String, KeyT, ValueT, Version)}.
+ * performed using {@link #replace(String, Object, Object, Version)}.
  * <li> Unconditional Removals will remove a Key regardless of what that Key's version is. The operation will also
  * succeed (albeit with no effect) if the Key does not exist. Such removals can be performed using
- * {@link #remove(String, KeyT)}.
+ * {@link #remove(String, Object)}.
  * <li> Conditional Removals will remove a Key only if the specified {@link Version} matches the one that is currently
- * present on the server. Such removals can be performed using {@link #remove(String, KeyT, Version)}.
+ * present on the server. Such removals can be performed using {@link #remove(String, Object, Version)}.
  * <li> Multi-key updates allow mixing different types of updates in the same update batch. Some entries may be conditioned
  * on their Keys not existing at all ({@link TableEntry#getKey()}{@link TableKey#getVersion()} equals
  * {@link Version#NOT_EXISTS}), some may be conditioned on specific versions and some may not have condition attached at
@@ -142,7 +142,7 @@ public interface KeyValueTable<KeyT, ValueT> extends AutoCloseable {
      * into this {@link KeyValueTable}. All changes are performed atomically (either all or none will be accepted).
      *
      * @param keyFamily The Key Family for the all provided Table Entries.
-     * @param entries   An {@link Iterable} of {@link Map.Entry} instances to insert or update.
+     * @param entries   An {@link Iterable} of {@code Map.Entry} instances to insert or update.
      * @return A CompletableFuture that, when completed, will contain a List of {@link Version} instances which
      * represent the versions for the inserted/updated keys. The size of this list will be the same as the number of
      * items in entries and the versions will be in the same order as the entries.

--- a/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
+++ b/client/src/main/java/io/pravega/client/tables/KeyValueTable.java
@@ -142,7 +142,7 @@ public interface KeyValueTable<KeyT, ValueT> extends AutoCloseable {
      * into this {@link KeyValueTable}. All changes are performed atomically (either all or none will be accepted).
      *
      * @param keyFamily The Key Family for the all provided Table Entries.
-     * @param entries   An {@link Iterable} of {@code Map.Entry} instances to insert or update.
+     * @param entries   An {@link Iterable} of {@link java.util.Map.Entry} instances to insert or update.
      * @return A CompletableFuture that, when completed, will contain a List of {@link Version} instances which
      * represent the versions for the inserted/updated keys. The size of this list will be the same as the number of
      * items in entries and the versions will be in the same order as the entries.

--- a/client/src/main/java/io/pravega/client/tables/KeyValueTableConfiguration.java
+++ b/client/src/main/java/io/pravega/client/tables/KeyValueTableConfiguration.java
@@ -25,6 +25,9 @@ public class KeyValueTableConfiguration implements Serializable {
     /**
      * The number of Partitions for a Key-Value Table. This value cannot be adjusted after the Key-Value Table has been
      * created.
+     *
+     * @param partitionCount The number of Partitions for a Key-Value Table.
+     * @return The number of Partitions for a Key-Value Table.
      */
     private final int partitionCount;
 }

--- a/client/src/main/java/io/pravega/client/tables/KeyValueTableMap.java
+++ b/client/src/main/java/io/pravega/client/tables/KeyValueTableMap.java
@@ -20,7 +20,7 @@ import lombok.NonNull;
  * {@link Map} implementation for a {@link KeyValueTable}'s Key Family.
  * <p>
  * All methods inherited from {@link Map} respect the contracts defined in that interface, except as noted below.
- * <p><p>
+ * <p>
  * Performance considerations:
  * <ul>
  * <li> The {@link Map} interface defines synchronous operations, however {@link KeyValueTable} defines async operations.
@@ -71,7 +71,7 @@ import lombok.NonNull;
  * <li>Invocations of {@link Collection#stream()}}, {@link Collection#spliterator()} or {@link Collection#toArray()} on
  * {@link #keySet()}, {@link #entrySet()} or {@link #values()} will invoke those collections' iterators (see above).
  * </ul>
- * <p><p>
+ * <p>
  * If {@link #getKeyFamily()} is null), the following operations are not supported and will throw throw
  * {@link UnsupportedOperationException}).
  * <ul>

--- a/client/src/main/java/io/pravega/client/tables/TableEntry.java
+++ b/client/src/main/java/io/pravega/client/tables/TableEntry.java
@@ -21,20 +21,23 @@ import lombok.ToString;
  * @param <KeyT>   Key Type.
  * @param <ValueT> Value Type
  */
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 public class TableEntry<KeyT, ValueT> {
     /**
      * The {@link TableKey}.
+     *
+     * @return The content of {@link TableKey}.
      */
     @NonNull
-    private final TableKey<KeyT> key;
+    @Getter private final TableKey<KeyT> key;
 
     /**
      * The Value.
+     *
+     * @return The value associated to the {@link TableKey}.
      */
-    private final ValueT value;
+    @Getter private final ValueT value;
 
     /**
      * Creates a new {@link TableEntry} with no specific version. When used with {@link KeyValueTable#replaceAll}, this

--- a/client/src/main/java/io/pravega/client/tables/TableEntry.java
+++ b/client/src/main/java/io/pravega/client/tables/TableEntry.java
@@ -21,6 +21,7 @@ import lombok.ToString;
  * @param <KeyT>   Key Type.
  * @param <ValueT> Value Type
  */
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 public class TableEntry<KeyT, ValueT> {
@@ -30,14 +31,14 @@ public class TableEntry<KeyT, ValueT> {
      * @return The content of {@link TableKey}.
      */
     @NonNull
-    @Getter private final TableKey<KeyT> key;
+    private final TableKey<KeyT> key;
 
     /**
      * The Value.
      *
      * @return The value associated to the {@link TableKey}.
      */
-    @Getter private final ValueT value;
+     private final ValueT value;
 
     /**
      * Creates a new {@link TableEntry} with no specific version. When used with {@link KeyValueTable#replaceAll}, this

--- a/client/src/main/java/io/pravega/client/tables/TableEntry.java
+++ b/client/src/main/java/io/pravega/client/tables/TableEntry.java
@@ -38,7 +38,7 @@ public class TableEntry<KeyT, ValueT> {
      *
      * @return The value associated to the {@link TableKey}.
      */
-     private final ValueT value;
+    private final ValueT value;
 
     /**
      * Creates a new {@link TableEntry} with no specific version. When used with {@link KeyValueTable#replaceAll}, this

--- a/client/src/main/java/io/pravega/client/tables/TableKey.java
+++ b/client/src/main/java/io/pravega/client/tables/TableKey.java
@@ -26,6 +26,9 @@ import lombok.ToString;
 public class TableKey<KeyT> {
     /**
      * The Key.
+     *
+     * @param key The Key.
+     * @return The Key.
      */
     @NonNull
     private final KeyT key;
@@ -33,6 +36,9 @@ public class TableKey<KeyT> {
     /**
      * The Version. If null, any updates for this Key will be unconditional. See {@link KeyValueTable} for details on
      * conditional updates.
+     *
+     * @param version Version associated with the key.
+     * @return Version associated with the key.
      */
     private final Version version;
 

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
@@ -135,7 +135,7 @@ public class KeyValueTableImpl<KeyT, ValueT> implements KeyValueTable<KeyT, Valu
      * Same as {@link #putAll(String, Iterable)}, but accepts an iterator.
      *
      * @param keyFamily The Key Family for the all provided Table Entries.
-     * @param entries   An {@link Iterable} of {@code Map.Entry} instances to insert or update.
+     * @param entries   An {@link Iterable} of {@link java.util.Map.Entry} instances to insert or update.
      * @return A CompletableFuture that, when completed, will contain a List of {@link Version} instances which
      * represent the versions for the inserted/updated keys. The size of this list will be the same as the number of
      * items in entries and the versions will be in the same order as the entries.

--- a/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
@@ -135,7 +135,7 @@ public class KeyValueTableImpl<KeyT, ValueT> implements KeyValueTable<KeyT, Valu
      * Same as {@link #putAll(String, Iterable)}, but accepts an iterator.
      *
      * @param keyFamily The Key Family for the all provided Table Entries.
-     * @param entries   An {@link Iterable} of {@link Map.Entry} instances to insert or update.
+     * @param entries   An {@link Iterable} of {@code Map.Entry} instances to insert or update.
      * @return A CompletableFuture that, when completed, will contain a List of {@link Version} instances which
      * represent the versions for the inserted/updated keys. The size of this list will be the same as the number of
      * items in entries and the versions will be in the same order as the entries.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
  * {@link TableSegmentKeyVersion#NOT_EXISTS}.
  *
  * A note about {@link ByteBuf}s. All the methods defined in this interface make use of {@link ByteBuf} either directly
- * or via {@link TableSegmentKey}, {@link TableSegmentEntry}. It is expected that no implementation of the {@link TableSegment}
+ * or via {@link TableSegmentKey}/{@link TableSegmentEntry}. It is expected that no implementation of the {@link TableSegment}
  * interface will either retain ({@link ByteBuf#retain()}) or release ({@link ByteBuf#release()}) these buffers during
  * execution. The lifecycle of these buffers should be maintained externally by the calling code, using the following
  * guidelines:

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
  * {@link TableSegmentKeyVersion#NOT_EXISTS}.
  *
  * A note about {@link ByteBuf}s. All the methods defined in this interface make use of {@link ByteBuf} either directly
- * or via {@link TableSegmentKey}/{@link TableSegmentEntry}. It is expected that no implementation of the {@link TableSegment}
+ * or via {@link TableSegmentKey}, {@link TableSegmentEntry}. It is expected that no implementation of the {@link TableSegment}
  * interface will either retain ({@link ByteBuf#retain()}) or release ({@link ByteBuf#release()}) these buffers during
  * execution. The lifecycle of these buffers should be maintained externally by the calling code, using the following
  * guidelines:

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletableFuture;
  * guidelines:
  * * For methods that accept externally-provided {@link ByteBuf}s, the calling code should call {@link ByteBuf#retain()}
  * prior to invoking the method on {@link TableSegment} and should invoke {@link ByteBuf#release()} afterwards.
- * * For methods that return internally-generated {@link} ByteBuf}s (such as {@link #get}), the calling code should
+ * * For methods that return internally-generated {@link ByteBuf}s (such as {@link #get}), the calling code should
  * invoke {@link ByteBuf#release()} as soon as it is done with processing the result. If the result needs to be held onto
  * for a longer duration, the caller should make a copy of it and release the {@link ByteBuf} that was provided from the
  * call.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletableFuture;
  * guidelines:
  * * For methods that accept externally-provided {@link ByteBuf}s, the calling code should call {@link ByteBuf#retain()}
  * prior to invoking the method on {@link TableSegment) and should invoke {@link ByteBuf#release()} afterwards.
- * * For methods that return internally-generated {@link} ByteBuf}s (such as {@link} #get), the calling code should
+ * * For methods that return internally-generated {@link} ByteBuf}s (such as {@link #get}), the calling code should
  * invoke {@link ByteBuf#release()} as soon as it is done with processing the result. If the result needs to be held onto
  * for a longer duration, the caller should make a copy of it and release the {@link ByteBuf} that was provided from the
  * call.

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegment.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CompletableFuture;
  * execution. The lifecycle of these buffers should be maintained externally by the calling code, using the following
  * guidelines:
  * * For methods that accept externally-provided {@link ByteBuf}s, the calling code should call {@link ByteBuf#retain()}
- * prior to invoking the method on {@link TableSegment) and should invoke {@link ByteBuf#release()} afterwards.
+ * prior to invoking the method on {@link TableSegment} and should invoke {@link ByteBuf#release()} afterwards.
  * * For methods that return internally-generated {@link} ByteBuf}s (such as {@link #get}), the calling code should
  * invoke {@link ByteBuf#release()} as soon as it is done with processing the result. If the result needs to be held onto
  * for a longer duration, the caller should make a copy of it and release the {@link ByteBuf} that was provided from the

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -39,7 +39,7 @@ public class CredentialsExtractorTest {
 
     @Test
     public void testExtractsCredentialsFromEnvVariables() {
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_method", "amethod");
         authEnvVariables.put("pravega_client_auth_token", "atoken");
 
@@ -59,7 +59,7 @@ public class CredentialsExtractorTest {
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
 
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_method", "amethod");
         authEnvVariables.put("pravega_client_auth_token", "atoken");
 
@@ -90,7 +90,7 @@ public class CredentialsExtractorTest {
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
 
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_method", "bmethod");
         authEnvVariables.put("pravega_client_auth_token", "btoken");
 
@@ -121,7 +121,7 @@ public class CredentialsExtractorTest {
 
     @Test
     public void testLoadsCredentialsObjOfAGenericTypeFromEnvVariablesIfLoadDynamicIsFalse() {
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_loadDynamic", "false");
         authEnvVariables.put("pravega_client_auth_method", "amethod");
         authEnvVariables.put("pravega_client_auth_token", "atoken");
@@ -144,7 +144,7 @@ public class CredentialsExtractorTest {
         properties.setProperty("pravega.client.auth.method", "amethod");
         properties.setProperty("pravega.client.auth.token", "atoken");
 
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
         authEnvVariables.put("pravega_client_auth_method", "amethod");
         authEnvVariables.put("pravega_client_auth_token", "atoken");
@@ -175,7 +175,7 @@ public class CredentialsExtractorTest {
 
     @Test
     public void testLoadsCredentialsObjOfARegisteredTypeFromEnvVariablesIfLoadDynamicIsTrue() {
-        Map authEnvVariables = new HashMap();
+        Map<String, String> authEnvVariables = new HashMap<>();
         authEnvVariables.put("pravega_client_auth_loadDynamic", "true");
         authEnvVariables.put("pravega_client_auth_method", "Bearer");
 

--- a/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
@@ -23,7 +23,7 @@ public class EventWriterConfigTest {
                 .automaticallyNoteTime(true)
                 .backoffMultiple(2)
                 .enableConnectionPooling(false)
-                .initalBackoffMillis(100)
+                .initialBackoffMillis(100)
                 .maxBackoffMillis(1000)
                 .retryAttempts(3)
                 .transactionTimeoutTime(100000)
@@ -31,7 +31,7 @@ public class EventWriterConfigTest {
         assertEquals(true, config.isAutomaticallyNoteTime());
         assertEquals(2, config.getBackoffMultiple());
         assertEquals(false, config.isEnableConnectionPooling());
-        assertEquals(100, config.getInitalBackoffMillis());
+        assertEquals(100, config.getInitialBackoffMillis());
         assertEquals(1000, config.getMaxBackoffMillis());
         assertEquals(3, config.getRetryAttempts());
         assertEquals(100000, config.getTransactionTimeoutTime());
@@ -40,7 +40,7 @@ public class EventWriterConfigTest {
     @Test
     public void testInvalidValues() {
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().backoffMultiple(-2).build());
-        assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().initalBackoffMillis(-2).build());
+        assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().initialBackoffMillis(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().maxBackoffMillis(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().retryAttempts(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().transactionTimeoutTime(-2).build());

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -250,6 +250,7 @@ public class ReaderGroupImplTest {
         return new StreamCutImpl(Stream.of(SCOPE, streamName), builder.build());
     }
     
+    @SuppressWarnings("unchecked")
     @Test
     public void testFutureCancelation() throws Exception {
         AtomicBoolean completed = new AtomicBoolean(false);

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableMapImplTests.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableMapImplTests.java
@@ -413,6 +413,7 @@ public class KeyValueTableMapImplTests extends KeyValueTableTestSetup {
     /**
      * Tests {@link KeyValueTableMapImpl#entrySet()} and all operations on it.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testEntrySet() {
         @Cleanup

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
@@ -125,7 +125,7 @@ public interface RevisionDataInput extends DataInput {
      * {@link RevisionDataOutput#writeCollection}.
      *
      * @param elementDeserializer  A Function that will decode a single element of the Collection from the given RevisionDataInput.
-     * @param newCollectionBuilder A {@link ImmutableCollection.Builder} that will create a new instance of the
+     * @param newCollectionBuilder A {@code ImmutableCollection.Builder} that will create a new instance of the
      *                             {@link ImmutableCollection} of desired type.
      * @param <T>                  Type of the elements in the Collection.
      * @param <C>                  Type of the Collection whose builder needs to be populated.
@@ -204,7 +204,7 @@ public interface RevisionDataInput extends DataInput {
      *
      * @param keyDeserializer   A Function that will decode a single Key of the Map from the given RevisionDataInput.
      * @param valueDeserializer A Function that will decode a single Value of the Map from the given RevisionDataInput.
-     * @param newMapBuilder     An {@link ImmutableMap.Builder} that will create a new instance of the {@link ImmutableMap}
+     * @param newMapBuilder     An {@code ImmutableMap.Builder} that will create a new instance of the {@link ImmutableMap}
      *                          type desired.
      * @param <K>               Type of the Keys in the Map.
      * @param <V>               Type of the Values in the Map.

--- a/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
+++ b/common/src/main/java/io/pravega/common/io/serialization/RevisionDataInput.java
@@ -125,8 +125,8 @@ public interface RevisionDataInput extends DataInput {
      * {@link RevisionDataOutput#writeCollection}.
      *
      * @param elementDeserializer  A Function that will decode a single element of the Collection from the given RevisionDataInput.
-     * @param newCollectionBuilder A {@code ImmutableCollection.Builder} that will create a new instance of the
-     *                             {@link ImmutableCollection} of desired type.
+     * @param newCollectionBuilder A {@link com.google.common.collect.ImmutableCollection.Builder} that will create a new instance of the
+     *                             {@link com.google.common.collect.ImmutableCollection} of desired type.
      * @param <T>                  Type of the elements in the Collection.
      * @param <C>                  Type of the Collection whose builder needs to be populated.
      * @throws IOException If an IO Exception occurred.
@@ -204,7 +204,8 @@ public interface RevisionDataInput extends DataInput {
      *
      * @param keyDeserializer   A Function that will decode a single Key of the Map from the given RevisionDataInput.
      * @param valueDeserializer A Function that will decode a single Value of the Map from the given RevisionDataInput.
-     * @param newMapBuilder     An {@code ImmutableMap.Builder} that will create a new instance of the {@link ImmutableMap}
+     * @param newMapBuilder     An {@link com.google.common.collect.ImmutableMap.Builder} that will create a new
+     *                          instance of the {@link com.google.common.collect.ImmutableMap}
      *                          type desired.
      * @param <K>               Type of the Keys in the Map.
      * @param <V>               Type of the Values in the Map.

--- a/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
@@ -79,7 +79,7 @@ public abstract class AbstractBufferView implements BufferView {
     protected static abstract class AbstractReader implements BufferView.Reader {
         /**
          * {@inheritDoc}
-         * Default implementation for {@link Reader#readInt()}. Derived classes should make every effort to override this
+         * Default implementation for {@code Reader#readInt()}. Derived classes should make every effort to override this
          * implementation with one that is as efficient as possible (if the {@link BufferView} implementation allows it).
          *
          * @return The read int.
@@ -92,7 +92,7 @@ public abstract class AbstractBufferView implements BufferView {
 
         /**
          * {@inheritDoc}
-         * Default implementation for {@link Reader#readLong()}. Derived classes should make every effort to override this
+         * Default implementation for {@code Reader#readLong()}. Derived classes should make every effort to override this
          * implementation with one that is as efficient as possible (if the {@link BufferView} implementation allows it).
          *
          * @return The read int.

--- a/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
@@ -79,8 +79,9 @@ public abstract class AbstractBufferView implements BufferView {
     protected static abstract class AbstractReader implements BufferView.Reader {
         /**
          * {@inheritDoc}
-         * Default implementation for {@code Reader#readInt()}. Derived classes should make every effort to override this
-         * implementation with one that is as efficient as possible (if the {@link BufferView} implementation allows it).
+         * Default implementation for {@link BufferView.Reader#readInt()}. Derived classes should make every effort to
+         * override this implementation with one that is as efficient as possible (if the {@link BufferView}
+         * implementation allows it).
          *
          * @return The read int.
          * @throws BufferView.Reader.OutOfBoundsException If {@link #available()} is less than {@link Integer#BYTES}.
@@ -92,8 +93,9 @@ public abstract class AbstractBufferView implements BufferView {
 
         /**
          * {@inheritDoc}
-         * Default implementation for {@code Reader#readLong()}. Derived classes should make every effort to override this
-         * implementation with one that is as efficient as possible (if the {@link BufferView} implementation allows it).
+         * Default implementation for {@link BufferView.Reader#readLong()}. Derived classes should make every effort to
+         * override this implementation with one that is as efficient as possible (if the {@link BufferView}
+         * implementation allows it).
          *
          * @return The read int.
          * @throws BufferView.Reader.OutOfBoundsException If {@link #available()} is less than {@link Long#BYTES}.

--- a/common/src/main/java/io/pravega/common/util/AsyncIterator.java
+++ b/common/src/main/java/io/pravega/common/util/AsyncIterator.java
@@ -104,7 +104,7 @@ public interface AsyncIterator<T> {
      * Returns a new {@link AsyncIterator} that wraps this instance and converts all items from this one into items of a
      * new type.
      *
-     * @param converter A {@link Function} that will convert {@link T} to {@link U}.
+     * @param converter A {@link Function} that will convert T to U.
      * @param <U>       New type.
      * @return A new {@link AsyncIterator}.
      */
@@ -116,7 +116,7 @@ public interface AsyncIterator<T> {
      * Returns a new {@link AsyncIterator} that wraps this instance and converts all items from this one into items of a
      * new type using an async call.
      *
-     * @param converter A {@link Function} that will convert {@link T} to {@link U}.
+     * @param converter A {@link Function} that will convert T to U.
      * @param <U>       New type.
      * @return A new {@link AsyncIterator}.
      */

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -518,7 +518,7 @@ public class EventProcessorTest {
         }
         assertEquals(count * expectedSum, actualSum);
 
-        // Stop the group, and await its termmination.
+        // Stop the group, and await its termination.
         group.stopAsync();
         group.awaitTerminated();
     }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1398,6 +1398,7 @@ public abstract class StreamMetadataTasksTest {
 
     @Test(timeout = 10000)
     public void testThrowSynchronousExceptionOnWriteEvent() {
+        @SuppressWarnings("unchecked")
         EventStreamWriter<ControllerEvent> requestEventWriter = mock(EventStreamWriter.class);
         doAnswer(x -> {
             throw new RuntimeException();
@@ -1479,6 +1480,7 @@ public abstract class StreamMetadataTasksTest {
         // being thrown.
         // For all subsequent times we will wait on waitOnLockFailed future.  
         doAnswer(x -> {
+            @SuppressWarnings("unchecked")
             CompletableFuture<Void> future = (CompletableFuture<Void>) x.callRealMethod();
             return future.exceptionally(e -> {
                 if (Exceptions.unwrap(e) instanceof LockFailedException) {

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
@@ -189,7 +189,7 @@ public interface TableStore {
      * <li>{@link ConditionalTableUpdateException} If {@link TableEntry#getKey()} {@link TableKey#hasVersion() hasVersion() } is true and
      * {@link TableEntry#getKey()} {@link TableKey#getVersion()} does not match the Table Entry's Key current Table Version. </li>
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment. </li>
-     * <li>{@link BadOffsetException} If there is a mismatch between the provided {@param tableSegmentOffset} and the actual segment length.<\li>
+     * <li>{@link BadOffsetException} If there is a mismatch between the provided {@code tableSegmentOffset} and the actual segment length.<\li>
      * </ul>
      */
     CompletableFuture<List<Long>> put(String segmentName, List<TableEntry> entries, long tableSegmentOffset, Duration timeout);
@@ -233,7 +233,7 @@ public interface TableStore {
      * <li>{@link ConditionalTableUpdateException} If {@link TableKey#hasVersion()} is true and {@link TableKey#getVersion()}.
      * does not match the Table Entry's Key current Table Version.
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment.
-     * <li>{@link BadOffsetException} If there is a mismatch between the provided {@param tableSegmentOffset} and the actual segment length.
+     * <li>{@link BadOffsetException} If there is a mismatch between the provided {@code tableSegmentOffset} and the actual segment length.
      * </ul>
      */
     CompletableFuture<Void> remove(String segmentName, Collection<TableKey> keys, long tableSegmentOffset, Duration timeout);
@@ -314,7 +314,7 @@ public interface TableStore {
      * @param fromPosition      The position to begin iteration at.
      * @param fetchTimeout      Timeout for each invocation to {@link AsyncIterator#getNext()}.
      * @return A CompletableFuture that, when completed, will return an {@link AsyncIterator} that can be used to iterate
-     * over all the {@link TableEntry} instances starting at {@param fromPosition}. If the operation failed, the Future will be failed with the
+     * over all the {@link TableEntry} instances starting at {@code fromPosition}. If the operation failed, the Future will be failed with the
      * causing exception. Notable exceptions:
      * <ul>
      * <li>{@link StreamSegmentNotExistsException} If the Table Segment does not exist.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/tables/TableStore.java
@@ -28,11 +28,11 @@ import java.util.concurrent.CompletableFuture;
  * Conditional vs Unconditional Updates
  * * The {@link #put(String, List, Duration)} and {@link #remove(String, Collection, Duration)} methods support conditional
  * updates.
- * * If at least one of the {@link TableEntry} instances in the {@link #put} call has {@link TableEntry#key}.{@link TableKey#hasVersion} true,
+ * * If at least one of the {@link TableEntry} instances in the {@link #put} call has {@link TableEntry#getKey()}.{@link TableKey#hasVersion} true,
  * or if at least one of the {@link TableKey} instances in the remove() call has {@link TableKey#hasVersion()} true, then
  * the operation will perform a Conditional Update. If the "hasVersion()" method returns false for ALL the items in the
  * respective collections, then the operation will perform an Unconditional Update.
- * * Conditional Updates compare the provided {@link TableKey#version} or {@link TableEntry#key} {@link TableKey#version}
+ * * Conditional Updates compare the provided {@link TableKey#getVersion()} or {@link TableEntry#getKey()} {@link TableKey#getVersion()}
  * against the version of the Key in the specified Table Segment. If the versions match, the Update (insert, update, remove)
  * will be allowed, otherwise it will be rejected. For a batched update (a Collection of {@link TableKey} or {@link TableEntry}),
  * all the items in the collection must meet the version comparison criteria in order for the entire batch to be accepted
@@ -148,9 +148,9 @@ public interface TableStore {
      * Inserts new or updates existing Table Entries into the given Table Segment.
      *
      * @param segmentName The name of the Table Segment to insert/update the Table Entries.
-     * @param entries     A List of {@link TableEntry} instances to insert or update. If {@link TableEntry#key} {@link TableKey#hasVersion}
+     * @param entries     A List of {@link TableEntry} instances to insert or update. If {@link TableEntry#getKey()} {@link TableKey#hasVersion}
      *                    returns true for at least one of the items in the list, then this will perform an atomic Conditional
-     *                    Update. If {@link TableEntry#key} {@link TableKey#version} hasVersion} returns false for ALL items in the list, then this
+     *                    Update. If {@link TableEntry#getKey()} {@link TableKey#getVersion()} hasVersion} returns false for ALL items in the list, then this
      *                    will perform an Unconditional update.
      * @param timeout     Timeout for the operation.
      * @return A CompletableFuture that, when completed, will contain a List with the current version of the each TableEntry
@@ -158,10 +158,10 @@ public interface TableStore {
      * the future will be failed with the causing exception. Notable exceptions:
      * <ul>
      * <li>{@link StreamSegmentNotExistsException} If the Table Segment does not exist.</li>
-     * <li>{@link TableKeyTooLongException} If {@link TableEntry#key} exceeds {@link #MAXIMUM_KEY_LENGTH}.</li>
-     * <li>{@link TableValueTooLongException} If {@link TableEntry#value} exceeds {@link #MAXIMUM_VALUE_LENGTH}.</li>
-     * <li>{@link ConditionalTableUpdateException} If {@link TableEntry#key} {@link TableKey#hasVersion() hasVersion() } is true and
-     * {@link TableEntry#key} {@link TableKey#version} does not match the Table Entry's Key current Table Version. </li>
+     * <li>{@link TableKeyTooLongException} If {@link TableEntry#getKey()} exceeds {@link #MAXIMUM_KEY_LENGTH}.</li>
+     * <li>{@link TableValueTooLongException} If {@link TableEntry#getValue()} exceeds {@link #MAXIMUM_VALUE_LENGTH}.</li>
+     * <li>{@link ConditionalTableUpdateException} If {@link TableEntry#getKey()} {@link TableKey#hasVersion() hasVersion() } is true and
+     * {@link TableEntry#getKey()} {@link TableKey#getVersion()} does not match the Table Entry's Key current Table Version. </li>
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment. </li>
      * </ul>
      */
@@ -172,10 +172,10 @@ public interface TableStore {
      * into the given Segment.
      *
      * @param segmentName        The name of the Table Segment to insert/update the Table Entries.
-     * @param entries            A List of {@link TableEntry} instances to insert or update. If {@link TableEntry#key}
-     *                           {@link TableKey#version hasVersion} returns true for at least one of the items in the list,
-     *                           then this will perform an atomic Conditional Update. If {@link TableEntry#key}
-     *                           {@link TableKey#version} hasVersion} returns false for ALL items in the list, then this
+     * @param entries            A List of {@link TableEntry} instances to insert or update. If {@link TableEntry#getKey()}
+     *                           {@link TableKey#getVersion()}  hasVersion} returns true for at least one of the items in the list,
+     *                           then this will perform an atomic Conditional Update. If {@link TableEntry#getKey()}
+     *                           {@link TableKey#getVersion()} hasVersion} returns false for ALL items in the list, then this
      *                           will just be conditioned on the tableSegmentOffset value.
      * @param tableSegmentOffset The expected offset of the TableSegment used for conditional (expected matches actual) appends.
      * @param timeout            Timeout for the operation.
@@ -184,10 +184,10 @@ public interface TableStore {
      * the future will be failed with the causing exception. Notable exceptions:
      * <ul>
      * <li>{@link StreamSegmentNotExistsException} If the Table Segment does not exist.</li>
-     * <li>{@link TableKeyTooLongException} If {@link TableEntry#key} exceeds {@link #maximumKeyLength()}.</li>
-     * <li>{@link TableValueTooLongException} If {@link TableEntry#value} exceeds {@link #maximumValueLength()}.</li>
-     * <li>{@link ConditionalTableUpdateException} If {@link TableEntry#key} {@link TableKey#hasVersion() hasVersion() } is true and
-     * {@link TableEntry#key} {@link TableKey#version} does not match the Table Entry's Key current Table Version. </li>
+     * <li>{@link TableKeyTooLongException} If {@link TableEntry#getKey()} exceeds {@link #MAXIMUM_KEY_LENGTH}.</li>
+     * <li>{@link TableValueTooLongException} If {@link TableEntry#getValue()} exceeds {@link #MAXIMUM_VALUE_LENGTH}.</li>
+     * <li>{@link ConditionalTableUpdateException} If {@link TableEntry#getKey()} {@link TableKey#hasVersion() hasVersion() } is true and
+     * {@link TableEntry#getKey()} {@link TableKey#getVersion()} does not match the Table Entry's Key current Table Version. </li>
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment. </li>
      * <li>{@link BadOffsetException} If there is a mismatch between the provided {@param tableSegmentOffset} and the actual segment length.<\li>
      * </ul>
@@ -207,8 +207,8 @@ public interface TableStore {
      * the future will be failed with the causing exception. Notable exceptions:
      * <ul>
      * <li>{@link StreamSegmentNotExistsException} If the Table Segment does not exist.
-     * <li>{@link TableKeyTooLongException} If {@link TableKey#key} exceeds {@link #MAXIMUM_KEY_LENGTH}.
-     * <li>{@link ConditionalTableUpdateException} If {@link TableKey#hasVersion()} is true and {@link TableKey#version}
+     * <li>{@link TableKeyTooLongException} If {@link TableKey#getKey()} exceeds {@link #MAXIMUM_KEY_LENGTH}.
+     * <li>{@link ConditionalTableUpdateException} If {@link TableKey#hasVersion()} is true and {@link TableKey#getVersion()}.
      * does not match the Table Entry's Key current Table Version.
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment.
      * </ul>
@@ -229,8 +229,8 @@ public interface TableStore {
      * the future will be failed with the causing exception. Notable exceptions:
      * <ul>
      * <li>{@link StreamSegmentNotExistsException} If the Table Segment does not exist.
-     * <li>{@link TableKeyTooLongException} If {@link TableKey#key} exceeds {@link #maximumKeyLength()}.
-     * <li>{@link ConditionalTableUpdateException} If {@link TableKey#hasVersion()} is true and {@link TableKey#version}
+     * <li>{@link TableKeyTooLongException} If {@link TableKey#getKey()} exceeds {@link #MAXIMUM_KEY_LENGTH}.
+     * <li>{@link ConditionalTableUpdateException} If {@link TableKey#hasVersion()} is true and {@link TableKey#getVersion()}.
      * does not match the Table Entry's Key current Table Version.
      * <li>{@link BadSegmentTypeException} If segmentName refers to a non-Table Segment.
      * <li>{@link BadOffsetException} If there is a mismatch between the provided {@param tableSegmentOffset} and the actual segment length.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -434,7 +434,7 @@ public abstract class MetadataStore implements AutoCloseable {
     }
 
     /**
-     * Invokes the {@link Connector#getMapSegmentId()} callback in order to assign an Id to a Segment. Upon completion,
+     * Invokes the {@code Connector#getMapSegmentId()} callback in order to assign an Id to a Segment. Upon completion,
      * this operation will have mapped the given Segment to a new internal Segment Id if none was provided in the given
      * SegmentInfo. If the given SegmentInfo already has a SegmentId set, then all efforts will be made to map that Segment
      * with the requested Segment Id.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -434,7 +434,7 @@ public abstract class MetadataStore implements AutoCloseable {
     }
 
     /**
-     * Invokes the {@code Connector#getMapSegmentId()} callback in order to assign an Id to a Segment. Upon completion,
+     * Invokes the {@link MetadataStore.Connector#getMapSegmentId()} callback in order to assign an Id to a Segment. Upon completion,
      * this operation will have mapped the given Segment to a new internal Segment Id if none was provided in the given
      * SegmentInfo. If the given SegmentInfo already has a SegmentId set, then all efforts will be made to map that Segment
      * with the requested Segment Id.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -671,7 +671,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
         for (Map.Entry<String, ByteArrayOutputStream> e : segmentContents.entrySet()) {
             String segmentName = e.getKey();
             byte[] expectedData = e.getValue().toByteArray();
-            AtomicReference<StreamSegmentInformation> info = new AtomicReference((StreamSegmentInformation) store.getStreamSegmentInfo(segmentName, TIMEOUT).join());
+            AtomicReference<StreamSegmentInformation> info = new AtomicReference<>((StreamSegmentInformation) store.getStreamSegmentInfo(segmentName, TIMEOUT).join());
             Assert.assertEquals("Unexpected Read Index length for segment " + segmentName, expectedData.length, info.get().getLength());
 
             AtomicLong expectedCurrentOffset = new AtomicLong(0);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -48,24 +48,25 @@ import static com.google.common.base.Strings.nullToEmpty;
  * This creates a circular dependency while reading or writing the data about these segments from the metadata segments.
  * System journal is a mechanism to break this circular dependency by having independent log of all layout changes to system segments.
  * During bootstrap all the system journal files are read and processed to re-create the state of the storage system segments.
- * Currently only two actions are considered viz. Addition of new chunks {@code ChunkAddedRecord} and truncation of segments {@code TruncationRecord}.
- * In addition to these two records, log also contains system snapshot records {@code SystemSnapshotRecord} which contains the state
- * of each storage system segments ({@code SegmentSnapshotRecord}) after replaying all available logs at the time of snapshots.
+ * Currently only two actions are considered viz. Addition of new chunks {@link SystemJournal.ChunkAddedRecord} and truncation of segments
+ * {@link SystemJournal.TruncationRecord}.
+ * In addition to these two records, log also contains system snapshot records {@link SystemJournal.SystemSnapshotRecord} which contains the state
+ * of each storage system segments ({@link SystemJournal.SegmentSnapshotRecord}) after replaying all available logs at the time of snapshots.
  * These snapshot records help avoid replaying entire log evey time. Each container instance records snapshot immediately after bootstrap.
  * To avoid data corruption, each instance writes to its own distinct log file/object.
  * The bootstrap algorithm also correctly ignores invalid log entries written by running instance which is no longer owner of the given container.
- * To prevent applying partial changes resulting from unexpected crash, the log records are written as {@code SystemJournalRecordBatch}.
+ * To prevent applying partial changes resulting from unexpected crash, the log records are written as {@link SystemJournal.SystemJournalRecordBatch}.
  * In such cases either a full batch is read and applied completely or no records in the batch are applied.
  */
 @Slf4j
 public class SystemJournal {
     /**
-     * Serializer for {@code SystemJournalRecordBatch}.
+     * Serializer for {@link SystemJournal.SystemJournalRecordBatch}.
      */
     private static final SystemJournalRecordBatch.SystemJournalRecordBatchSerializer BATCH_SERIALIZER = new SystemJournalRecordBatch.SystemJournalRecordBatchSerializer();
 
     /**
-     * Serializer for {@code SystemSnapshotRecord}.
+     * Serializer for {@link SystemJournal.SystemSnapshotRecord}.
      */
     private static final SystemSnapshotRecord.Serializer SYSTEM_SNAPSHOT_SERIALIZER = new SystemSnapshotRecord.Serializer();
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -48,24 +48,24 @@ import static com.google.common.base.Strings.nullToEmpty;
  * This creates a circular dependency while reading or writing the data about these segments from the metadata segments.
  * System journal is a mechanism to break this circular dependency by having independent log of all layout changes to system segments.
  * During bootstrap all the system journal files are read and processed to re-create the state of the storage system segments.
- * Currently only two actions are considered viz. Addition of new chunks {@link ChunkAddedRecord} and truncation of segments {@link TruncationRecord}.
- * In addition to these two records, log also contains system snapshot records {@link SystemSnapshotRecord} which contains the state
- * of each storage system segments ({@link SegmentSnapshotRecord}) after replaying all available logs at the time of snapshots.
+ * Currently only two actions are considered viz. Addition of new chunks {@code ChunkAddedRecord} and truncation of segments {@code TruncationRecord}.
+ * In addition to these two records, log also contains system snapshot records {@code SystemSnapshotRecord} which contains the state
+ * of each storage system segments ({@code SegmentSnapshotRecord}) after replaying all available logs at the time of snapshots.
  * These snapshot records help avoid replaying entire log evey time. Each container instance records snapshot immediately after bootstrap.
  * To avoid data corruption, each instance writes to its own distinct log file/object.
  * The bootstrap algorithm also correctly ignores invalid log entries written by running instance which is no longer owner of the given container.
- * To prevent applying partial changes resulting from unexpected crash, the log records are written as {@link SystemJournalRecordBatch}.
+ * To prevent applying partial changes resulting from unexpected crash, the log records are written as {@code SystemJournalRecordBatch}.
  * In such cases either a full batch is read and applied completely or no records in the batch are applied.
  */
 @Slf4j
 public class SystemJournal {
     /**
-     * Serializer for {@link SystemJournalRecordBatch}.
+     * Serializer for {@code SystemJournalRecordBatch}.
      */
     private static final SystemJournalRecordBatch.SystemJournalRecordBatchSerializer BATCH_SERIALIZER = new SystemJournalRecordBatch.SystemJournalRecordBatchSerializer();
 
     /**
-     * Serializer for {@link SystemSnapshotRecord}.
+     * Serializer for {@code SystemSnapshotRecord}.
      */
     private static final SystemSnapshotRecord.Serializer SYSTEM_SNAPSHOT_SERIALIZER = new SystemSnapshotRecord.Serializer();
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
@@ -65,7 +65,7 @@ public class ChunkMetadata extends StorageMetadata {
     /**
      * Creates a deep copy of this instance.
      *
-     * @return
+     * @return Deep copy of this instance.
      */
     @Override
     public StorageMetadata deepCopy() {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
@@ -147,7 +147,7 @@ public class SegmentMetadata extends StorageMetadata {
     /**
      * Creates a copy of this instance.
      *
-     * @return
+     * @return Copy of this instance.
      */
     @Override
     public StorageMetadata deepCopy() {

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -71,7 +71,7 @@ public class MetricsNamesTest {
 
     @Test
     public void testMetricKeyWithSingleNull() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", (String) null);
+        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", null, null);
         assertEquals("metric", keys.getCacheKey());
         assertEquals("metric", keys.getRegistryKey());
     }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @Slf4j
 public class MetricsNamesTest {
@@ -20,7 +21,7 @@ public class MetricsNamesTest {
     @Test
     public void testFailMetricName() {
 
-        assertEquals(null, MetricsNames.failMetricName(null));
+        assertNull(MetricsNames.failMetricName(null));
         assertEquals("", MetricsNames.failMetricName(""));
         assertEquals("tag_fail", MetricsNames.failMetricName("tag"));
         assertEquals("0_fail", MetricsNames.failMetricName("0"));
@@ -61,12 +62,12 @@ public class MetricsNamesTest {
 
     @Test (expected = IllegalArgumentException.class)
     public void testMetricKeyWithTagNameOnly() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", "tagName");
+        MetricsNames.metricKey("metric", "tagName");
     }
 
     @Test (expected = IllegalArgumentException.class)
     public void testMetricKeyWithOddNumberTags() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", "tag1", "value1", "tag2");
+        MetricsNames.metricKey("metric", "tag1", "value1", "tag2");
     }
 
     @Test
@@ -78,6 +79,6 @@ public class MetricsNamesTest {
 
     @Test  (expected = IllegalArgumentException.class)
     public void testMetricKeyWithDoubleNull() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", null, null);
+        MetricsNames.metricKey("metric", null, null);
     }
 }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -71,7 +71,7 @@ public class MetricsNamesTest {
 
     @Test
     public void testMetricKeyWithSingleNull() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", null);
+        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", (String) null);
         assertEquals("metric", keys.getCacheKey());
         assertEquals("metric", keys.getRegistryKey());
     }

--- a/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/MetricsNamesTest.java
@@ -72,7 +72,7 @@ public class MetricsNamesTest {
 
     @Test
     public void testMetricKeyWithSingleNull() {
-        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", null, null);
+        MetricsNames.MetricKey keys = MetricsNames.metricKey("metric", (String[]) null);
         assertEquals("metric", keys.getCacheKey());
         assertEquals("metric", keys.getRegistryKey());
     }

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsLogAppenderTests.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/MetricsLogAppenderTests.java
@@ -235,6 +235,7 @@ public class MetricsLogAppenderTests {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public Map<String, String> getMdc() {
             return null;
         }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -2358,7 +2358,7 @@ public final class WireCommands {
         }
 
         /**
-         * Releases any resources used by this command, if needed ({@link #isReleased()} is false. This method has no
+         * Releases any resources used by this command, if needed ({@code #isReleased()} is false. This method has no
          * effect if invoked multiple times or if no resource release is required.
          */
         public void release() {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -2358,7 +2358,7 @@ public final class WireCommands {
         }
 
         /**
-         * Releases any resources used by this command, if needed ({@code #isReleased()} is false. This method has no
+         * Releases any resources used by this command, if needed {@code #isReleased()} is false. This method has no
          * effect if invoked multiple times or if no resource release is required.
          */
         public void release() {

--- a/shared/protocol/src/test/java/io/pravega/shared/metrics/ClientMetricKeysTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/metrics/ClientMetricKeysTest.java
@@ -37,7 +37,7 @@ public class ClientMetricKeysTest {
 
     @Test
     public void testMetricKeyEmptyTags() {
-        String metric = CLIENT_APPEND_LATENCY.metric( null);
+        String metric = CLIENT_APPEND_LATENCY.metric((String) null);
         assertEquals(CLIENT_APPEND_LATENCY.getMetricKey(), metric);
 
         metric = CLIENT_APPEND_LATENCY.metric();

--- a/shared/protocol/src/test/java/io/pravega/shared/metrics/ClientMetricKeysTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/metrics/ClientMetricKeysTest.java
@@ -37,7 +37,7 @@ public class ClientMetricKeysTest {
 
     @Test
     public void testMetricKeyEmptyTags() {
-        String metric = CLIENT_APPEND_LATENCY.metric((String) null);
+        String metric = CLIENT_APPEND_LATENCY.metric((String[]) null);
         assertEquals(CLIENT_APPEND_LATENCY.getMetricKey(), metric);
 
         metric = CLIENT_APPEND_LATENCY.metric();

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/AppendEncodeDecodeTest.java
@@ -130,11 +130,13 @@ public class AppendEncodeDecodeTest extends LeakDetectorTestSuite {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void shutdown() {
 
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public List<Runnable> shutdownNow() {
             return null;
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
@@ -10,7 +10,6 @@
 package io.pravega.test.integration.controller.server;
 
 import com.google.common.base.Preconditions;
-import io.netty.util.internal.ConcurrentSet;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
@@ -58,6 +57,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -476,7 +476,7 @@ public class EventProcessorTest {
 
         // write 10 events and read them back from the queue passed to first event processor's
         List<Integer> input = IntStream.range(0, 10).boxed().collect(Collectors.toList());
-        ConcurrentSet<Integer> output = new ConcurrentSet<>();
+        ConcurrentSkipListSet<Integer> output = new ConcurrentSkipListSet<>();
 
         for (int val : input) {
             writer.writeEvent(new TestEvent(val));
@@ -518,7 +518,7 @@ public class EventProcessorTest {
 
         AtomicInteger queue1EntriesFound = new AtomicInteger(0);
         AtomicInteger queue2EntriesFound = new AtomicInteger(0);
-        ConcurrentSet<Integer> output2 = new ConcurrentSet<>();
+        ConcurrentSkipListSet<Integer> output2 = new ConcurrentSkipListSet<>();
 
         // wait until rebalance may have happened. 
         ReaderGroupManager groupManager = new ReaderGroupManagerImpl(scope, controller, clientFactory);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTransactionOrderTest.java
@@ -9,7 +9,6 @@
  */
 package io.pravega.test.integration.endtoendtest;
 
-import io.netty.util.internal.ConcurrentSet;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
@@ -53,6 +52,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -84,7 +84,7 @@ public class EndToEndTransactionOrderTest {
     ConcurrentHashMap<Integer, UUID> eventToTxnMap = new ConcurrentHashMap<>();
     ConcurrentHashMap<UUID, String> txnToWriter = new ConcurrentHashMap<>();
     AtomicInteger counter = new AtomicInteger();
-    ConcurrentSet<UUID> uncommitted = new ConcurrentSet<>();
+    ConcurrentSkipListSet<UUID> uncommitted = new ConcurrentSkipListSet<>();
     TestingServer zkTestServer;
     ControllerWrapper controllerWrapper;
     Controller controller;
@@ -213,7 +213,7 @@ public class EndToEndTransactionOrderTest {
         }
     }
 
-    private CompletableFuture<Void> waitTillCommitted(Controller controller, Stream s, UUID key, ConcurrentSet<UUID> uncommitted) {
+    private CompletableFuture<Void> waitTillCommitted(Controller controller, Stream s, UUID key, ConcurrentSkipListSet<UUID> uncommitted) {
         AtomicBoolean committed = new AtomicBoolean(false);
         AtomicInteger counter = new AtomicInteger(0);
         // check 6 times with 5 second gap until transaction is committed. if it is not committed, declare it uncommitted

--- a/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/AbstractReadWriteTest.java
@@ -10,7 +10,6 @@
 package io.pravega.test.system;
 
 import com.google.common.base.Preconditions;
-import io.netty.util.internal.ConcurrentSet;
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.EventRead;
@@ -34,6 +33,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -92,8 +92,8 @@ abstract class AbstractReadWriteTest extends AbstractSystemTest {
         final CompletableFuture<Void> newWritersComplete = new CompletableFuture<>();
         final CompletableFuture<Void> readersComplete = new CompletableFuture<>();
         final List<CompletableFuture<Void>> txnStatusFutureList = synchronizedList(new ArrayList<>());
-        final ConcurrentSet<UUID> committingTxn = new ConcurrentSet<>();
-        final ConcurrentSet<UUID> abortedTxn = new ConcurrentSet<>();
+        final ConcurrentSkipListSet<UUID> committingTxn = new ConcurrentSkipListSet<>();
+        final ConcurrentSkipListSet<UUID> abortedTxn = new ConcurrentSkipListSet<>();
         final boolean txnWrite;
 
         final AtomicLong writtenEvents = new AtomicLong();


### PR DESCRIPTION
**Change log description**  
Fixes several compile and javadoc related warnings throughout the project.

**Purpose of the change**  
Fixes #3373, fixes #4003, fixes #2985, fixes #5054.

**What the code does**  
Removes multiple compile and javadoc related warnings across several components.

**How to verify it**  
All tests should be passing as before. No warnings should be seen when downloading logs from Travis or when building locally.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>