### PR TITLE
Issue 5095: DR Integration tests included for multiple containers and Transactional writers

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -31,7 +31,6 @@ import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
@@ -738,7 +737,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         }
     }
 
-    private void writeTransactionalEvents(String streamName, ClientFactoryImpl clientFactory) {
+    private void writeEvents(String streamName, ClientFactoryImpl clientFactory) {
         EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
                 new UTF8StringSerializer(),
                 EventWriterConfig.builder().build());
@@ -750,10 +749,10 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         writer.close();
     }
 
-    private void writeEvents(String streamName, ClientFactoryImpl clientFactory) throws TxnFailedException {
+    private void writeTransactionalEvents(String streamName, ClientFactoryImpl clientFactory) throws TxnFailedException {
         EventWriterConfig writerConfig = EventWriterConfig.builder().transactionTimeoutTime(10000).build();
         @Cleanup
-        TransactionalEventStreamWriter<String> txnWriter = clientFactory.createTransactionalEventWriter(streamName, new JavaSerializer<>(),
+        TransactionalEventStreamWriter<String> txnWriter = clientFactory.createTransactionalEventWriter(streamName, new UTF8StringSerializer(),
                 writerConfig);
 
         Transaction<String> transaction = txnWriter.beginTxn();

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -591,6 +591,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
     public void testDurableDataLogFailRecoveryTransactionalWriter() throws Exception {
         int instanceId = 0;
         int containerCount = 4;
+
         // Creating a long term storage only once here.
         this.storageFactory = new InMemoryStorageFactory(executorService());
         log.info("Created a long term storage.");

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -184,7 +184,9 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
             try {
                 this.bookKeeperServiceRunner.startAll();
             } catch (Exception e) {
+                log.error("Exception occurred while starting bookKeeper service.", e);
                 this.close();
+                throw e;
             }
             bkService.set(this.bookKeeperServiceRunner);
 

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -100,7 +100,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofMillis(100 * 1000);
     private static final Duration READ_TIMEOUT = Duration.ofMillis(500);
-    private static final Duration TRANSACTION_TIMEOUT = Duration.ofMillis(500);
+    private static final Duration TRANSACTION_TIMEOUT = Duration.ofMillis(10000);
 
     /**
      * Write 300 events to different segments.

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -801,8 +801,14 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
     private CompletableFuture<Void> waitForSegmentsInStorage(Collection<String> segmentNames, StreamSegmentStore baseStore,
                                                              Storage storage) {
         ArrayList<CompletableFuture<Void>> segmentsCompletion = new ArrayList<>();
+        SegmentProperties sp = null;
         for (String segmentName : segmentNames) {
-            SegmentProperties sp = baseStore.getStreamSegmentInfo(segmentName, TIMEOUT).join();
+            try {
+                sp = baseStore.getStreamSegmentInfo(segmentName, TIMEOUT).join();
+            } catch (Exception e) {
+                log.info("Segment '{}' doesn't exist.", segmentName);
+                continue;
+            }
             log.info("Segment properties = {}", sp);
             segmentsCompletion.add(waitForSegmentInStorage(sp, storage));
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -292,7 +292,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
     }
 
     /**
-     * Creates a controller instance and runs it.
+     * Creates a client to read and write events.
      */
     private static class ClientRunner {
         private final ConnectionFactory connectionFactory;

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -181,7 +181,11 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
                     .ledgersPath("/pravega/bookkeeper/ledgers")
                     .bookiePorts(bookiePorts)
                     .build();
-            this.bookKeeperServiceRunner.startAll();
+            try {
+                this.bookKeeperServiceRunner.startAll();
+            } catch (Exception e) {
+                this.close();
+            }
             bkService.set(this.bookKeeperServiceRunner);
 
             // Create a ZKClient with a unique namespace.


### PR DESCRIPTION
**Change log description**  
The PR which explains about DR Integration test in detail is: #4716 
A short summary: It tests the scenario when durable data log fails after all the segments have been flushed to the long term storage. In such a situation, debug segment container(s) are started to restore the data in a new durable data log.
In this PR, tests have been included to start multiple debug segment containers and use transactions for writing events.

**Purpose of the change**  
Partially fixes #5095 

**What the code does**  
There are two tests which have been included here:
1. Tests the DR scenario when 4 containers are used in running normal segment store and then 4 debug segment containers are created for data restoration.
2. Tests the scenario when events are written in the form of transactions.
 
**How to verify it**  
Build shall pass.