### PR TITLE
Issue 5100: In Integration Tests, KVTable Creation should fail when partition count is 0

### DIFF
--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -1898,6 +1898,11 @@ public class ControllerImplTest {
                 KeyValueTableConfiguration.builder().partitionCount(1).build());
         AssertExtensions.assertFutureThrows("Server should throw exception",
                 createKVTableStatus, Throwable -> true);
+
+        createKVTableStatus = controllerClient.createKeyValueTable("scope1", "kvtable6",
+                KeyValueTableConfiguration.builder().partitionCount(0).build());
+        AssertExtensions.assertFutureThrows("Server should throw exception",
+                createKVTableStatus, Throwable -> true);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -1901,8 +1901,8 @@ public class ControllerImplTest {
 
         createKVTableStatus = controllerClient.createKeyValueTable("scope1", "kvtable6",
                 KeyValueTableConfiguration.builder().partitionCount(0).build());
-        AssertExtensions.assertFutureThrows("Server should throw exception",
-                createKVTableStatus, Throwable -> true);
+        AssertExtensions.assertFutureThrows("Server should throw IllegalArgumentException.",
+                createKVTableStatus, IllegalArgumentException -> true);
     }
 
     @Test

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -108,6 +108,7 @@ public class ControllerService {
                                                                             final long createTimestamp) {
         Preconditions.checkNotNull(kvtConfig, "kvTableConfig");
         Preconditions.checkArgument(createTimestamp >= 0);
+        Preconditions.checkArgument(kvtConfig.getPartitionCount() > 0);
         Timer timer = new Timer();
         try {
             NameUtils.validateUserKeyValueTableName(kvtName);

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithKVTableTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithKVTableTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.connection.impl.ConnectionFactory;
+import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
+import io.pravega.client.tables.KeyValueTableConfiguration;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+
+import io.pravega.common.tracing.RequestTracker;
+import io.pravega.controller.metrics.StreamMetrics;
+import io.pravega.controller.metrics.TransactionMetrics;
+import io.pravega.controller.mocks.ControllerEventStreamWriterMock;
+import io.pravega.controller.mocks.EventHelperMock;
+import io.pravega.controller.mocks.SegmentHelperMock;
+import io.pravega.controller.server.eventProcessor.requesthandlers.AutoScaleTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.DeleteStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.ScaleOperationTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.SealStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.StreamRequestHandler;
+import io.pravega.controller.server.eventProcessor.requesthandlers.TruncateStreamTask;
+import io.pravega.controller.server.eventProcessor.requesthandlers.UpdateStreamTask;
+import io.pravega.controller.server.rpc.auth.GrpcAuthHelper;
+import io.pravega.controller.store.kvtable.KVTableMetadataStore;
+import io.pravega.controller.store.stream.AbstractStreamMetadataStore;
+import io.pravega.controller.store.stream.BucketStore;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import io.pravega.controller.store.task.TaskMetadataStore;
+import io.pravega.controller.store.task.TaskStoreFactory;
+import io.pravega.controller.task.EventHelper;
+import io.pravega.controller.task.KeyValueTable.TableMetadataTasks;
+import io.pravega.controller.task.Stream.StreamMetadataTasks;
+import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
+
+import io.pravega.test.common.TestingServerStarter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for KeyValueTables API in ControllerService
+ */
+@Slf4j
+public abstract class ControllerServiceWithKVTableTest {
+    private static final String SCOPE = "scope";
+    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+    protected CuratorFramework zkClient;
+    protected SegmentHelper segmentHelperMock;
+
+    private ControllerService consumer;
+    private TestingServer zkServer;
+    private StreamMetadataTasks streamMetadataTasks;
+
+    private StreamTransactionMetadataTasks streamTransactionMetadataTasks;
+    private ConnectionFactory connectionFactory;
+    private StreamMetadataStore streamStore;
+    private RequestTracker requestTracker = new RequestTracker(true);
+
+    private KVTableMetadataStore kvtStore;
+    private TableMetadataTasks kvtMetadataTasks;
+
+    @Before
+    public void setup() {
+        try {
+            zkServer = new TestingServerStarter().start();
+        } catch (Exception e) {
+            log.error("Error starting ZK server", e);
+        }
+        zkClient = CuratorFrameworkFactory.newClient(zkServer.getConnectString(),
+                new ExponentialBackoffRetry(200, 10, 5000));
+        zkClient.start();
+
+        segmentHelperMock = SegmentHelperMock.getSegmentHelperMockForTables(executor);
+        streamStore = spy(getStore());
+        BucketStore bucketStore = StreamStoreFactory.createZKBucketStore(zkClient, executor);
+        TaskMetadataStore taskMetadataStore = TaskStoreFactory.createZKStore(zkClient, executor);
+        connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder()
+                                                                  .controllerURI(URI.create("tcp://localhost"))
+                                                                  .build());
+        GrpcAuthHelper disabledAuthHelper = GrpcAuthHelper.getDisabledAuthHelper();
+        StreamMetrics.initialize();
+        TransactionMetrics.initialize();
+        EventHelper helperMock = EventHelperMock.getEventHelperMock(executor, "host", ((AbstractStreamMetadataStore) streamStore).getHostTaskIndex());
+        streamMetadataTasks = new StreamMetadataTasks(streamStore, bucketStore, taskMetadataStore, segmentHelperMock,
+                executor, "host", disabledAuthHelper, requestTracker, helperMock);
+        streamTransactionMetadataTasks = new StreamTransactionMetadataTasks(streamStore, segmentHelperMock, executor, "host", disabledAuthHelper);
+        StreamRequestHandler streamRequestHandler = new StreamRequestHandler(new AutoScaleTask(streamMetadataTasks, streamStore, executor),
+                new ScaleOperationTask(streamMetadataTasks, streamStore, executor),
+                new UpdateStreamTask(streamMetadataTasks, streamStore, bucketStore, executor),
+                new SealStreamTask(streamMetadataTasks, streamTransactionMetadataTasks, streamStore, executor),
+                new DeleteStreamTask(streamMetadataTasks, streamStore, bucketStore, executor),
+                new TruncateStreamTask(streamMetadataTasks, streamStore, executor),
+                streamStore,
+                executor);
+
+        streamMetadataTasks.setRequestEventWriter(new ControllerEventStreamWriterMock(streamRequestHandler, executor));
+
+        kvtStore = spy(getKVTStore());
+        kvtMetadataTasks = spy(new TableMetadataTasks(kvtStore, segmentHelperMock, executor, executor,
+                "host", GrpcAuthHelper.getDisabledAuthHelper(),
+                requestTracker, helperMock));
+
+        consumer = new ControllerService(kvtStore, kvtMetadataTasks, streamStore, bucketStore, streamMetadataTasks, streamTransactionMetadataTasks, segmentHelperMock, executor, null);
+    }
+
+    abstract StreamMetadataStore getStore();
+
+    abstract KVTableMetadataStore getKVTStore();
+
+    @After
+    public void teardown() throws Exception {
+        streamMetadataTasks.close();
+        streamTransactionMetadataTasks.close();
+        streamStore.close();
+        kvtMetadataTasks.close();
+        kvtStore.close();
+        zkClient.close();
+        zkServer.close();
+        connectionFactory.close();
+        StreamMetrics.reset();
+        TransactionMetrics.reset();
+        ExecutorServiceHelpers.shutdown(executor);
+    }
+
+    @Test(timeout = 5000)
+    public void createKeyValueTableTest() {
+        assertThrows(IllegalArgumentException.class, () -> consumer.createKeyValueTable(SCOPE, "kvtzero", KeyValueTableConfiguration.builder().partitionCount(0).build(), System.currentTimeMillis()).join());
+    }
+
+
+}

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithPravegaTablesKVTableTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithPravegaTablesKVTableTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.controller.server;
+
+import io.pravega.controller.server.rpc.auth.GrpcAuthHelper;
+import io.pravega.controller.store.kvtable.KVTableMetadataStore;
+import io.pravega.controller.store.kvtable.KVTableStoreFactory;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j 
+public class ControllerServiceWithPravegaTablesKVTableTest extends ControllerServiceWithKVTableTest {
+    @Override
+    StreamMetadataStore getStore() {
+        return StreamStoreFactory.createPravegaTablesStore(segmentHelperMock,
+                GrpcAuthHelper.getDisabledAuthHelper(), zkClient, executor);
+    }
+
+    @Override
+    KVTableMetadataStore getKVTStore() {
+        return KVTableStoreFactory.createPravegaTablesStore(segmentHelperMock,
+                GrpcAuthHelper.getDisabledAuthHelper().getDisabledAuthHelper(), zkClient, executor);
+    }
+}

--- a/test/integration/src/test/java/io/pravega/test/integration/KeyValueTableTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/KeyValueTableTest.java
@@ -16,7 +16,6 @@ import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.connection.impl.ConnectionPoolImpl;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
 import io.pravega.client.control.impl.Controller;
-import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.tables.KeyValueTable;
 import io.pravega.client.tables.KeyValueTableClientConfiguration;
@@ -39,7 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;

--- a/test/integration/src/test/java/io/pravega/test/integration/KeyValueTableTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/KeyValueTableTest.java
@@ -16,6 +16,7 @@ import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.connection.impl.ConnectionPoolImpl;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
 import io.pravega.client.control.impl.Controller;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.tables.KeyValueTable;
 import io.pravega.client.tables.KeyValueTableClientConfiguration;
@@ -38,6 +39,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
@@ -45,6 +48,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 
 /**
  * Integration test for {@link KeyValueTable}s using real Segment Store, Controller and connection.
@@ -129,6 +134,11 @@ public class KeyValueTableTest extends KeyValueTableTestBase {
 
         // Verify re-creation does not work.
         Assert.assertFalse(this.controller.createKeyValueTable(kvt1.getScope(), kvt1.getKeyValueTableName(), DEFAULT_CONFIG).join());
+
+        // Try to create a KVTable with 0 paritions, and it should fail
+        val kvtZero = newKeyValueTableName();
+        assertThrows(IllegalArgumentException.class, () -> this.controller.createKeyValueTable(kvtZero.getScope(), kvtZero.getKeyValueTableName(),
+                KeyValueTableConfiguration.builder().partitionCount(0).build()).join());
 
         // Create 2 more KVTables
         val kvt2 = newKeyValueTableName();


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Integration tests use "LocalController" implementation of "Controller" interface, which is not used by the client.
The Client uses ControllerImpl implementation of Controller interface which has a check for partitionCount and hence the table creation errors out when using ControllerImpl with '0' partitionCount.
However, LocalController does not have this check and so creates the KVTable successfully even with a parititonCount=0.

**Purpose of the change**  
Fixes #5100

**What the code does**  
Added a check to ControllerService to check for partitionCount > 0 and throw and IllegalArgumentException if it is <=0.

**How to verify it**  
Added a new UT to ControllerServiceImplTest to cover the 0 partitionCount scenario.
Added a new test case to Integration Tests for creating a KeyValueTable with partitionCount 0.
Both above tests should return IllegalArgumentException for partitionCount=0.
All other unit and integration tests should pass.
