### PR TITLE
Issue 5126: disabled metrics by default to prevent misconfigs

### DIFF
--- a/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
@@ -99,6 +99,7 @@ public class IntermittentCnxnFailureTest {
     @Before
     public void setup() throws Exception {
         MetricsConfig metricsConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
         metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(60));

--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricsConfig.java
@@ -22,7 +22,7 @@ import java.time.Duration;
  */
 public class MetricsConfig {
     //region Config Names
-    public final static Property<Boolean> ENABLE_STATISTICS = Property.named("statistics.enable", true, "enableStatistics");
+    public final static Property<Boolean> ENABLE_STATISTICS = Property.named("statistics.enable", false, "enableStatistics");
     public final static Property<Long> DYNAMIC_CACHE_SIZE = Property.named("dynamicCache.size", 10000000L, "dynamicCacheSize");
     public final static Property<Integer> DYNAMIC_CACHE_EVICTION_DURATION_MINUTES = Property.named("dynamicCache.eviction.duration.minutes", 3, "dynamicCacheEvictionDurationMinutes");
     public final static Property<Integer> OUTPUT_FREQUENCY = Property.named("output.frequency.seconds", 60, "outputFrequencySeconds");

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/RegistryConfigUtilTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/RegistryConfigUtilTest.java
@@ -28,6 +28,7 @@ public class RegistryConfigUtilTest {
     @Test
     public void testStatsDConfig() {
         MetricsConfig appConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.OUTPUT_FREQUENCY, 37)
                 .with(MetricsConfig.METRICS_PREFIX, "statsDPrefix")
                 .with(MetricsConfig.STATSD_HOST, "localhost")

--- a/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsProviderTest.java
+++ b/shared/metrics/src/test/java/io/pravega/shared/metrics/StatsProviderTest.java
@@ -34,6 +34,7 @@ public class StatsProviderTest {
         CompositeMeterRegistry localRegistry = new CompositeMeterRegistry();
 
         MetricsConfig appConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, true)
                 .with(MetricsConfig.ENABLE_INFLUXDB_REPORTER, false)
                 .build();
@@ -53,6 +54,7 @@ public class StatsProviderTest {
     @Test
     public void testStatsProviderStartWithoutExporting() {
         MetricsConfig appConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, true)
                 .with(MetricsConfig.ENABLE_INFLUXDB_REPORTER, true)
                 .build();
@@ -74,6 +76,7 @@ public class StatsProviderTest {
     @Test (expected = Exception.class)
     public void testStatsProviderNoRegisterBound() {
         MetricsConfig appConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .with(MetricsConfig.ENABLE_INFLUXDB_REPORTER, false)
                 .build();

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerMetricsTest.java
@@ -86,8 +86,9 @@ public class ControllerMetricsTest {
     @Before
     public void setUp() throws Exception {
         MetricsConfig metricsConfig = MetricsConfig.builder()
-                                                   .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
-                                                   .build();
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
+                .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
+                .build();
         metricsConfig.setDynamicCacheEvictionDuration(Duration.ofMinutes(5));
 
         MetricsProvider.initialize(metricsConfig);

--- a/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/MetricsTest.java
@@ -100,6 +100,7 @@ public class MetricsTest extends ThreadPooledTestSuite {
         log.info("Initializing metrics provider ...");
 
         MetricsConfig metricsConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
         metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(2));

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -85,6 +85,7 @@ public class StreamMetricsTest {
         log.info("Initializing metrics provider ...");
 
         MetricsConfig metricsConfig = MetricsConfig.builder()
+                .with(MetricsConfig.ENABLE_STATISTICS, true)
                 .with(MetricsConfig.ENABLE_STATSD_REPORTER, false)
                 .build();
         metricsConfig.setDynamicCacheEvictionDuration(Duration.ofSeconds(60));


### PR DESCRIPTION
Signed-off-by: Kevin Han <kevinhan88@gmail.com>

**Change log description**  
We disabled metrics inside config.properties, expecting metrics is off for scenario such as system tests, unless it's enabled explicitly.
This config only works for Segmentstore but not controller, due to a bug in Controller's config propagation mechanism.
We recently disabled StatsD by default, hence Controller in system test hit an obvious illegal situation - metrics is enabled, but no exporter is defined.
This change is to disable metrics by default inside source code MetricsConfig.java, so the bug above will not have negative impact.

Long term solution is to be addressed separately.

**Purpose of the change**  
Fixes #5126 

**What the code does**  
Disabled ENABLE_STATISTICS by default.

**How to verify it**  
Unit tests should pass;
Controller in system test should stop complaining No metrics exporter defined when metrics is enabled.
