### PR TITLE
Issue 5137:  Remove dependency on netty-transport-native-epoll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,10 +250,13 @@ project('client') {
         compile project(':shared:authplugin')
         compile project(':shared:protocol')
         compile project(":shared:controller-api")
+
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        // this is used to create a mock server.
+        testCompile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
     }
 
     javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -250,9 +250,6 @@ project('client') {
         compile project(':shared:authplugin')
         compile project(':shared:protocol')
         compile project(":shared:controller-api")
-        // Ensure epoll native transport is used for linux-x86_64 architecture systems.
-        // The client fallsback to NIO based transport if epoll is not available.
-        compile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion


### PR DESCRIPTION
**Change log description**  
Remove dependency on netty-transport-native-epoll.

**Purpose of the change**  
Fixes #5137 

**What the code does**  
Remove dependency for epoll-native-transport on the client as it is redundant.

**How to verify it**  
No changes to functionality. All the tests should continue to pass.
[client.deps_PR_5138.txt](https://github.com/pravega/pravega/files/5166257/client.deps_PR_5138.txt)
