### PR TITLE
Issue 5033: (SLTS) - Read ChunkedSegmentStorageConfig from properties.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
@@ -27,6 +27,9 @@ import java.util.concurrent.ExecutorService;
 @RequiredArgsConstructor
 public class ExtendedS3SimpleStorageFactory implements StorageFactory {
     @NonNull
+    private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
+
+    @NonNull
     private final ExtendedS3StorageConfig config;
 
     @NonNull
@@ -37,7 +40,7 @@ public class ExtendedS3SimpleStorageFactory implements StorageFactory {
         ChunkedSegmentStorage storageProvider = new ChunkedSegmentStorage(
                 new ExtendedS3ChunkStorage(createS3Client(), this.config),
                 this.executor,
-                ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+                this.chunkedSegmentStorageConfig);
         return storageProvider;
     }
 

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactoryCreator.java
@@ -15,6 +15,7 @@ import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
 import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -26,7 +27,9 @@ public class ExtendedS3StorageFactoryCreator implements StorageFactoryCreator {
         Preconditions.checkNotNull(executor, "executor");
         Preconditions.checkArgument(storageFactoryInfo.getName().equals("EXTENDEDS3"));
         if (storageFactoryInfo.getStorageLayoutType().equals(StorageLayoutType.CHUNKED_STORAGE)) {
-            return new ExtendedS3SimpleStorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), executor);
+            return new ExtendedS3SimpleStorageFactory(setup.getConfig(ChunkedSegmentStorageConfig::builder),
+                    setup.getConfig(ExtendedS3StorageConfig::builder),
+                    executor);
         } else {
             return new ExtendedS3StorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), executor);
         }

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
@@ -13,16 +13,19 @@ import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.ExecutorService;
 
 /**
- * Factory for FileSystem {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link FileSystemChunkStorage}.
+ * Factory for ExtendedS3 {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link FileSystemChunkStorage}.
  */
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class FileSystemSimpleStorageFactory implements StorageFactory {
+    @NonNull
+    private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
+
     @NonNull
     private final FileSystemStorageConfig config;
 
@@ -34,7 +37,7 @@ public class FileSystemSimpleStorageFactory implements StorageFactory {
         ChunkedSegmentStorage storageProvider = new ChunkedSegmentStorage(
                 new FileSystemChunkStorage(this.config),
                 this.executor,
-                ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+                this.chunkedSegmentStorageConfig);
         return storageProvider;
     }
 }

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
@@ -13,15 +13,15 @@ import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.ExecutorService;
 
 /**
- * Factory for ExtendedS3 {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link FileSystemChunkStorage}.
+ * Factory for FileSystem {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link FileSystemChunkStorage}.
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class FileSystemSimpleStorageFactory implements StorageFactory {
     @NonNull
     private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageFactoryCreator.java
@@ -15,6 +15,7 @@ import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
 import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -41,7 +42,9 @@ public class FileSystemStorageFactoryCreator implements StorageFactoryCreator {
         Preconditions.checkNotNull(executor, "executor");
         Preconditions.checkArgument(storageFactoryInfo.getName().equals("FILESYSTEM"));
         if (storageFactoryInfo.getStorageLayoutType().equals(StorageLayoutType.CHUNKED_STORAGE)) {
-            return new FileSystemSimpleStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), executor);
+            return new FileSystemSimpleStorageFactory(setup.getConfig(ChunkedSegmentStorageConfig::builder),
+                    setup.getConfig(FileSystemStorageConfig::builder),
+                    executor);
         } else {
             return new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), executor);
         }

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
@@ -13,18 +13,23 @@ import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.Executor;
 
 /**
  * Factory for HDFS {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link HDFSChunkStorage}.
  */
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class HDFSSimpleStorageFactory implements StorageFactory {
+
+    @NonNull
+    private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
+
     @NonNull
     private final HDFSStorageConfig config;
+
     @NonNull
     private final Executor executor;
 
@@ -33,7 +38,7 @@ public class HDFSSimpleStorageFactory implements StorageFactory {
         ChunkedSegmentStorage storageProvider = new ChunkedSegmentStorage(
                 new HDFSChunkStorage(this.config),
                 this.executor,
-                ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+                this.chunkedSegmentStorageConfig);
         return storageProvider;
     }
 }

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
@@ -13,15 +13,15 @@ import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.Executor;
 
 /**
  * Factory for HDFS {@link Storage} implemented using {@link ChunkedSegmentStorage} and {@link HDFSChunkStorage}.
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class HDFSSimpleStorageFactory implements StorageFactory {
 
     @NonNull

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSStorageFactoryCreator.java
@@ -15,6 +15,7 @@ import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
 import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -41,7 +42,9 @@ public class HDFSStorageFactoryCreator implements StorageFactoryCreator {
         Preconditions.checkNotNull(executor, "executor");
         Preconditions.checkArgument(storageFactoryInfo.getName().equals("HDFS"));
         if (storageFactoryInfo.getStorageLayoutType().equals(StorageLayoutType.CHUNKED_STORAGE)) {
-            return new HDFSSimpleStorageFactory(setup.getConfig(HDFSStorageConfig::builder), executor);
+            return new HDFSSimpleStorageFactory(setup.getConfig(ChunkedSegmentStorageConfig::builder),
+                    setup.getConfig(HDFSStorageConfig::builder),
+                    executor);
         } else {
             return new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), executor);
         }

--- a/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
+++ b/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
 import io.pravega.segmentstore.storage.SyncStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.storage.extendeds3.ExtendedS3SimpleStorageFactory;
 import io.pravega.storage.extendeds3.ExtendedS3StorageConfig;
 import io.pravega.storage.extendeds3.ExtendedS3StorageFactory;
@@ -63,7 +64,7 @@ public class StorageFactoryTests {
 
         // Simple Storage
         ConfigSetup configSetup1 = mock(ConfigSetup.class);
-        when(configSetup1.getConfig(any())).thenReturn(HDFSStorageConfig.builder().build());
+        when(configSetup1.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, HDFSStorageConfig.builder().build());
         val factory1 = factoryCreator.createFactory(expected[0], configSetup1, new ScheduledThreadPoolExecutor(1));
         Assert.assertTrue(factory1 instanceof HDFSSimpleStorageFactory);
 
@@ -109,7 +110,7 @@ public class StorageFactoryTests {
                 .with(ExtendedS3StorageConfig.BUCKET, "bucket")
                 .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
                 .build();
-        when(configSetup1.getConfig(any())).thenReturn(config);
+        when(configSetup1.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, config);
         val factory1 = factoryCreator.createFactory(expected[0], configSetup1, new ScheduledThreadPoolExecutor(1));
         Assert.assertTrue(factory1 instanceof ExtendedS3SimpleStorageFactory);
 
@@ -150,7 +151,7 @@ public class StorageFactoryTests {
 
         // Simple Storage
         ConfigSetup configSetup1 = mock(ConfigSetup.class);
-        when(configSetup1.getConfig(any())).thenReturn(FileSystemStorageConfig.builder().build());
+        when(configSetup1.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, FileSystemStorageConfig.builder().build());
         val factory1 = factoryCreator.createFactory(expected[0], configSetup1, new ScheduledThreadPoolExecutor(1));
         Assert.assertTrue(factory1 instanceof FileSystemSimpleStorageFactory);
 
@@ -175,27 +176,39 @@ public class StorageFactoryTests {
         val executor = new ScheduledThreadPoolExecutor(1);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new FileSystemSimpleStorageFactory(null, executor),
+                () -> new FileSystemSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, null, executor),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new ExtendedS3SimpleStorageFactory(null, executor),
+                () -> new ExtendedS3SimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, null, executor),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new HDFSSimpleStorageFactory(null, executor),
+                () -> new HDFSSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, null, executor),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new FileSystemSimpleStorageFactory(FileSystemStorageConfig.builder().build(), null),
+                () -> new FileSystemSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, FileSystemStorageConfig.builder().build(), null),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new ExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig.builder().build(), null),
+                () -> new ExtendedS3SimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, ExtendedS3StorageConfig.builder().build(), null),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows(
                 " should throw exception.",
-                () -> new HDFSSimpleStorageFactory(HDFSStorageConfig.builder().build(), null),
+                () -> new HDFSSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, HDFSStorageConfig.builder().build(), null),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw exception.",
+                () -> new FileSystemSimpleStorageFactory(null, FileSystemStorageConfig.builder().build(), executor),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw exception.",
+                () -> new ExtendedS3SimpleStorageFactory(null, ExtendedS3StorageConfig.builder().build(), executor),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw exception.",
+                () -> new HDFSSimpleStorageFactory(null, HDFSStorageConfig.builder().build(), executor),
                 ex -> ex instanceof NullPointerException);
     }
 }

--- a/config/config.properties
+++ b/config/config.properties
@@ -106,6 +106,47 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 # pravegaservice.storage.layout=ROLLING_STORAGE
 # NOTE: ChunkedSegmentStorage is an experimental feature. Its behavior and/or API should be expected to be in flux until fully released.
 
+# Size of chunk in bytes above which it is no longer considered a small object.
+# For small source objects, concat is not used.
+# Valid values: non-negative long
+# Default value: 0
+# storage.concat.size.bytes.min=0
+
+# Size of chunk in bytes above which it is no longer considered for concat.
+# Valid values: non-negative long
+# Default value: 9223372036854775807
+# storage.concat.size.bytes.max=9223372036854775807
+
+# Maximum size for the buffer used while copying of data from one chunk to other.
+# Valid values: non-negative integer
+# Default value: 1048576 (1 MB)
+# storage.appends.buffer.size.bytes.max=1048576
+
+# Max number of indexed segments to keep in read cache.
+# Valid values: non-negative integer
+# Default value: 1024 (1 K)
+# storage.readindex.segments.max=1024
+
+# Max number of indexed chunks to keep per segment in read cache.
+# Valid values: non-negative integer
+# Default value: 1024 (1 K)
+# storage.readindex.chunksPerSegment.max=1024
+
+# Max number of indexed chunks to keep in cache.
+# Valid values: non-negative integer
+# Default value: 16384 (16 K)
+# storage.readindex.chunks.max=16384
+
+# The maximum size of a single Segment Chunk in Storage for metadata segments.
+# Valid values: non-negative long
+# Default value: 4611686018427387903
+# storage.metadata.rollover.size.bytes.max=4611686018427387903
+
+# Whether the append functionality is disabled.
+# Valid values: true, false
+# Default value: false
+# storage.appends.disable=false
+
 # Storage NO-OP Mode: in No-Op mode, user stream segment writing is no-oped; user stream segment reading is not supported.
 # This mode is used to avoid storage interference in testing while still keep the system functioning as usual.
 # NOTE: pravegaservice.storage.impl.name is still used to store metadata and system segments, which are required for the functioning of the Pravega Cluster.

--- a/config/config.properties
+++ b/config/config.properties
@@ -112,7 +112,7 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 # Default value: 0
 # storage.concat.size.bytes.min=0
 
-# Size of chunk in bytes above which it is no longer considered for concat.
+# Max size of chunk in bytes above which it is no longer considered for concat.
 # Valid values: non-negative long
 # Default value: 9223372036854775807
 # storage.concat.size.bytes.max=9223372036854775807
@@ -138,14 +138,14 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 # storage.readindex.chunks.max=16384
 
 # The maximum size of a single Segment Chunk in Storage for metadata segments.
-# Valid values: non-negative long
+# Valid values: non-negative long less than 4611686018427387904.
 # Default value: 4611686018427387903
 # storage.metadata.rollover.size.bytes.max=4611686018427387903
 
-# Whether the append functionality is disabled.
+# Whether the append functionality is enabled.
 # Valid values: true, false
-# Default value: false
-# storage.appends.disable=false
+# Default value: true
+# storage.appends.enable=true
 
 # Storage NO-OP Mode: in No-Op mode, user stream segment writing is no-oped; user stream segment reading is not supported.
 # This mode is used to avoid storage interference in testing while still keep the system functioning as usual.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.host;
 
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
 import io.pravega.storage.filesystem.FileSystemSimpleStorageFactory;
@@ -47,7 +48,9 @@ public class FileSystemIntegrationTest extends BookKeeperIntegrationTestBase {
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
                 .withStorageFactory(setup -> useChunkedSegmentStorage ?
-                        new FileSystemSimpleStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor())
+                        new FileSystemSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                                setup.getConfig(FileSystemStorageConfig::builder),
+                                setup.getStorageExecutor())
                         : new FileSystemStorageFactory(setup.getConfig(FileSystemStorageConfig::builder), setup.getStorageExecutor())
                 )
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/HDFSIntegrationTest.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server.host;
 
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
 import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
 import io.pravega.storage.hdfs.HDFSClusterHelpers;
@@ -74,7 +75,9 @@ public class HDFSIntegrationTest extends BookKeeperIntegrationTestBase {
         return ServiceBuilder
                 .newInMemoryBuilder(builderConfig)
                 .withStorageFactory(setup -> useChunkedSegmentStorage ?
-                        new HDFSSimpleStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor())
+                        new HDFSSimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                                setup.getConfig(HDFSStorageConfig::builder),
+                                setup.getStorageExecutor())
                         : new HDFSStorageFactory(setup.getConfig(HDFSStorageConfig::builder), setup.getStorageExecutor()))
                 .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder), getBookkeeper().getZkClient(), setup.getCoreExecutor()));
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/StorageLoaderTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/StorageLoaderTest.java
@@ -16,6 +16,7 @@ import io.pravega.segmentstore.storage.ConfigSetup;
 import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageLayoutType;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.mocks.InMemoryStorageFactory;
 import io.pravega.segmentstore.storage.noop.NoOpStorageFactory;
 import io.pravega.segmentstore.storage.noop.StorageExtraConfig;
@@ -97,7 +98,7 @@ public class StorageLoaderTest {
         val extraConfig = StorageExtraConfig.builder()
                 .with(StorageExtraConfig.STORAGE_NO_OP_MODE, false)
                 .build();
-        when(configSetup.getConfig(any())).thenReturn(extraConfig, FileSystemStorageConfig.builder().build());
+        when(configSetup.getConfig(any())).thenReturn(extraConfig, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, FileSystemStorageConfig.builder().build());
 
         val factory  = getStorageFactory(configSetup, storageType, "FILESYSTEM", StorageLayoutType.CHUNKED_STORAGE);
         assertTrue(factory instanceof FileSystemSimpleStorageFactory);
@@ -122,7 +123,7 @@ public class StorageLoaderTest {
         val extraConfig = StorageExtraConfig.builder()
                 .with(StorageExtraConfig.STORAGE_NO_OP_MODE, false)
                 .build();
-        when(configSetup.getConfig(any())).thenReturn(extraConfig, HDFSStorageConfig.builder().build());
+        when(configSetup.getConfig(any())).thenReturn(extraConfig, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, HDFSStorageConfig.builder().build());
         val factory = getStorageFactory(configSetup, storageType, "HDFS", StorageLayoutType.CHUNKED_STORAGE);
         assertTrue(factory instanceof HDFSSimpleStorageFactory);
     }
@@ -158,7 +159,7 @@ public class StorageLoaderTest {
         val extraConfig = StorageExtraConfig.builder()
                 .with(StorageExtraConfig.STORAGE_NO_OP_MODE, false)
                 .build();
-        when(configSetup.getConfig(any())).thenReturn(extraConfig, config);
+        when(configSetup.getConfig(any())).thenReturn(extraConfig, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, config);
 
         val factory = getStorageFactory(configSetup, storageType, "EXTENDEDS3", StorageLayoutType.CHUNKED_STORAGE);
         assertTrue(factory instanceof ExtendedS3SimpleStorageFactory);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -725,7 +725,7 @@ public class ChunkedSegmentStorage implements Storage {
     }
 
     private boolean shouldAppend() {
-        return chunkStorage.supportsAppend() && !config.isAppendsDisabled();
+        return chunkStorage.supportsAppend() && config.isAppendEnabled();
     }
 
     private boolean shouldDefrag() {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -31,7 +31,7 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> MAX_INDEXED_SEGMENTS = Property.named("readindex.segments.max", 1024);
     public static final Property<Integer> MAX_INDEXED_CHUNKS_PER_SEGMENTS = Property.named("readindex.chunksPerSegment.max", 1024);
     public static final Property<Integer> MAX_INDEXED_CHUNKS = Property.named("readindex.chunks.max", 16 * 1024);
-    public static final Property<Boolean> APPEND_DISABLED = Property.named("appends.disable", false);
+    public static final Property<Boolean> APPENDS_ENABLED = Property.named("appends.enable", true);
     public static final Property<Long> DEFAULT_ROLLOVER_SIZE = Property.named("metadata.rollover.size.bytes.max", SegmentRollingPolicy.MAX_CHUNK_LENGTH);
 
     /**
@@ -45,7 +45,7 @@ public class ChunkedSegmentStorageConfig {
             .maxIndexedSegments(1024)
             .maxIndexedChunksPerSegment(1024)
             .maxIndexedChunks(16 * 1024)
-            .appendsDisabled(false)
+            .appendEnabled(true)
             .build();
 
     static final String COMPONENT_CODE = "storage";
@@ -95,10 +95,10 @@ public class ChunkedSegmentStorageConfig {
     final private int maxIndexedChunks;
 
     /**
-     * Whether the append functionality is disabled.
+     * Whether the append functionality is enabled or disabled.
      */
     @Getter
-    final private boolean appendsDisabled;
+    final private boolean appendEnabled;
 
     /**
      * Creates a new instance of the ChunkedSegmentStorageConfig class.
@@ -106,7 +106,7 @@ public class ChunkedSegmentStorageConfig {
      * @param properties The TypedProperties object to read Properties from.
      */
     ChunkedSegmentStorageConfig(TypedProperties properties) throws ConfigurationException {
-        this.appendsDisabled = properties.getBoolean(APPEND_DISABLED);
+        this.appendEnabled = properties.getBoolean(APPENDS_ENABLED);
         this.maxBufferSizeForChunkDataTransfer = properties.getInt(MAX_BUFFER_SIZE_FOR_APPENDS);
         this.minSizeLimitForConcat = properties.getLong(MIN_SIZE_LIMIT_FOR_CONCAT);
         this.maxSizeLimitForConcat = properties.getLong(MAX_SIZE_LIMIT_FOR_CONCAT);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -224,7 +224,7 @@ public class SystemJournal {
             Preconditions.checkState(bytesWritten == bytes.getLength());
             systemJournalOffset += bytesWritten;
             // Add a new log file if required.
-            if (!chunkStorage.supportsAppend() || config.isAppendsDisabled()) {
+            if (!chunkStorage.supportsAppend() || !config.isAppendEnabled()) {
                 currentFileIndex++;
                 systemJournalOffset = 0;
             }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.common.util.TypedProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * Tests for {@link ChunkedSegmentStorageConfig}.
+ */
+public class ChunkedSegmentStorageConfigTests {
+    @Test
+    public void testProvidedValues() {
+        Properties props = new Properties();
+        props.setProperty(ChunkedSegmentStorageConfig.APPEND_DISABLED.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "true");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_BUFFER_SIZE_FOR_APPENDS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "1");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_SIZE_LIMIT_FOR_CONCAT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "2");
+        props.setProperty(ChunkedSegmentStorageConfig.MIN_SIZE_LIMIT_FOR_CONCAT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "3");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_INDEXED_SEGMENTS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "4");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_INDEXED_CHUNKS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "5");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_INDEXED_CHUNKS_PER_SEGMENTS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "6");
+        props.setProperty(ChunkedSegmentStorageConfig.DEFAULT_ROLLOVER_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "7");
+
+        TypedProperties typedProperties = new TypedProperties(props, "storage");
+        ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
+        Assert.assertTrue(config.isAppendsDisabled());
+        Assert.assertEquals(config.getMaxBufferSizeForChunkDataTransfer(), 1);
+        Assert.assertEquals(config.getMaxSizeLimitForConcat(), 2);
+        Assert.assertEquals(config.getMinSizeLimitForConcat(), 3);
+        Assert.assertEquals(config.getMaxIndexedSegments(), 4);
+        Assert.assertEquals(config.getMaxIndexedChunks(), 5);
+        Assert.assertEquals(config.getMaxIndexedChunksPerSegment(), 6);
+        Assert.assertEquals(config.getDefaultRollingPolicy().getMaxLength(), 7);
+    }
+
+    @Test
+    public void testDefaultValues() {
+        Properties props = new Properties();
+
+        TypedProperties typedProperties = new TypedProperties(props, "storage");
+        ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
+        Assert.assertFalse(config.isAppendsDisabled());
+        Assert.assertEquals(config.getMaxBufferSizeForChunkDataTransfer(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxBufferSizeForChunkDataTransfer());
+        Assert.assertEquals(config.getMaxSizeLimitForConcat(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxSizeLimitForConcat());
+        Assert.assertEquals(config.getMinSizeLimitForConcat(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinSizeLimitForConcat());
+        Assert.assertEquals(config.getMaxIndexedSegments(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedSegments());
+        Assert.assertEquals(config.getMaxIndexedChunks(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedChunks());
+        Assert.assertEquals(config.getMaxIndexedChunksPerSegment(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedChunksPerSegment());
+        Assert.assertEquals(config.getDefaultRollingPolicy().getMaxLength(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getDefaultRollingPolicy().getMaxLength());
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -22,7 +22,7 @@ public class ChunkedSegmentStorageConfigTests {
     @Test
     public void testProvidedValues() {
         Properties props = new Properties();
-        props.setProperty(ChunkedSegmentStorageConfig.APPEND_DISABLED.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "true");
+        props.setProperty(ChunkedSegmentStorageConfig.APPENDS_ENABLED.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "false");
         props.setProperty(ChunkedSegmentStorageConfig.MAX_BUFFER_SIZE_FOR_APPENDS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "1");
         props.setProperty(ChunkedSegmentStorageConfig.MAX_SIZE_LIMIT_FOR_CONCAT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "2");
         props.setProperty(ChunkedSegmentStorageConfig.MIN_SIZE_LIMIT_FOR_CONCAT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "3");
@@ -33,7 +33,7 @@ public class ChunkedSegmentStorageConfigTests {
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
-        Assert.assertTrue(config.isAppendsDisabled());
+        Assert.assertFalse(config.isAppendEnabled());
         Assert.assertEquals(config.getMaxBufferSizeForChunkDataTransfer(), 1);
         Assert.assertEquals(config.getMaxSizeLimitForConcat(), 2);
         Assert.assertEquals(config.getMinSizeLimitForConcat(), 3);
@@ -49,7 +49,7 @@ public class ChunkedSegmentStorageConfigTests {
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
-        Assert.assertFalse(config.isAppendsDisabled());
+        Assert.assertEquals(config.isAppendEnabled(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.isAppendEnabled());
         Assert.assertEquals(config.getMaxBufferSizeForChunkDataTransfer(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxBufferSizeForChunkDataTransfer());
         Assert.assertEquals(config.getMaxSizeLimitForConcat(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxSizeLimitForConcat());
         Assert.assertEquals(config.getMinSizeLimitForConcat(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinSizeLimitForConcat());


### PR DESCRIPTION
Ability to initialize ChunkedSegmentStorageConfig values from config file or properties.
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Ability to initialize ChunkedSegmentStorageConfig values from config file or properties.

**Purpose of the change**  
Fixes #5033  SLTS - Ability to initialize ChunkedSegmentStorageConfig values from config file or properties.

**What the code does**  
Read values from config file or properties and use them during initialization.

**How to verify it**  
Clean build. Manual testing.
