### PR TITLE
Issue 5068: (Cherry-pick to r0.7) Sanitize gRPC call metadata before logging (#5069)

### DIFF
--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/tracing/RPCTracingHelpers.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/tracing/RPCTracingHelpers.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.shared.controller.tracing;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -47,6 +48,12 @@ public final class RPCTracingHelpers {
 
     public static ServerInterceptor getServerInterceptor(RequestTracker requestTracker) {
         return new TaggingServerInterceptor(requestTracker);
+    }
+
+    @VisibleForTesting
+    static String toSanitizedString(Metadata headers) {
+        return headers == null ? "null" :
+                headers.toString().replaceAll("authorization=.*(?=,)|authorization=.*(?=\\))", "authorization=xxxxx");
     }
 
     /**
@@ -107,7 +114,7 @@ public final class RPCTracingHelpers {
                         requestTag.getRequestDescriptor());
             } else {
                 log.debug("No tags provided for call {} in headers: {}.", call.getMethodDescriptor().getFullMethodName(),
-                        headers);
+                        toSanitizedString(headers));
             }
 
             return next.startCall(new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/tracing/RPCTracingHelpersTest.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/tracing/RPCTracingHelpersTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test to check the correct management of tracing request headers by the client/server interceptors.
@@ -80,5 +81,55 @@ public class RPCTracingHelpersTest {
         serverInterceptor.interceptCall(serverCall, headers, serverCallHandler);
         assertEquals(1, requestTracker.getNumDescriptors());
         assertEquals(requestId, requestTracker.getRequestIdFor(requestDescriptor));
+    }
+
+    @Test
+    public void toSanitizeStringReplacesAuthHeaderInTheMiddle() {
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of("firstHeader", Metadata.ASCII_STRING_MARSHALLER), "dummy-value");
+
+        // dXNlcm5hbWU6c3VwZXItc2VjcmV0LXBhc3N3b3Jk is base64 encoded value of `test-user:super-secret-password`
+        metadata.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER),
+                "Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==");
+        metadata.put(Metadata.Key.of("lastHeader", Metadata.ASCII_STRING_MARSHALLER),
+                "dummy-value");
+
+        assertTrue(metadata.toString().contains("authorization=Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==,"));
+
+        String sanitizedString = RPCTracingHelpers.toSanitizedString(metadata);
+        assertFalse(sanitizedString.contains("authorization=Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==,"));
+        assertTrue(sanitizedString.contains("authorization=xxxxx,"));
+    }
+
+    @Test
+    public void toSanitizeStringReplacesAuthHeaderInTheEnd() {
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of("first", Metadata.ASCII_STRING_MARSHALLER), "dummy-value");
+        metadata.put(Metadata.Key.of("middle", Metadata.ASCII_STRING_MARSHALLER),
+                "dummy-value");
+
+        // dXNlcm5hbWU6c3VwZXItc2VjcmV0LXBhc3N3b3Jk is base64 encoded value of `test-user:super-secret-password`
+        metadata.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER),
+                "Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==");
+
+        assertTrue(metadata.toString().contains("authorization=Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==)"));
+        String sanitizedString = RPCTracingHelpers.toSanitizedString(metadata);
+        assertFalse(sanitizedString.contains("authorization=Basic dGVzdC11c2VyOnN1cGVyLXNlY3JldC1wYXNzd29yZA==)"));
+        assertTrue(sanitizedString.contains("authorization=xxxxx)"));
+    }
+
+    @Test
+    public void toSanitizeStringReplacesNothingIfAuthorizationHeaderIsMissing() {
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of("first", Metadata.ASCII_STRING_MARSHALLER), "dummy-value");
+        metadata.put(Metadata.Key.of("middle", Metadata.ASCII_STRING_MARSHALLER), "dummy-value");
+        metadata.put(Metadata.Key.of("last", Metadata.ASCII_STRING_MARSHALLER), "dummy-value");
+
+        assertEquals(metadata.toString(), RPCTracingHelpers.toSanitizedString(metadata));
+    }
+
+    @Test
+    public void toSanitizeStringReturnsNullIfMetadataIsNull() {
+        assertEquals("null", RPCTracingHelpers.toSanitizedString(null));
     }
 }


### PR DESCRIPTION
**Change log description**  
Cherypicks PR #5069 to r0.7 for v0.7.2. 

**Purpose of the change**  
Fixes #5068. 

**What the code does**  
See details in PR #5069. 

**How to verify it**  
See PR #5069. 
