### PR TITLE
Issue 5147: Added check for service in init_kubernetes.sh script

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -49,12 +49,12 @@ init_kubernetes() {
         export PUBLISHED_PORT=""
         local service=$( k8 "${ns}" "services" "${podname}" .kind )
 
-        while [[  "$service" != "Service" ]]; 
-        do
-            echo "Trying to get service"     
-            service=$( k8 "${ns}" "services" "${podname}" .kind )
-        done
-	
+        if [[  "$service" != "Service" ]];
+        then 
+            echo "Failed to get Service"
+            exit 1     
+        fi
+
 	export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".metadata.annotations[\"external-dns.alpha.kubernetes.io/hostname\"]" )
 
         if [[ -n ${PUBLISHED_ADDRESS} && "${PUBLISHED_ADDRESS:${#PUBLISHED_ADDRESS}-1}" == "." ]];

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -47,7 +47,7 @@ init_kubernetes() {
         local podname=${POD_NAME}
         export PUBLISHED_ADDRESS=""
         export PUBLISHED_PORT=""
-        service=$( k8 "${ns}" "services" "${podname}" .kind )
+        local service=$( k8 "${ns}" "services" "${podname}" .kind )
 
     while [[  "$service" != "Service" ]]; 
     do

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -51,7 +51,7 @@ init_kubernetes() {
 
         if [[  "$service" != "Service" ]];
         then 
-            echo "Failed to get Service"
+            echo "Failed to get External Service. Exiting..."
             exit 1     
         fi
 

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -49,11 +49,11 @@ init_kubernetes() {
         export PUBLISHED_PORT=""
         local service=$( k8 "${ns}" "services" "${podname}" .kind )
 
-    while [[  "$service" != "Service" ]]; 
-    do
-           echo "Trying to get service"     
-           service=$( k8 "${ns}" "services" "${podname}" .kind )
-    done
+        while [[  "$service" != "Service" ]]; 
+        do
+            echo "Trying to get service"     
+            service=$( k8 "${ns}" "services" "${podname}" .kind )
+        done
 	
 	export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".metadata.annotations[\"external-dns.alpha.kubernetes.io/hostname\"]" )
 

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -47,6 +47,13 @@ init_kubernetes() {
         local podname=${POD_NAME}
         export PUBLISHED_ADDRESS=""
         export PUBLISHED_PORT=""
+        service=$( k8 "${ns}" "services" "${podname}" .kind )
+
+    while [[  "$service" != "Service" ]]; 
+    do
+           echo "Trying to get service"     
+           service=$( k8 "${ns}" "services" "${podname}" .kind )
+    done
 	
 	export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".metadata.annotations[\"external-dns.alpha.kubernetes.io/hostname\"]" )
 


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

**Change log description**  
init_kubernetes.sh script is not handling the case where ss pod might come up before the service when External Access is enabled and that's causing a problem when domainName is specified in the pravega manifest as in that case ss pods might get the wrong publishedIPAddress. 

**Purpose of the change**  
Fixes #5147 

**What the code does**  
Script checks for the presence of service in case we deploy pravega with external service enabled and when it finds the service then only it will set the publishedIPAddress.
When a service doesn't exists segment store pod will go into **CrashLoopBackOff** state and will be in that state only till the External service comes up post the service starts segment store pod will also recover and will set the correct publishedIPAddress.

**How to verify it**  
1) Deploy Pravega with external access enabled and delete service continuously and delete the pod once when the new pod comes up it will go into **CrashLoopBackOff** state and will wait continuously for the service to be there and will have the following message in its logs
```
Failed to get External Service. Exiting...
```
2) now stop deleting the service and the service will come up post that ss pod will recover and will get the correct publishedIPAddress.
I have checked both of the above scenarios.