### PR TITLE
Issue 5070: Cherry pick fix for issue 4476 to branch r0.7

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -10,12 +10,16 @@
 package io.pravega.controller.server.eventProcessor;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractIdleService;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.netty.impl.ConnectionFactory;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.Controller;
+import io.pravega.client.stream.Position;
+import io.pravega.client.stream.impl.PositionImpl;
+
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.concurrent.Futures;
@@ -50,15 +54,22 @@ import io.pravega.controller.util.Config;
 import io.pravega.shared.controller.event.AbortEvent;
 import io.pravega.shared.controller.event.CommitEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -76,6 +87,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
     private static final long DELAY = 100;
     private static final int MULTIPLIER = 10;
     private static final long MAX_DELAY = 10000;
+    private static final long TRUNCATION_INTERVAL_MILLIS = Duration.ofMinutes(10).toMillis();
 
     private final String objectId;
     private final ControllerEventProcessorConfig config;
@@ -92,6 +104,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
     private final CommitRequestHandler commitRequestHandler;
     private final AbortRequestHandler abortRequestHandler;
     private final long rebalanceIntervalMillis;
+    private final AtomicLong truncationInterval;
     private ScheduledExecutorService rebalanceExecutor;
 
     public ControllerEventProcessors(final String host,
@@ -139,6 +152,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
         this.abortRequestHandler = new AbortRequestHandler(streamMetadataStore, streamMetadataTasks, executor);
         this.executor = executor;
         this.rebalanceIntervalMillis = config.getRebalanceIntervalMillis();
+        this.truncationInterval = new AtomicLong(TRUNCATION_INTERVAL_MILLIS);
     }
 
     @Override
@@ -267,7 +281,64 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
         return createStreams().thenAcceptAsync(x -> {
             streamMetadataTasks.initializeStreamWriters(clientFactory, config.getRequestStreamName());
             streamTransactionMetadataTasks.initializeStreamWriters(clientFactory, config);
+
+            long delay = truncationInterval.get();
+            Futures.loop(this::isRunning, () -> Futures.delayedFuture(
+                    () -> truncate(config.getRequestStreamName(), config.getRequestReaderGroupName(), streamMetadataTasks), delay, executor), executor);
+            Futures.loop(this::isRunning, () -> Futures.delayedFuture(
+                    () -> truncate(config.getCommitStreamName(), config.getCommitReaderGroupName(), streamMetadataTasks), delay, executor), executor);
+            Futures.loop(this::isRunning, () -> Futures.delayedFuture(
+                    () -> truncate(config.getAbortStreamName(), config.getAbortReaderGroupName(), streamMetadataTasks), delay, executor), executor);
         }, executor);
+    }
+
+    @VisibleForTesting
+    CompletableFuture<Void> truncate(String streamName, String readergroupName, StreamMetadataTasks streamMetadataTasks) {
+        Preconditions.checkState(isRunning());
+        try {
+            // 1. get all processes from checkpoint store 
+            // 2. get the all checkpoints for all readers in the readergroup for the stream.
+            // 3. consolidate all checkpoints to create a stream cut. 
+            // 4. submit a truncation job for the stream
+            Map<String, Position> positions = new HashMap<>();
+            for (String process : checkpointStore.getProcesses()) {
+                positions.putAll(checkpointStore.getPositions(process, readergroupName));
+            }
+            Map<Long, Long> streamcut = positions
+                    .entrySet().stream().map(x -> x.getValue() == null ? Collections.<Long, Long>emptyMap() : convertPosition(x))
+                    .reduce(Collections.emptyMap(), (x, y) -> {
+                        Map<Long, Long> result = new HashMap<>(x);
+                        y.forEach((a, b) -> {
+                            if (x.containsKey(a)) {
+                                result.put(a, Math.max(x.get(a), b));
+                            } else {
+                                result.put(a, b);
+                            }
+                        });
+                        return result;
+                    });
+            // Start a truncation job, but handle its exception cases by simply logging it. We will not fail the future
+            // so that the loop can continue in the next iteration and attempt to truncate the stream. 
+            return streamMetadataTasks.startTruncation(config.getScopeName(), streamName, streamcut, null, 0L)
+                                      .handle((r, e) -> {
+                                          if (e != null) {
+                                              log.warn("Submission for truncation for stream {} failed. Will be retried in next iteration.",
+                                                      streamName);
+                                          } else {
+                                              log.debug("truncation for stream {} at streamcut {} submitted.", streamName, streamcut);
+                                          }
+                                          return null;
+                                      });
+        } catch (Exception e) {
+            // we will catch and log all exceptions and return a completed future so that the truncation is attempted in the
+            // next iteration
+            log.warn("Encountered exception attempting to truncate stream. {}", Exceptions.unwrap(e).getMessage());
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private Map<Long, Long> convertPosition(Map.Entry<String, Position> x) {
+        return ((PositionImpl) x.getValue().asImpl()).getOwnedSegmentsWithOffsets().entrySet().stream().collect(Collectors.toMap(y -> y.getKey().getSegmentId(), y -> y.getValue()));
     }
 
     private CompletableFuture<Void> handleOrphanedReaders(final EventProcessorGroup<? extends ControllerEvent> group,
@@ -441,5 +512,10 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
             log.info("Awaiting termination of request event processors");
             requestEventProcessors.awaitTerminated();
         }
+    }
+    
+    @VisibleForTesting
+    void setTruncationInterval(long interval) {
+        truncationInterval.set(interval);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -430,7 +430,7 @@ public class StreamMetadataTasks extends TaskBase {
                 });
     }
 
-    private CompletableFuture<Boolean> startTruncation(String scope, String stream, Map<Long, Long> streamCut,
+    public CompletableFuture<Boolean> startTruncation(String scope, String stream, Map<Long, Long> streamCut,
                                                        OperationContext contextOpt, long requestId) {
         final OperationContext context = contextOpt == null ? streamMetadataStore.createContext(scope, stream) : contextOpt;
 

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -12,6 +12,9 @@ package io.pravega.controller.server.eventProcessor;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Service;
 import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.impl.PositionImpl;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.eventProcessor.EventProcessorGroup;
 import io.pravega.controller.eventProcessor.EventProcessorSystem;
@@ -27,41 +30,36 @@ import io.pravega.shared.controller.event.AbortEvent;
 import io.pravega.shared.controller.event.CommitEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
 import io.pravega.client.netty.impl.ConnectionFactory;
-import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.impl.Controller;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import io.pravega.test.common.ThreadPooledTestSuite;
+
+import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-public class ControllerEventProcessorsTest {
-    ScheduledExecutorService executor;
-
-    @Before
-    public void setUp() {
-        executor = Executors.newSingleThreadScheduledExecutor();
-    }
-
-    @After
-    public void tearDown() {
-        executor.shutdown();
+public class ControllerEventProcessorsTest extends ThreadPooledTestSuite {
+    @Override
+    public int getThreadPoolSize() {
+        return 10;
     }
     
     @Test(timeout = 10000)
@@ -87,77 +85,7 @@ public class ControllerEventProcessorsTest {
         StreamTransactionMetadataTasks streamTransactionMetadataTasks = mock(StreamTransactionMetadataTasks.class);
         ControllerEventProcessorConfig config = ControllerEventProcessorConfigImpl.withDefault();
         EventProcessorSystem system = mock(EventProcessorSystem.class);
-        EventProcessorGroup<ControllerEvent> processor = new EventProcessorGroup<ControllerEvent>() {
-            @Override
-            public void notifyProcessFailure(String process) throws CheckpointStoreException {
-
-            }
-
-            @Override
-            public EventStreamWriter<ControllerEvent> getWriter() {
-                return null;
-            }
-
-            @Override
-            public Set<String> getProcesses() throws CheckpointStoreException {
-                return Sets.newHashSet("host1", "host2");
-            }
-
-            @Override
-            public Service startAsync() {
-                return null;
-            }
-
-            @Override
-            public boolean isRunning() {
-                return false;
-            }
-
-            @Override
-            public State state() {
-                return null;
-            }
-
-            @Override
-            public Service stopAsync() {
-                return null;
-            }
-
-            @Override
-            public void awaitRunning() {
-
-            }
-
-            @Override
-            public void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
-
-            }
-
-            @Override
-            public void awaitTerminated() {
-
-            }
-
-            @Override
-            public void awaitTerminated(long timeout, TimeUnit unit) throws TimeoutException {
-
-            }
-
-            @Override
-            public Throwable failureCause() {
-                return null;
-            }
-
-            @Override
-            public void addListener(Listener listener, Executor executor) {
-
-            }
-
-            @Override
-            public void close() throws Exception {
-
-            }
-        };
+        EventProcessorGroup<ControllerEvent> processor = getProcessor();
 
         try {
             when(system.createEventProcessorGroup(any(), any(), any())).thenReturn(processor);
@@ -166,9 +94,10 @@ public class ControllerEventProcessorsTest {
         }
 
         ControllerEventProcessors processors = new ControllerEventProcessors("host1",
-                config, localController, checkpointStore, streamStore, bucketStore, 
+                config, localController, checkpointStore, streamStore, bucketStore,
                 connectionFactory, streamMetadataTasks, streamTransactionMetadataTasks,
-                system, executor);
+                system, executorService());
+
         processors.startAsync();
         processors.awaitRunning();
         assertTrue(Futures.await(processors.sweepFailedProcesses(() -> Sets.newHashSet("host1"))));
@@ -233,7 +162,7 @@ public class ControllerEventProcessorsTest {
         ControllerEventProcessors processors = new ControllerEventProcessors("host1",
                 config, controller, checkpointStore, streamStore, bucketStore,
                 connectionFactory, streamMetadataTasks, streamTransactionMetadataTasks,
-                system, executor);
+                system, executorService());
 
         // call bootstrap on ControllerEventProcessors
         processors.bootstrap(streamTransactionMetadataTasks, streamMetadataTasks);
@@ -283,4 +212,184 @@ public class ControllerEventProcessorsTest {
         createStreamResponsesList.get(5).complete(true);
     }
     
+    @Test(timeout = 10000L)
+    public void testTruncate() throws CheckpointStoreException, InterruptedException {
+        Controller controller = mock(Controller.class);
+        CheckpointStore checkpointStore = mock(CheckpointStore.class);
+        StreamMetadataStore streamStore = mock(StreamMetadataStore.class);
+        BucketStore bucketStore = mock(BucketStore.class);
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        StreamMetadataTasks streamMetadataTasks = mock(StreamMetadataTasks.class);
+        StreamTransactionMetadataTasks streamTransactionMetadataTasks = mock(StreamTransactionMetadataTasks.class);
+        ControllerEventProcessorConfig config = ControllerEventProcessorConfigImpl.withDefault();
+        EventProcessorSystem system = mock(EventProcessorSystem.class);
+
+        Map<Segment, Long> map1 = new HashMap<>();
+        map1.put(new Segment("scope", "stream", 0L), 10L);
+        map1.put(new Segment("scope", "stream", 1L), 10L);
+        map1.put(new Segment("scope", "stream", 2L), 20L);
+        Map<Segment, Long> map2 = new HashMap<>();
+        map2.put(new Segment("scope", "stream", 0L), 20L);
+        map2.put(new Segment("scope", "stream", 2L), 10L);
+        Map<Segment, Long> map3 = new HashMap<>();
+        map3.put(new Segment("scope", "stream", 3L), 0L);
+        map3.put(new Segment("scope", "stream", 4L), 10L);
+        map3.put(new Segment("scope", "stream", 5L), 20L);
+
+        PositionImpl position1 = mock(PositionImpl.class);
+        when(position1.getOwnedSegmentsWithOffsets()).thenReturn(map1);
+        when(position1.asImpl()).thenReturn(position1);
+        PositionImpl position2 = mock(PositionImpl.class);
+        when(position2.getOwnedSegmentsWithOffsets()).thenReturn(map2);
+        when(position2.asImpl()).thenReturn(position2);
+        PositionImpl position3 = mock(PositionImpl.class);
+        when(position3.getOwnedSegmentsWithOffsets()).thenReturn(map3);
+        when(position3.asImpl()).thenReturn(position3);
+        
+        doAnswer(x -> getProcessor()).when(system).createEventProcessorGroup(any(), any(), any());
+
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(controller).createScope(anyString());
+        doAnswer(x -> CompletableFuture.completedFuture(null)).when(controller).createStream(anyString(), anyString(), any());
+
+        doAnswer(x -> null).when(streamMetadataTasks).initializeStreamWriters(any(), anyString());
+        doAnswer(x -> null).when(streamTransactionMetadataTasks).initializeStreamWriters(any(EventStreamClientFactory.class),
+                any(ControllerEventProcessorConfig.class));
+        
+        // first throw checkpoint store exception
+        CompletableFuture<Void> signal = new CompletableFuture<>();
+        doAnswer(x -> {
+            signal.complete(null);
+            throw new CheckpointStoreException("checkpointstoreexception");
+        }).when(checkpointStore).getProcesses();
+
+        ControllerEventProcessors processors = new ControllerEventProcessors("host1",
+                config, controller, checkpointStore, streamStore, bucketStore,
+                connectionFactory, streamMetadataTasks, streamTransactionMetadataTasks,
+                system, executorService());
+
+        // set truncation interval
+        processors.setTruncationInterval(100L);
+        processors.startAsync();
+        processors.awaitRunning();
+        ControllerEventProcessors processorsSpied = spy(processors);
+        processorsSpied.bootstrap(streamTransactionMetadataTasks, streamMetadataTasks);
+
+        signal.join();
+        verify(processorsSpied, atLeastOnce()).truncate(any(), any(), any());
+        verify(checkpointStore, atLeastOnce()).getProcesses();
+        verify(checkpointStore, never()).getPositions(anyString(), anyString());
+        verify(streamMetadataTasks, never()).startTruncation(anyString(), anyString(), any(), any(), anyLong());
+        
+        // now set the checkpoint store to return correct values
+        doAnswer(x -> Sets.newHashSet("p1", "p2", "p3")).when(checkpointStore).getProcesses();
+        doAnswer(x -> Collections.singletonMap("r1", position1)).when(checkpointStore).getPositions(eq("p1"), anyString());
+        doAnswer(x -> Collections.singletonMap("r2", position2)).when(checkpointStore).getPositions(eq("p2"), anyString());
+        doAnswer(x -> Collections.singletonMap("r3", position3)).when(checkpointStore).getPositions(eq("p3"), anyString());
+
+        CountDownLatch latch = new CountDownLatch(4);
+        AtomicInteger counter = new AtomicInteger();
+        doAnswer(x -> {
+            latch.countDown();
+            counter.getAndIncrement();
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            if (counter.get() == 1) {
+                // let one of the processors throw the exception. this should still be retried in the next cycle.
+                throw new RuntimeException();
+            } else if (counter.get() == 2) {
+                // let one of the processors throw the exception. this should still be retried in the next cycle.
+                return CompletableFuture.completedFuture(false);
+            }
+            return CompletableFuture.completedFuture(true);
+        }).when(streamMetadataTasks).startTruncation(anyString(), anyString(), any(), any(), anyLong());
+
+        latch.await();
+
+        // verify that truncate method is being called periodically. 
+        verify(processorsSpied, atLeastOnce()).truncate(config.getRequestStreamName(), config.getRequestReaderGroupName(), streamMetadataTasks);
+        verify(processorsSpied, atLeastOnce()).truncate(config.getCommitStreamName(), config.getCommitReaderGroupName(), streamMetadataTasks);
+        verify(processorsSpied, atLeastOnce()).truncate(config.getAbortStreamName(), config.getAbortReaderGroupName(), streamMetadataTasks);
+
+        verify(checkpointStore, atLeastOnce()).getPositions("p1", config.getRequestReaderGroupName());
+        verify(checkpointStore, atLeastOnce()).getPositions("p1", config.getCommitReaderGroupName());
+        verify(checkpointStore, atLeastOnce()).getPositions("p1", config.getAbortReaderGroupName());
+    }
+
+    private EventProcessorGroup<ControllerEvent> getProcessor() {
+        return new EventProcessorGroup<ControllerEvent>() {
+            @Override
+            public void notifyProcessFailure(String process) throws CheckpointStoreException {
+
+            }
+
+            @Override
+            public EventStreamWriter<ControllerEvent> getWriter() {
+                return null;
+            }
+
+            @Override
+            public Set<String> getProcesses() throws CheckpointStoreException {
+                return Sets.newHashSet("host1", "host2");
+            }
+            
+            @Override
+            public Service startAsync() {
+                return null;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return false;
+            }
+
+            @Override
+            public State state() {
+                return null;
+            }
+
+            @Override
+            public Service stopAsync() {
+                return null;
+            }
+
+            @Override
+            public void awaitRunning() {
+
+            }
+
+            @Override
+            public void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
+
+            }
+
+            @Override
+            public void awaitTerminated() {
+
+            }
+
+            @Override
+            public void awaitTerminated(long timeout, TimeUnit unit) throws TimeoutException {
+
+            }
+
+            @Override
+            public Throwable failureCause() {
+                return null;
+            }
+
+            @Override
+            public void addListener(Listener listener, Executor executor) {
+
+            }
+
+            @Override
+            public void close() throws Exception {
+
+            }
+        };
+    }
+
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -286,7 +286,7 @@ public class ControllerEventProcessorsTest extends ThreadPooledTestSuite {
         doAnswer(x -> Collections.singletonMap("r2", position2)).when(checkpointStore).getPositions(eq("p2"), anyString());
         doAnswer(x -> Collections.singletonMap("r3", position3)).when(checkpointStore).getPositions(eq("p3"), anyString());
 
-        CountDownLatch latch = new CountDownLatch(4);
+        CountDownLatch latch = new CountDownLatch(3);
         AtomicInteger counter = new AtomicInteger();
         doAnswer(x -> {
             latch.countDown();


### PR DESCRIPTION
Truncate internal streams used by controller periodically using the event position from the event that has been successfully processed.

Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
 Truncate internal streams to reclaim storage space (#5044)

**Purpose of the change**  
Fixes #5070 

**What the code does**  
Cherry pick PR 5044 into branch r0.7

**How to verify it**  
All Unit and integration tests should pass.
