### PR TITLE
Issue 5093: validate internal and external names

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -35,6 +35,21 @@ public final class NameUtils {
     public static final String READER_GROUP_STREAM_PREFIX = INTERNAL_NAME_PREFIX + "RG";
 
     /**
+     * Size of the prefix or suffix included with the user stream name.
+     */
+    public static final int MAX_PREFIX_OR_SUFFIX_SIZE = 5;
+
+    /**
+     * Size of the overall name as permitted by the host.
+     */
+    public static final int MAX_NAME_SIZE = 255;
+
+    /**
+     * Size of the name that can be specified by user.
+     */
+    public static final int MAX_GIVEN_NAME_SIZE = MAX_NAME_SIZE - MAX_PREFIX_OR_SUFFIX_SIZE;
+
+    /**
      * This is used for composing metric tags.
      */
     static final String TAG_SCOPE = "scope";
@@ -119,23 +134,6 @@ public final class NameUtils {
      */
     @Getter(AccessLevel.PACKAGE)
     private static final String MARK_PREFIX = INTERNAL_NAME_PREFIX + "MARK";
-
-    /**
-     * Size of the prefix or suffix included with the user stream name
-     */
-    public static final int MAX_PREFIX_OR_SUFFIX_SIZE = 5;
-
-    /**
-     * Size of the overall name as permitted by the host
-     */
-    public static final int MAX_NAME_SIZE = 255;
-
-
-    /**
-     * Size of the name that can be specified by user
-     */
-    public static final int MAX_GIVEN_NAME_SIZE = MAX_NAME_SIZE - MAX_PREFIX_OR_SUFFIX_SIZE;
-
 
     //endregion
 

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -120,6 +120,22 @@ public final class NameUtils {
     @Getter(AccessLevel.PACKAGE)
     private static final String MARK_PREFIX = INTERNAL_NAME_PREFIX + "MARK";
 
+    /**
+     * Size of the prefix or suffix included with the user stream name
+     */
+    public static final int MAX_PREFIX_OR_SUFFIX_SIZE = 5;
+
+    /**
+     * Size of the overall name as permitted by the host
+     */
+    public static final int MAX_NAME_SIZE = 255;
+
+
+    /**
+     * Size of the name that can be specified by user
+     */
+    public static final int MAX_GIVEN_NAME_SIZE = MAX_NAME_SIZE - MAX_PREFIX_OR_SUFFIX_SIZE;
+
 
     //endregion
 
@@ -624,7 +640,7 @@ public final class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
-        Preconditions.checkArgument(name.length() < 256, "Name must have less than 256 characters");
+        Preconditions.checkArgument(name.length() < MAX_GIVEN_NAME_SIZE + 1, String.format("Name cannot exceed %d characters", MAX_GIVEN_NAME_SIZE));
         Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
@@ -649,7 +665,7 @@ public final class NameUtils {
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
         final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
-        Preconditions.checkArgument(name.length() < 256, "Name must have less than 256 characters");
+        Preconditions.checkArgument(name.length() < MAX_NAME_SIZE + 1, String.format("Name cannot exceed %d characters", MAX_NAME_SIZE));
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -638,7 +638,7 @@ public final class NameUtils {
      */
     public static String validateUserStreamName(String name) {
         Preconditions.checkNotNull(name);
-        Preconditions.checkArgument(name.length() < MAX_GIVEN_NAME_SIZE + 1, String.format("Name cannot exceed %d characters", MAX_GIVEN_NAME_SIZE));
+        Preconditions.checkArgument(name.length() <= MAX_GIVEN_NAME_SIZE, "Name cannot exceed %s characters", MAX_GIVEN_NAME_SIZE);
         Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
         return name;
     }
@@ -663,7 +663,7 @@ public final class NameUtils {
 
         // In addition to user stream names, pravega internally created stream have a special prefix.
         final String matcher = "[" + INTERNAL_NAME_PREFIX + "]?[\\p{Alnum}\\.\\-]+";
-        Preconditions.checkArgument(name.length() < MAX_NAME_SIZE + 1, String.format("Name cannot exceed %d characters", MAX_NAME_SIZE));
+        Preconditions.checkArgument(name.length() <= MAX_NAME_SIZE, "Name cannot exceed %s characters", MAX_NAME_SIZE);
         Preconditions.checkArgument(name.matches(matcher), "Name must be " + matcher);
         return name;
     }
@@ -675,7 +675,10 @@ public final class NameUtils {
      * @return The name in the case is valid.
      */
     public static String validateUserScopeName(String name) {
-        return validateUserStreamName(name);
+        Preconditions.checkNotNull(name);
+        Preconditions.checkArgument(name.length() <= MAX_NAME_SIZE, "Name cannot exceed %s characters", MAX_NAME_SIZE);
+        Preconditions.checkArgument(name.matches("[\\p{Alnum}\\.\\-]+"), "Name must be a-z, 0-9, ., -.");
+        return name;
     }
 
     /**

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -93,6 +93,10 @@ public class NameUtilsTest {
         NameUtils.validateUserScopeName("stream123");
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateUserScopeName("_stream"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateUserScopeName(null));
+        int targetStringLength = NameUtils.MAX_NAME_SIZE + 1;
+        final String externalName = randomAlphanumeric(targetStringLength);
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateUserScopeName(externalName));
     }
 
     @Test
@@ -103,6 +107,10 @@ public class NameUtilsTest {
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system_scope"));
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateScopeName("system/scope"));
         AssertExtensions.assertThrows(NullPointerException.class, () -> NameUtils.validateScopeName(null));
+        int targetStringLength = NameUtils.MAX_NAME_SIZE + 1;
+        final String internalName = randomAlphanumeric(targetStringLength);
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> NameUtils.validateScopeName(internalName));
 
     }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -10,7 +10,6 @@
 package io.pravega.shared;
 
 import io.pravega.test.common.AssertExtensions;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -20,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -78,18 +78,14 @@ public class NameUtilsTest {
     public void testStreamNameLimit() {
         int leftLimit = 48; // numeral '0'
         int rightLimit = 122; // letter 'z'
-        int targetStringLength = 256;
-        Random random = new Random();
-        random.setSeed(0);
-        String generatedString = random.ints(leftLimit, rightLimit + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-                .limit(targetStringLength)
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
+        int targetStringLength = NameUtils.MAX_NAME_SIZE + 1;
+        final String internalName = randomAlphanumeric(targetStringLength);
         AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateStreamName(generatedString));
+                () -> NameUtils.validateStreamName(internalName));
+        targetStringLength = NameUtils.MAX_GIVEN_NAME_SIZE + 1;
+        final String externalName = randomAlphanumeric(targetStringLength);
         AssertExtensions.assertThrows(IllegalArgumentException.class,
-                () -> NameUtils.validateUserStreamName(generatedString));
+                () -> NameUtils.validateUserStreamName(externalName));
     }
 
     @Test


### PR DESCRIPTION
**Change log description**  
Issue 5080 put restriction on the length of the name. This adds different restrictions to internal and external names.

**Purpose of the change**  
Fixes #5093

**What the code does**  
takes prefix or suffix into consideration when internal names are created.

**How to verify it**  
added unit-tests
