### PR TITLE
Issue 5119: (SegmentStore) Copy-on-Read for Table Segment Compaction (#5120) [Cherry-pick]

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
@@ -63,9 +63,27 @@ public interface ReadResult extends Iterator<ReadResultEntry>, AutoCloseable {
      * Note that this does not track the individual consumption within the objects returned by next().
      *
      * @return number of bytes consumed via the next method invocation
-     *
      */
     int getConsumedLength();
+
+    /**
+     * Gets a value indicating whether "Copy-on-Read" is enabled for Cache retrievals. See {@link #setCopyOnRead} for
+     * more details.
+     *
+     * @return True if copy-on-read is enabled for this {@link ReadResult}, false otherwise.
+     */
+    boolean isCopyOnRead();
+
+    /**
+     * Sets a value indicating whether "Copy-on-Read" is to be enabled for any Cache entry retrievals
+     * ({@link ReadResultEntry#getType()} equals {@link ReadResultEntryType#Cache}). If true, then any data extracted
+     * from the Cache will be copied into a new buffer (and thus decoupled from the cache). Use this option if you expect
+     * your result to be used across requests or for longer periods of time, as this will prevent the {@link ReadResult}
+     * from being invalidated in case of an eventual cache eviction.
+     *
+     * @param value True if enabling copy-on-read for this {@link ReadResult}, false otherwise.
+     */
+    void setCopyOnRead(boolean value);
 
     /**
      * Gets a value indicating whether this ReadResult is fully consumed (either because it was read in its entirety

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -109,6 +109,7 @@ public class PravegaRequestProcessorTest {
         boolean closed = false;
         final List<ReadResultEntry> results;
         long currentOffset = 0;
+        boolean copyOnRead = false;
 
         @Override
         public boolean hasNext() {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -715,8 +715,8 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      */
     private void triggerFutureReads(Collection<FutureReadResultEntry> futureReads) {
         for (FutureReadResultEntry r : futureReads) {
-            ReadResultEntry entry = getSingleReadResultEntry(r.getStreamSegmentOffset(), r.getRequestedReadLength());
-            assert entry != null : "Serving a StorageReadResultEntry with a null result";
+            ReadResultEntry entry = getSingleReadResultEntry(r.getStreamSegmentOffset(), r.getRequestedReadLength(), false);
+            assert entry != null : "Serving a FutureReadResultEntry with a null result";
             assert !(entry instanceof FutureReadResultEntry) : "Serving a FutureReadResultEntry with another FutureReadResultEntry.";
 
             log.trace("{}: triggerFutureReads (Offset = {}, Type = {}).", this.traceObjectId, r.getStreamSegmentOffset(), entry.getType());
@@ -776,7 +776,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 return null;
             } else {
                 // Fetch data from the cache for the first entry, but do not update the cache hit stats.
-                nextEntry = createMemoryRead(indexEntry, startOffset, length, false);
+                nextEntry = createMemoryRead(indexEntry, startOffset, length, false, false);
             }
         }
 
@@ -878,9 +878,10 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      *
      * @param resultStartOffset The Offset within the StreamSegment where to start returning data from.
      * @param maxLength         The maximum number of bytes to return.
+     * @param makeCopy          If true, any data retrieved from the Cache will be copied into a Heap buffer before being returned.
      * @return A ReadResultEntry representing the data to return.
      */
-    private CompletableReadResultEntry getSingleReadResultEntry(long resultStartOffset, int maxLength) {
+    private CompletableReadResultEntry getSingleReadResultEntry(long resultStartOffset, int maxLength, boolean makeCopy) {
         Exceptions.checkNotClosed(this.closed, this);
 
         if (maxLength < 0) {
@@ -912,11 +913,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                         result = createDataNotAvailableRead(resultStartOffset, maxLength);
                     } else if (indexEntry.isDataEntry()) {
                         // ResultStartOffset is after the StartOffset and before the End Offset of this entry.
-                        result = createMemoryRead(indexEntry, resultStartOffset, maxLength, true);
+                        result = createMemoryRead(indexEntry, resultStartOffset, maxLength, true, makeCopy);
                     } else if (indexEntry instanceof RedirectIndexEntry) {
                         // ResultStartOffset is after the StartOffset and before the End Offset of this entry, but this
                         // is a Redirect; reissue the request to the appropriate index.
-                        result = createRedirectedRead(resultStartOffset, maxLength, (RedirectIndexEntry) indexEntry);
+                        result = createRedirectedRead(resultStartOffset, maxLength, (RedirectIndexEntry) indexEntry, makeCopy);
                     }
                 }
             }
@@ -939,12 +940,13 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      *
      * @param resultStartOffset The Offset within the StreamSegment where to start returning data from.
      * @param maxLength         The maximum number of bytes to return.
+     * @param makeCopy          If true, any data retrieved from the Cache will be copied into a Heap buffer before being returned.
      * @return A ReadResultEntry representing the data to return.
      */
-    private CompletableReadResultEntry getMultiReadResultEntry(long resultStartOffset, int maxLength) {
+    private CompletableReadResultEntry getMultiReadResultEntry(long resultStartOffset, int maxLength, boolean makeCopy) {
         int readLength = 0;
 
-        CompletableReadResultEntry nextEntry = getSingleReadResultEntry(resultStartOffset, maxLength);
+        CompletableReadResultEntry nextEntry = getSingleReadResultEntry(resultStartOffset, maxLength, makeCopy);
         if (nextEntry == null || !(nextEntry instanceof CacheReadResultEntry)) {
             // We can only coalesce CacheReadResultEntries.
             return nextEntry;
@@ -961,7 +963,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 break;
             }
 
-            nextEntry = getSingleMemoryReadResultEntry(resultStartOffset + readLength, maxLength - readLength);
+            nextEntry = getSingleMemoryReadResultEntry(resultStartOffset + readLength, maxLength - readLength, makeCopy);
         } while (nextEntry != null);
 
         // Coalesce the results into a single InputStream and return the result.
@@ -975,9 +977,10 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      *
      * @param resultStartOffset The Offset within the StreamSegment where to start returning data from.
      * @param maxLength         The maximum number of bytes to return.
+     * @param makeCopy          If true, any data retrieved from the Cache will be copied into a Heap buffer before being returned.
      * @return A CacheReadResultEntry representing the data to return.
      */
-    private CacheReadResultEntry getSingleMemoryReadResultEntry(long resultStartOffset, int maxLength) {
+    private CacheReadResultEntry getSingleMemoryReadResultEntry(long resultStartOffset, int maxLength, boolean makeCopy) {
         Exceptions.checkNotClosed(this.closed, this);
 
         if (maxLength > 0 && checkReadAvailability(resultStartOffset, false) == ReadAvailability.Available) {
@@ -986,7 +989,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 ReadIndexEntry indexEntry = this.indexEntries.get(resultStartOffset);
                 if (indexEntry != null && indexEntry.isDataEntry()) {
                     // We found an entry; return a result for it.
-                    return createMemoryRead(indexEntry, resultStartOffset, maxLength, true);
+                    return createMemoryRead(indexEntry, resultStartOffset, maxLength, true, makeCopy);
                 }
             }
         }
@@ -995,7 +998,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         return null;
     }
 
-    private CompletableReadResultEntry createRedirectedRead(long streamSegmentOffset, int maxLength, RedirectIndexEntry entry) {
+    private CompletableReadResultEntry createRedirectedRead(long streamSegmentOffset, int maxLength, RedirectIndexEntry entry, boolean makeCopy) {
         StreamSegmentReadIndex redirectedIndex = entry.getRedirectReadIndex();
         long redirectOffset = streamSegmentOffset - entry.getStreamSegmentOffset();
         long entryLength = entry.getLength();
@@ -1011,7 +1014,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             maxLength = (int) entryLength;
         }
 
-        CompletableReadResultEntry result = redirectedIndex.getSingleReadResultEntry(redirectOffset, maxLength);
+        CompletableReadResultEntry result = redirectedIndex.getSingleReadResultEntry(redirectOffset, maxLength, makeCopy);
         if (result != null) {
             // Since this is a redirect to a (merged) Transaction, it is possible that between now and when the caller
             // invokes the requestContent() on the entry the Transaction may be fully merged (in Tier2). If that's the
@@ -1020,14 +1023,15 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             // yield the right result. However, in order to recover from this without the caller's intervention, we pass
             // a pointer to getSingleReadResultEntry to the RedirectedReadResultEntry in case it fails with such an exception;
             // that class has logic in it to invoke it if needed and get the right entry.
-            result = new RedirectedReadResultEntry(result, entry.getStreamSegmentOffset(), this::getOrRegisterRedirectedRead, redirectedIndex.metadata.getId());
+            result = new RedirectedReadResultEntry(result, entry.getStreamSegmentOffset(),
+                    (rso, ml, sourceSegmentId) -> getOrRegisterRedirectedRead(rso, ml, sourceSegmentId, makeCopy), redirectedIndex.metadata.getId());
         }
 
         return result;
     }
 
-    private CompletableReadResultEntry getOrRegisterRedirectedRead(long resultStartOffset, int maxLength, long sourceSegmentId) {
-        CompletableReadResultEntry result = getSingleReadResultEntry(resultStartOffset, maxLength);
+    private CompletableReadResultEntry getOrRegisterRedirectedRead(long resultStartOffset, int maxLength, long sourceSegmentId, boolean makeCopy) {
+        CompletableReadResultEntry result = getSingleReadResultEntry(resultStartOffset, maxLength, makeCopy);
         if (result instanceof RedirectedReadResultEntry) {
             // The merger isn't completed yet. Register the read so that it is completed when the merger is done.
             PendingMerge pendingMerge;
@@ -1051,7 +1055,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                     log.debug("{}: Pending Merge for id {} was sealed for {}; re-issuing.", this.traceObjectId, sourceSegmentId, result);
                 }
 
-                result = getSingleReadResultEntry(resultStartOffset, maxLength);
+                result = getSingleReadResultEntry(resultStartOffset, maxLength, makeCopy);
             }
         }
 
@@ -1094,9 +1098,10 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      * @param streamSegmentOffset The Offset in the StreamSegment where to the ReadResultEntry starts at.
      * @param maxLength           The maximum length of the Read, from the Offset of this ReadResultEntry.
      * @param updateStats         If true, the entry's cache generation is updated as a result of this call.
+     * @param makeCopy          If true, any data retrieved from the Cache will be copied into a Heap buffer before being returned.
      */
     @GuardedBy("lock")
-    private CacheReadResultEntry createMemoryRead(ReadIndexEntry entry, long streamSegmentOffset, int maxLength, boolean updateStats) {
+    private CacheReadResultEntry createMemoryRead(ReadIndexEntry entry, long streamSegmentOffset, int maxLength, boolean updateStats, boolean makeCopy) {
         assert streamSegmentOffset >= entry.getStreamSegmentOffset() : String.format("streamSegmentOffset{%d} < entry.getStreamSegmentOffset{%d}", streamSegmentOffset, entry.getStreamSegmentOffset());
 
         int entryOffset = (int) (streamSegmentOffset - entry.getStreamSegmentOffset());
@@ -1112,7 +1117,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             entry.setGeneration(generation);
         }
 
-        return new CacheReadResultEntry(entry.getStreamSegmentOffset() + entryOffset, data.slice(entryOffset, length));
+        data = data.slice(entryOffset, length);
+        if (makeCopy) {
+            data = new ByteArraySegment(data.getCopy());
+        }
+        return new CacheReadResultEntry(entry.getStreamSegmentOffset() + entryOffset, data);
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
@@ -14,7 +14,6 @@ import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import java.util.concurrent.CancellationException;
-import java.util.function.BiFunction;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.NonNull;
@@ -40,6 +39,8 @@ class StreamSegmentReadResult implements ReadResult {
     private boolean canRead;
     @GuardedBy("this")
     private boolean closed;
+    @GuardedBy("this")
+    private boolean copyOnRead;
 
     //endregion
 
@@ -83,6 +84,16 @@ class StreamSegmentReadResult implements ReadResult {
     @Override
     public synchronized int getConsumedLength() {
         return this.consumedLength;
+    }
+
+    @Override
+    public synchronized boolean isCopyOnRead() {
+        return this.copyOnRead;
+    }
+
+    @Override
+    public synchronized void setCopyOnRead(boolean value) {
+        this.copyOnRead = value;
     }
 
     @Override
@@ -167,7 +178,7 @@ class StreamSegmentReadResult implements ReadResult {
         // Retrieve the next item.
         long startOffset = this.streamSegmentStartOffset + this.consumedLength;
         int remainingLength = this.maxResultLength - this.consumedLength;
-        CompletableReadResultEntry entry = this.getNextItem.apply(startOffset, remainingLength);
+        CompletableReadResultEntry entry = this.getNextItem.apply(startOffset, remainingLength, this.copyOnRead);
 
         if (entry == null) {
             assert remainingLength <= 0 : String.format("No ReadResultEntry received when one was expected. Offset %d, MaxLen %d.", startOffset, remainingLength);
@@ -206,10 +217,12 @@ class StreamSegmentReadResult implements ReadResult {
     //region NextEntrySupplier
 
     /**
-     * Defines a Function that given a startOffset (long) and remainingLength (int), returns the next entry to be consumed (ReadResultEntry).
+     * Defines a Function that given a startOffset (long), remainingLength (int) and whether to make a copy of any returned
+     * cached data, returns the next entry to be consumed (CompletableReadResultEntry).
      */
     @FunctionalInterface
-    interface NextEntrySupplier extends BiFunction<Long, Integer, CompletableReadResultEntry> {
+    interface NextEntrySupplier {
+        CompletableReadResultEntry apply(Long startOffset, Integer remainingLength, Boolean makeCopy);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentStorageReader.java
@@ -95,7 +95,7 @@ public final class StreamSegmentStorageReader {
         }
 
         @Override
-        public CompletableReadResultEntry apply(Long readOffset, Integer readLength) {
+        public CompletableReadResultEntry apply(Long readOffset, Integer readLength, Boolean makeCopyIgnored) {
             if (readOffset < this.segmentInfo.getStartOffset()) {
                 // We attempted to read from a truncated portion of the Segment.
                 return new TruncatedReadResultEntry(readOffset, readLength, this.segmentInfo.getStartOffset(), this.segmentInfo.getName());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -189,6 +189,9 @@ class TableCompactor {
      */
     private CompletableFuture<CompactionArgs> readCandidates(DirectSegmentAccess segment, long startOffset, int maxLength, TimeoutTimer timer) {
         ReadResult rr = segment.read(startOffset, maxLength, timer.getRemaining());
+        // Make a copy of all retrieved data since it may take a while until we are ready to write it back to the segment;
+        // we do not want the cache to be evicted from underneath us and thus invalidate our result.
+        rr.setCopyOnRead(true);
         return AsyncReadResultProcessor.processAll(rr, this.executor, timer.getRemaining())
                 .thenApply(inputData -> parseEntries(inputData, startOffset, maxLength));
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -262,10 +262,10 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
      * @param lastIndexedOffset The last offset in the Table Segment that was indexed.
      */
     private void flushComplete(long lastIndexedOffset) {
+        log.debug("{}: FlushComplete (State={}).", this.traceObjectId, this.aggregator);
         this.aggregator.reset();
         this.aggregator.setLastIndexedOffset(lastIndexedOffset);
         this.connector.notifyIndexOffsetChanged(this.aggregator.getLastIndexedOffset());
-        log.debug("{}: FlushComplete (State={}).", this.traceObjectId, this.aggregator);
     }
 
     /**
@@ -282,7 +282,8 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
     private CompletableFuture<TableWriterFlushResult> flushOnce(DirectSegmentAccess segment, TimeoutTimer timer) {
         // Index all the keys in the segment range pointed to by the aggregator.
         KeyUpdateCollection keyUpdates = readKeysFromSegment(segment, this.aggregator.getFirstOffset(), this.aggregator.getLastOffset(), timer);
-        log.debug("{}: Flush.ReadFromSegment {} UpdateKeys(s).", this.traceObjectId, keyUpdates.getUpdates().size());
+        log.debug("{}: Flush.ReadFromSegment KeyCount={}, UpdateCount={}, HighestCopiedOffset={}, LastIndexedOffset={}.", this.traceObjectId,
+                keyUpdates.getUpdates().size(), keyUpdates.getTotalUpdateCount(), keyUpdates.getHighestCopiedOffset(), keyUpdates.getLastIndexedOffset());
 
         // Group keys by their assigned TableBucket (whether existing or not), then fetch all existing keys
         // for each such bucket and finally (reindex) update the bucket.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessorTests.java
@@ -63,7 +63,7 @@ public class AsyncReadResultProcessorTests extends ThreadPooledTestSuite {
 
         // Setup an entry provider supplier.
         AtomicInteger currentIndex = new AtomicInteger();
-        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length) -> {
+        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length, makeCopy) -> {
             int idx = currentIndex.getAndIncrement();
             if (idx >= entries.size()) {
                 return null;
@@ -101,7 +101,7 @@ public class AsyncReadResultProcessorTests extends ThreadPooledTestSuite {
 
         // Setup an entry provider supplier.
         AtomicInteger currentIndex = new AtomicInteger();
-        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length) -> {
+        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length, makeCopy) -> {
             int idx = currentIndex.getAndIncrement();
             if (idx >= entries.size()) {
                 return null;
@@ -139,7 +139,7 @@ public class AsyncReadResultProcessorTests extends ThreadPooledTestSuite {
         final Semaphore barrier = new Semaphore(0);
 
         // Setup an entry provider supplier that returns Future Reads, which will eventually fail.
-        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length) -> {
+        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length, makeCopy) -> {
             Supplier<BufferView> entryContentsSupplier = () -> {
                 barrier.acquireUninterruptibly();
                 throw new IntentionalException("Intentional");
@@ -180,7 +180,7 @@ public class AsyncReadResultProcessorTests extends ThreadPooledTestSuite {
 
         // Setup an entry provider supplier.
         AtomicInteger currentIndex = new AtomicInteger();
-        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length) -> {
+        StreamSegmentReadResult.NextEntrySupplier supplier = (offset, length, makeCopy) -> {
             int idx = currentIndex.getAndIncrement();
             if (idx == entries.size() - 1) {
                 // Future read result.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -14,6 +14,7 @@ import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
 import io.pravega.test.common.AssertExtensions;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import lombok.Cleanup;
@@ -33,12 +34,33 @@ public class StreamSegmentReadResultTests {
     public Timeout globalTimeout = Timeout.seconds(10);
 
     /**
+     * Tests the ability to properly set Copy-on-Read.
+     */
+    @Test
+    public void testCopyOnRead() {
+        AtomicBoolean expectedMakeCopy = new AtomicBoolean(false);
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> {
+            Assert.assertEquals(expectedMakeCopy.get(), makeCopy);
+            return TestReadResultEntry.endOfSegment(offset, length);
+        };
+        @Cleanup
+        StreamSegmentReadResult r1 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
+        r1.next();
+
+        @Cleanup
+        StreamSegmentReadResult r2 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
+        r2.setCopyOnRead(true);
+        expectedMakeCopy.set(true);
+        r2.next();
+    }
+
+    /**
      * Tests the next() method which ends when the result is fully consumed (via offsets).
      */
     @Test
     public void testNextFullyConsumed() {
         AtomicReference<TestReadResultEntry> nextEntry = new AtomicReference<>();
-        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length) -> nextEntry.get();
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> nextEntry.get();
 
         // We issue a read with length = MAX_RESULT_LENGTH, and return items, 1 byte at a time.
         @Cleanup
@@ -93,7 +115,7 @@ public class StreamSegmentReadResultTests {
 
     private void testNextTerminal(BiFunction<Long, Integer, TestReadResultEntry> terminalEntryCreator) {
         AtomicReference<TestReadResultEntry> nextEntry = new AtomicReference<>();
-        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length) -> nextEntry.get();
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> nextEntry.get();
 
         // We issue a read with length = MAX_RESULT_LENGTH, and return only half the items, 1 byte at a time.
         @Cleanup
@@ -127,7 +149,7 @@ public class StreamSegmentReadResultTests {
     @Test
     public void testClose() {
         AtomicReference<TestReadResultEntry> nextEntry = new AtomicReference<>();
-        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length) -> nextEntry.get();
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> nextEntry.get();
 
         // We issue a read with length = MAX_RESULT_LENGTH, but we only get to read one item from it.
         StreamSegmentReadResult r = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
@@ -148,9 +170,9 @@ public class StreamSegmentReadResultTests {
      * Tests the ability to only return a next item if the previous returned item hasn't been consumed yet.
      */
     @Test
-    public void testNextWaitOnPrevious() throws Exception {
+    public void testNextWaitOnPrevious() {
         AtomicReference<TestReadResultEntry> nextEntry = new AtomicReference<>();
-        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length) -> nextEntry.get();
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> nextEntry.get();
 
         // We issue a read, get one item, do not consume it, and then read a second time.
         @Cleanup

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
@@ -62,11 +63,21 @@ class SegmentMock implements DirectSegmentAccess {
     private final ScheduledExecutorService executor;
     @GuardedBy("this")
     private BiConsumer<Long, Integer> appendCallback;
+    private final AtomicInteger readRequestCount = new AtomicInteger();
+    private final AtomicInteger copyOnReadCount = new AtomicInteger();
 
     SegmentMock(ScheduledExecutorService executor) {
         this(new StreamSegmentMetadata("Mock", 0, 0), executor);
         this.metadata.setLength(0);
         this.metadata.setStorageLength(0);
+    }
+
+    int getReadRequestCount() {
+        return this.readRequestCount.get();
+    }
+
+    int getCopyOnReadCount() {
+        return this.copyOnReadCount.get();
     }
 
     /**
@@ -284,8 +295,17 @@ class SegmentMock implements DirectSegmentAccess {
     //region TruncateableReadResultMock
 
     private class TruncateableReadResultMock extends ReadResultMock {
-        TruncateableReadResultMock(long streamSegmentStartOffset, ArrayView data, int maxResultLength, int entryLength) {
+        private TruncateableReadResultMock(long streamSegmentStartOffset, ArrayView data, int maxResultLength, int entryLength) {
             super(streamSegmentStartOffset, data, maxResultLength, entryLength);
+            readRequestCount.incrementAndGet();
+        }
+
+        @Override
+        public void setCopyOnRead(boolean copyOnRead) {
+            if (copyOnRead != isCopyOnRead()) {
+                copyOnReadCount.addAndGet(copyOnRead ? 1 : -1);
+            }
+            super.setCopyOnRead(copyOnRead);
         }
 
         @Override


### PR DESCRIPTION

**Change log description**  
Updated the ReadResult interface with the ability to specify "copy-on-read" behavior for any data that is returned from the cache. If set, any data that is returned from the cache is copied into a heap buffer and served from there. Default is not set.

Updated TableCompactor to make use of this functionality.

Signed-off-by: Andrei Paduroiu <andrei.paduroiu@emc.com>

Co-authored-by: Sachin Jayant Joshi <44757683+sachin-j-joshi@users.noreply.github.com>

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/5131

**What the code does**  
Cherry picks https://github.com/pravega/pravega/pull/5120

**How to verify it**  
Build should pass.
