### PR TITLE
Issue 5080: Adding character length checks for scope and stream name.

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -624,6 +624,7 @@ public final class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
+        Preconditions.checkArgument(name.length()<256, "Name must have less than 256 characters");
         Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
@@ -648,6 +649,7 @@ public final class NameUtils {
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
         final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
+        Preconditions.checkArgument(name.length()<256, "Name must have less than 256 characters");
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -624,7 +624,7 @@ public final class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
-        Preconditions.checkArgument(name.length()<256, "Name must have less than 256 characters");
+        Preconditions.checkArgument(name.length() < 256, "Name must have less than 256 characters");
         Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
@@ -649,7 +649,7 @@ public final class NameUtils {
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
         final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
-        Preconditions.checkArgument(name.length()<256, "Name must have less than 256 characters");
+        Preconditions.checkArgument(name.length() < 256, "Name must have less than 256 characters");
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -1,21 +1,19 @@
 /**
  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.shared;
 
 import io.pravega.test.common.AssertExtensions;
-
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -61,18 +59,15 @@ public class NameUtilsTest {
         Assert.assertEquals(2, tokens.size());
         Assert.assertEquals(scope, tokens.get(0));
         Assert.assertEquals(kvt, tokens.get(1));
-        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens(scope),
-                ex -> ex instanceof IllegalArgumentException);
-        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens("a/b/c"),
-                ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens(scope), ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens("a/b/c"), ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testStreamNameVerifier() {
         NameUtils.validateStreamName("_systemstream123");
         NameUtils.validateStreamName("stream123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateStreamName("system_stream123"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("system_stream123"));
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("stream/123"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateStreamName(null));
         NameUtils.validateStreamName("a-b-c");
@@ -108,10 +103,8 @@ public class NameUtilsTest {
 
         NameUtils.validateScopeName("_systemscope123");
         NameUtils.validateScopeName("userscope123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateScopeName("system_scope"));
-        AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateScopeName("system/scope"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system_scope"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system/scope"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateScopeName(null));
 
     }
@@ -119,8 +112,7 @@ public class NameUtilsTest {
     @Test
     public void testReaderGroupNameVerifier() {
         NameUtils.validateReaderGroupName("stream123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateReaderGroupName("_stream"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateReaderGroupName("_stream"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateReaderGroupName(null));
     }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -80,6 +80,7 @@ public class NameUtilsTest {
         int rightLimit = 122; // letter 'z'
         int targetStringLength = 256;
         Random random = new Random();
+        random.setSeed(0);
         String generatedString = random.ints(leftLimit, rightLimit + 1)
                 .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
                 .limit(targetStringLength)

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -1,18 +1,21 @@
 /**
  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.shared;
 
 import io.pravega.test.common.AssertExtensions;
+
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -58,19 +61,39 @@ public class NameUtilsTest {
         Assert.assertEquals(2, tokens.size());
         Assert.assertEquals(scope, tokens.get(0));
         Assert.assertEquals(kvt, tokens.get(1));
-        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens(scope), ex -> ex instanceof IllegalArgumentException);
-        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens("a/b/c"), ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens(scope),
+                ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows("", () -> NameUtils.extractScopedNameTokens("a/b/c"),
+                ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testStreamNameVerifier() {
         NameUtils.validateStreamName("_systemstream123");
         NameUtils.validateStreamName("stream123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("system_stream123"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateStreamName("system_stream123"));
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName("stream/123"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateStreamName(null));
         NameUtils.validateStreamName("a-b-c");
         NameUtils.validateStreamName("1.2.3");
+    }
+
+    @Test
+    public void testStreamNameLimit() {
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 256;
+        Random random = new Random();
+        String generatedString = random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateStreamName(generatedString));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateUserStreamName(generatedString));
     }
 
     @Test
@@ -85,8 +108,10 @@ public class NameUtilsTest {
 
         NameUtils.validateScopeName("_systemscope123");
         NameUtils.validateScopeName("userscope123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system_scope"));
-        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system/scope"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateScopeName("system_scope"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateScopeName("system/scope"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateScopeName(null));
 
     }
@@ -94,7 +119,8 @@ public class NameUtilsTest {
     @Test
     public void testReaderGroupNameVerifier() {
         NameUtils.validateReaderGroupName("stream123");
-        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateReaderGroupName("_stream"));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateReaderGroupName("_stream"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateReaderGroupName(null));
     }
 


### PR DESCRIPTION
Signed-off-by: Atharva Joshi <Atharva.Joshi@dell.com>

**Change log description**  
Character length limit check is added for scope and stream name.

**Purpose of the change**  
Fixes #5080 

**What the code does**  
Adds a precondition check to the validateStreamName & validateUserStreamName methods in NameUtils.java class to ensure that stream and scope name do not exceed 255 characters.

**How to verify it**  
Attempt to add a scope or stream with a name having more than 255 characters.
