### PR TITLE
Issue 5089: Prepare r0.8 branch for release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ k8ClientVersion=8.0.0
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.8.0-SNAPSHOT
+pravegaVersion=0.8.0
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**  
Prepare r0.8 branch for release.

**Purpose of the change**  
Fixes #5089 

**What the code does**  
Modifies `pravegaVersion` property in `gradle.properties` to `0.8.0` (from `0.8.0-SNAPSHOT`

**How to verify it**  
Inspect the file.