### PR TITLE
Issue 5054: Fix typo in EventWriterConfig: inital -> initial

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamFactoryImpl.java
@@ -30,7 +30,7 @@ public class ConditionalOutputStreamFactoryImpl implements ConditionalOutputStre
     }
 
     private RetryWithBackoff getRetryFromConfig(EventWriterConfig config) {
-        return Retry.withExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+        return Retry.withExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                     config.getRetryAttempts(), config.getMaxBackoffMillis());
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamFactoryImpl.java
@@ -65,7 +65,7 @@ public class SegmentOutputStreamFactoryImpl implements SegmentOutputStreamFactor
     }
 
     private RetryWithBackoff getRetryFromConfig(EventWriterConfig config) {
-        return Retry.withExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+        return Retry.withExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                     config.getRetryAttempts(), config.getMaxBackoffMillis());
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -20,7 +20,7 @@ import lombok.Data;
 public class EventWriterConfig implements Serializable {
     
     private static final long serialVersionUID = 1L;
-    private final int initalBackoffMillis;
+    private final int initialBackoffMillis;
     private final int maxBackoffMillis;
     private final int retryAttempts;
     private final int backoffMultiple;
@@ -56,7 +56,7 @@ public class EventWriterConfig implements Serializable {
 
     public static final class EventWriterConfigBuilder {
         private static final long MIN_TRANSACTION_TIMEOUT_TIME_MILLIS = 10000;
-        private int initalBackoffMillis = 1;
+        private int initialBackoffMillis = 1;
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
@@ -67,11 +67,11 @@ public class EventWriterConfig implements Serializable {
         
         public EventWriterConfig build() {
             Preconditions.checkArgument(transactionTimeoutTime >= MIN_TRANSACTION_TIMEOUT_TIME_MILLIS, "Transaction time must be at least 10 seconds.");
-            Preconditions.checkArgument(initalBackoffMillis >= 0, "Backoff times must be positive numbers");
+            Preconditions.checkArgument(initialBackoffMillis >= 0, "Backoff times must be positive numbers");
             Preconditions.checkArgument(backoffMultiple >= 0, "Backoff multiple must be positive numbers");
             Preconditions.checkArgument(maxBackoffMillis >= 0, "Backoff times must be positive numbers");
             Preconditions.checkArgument(retryAttempts >= 0, "Retry attempts must be a positive number");
-            return new EventWriterConfig(initalBackoffMillis, maxBackoffMillis, retryAttempts, backoffMultiple,
+            return new EventWriterConfig(initialBackoffMillis, maxBackoffMillis, retryAttempts, backoffMultiple,
                                          enableConnectionPooling,
                                          transactionTimeoutTime,
                                          automaticallyNoteTime);

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -143,7 +143,7 @@ public class EventStreamWriterImpl<Type> implements EventStreamWriter<Type> {
     private void handleLogSealed(Segment segment) {
         sealedSegmentQueue.add(segment);
         retransmitPool.execute(() -> {
-            Retry.indefinitelyWithExpBackoff(config.getInitalBackoffMillis(), config.getBackoffMultiple(),
+            Retry.indefinitelyWithExpBackoff(config.getInitialBackoffMillis(), config.getBackoffMultiple(),
                                              config.getMaxBackoffMillis(),
                                              t -> log.error("Encountered exception when handling a sealed segment: ", t))
                  .run(() -> {

--- a/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
@@ -23,7 +23,7 @@ public class EventWriterConfigTest {
                 .automaticallyNoteTime(true)
                 .backoffMultiple(2)
                 .enableConnectionPooling(false)
-                .initalBackoffMillis(100)
+                .initialBackoffMillis(100)
                 .maxBackoffMillis(1000)
                 .retryAttempts(3)
                 .transactionTimeoutTime(100000)
@@ -31,7 +31,7 @@ public class EventWriterConfigTest {
         assertEquals(true, config.isAutomaticallyNoteTime());
         assertEquals(2, config.getBackoffMultiple());
         assertEquals(false, config.isEnableConnectionPooling());
-        assertEquals(100, config.getInitalBackoffMillis());
+        assertEquals(100, config.getInitialBackoffMillis());
         assertEquals(1000, config.getMaxBackoffMillis());
         assertEquals(3, config.getRetryAttempts());
         assertEquals(100000, config.getTransactionTimeoutTime());
@@ -40,7 +40,7 @@ public class EventWriterConfigTest {
     @Test
     public void testInvalidValues() {
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().backoffMultiple(-2).build());
-        assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().initalBackoffMillis(-2).build());
+        assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().initialBackoffMillis(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().maxBackoffMillis(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().retryAttempts(-2).build());
         assertThrows(IllegalArgumentException.class, () -> EventWriterConfig.builder().transactionTimeoutTime(-2).build());


### PR DESCRIPTION
**Change log description**  
Fixes typo in `initalBackoffMillis` to `initialBackoffMillis`

**Purpose of the change**  
To fix a typo in an important public client API.
Fixes #5054

**What the code does**  
Corrects a typo and compensates for that correction in tests.

**How to verify it**  
Tests pass.

*This is a breaking change.*