### PR TITLE
Issue 5063: Update Pravega Website references to `https` URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You may obtain a copy of the License at
 
 Pravega is an open source distributed storage service implementing **Streams**. It offers Stream as the main primitive for the foundation of reliable storage systems: a *high-performance, durable, elastic, and unlimited append-only byte stream with strict ordering and consistency*.
 
-To learn more about Pravega, visit http://pravega.io
+To learn more about Pravega, visit https://pravega.io
 
 ## Prerequisites
 
@@ -76,7 +76,7 @@ Don’t hesitate to ask! Contact the developers and community on [slack](https:/
 ## Documentation
 
 The Pravega documentation is hosted on the website:
-<http://pravega.io/docs/latest> or in the [documentation](documentation/src/docs) directory of the source code.
+<https://pravega.io/docs/latest> or in the [documentation](documentation/src/docs) directory of the source code.
 
 ## Contributing
 

--- a/documentation/src/docs/basic-reader-and-writer.md
+++ b/documentation/src/docs/basic-reader-and-writer.md
@@ -14,7 +14,7 @@ Writer that writes to a Stream. A simple sample application of both can be
 found in the [Pravega samples repository](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md) (`HelloWorldReader` and  `HelloWorldWriter`) applications. These samples give a sense on how a Java application could use the Pravega's Java Client Library to access Pravega functionality.
 
 Instructions for running the sample applications can be found in the [Pravega
-Samples](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md). Get familiar with the [Pravega Concepts](http://pravega.io/docs/latest/pravega-concepts/)
+Samples](https://github.com/pravega/pravega-samples/blob/v0.5.0/pravega-client-examples/README.md). Get familiar with the [Pravega Concepts](https://pravega.io/docs/latest/pravega-concepts/)
 before executing the sample applications.
 
 ## HelloWorldWriter

--- a/documentation/src/docs/controller-service.md
+++ b/documentation/src/docs/controller-service.md
@@ -806,5 +806,5 @@ The details about implementation, especially with respect to how the metadata is
 
 # Resources
 
-- [Pravega](http://pravega.io/)
+- [Pravega](https://pravega.io/)
 - [Code](https://github.com/pravega/pravega/tree/master/controller)

--- a/documentation/src/docs/wire-protocol.md
+++ b/documentation/src/docs/wire-protocol.md
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 -->
 # Pravega Streaming Service Wire Protocol
 
-This page describes the proposed Wire Protocol for the Streaming Service. See [Pravega Concepts](http://pravega.io/docs/latest/pravega-concepts) for more information.
+This page describes the proposed Wire Protocol for the Streaming Service. See [Pravega Concepts](https://pravega.io/docs/latest/pravega-concepts) for more information.
 
 # Protocol
 

--- a/documentation/src/mkdocs.yml
+++ b/documentation/src/mkdocs.yml
@@ -7,7 +7,7 @@
 #    http://www.apache.org/licenses/LICENSE-2.0
 
 site_name: 'Exploring Pravega'
-site_url: 'http://pravega.io/'
+site_url: 'https://pravega.io/'
 site_description: 'Documentation to help you get familiar with Pravega'
 
 repo_url: 'https://github.com/pravega/pravega'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -42,7 +42,7 @@ plugins.withId('maven') {
                 pom.artifactId = "pravega" + project.path.replace(':', '-')
                 pom.project {
                     name "Pravega"
-                    url "http://pravega.io"
+                    url "https://pravega.io"
                     description "Streaming Storage Platform"
                     scm {
                         url 'https://github.com/pravega/pravega/tree/master'

--- a/shared/controller-api/src/main/swagger/Controller.yaml
+++ b/shared/controller-api/src/main/swagger/Controller.yaml
@@ -23,17 +23,17 @@ tags:
   description: "Scope related APIs"
   externalDocs:
     description: "Find out more about pravega"
-    url: "http://pravega.io"
+    url: "https://pravega.io"
 - name: "Streams"
   description: "Stream related APIs"
   externalDocs:
     description: "Find out more about pravega"
-    url: "http://pravega.io"
+    url: "https://pravega.io"
 - name: "ReaderGroups"
   description: "Reader group related APIs"
   externalDocs:
     description: "Find out more about pravega"
-    url: "http://pravega.io"
+    url: "https://pravega.io"
 schemes:
   - http
 paths:


### PR DESCRIPTION
**Change log description**  
Update Website URL references to `https://pravega.io` (from `http` to `https`). 

**Purpose of the change**  
Fixes #5063. 

**What the code does**  
Updates Pravega website URLs in documentation and config. 

**How to verify it**  
