### PR TITLE
Issue 5106: (R0.8) Cherry-pick #5103 

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -894,7 +894,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         if (ra == ReadAvailability.BeyondLastOffset) {
             result = new EndOfStreamSegmentReadResultEntry(resultStartOffset, maxLength);
         } else if (ra == ReadAvailability.BeforeStartOffset) {
-            result = new TruncatedReadResultEntry(resultStartOffset, maxLength, this.metadata.getStartOffset());
+            result = new TruncatedReadResultEntry(resultStartOffset, maxLength, this.metadata.getStartOffset(), this.metadata.getName());
         } else {
             // Look up an entry in the index that contains our requested start offset.
             synchronized (this.lock) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
@@ -98,7 +98,7 @@ public final class StreamSegmentStorageReader {
         public CompletableReadResultEntry apply(Long readOffset, Integer readLength) {
             if (readOffset < this.segmentInfo.getStartOffset()) {
                 // We attempted to read from a truncated portion of the Segment.
-                return new TruncatedReadResultEntry(readOffset, readLength, this.segmentInfo.getStartOffset());
+                return new TruncatedReadResultEntry(readOffset, readLength, this.segmentInfo.getStartOffset(), this.segmentInfo.getName());
             } else if (readOffset >= this.segmentInfo.getLength()) {
                 // We've reached the end of a Sealed Segment.
                 return new EndOfStreamSegmentReadResultEntry(readOffset, readLength);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/TruncatedReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/TruncatedReadResultEntry.java
@@ -22,9 +22,10 @@ class TruncatedReadResultEntry extends ReadResultEntryBase {
      * @param segmentReadOffset   The offset in the StreamSegment that this entry starts at.
      * @param requestedReadLength The maximum number of bytes requested for read.
      * @param segmentStartOffset  The first offset in the StreamSegment available for reading.
+     * @param segmentName         Name of the segment.
      */
-    TruncatedReadResultEntry(long segmentReadOffset, int requestedReadLength, long segmentStartOffset) {
+    TruncatedReadResultEntry(long segmentReadOffset, int requestedReadLength, long segmentStartOffset, String segmentName) {
         super(ReadResultEntryType.Truncated, segmentReadOffset, requestedReadLength);
-        fail(new StreamSegmentTruncatedException(segmentStartOffset));
+        fail(new StreamSegmentTruncatedException(segmentName, segmentStartOffset, segmentReadOffset));
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -65,6 +65,10 @@ import lombok.val;
 public class ContainerTableExtensionImpl implements ContainerTableExtension {
     //region Members
 
+    /**
+     * Default value used for when no offset is provided for a remove or put call.
+     */
+    private static final int NO_OFFSET = -1;
     private static final int MAX_BATCH_SIZE = 32 * EntrySerializer.MAX_SERIALIZATION_LENGTH;
     /**
      * The default value to supply to a {@link WriterTableProcessor} to indicate how big compactions need to be.
@@ -76,12 +80,9 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
      * The default Segment Attributes to set for every new Table Segment. These values will override the corresponding
      * defaults from {@link TableAttributes#DEFAULT_VALUES}.
      */
-    private static final Map<UUID, Long> DEFAULT_ATTRIBUTES = ImmutableMap.of(TableAttributes.MIN_UTILIZATION, 75L,
+    @VisibleForTesting
+    static final Map<UUID, Long> DEFAULT_COMPACTION_ATTRIBUTES = ImmutableMap.of(TableAttributes.MIN_UTILIZATION, 75L,
             Attributes.ROLLOVER_SIZE, 4L * DEFAULT_MAX_COMPACTION_SIZE);
-    /**
-     * Default value used for when no offset is provided for a remove or put call.
-     */
-    private static final int NO_OFFSET = -1;
 
     private final SegmentContainer segmentContainer;
     private final ScheduledExecutorService executor;
@@ -171,6 +172,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     public CompletableFuture<Void> createSegment(@NonNull String segmentName, boolean sorted, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
         val attributes = new HashMap<>(TableAttributes.DEFAULT_VALUES);
+        attributes.putAll(DEFAULT_COMPACTION_ATTRIBUTES);
         if (sorted) {
             attributes.put(TableAttributes.SORTED, Attributes.BOOLEAN_TRUE);
         }
@@ -181,7 +183,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
         // will need to accept external configuration that defines at least MIN_UTILIZATION.
         val attributeUpdates = attributes
                 .entrySet().stream()
-                .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, DEFAULT_ATTRIBUTES.getOrDefault(e.getKey(), e.getValue())))
+                .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, e.getValue()))
                 .collect(Collectors.toList());
         logRequest("createSegment", segmentName);
         return this.segmentContainer.createStreamSegment(segmentName, attributeUpdates, timeout);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImplTests.java
@@ -88,6 +88,10 @@ public class ContainerTableExtensionImplTests extends ThreadPooledTestSuite {
 
         context.ext.createSegment(SEGMENT_NAME, TIMEOUT).join();
         Assert.assertNotNull("Segment not created", context.segment());
+
+        val attributes = context.segment().getAttributes(ContainerTableExtensionImpl.DEFAULT_COMPACTION_ATTRIBUTES.keySet(), false, TIMEOUT).join();
+        AssertExtensions.assertMapEquals("Unexpected compaction attributes.", ContainerTableExtensionImpl.DEFAULT_COMPACTION_ATTRIBUTES, attributes);
+
         val tableSegmentProcessors = context.ext.createWriterSegmentProcessors(context.segment().getMetadata());
         Assert.assertFalse("Expecting Writer Table Processors for table segment.", tableSegmentProcessors.isEmpty());
 


### PR DESCRIPTION
**Change log description**  
Cherrypick #5103 into 0.7.
- Issue 5102: (SegmentStore) TableSegment Rollover Size not properly set.

**Purpose of the change**  
Fixes #5016.

**What the code does**  
Cherrypick #5103 into 0.7.

**How to verify it**  
Build must pass.
