### PR TITLE
Issue 5144: Force token refresh when segment store indicates token expiry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,13 +250,13 @@ project('client') {
         compile project(':shared:authplugin')
         compile project(':shared:protocol')
         compile project(":shared:controller-api")
-        // Ensure epoll native transport is used for linux-x86_64 architecture systems.
-        // The client fallsback to NIO based transport if epoll is not available.
-        compile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
+
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        // this is used to create a mock server.
+        testCompile group: 'io.netty', name: 'netty-transport-native-epoll', version: nettyVersion, classifier: 'linux-x86_64'
     }
 
     javadoc {

--- a/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
@@ -10,6 +10,7 @@
 package io.pravega.client.connection.impl;
 
 import io.pravega.auth.AuthenticationException;
+import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.control.impl.Controller;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.impl.ConnectionClosedException;
@@ -78,7 +79,11 @@ public class RawClient implements AutoCloseable {
         @Override
         public void authTokenCheckFailed(WireCommands.AuthTokenCheckFailed authTokenCheckFailed) {
             log.warn("Auth token check failed on segment {} with {}", segmentId, authTokenCheckFailed);
-            closeConnection(new AuthenticationException(authTokenCheckFailed.toString()));
+            if (authTokenCheckFailed.isTokenExpired()) {
+                closeConnection(new TokenExpiredException(authTokenCheckFailed.getServerStackTrace()));
+            } else {
+                closeConnection(new AuthenticationException(authTokenCheckFailed.toString()));
+            }
         }
     }
 

--- a/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
+++ b/client/src/main/java/io/pravega/client/security/auth/DelegationTokenProvider.java
@@ -33,4 +33,9 @@ public interface DelegationTokenProvider {
      * @return whether the population was successful
      */
     boolean populateToken(String token);
+
+    /**
+     * Signals the object that the token it may be holding has expired.
+     */
+    void signalTokenExpired();
 }

--- a/client/src/main/java/io/pravega/client/security/auth/EmptyTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/EmptyTokenProviderImpl.java
@@ -25,4 +25,9 @@ public class EmptyTokenProviderImpl implements DelegationTokenProvider {
     public boolean populateToken(String token) {
         return false;
     }
+
+    @Override
+    public void signalTokenExpired() {
+        // Do nothing
+    }
 }

--- a/client/src/main/java/io/pravega/client/security/auth/StringTokenProviderImpl.java
+++ b/client/src/main/java/io/pravega/client/security/auth/StringTokenProviderImpl.java
@@ -36,4 +36,9 @@ public class StringTokenProviderImpl implements DelegationTokenProvider {
         this.token.set(token);
         return true;
     }
+
+    @Override
+    public void signalTokenExpired() {
+        // Do nothing
+    }
 }

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -76,8 +76,6 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
                         return cause instanceof Exception &&
                                 (hasTokenExpired || cause instanceof ConnectionFailedException);
                     })
-                    //.retryingOn(ConnectionFailedException.class)
-                    //.throwingOn(SegmentSealedException.class)
                     .run(() -> {
                         if (client == null || client.isClosed()) {
                             client = new RawClient(controller, connectionPool, segmentId);

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.segment.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.Unpooled;
 import io.pravega.auth.AuthenticationException;
 import io.pravega.auth.TokenExpiredException;
@@ -114,7 +115,7 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         if (reply instanceof AppendSetup) {
             return (AppendSetup) reply;
         } else {
-            throw handelUnexpectedReply(reply);
+            throw handleUnexpectedReply(reply);
         }
     }
 
@@ -124,11 +125,12 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         } else if (reply instanceof ConditionalCheckFailed) {
             return false;
         } else {
-            throw handelUnexpectedReply(reply);
+            throw handleUnexpectedReply(reply);
         }
     }
-    
-    private RuntimeException handelUnexpectedReply(Reply reply) {
+
+    @VisibleForTesting
+    RuntimeException handleUnexpectedReply(Reply reply) {
         closeConnection(reply.toString());
         if (reply instanceof WireCommands.NoSuchSegment) {
             throw new NoSuchSegmentException(reply.toString());

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -124,7 +124,8 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             WireCommands.AuthTokenCheckFailed authTokenCheckReply = (WireCommands.AuthTokenCheckFailed) reply;
             if (authTokenCheckReply.isTokenExpired()) {
                 log.info("Delegation token expired");
-                // We want to have the request retried by the client in this case.
+                // We want to have the request retried by the client in this case, with a renewed token.
+                this.tokenProvider.signalTokenExpired();
                 throw new ConnectionFailedException(new TokenExpiredException(authTokenCheckReply.toString()));
             } else {
                 log.info("Delegation token invalid");

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -563,6 +563,9 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
     }
 
     private void failConnection(Throwable e) {
+        if (e instanceof TokenExpiredException) {
+            this.tokenProvider.signalTokenExpired();
+        }
         log.warn("Failing connection for writer {} with exception {}", writerId, e.toString());
         state.failConnection(Exceptions.unwrap(e));
         reconnect();

--- a/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/TableSegmentImpl.java
@@ -12,7 +12,7 @@ package io.pravega.client.tables.impl;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.pravega.auth.AuthenticationException;
+import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.connection.impl.RawClient;
 import io.pravega.client.control.impl.Controller;
@@ -73,7 +73,7 @@ class TableSegmentImpl implements TableSegment {
     private final ConnectionPool connectionPool;
     private final DelegationTokenProvider tokenProvider;
     /**
-     * We only retry {@link AuthenticationException} and {@link ConnectionFailedException}. Any other exceptions are not
+     * We only retry {@link TokenExpiredException} and {@link ConnectionFailedException}. Any other exceptions are not
      * retryable and should be bubbled up to the caller.
      * <p>
      * These exceptions are thrown by {@link RawClient} and therefore we do not need to handle the underlying
@@ -537,7 +537,7 @@ class TableSegmentImpl implements TableSegment {
 
     private static boolean isRetryableException(Throwable ex) {
         ex = Exceptions.unwrap(ex);
-        return ex instanceof AuthenticationException || ex instanceof ConnectionFailedException;
+        return ex instanceof TokenExpiredException || ex instanceof ConnectionFailedException;
     }
 
     private void checkBatchSize(int count, int serializationLength) {

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -10,6 +10,7 @@
 package io.pravega.client.segment.impl;
 
 import io.netty.buffer.Unpooled;
+import io.pravega.auth.AuthenticationException;
 import io.pravega.client.connection.impl.ClientConnection;
 import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import lombok.Cleanup;
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -145,6 +147,38 @@ public class AsyncSegmentInputStreamTest extends LeakDetectorTestSuite {
         verifyNoMoreInteractions(c);
         // ensure retrieve Token is invoked for every retry.
         verify(tokenProvider, times(2)).retrieveToken();
+    }
+
+    @SneakyThrows
+    @Test(timeout = 10000)
+    public void testAuthenticationFailure() {
+        Segment segment = new Segment("scope", "testRead", 1);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
+        Semaphore dataAvailable = new Semaphore(0);
+
+        @Cleanup
+        AsyncSegmentInputStreamImpl in = new AsyncSegmentInputStreamImpl(controller, connectionFactory, segment,
+                DelegationTokenProviderFactory.createWithEmptyToken(), dataAvailable);
+        ClientConnection c = mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, c);
+
+        //Non-token expiry auth token check failure response from Segment store.
+        WireCommands.AuthTokenCheckFailed authTokenCheckFailed = new WireCommands.AuthTokenCheckFailed( in.getRequestId(), "SomeException",
+                WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_CHECK_FAILED);
+
+        //Trigger read.
+        CompletableFuture<SegmentRead> readFuture = in.read(1234, 5678);
+        assertEquals(0, dataAvailable.availablePermits());
+
+        //verify that a response from Segment store completes the readFuture and the future completes with the specified exception.
+        AssertExtensions.assertBlocks(() -> assertThrows(AuthenticationException.class, () -> readFuture.get()), () -> {
+            ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+            processor.process(authTokenCheckFailed);
+        });
+        verify(c).send(eq(new WireCommands.ReadSegment(segment.getScopedName(), 1234, 5678, "", in.getRequestId())));
+        assertTrue(!Futures.isSuccessful(readFuture)); // verify read future completedExceptionally
     }
 
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamTest.java
@@ -78,7 +78,8 @@ public class AsyncSegmentInputStreamTest extends LeakDetectorTestSuite {
         }).doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
-            connectionFactory.getProcessor(endpoint).authTokenCheckFailed(new WireCommands.AuthTokenCheckFailed(in.getRequestId(), "SomeException"));
+            connectionFactory.getProcessor(endpoint).authTokenCheckFailed(new WireCommands.AuthTokenCheckFailed(
+                    in.getRequestId(), "SomeException", WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED));
             return null;
         }
         }).doAnswer(new Answer<Void>() {

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client.segment.impl;
 
+import io.pravega.auth.AuthenticationException;
 import io.pravega.client.connection.impl.ClientConnection;
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.stream.EventWriterConfig;
@@ -26,6 +27,8 @@ import io.pravega.test.common.AssertExtensions;
 import java.nio.ByteBuffer;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -159,6 +162,73 @@ public class ConditionalOutputStreamTest {
             }
         }).when(mock).send(any(ConditionalAppend.class));
         AssertExtensions.assertThrows(SegmentSealedException.class, () -> cOut.write(data, 0));
+    }
+
+    @SneakyThrows
+    @Test(timeout = 10000)
+    public void testRetriesOnTokenExpiry() {
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
+        ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
+        Segment segment = new Segment("scope", "testWrite", 1);
+        ConditionalOutputStream objectUnderTest = factory.createConditionalOutputStream(segment,
+                DelegationTokenProviderFactory.create("token", controller, segment),
+                EventWriterConfig.builder().build());
+        ByteBuffer data = ByteBuffer.allocate(10);
+
+        ClientConnection clientConnection = Mockito.mock(ClientConnection.class);
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        connectionFactory.provideConnection(location, clientConnection);
+        setupAppend(connectionFactory, segment, clientConnection, location);
+
+        final AtomicLong retryCounter = new AtomicLong(0);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ConditionalAppend argument = (ConditionalAppend) invocation.getArgument(0);
+                ReplyProcessor processor = connectionFactory.getProcessor(location);
+
+                if (retryCounter.getAndIncrement() < 2) {
+                    processor.process(new WireCommands.AuthTokenCheckFailed(argument.getRequestId(), "SomeException",
+                            WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED));
+                } else {
+                    processor.process(new WireCommands.DataAppended(argument.getRequestId(),
+                            argument.getWriterId(), argument.getEventNumber(), 0, -1));
+                }
+                return null;
+            }
+        }).when(clientConnection).send(any(ConditionalAppend.class));
+        assertTrue(objectUnderTest.write(data, 0));
+        assertEquals(3, retryCounter.get());
+    }
+
+    @Test(timeout = 10000)
+    public void testNonExpiryTokenCheckFailure() throws ConnectionFailedException {
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
+        ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
+        Segment segment = new Segment("scope", "testWrite", 1);
+        ConditionalOutputStream objectUnderTest = factory.createConditionalOutputStream(segment,
+                DelegationTokenProviderFactory.create("token", controller, segment),
+                EventWriterConfig.builder().build());
+        ByteBuffer data = ByteBuffer.allocate(10);
+
+        ClientConnection clientConnection = Mockito.mock(ClientConnection.class);
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        connectionFactory.provideConnection(location, clientConnection);
+        setupAppend(connectionFactory, segment, clientConnection, location);
+
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ConditionalAppend argument = (ConditionalAppend) invocation.getArgument(0);
+                ReplyProcessor processor = connectionFactory.getProcessor(location);
+                processor.process(new WireCommands.AuthTokenCheckFailed(argument.getRequestId(), "SomeException",
+                                WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_CHECK_FAILED));
+                return null;
+            }
+        }).when(clientConnection).send(any(ConditionalAppend.class));
+        AssertExtensions.assertThrows(AuthenticationException.class, () -> objectUnderTest.write(data, 0));
     }
     
     /**

--- a/client/src/test/java/io/pravega/client/tables/impl/TableSegmentImplTest.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/TableSegmentImplTest.java
@@ -350,7 +350,7 @@ public class TableSegmentImplTest extends ThreadPooledTestSuite {
         // others need to be handled by TableSegmentImpl.handleReply.
         val failureReplies = Arrays.<Function<Long, Reply>>asList(
                 requestId -> new WireCommands.WrongHost(requestId, SEGMENT.getScopedName(), "NewHost", ""),
-                requestId -> new WireCommands.AuthTokenCheckFailed(requestId, ""),
+                requestId -> new WireCommands.AuthTokenCheckFailed(requestId, "", WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED),
                 requestId -> new WireCommands.OperationUnsupported(requestId, "Intentional", ""));
 
         for (val fr : failureReplies) {


### PR DESCRIPTION
**Change log description**  
Force token refresh when the Segment Store indicates token expiry.

**Purpose of the change**  
Fixes #5144 

**What the code does**  
Implements a signaling mechanism such that the client can signal the DelegationTokenProvider of the token expiry so that it refreshes the token upon the next call to `retrieveToken()`. 

**How to verify it**  
All tests must pass. 
