### PR TITLE
Issue 5096: set the default value of StatsD reporter to false

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -265,7 +265,7 @@ metrics.statistics.enable=false
 
 # Whether to enable StatsD reporting.
 # Valid values: 'true' or 'false'.
-#metrics.statsD.reporter.enable=true
+#metrics.statsD.reporter.enable=false
 
 # StatsD endpoint host name.
 #metrics.statsD.connect.host=localhost

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -34,7 +34,7 @@ public class MetricsConfig {
     public final static Property<String> INFLUXDB_USERNAME = Property.named("influxDB.connect.credentials.username", "", "influxDBUserName");
     public final static Property<String> INFLUXDB_PASSWORD = Property.named("influxDB.connect.credentials.pwd", "", "influxDBPassword");
     public final static Property<String> INFLUXDB_RETENTION_POLICY = Property.named("influxDB.retention", "", "influxDBRetention");
-    public final static Property<Boolean> ENABLE_STATSD_REPORTER = Property.named("statsD.reporter.enable", true, "enableStatsDReporter");
+    public final static Property<Boolean> ENABLE_STATSD_REPORTER = Property.named("statsD.reporter.enable", false, "enableStatsDReporter");
     public final static Property<Boolean> ENABLE_INFLUXDB_REPORTER = Property.named("influxDB.reporter.enable", false, "enableInfluxDBReporter");
     public static final String COMPONENT_CODE = "metrics";
 


### PR DESCRIPTION
Signed-off-by: Kevin Han <kevinhan88@gmail.com>

**Change log description**  
Set the default value of StatsD reporter to false to prevent accidental switching on

**Purpose of the change**  
Closes #5096 

**What the code does**  
(Detailed description of the code changes)
config.properties: #metrics.statsD.reporter.enable=false 
MetricsConfig: ENABLE_STATSD_REPORTER defaultValue was set to false

**How to verify it**  
All tests should pass.
By default, StatsD metric reporter should be turned off.
