### PR TITLE
Issue 5155: (SegmentStore) Enabling copy-on-read for all Segment Reads

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -224,6 +224,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
      * an appropriate message is sent back over the connection.
      */
     private void handleReadResult(ReadSegment request, ReadResult result) {
+        result.setCopyOnRead(true); // Get a copy of any data from the cache to avoid losing it due to cache eviction.
         String segment = request.getSegment();
         ArrayList<BufferView> cachedEntries = new ArrayList<>();
         ReadResultEntry nonCachedEntry = collectCachedEntries(request.getOffset(), result, cachedEntries);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -63,6 +63,7 @@ import lombok.Cleanup;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -118,6 +119,7 @@ public class PravegaRequestProcessorTest {
 
         @Override
         public ReadResultEntry next() {
+            Assert.assertTrue("Expected copy-on-read enabled for all segment reads.", this.copyOnRead);
             ReadResultEntry result = results.remove(0);
             currentOffset = result.getStreamSegmentOffset();
             return result;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
@@ -118,8 +118,10 @@ abstract class TableBucketReader<ResultT> {
         return Futures.loop(
                 () -> offset.get() >= 0,
                 () -> {
-                    // Read the Key from the Segment.
+                    // Read the Key from the Segment. Copy it out of the Segment to avoid losing it or getting corrupted
+                    // values back in case of a cache eviction. See {@link ReadResult#setCopyOnRead(boolean)}.
                     ReadResult readResult = segment.read(offset.get(), getMaxReadLength(), timer.getRemaining());
+                    readResult.setCopyOnRead(true);
                     val reader = getReader(null, offset.get(), timer);
                     AsyncReadResultProcessor.process(readResult, reader, this.executor);
                     return reader.getResult()
@@ -153,7 +155,10 @@ abstract class TableBucketReader<ResultT> {
         Futures.loop(
                 () -> !result.isDone(),
                 () -> {
+                    // Read the Key from the Segment. Copy it out of the Segment to avoid losing it or getting corrupted
+                    // values back in case of a cache eviction. See {@link ReadResult#setCopyOnRead(boolean)}.
                     ReadResult readResult = this.segment.read(offset.get(), maxReadLength, timer.getRemaining());
+                    readResult.setCopyOnRead(true);
                     val reader = getReader(soughtKey, offset.get(), timer);
                     AsyncReadResultProcessor.process(readResult, reader, this.executor);
                     return reader

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableCompactorTests.java
@@ -273,9 +273,6 @@ public class TableCompactorTests extends ThreadPooledTestSuite {
         // In the real world, the IndexWriter will readjust this number as appropriate when reindexing these values.
         Assert.assertEquals("Expecting TOTAL_ENTRY_COUNT to be 0 after a full compaction.",
                 0, context.indexWriter.getTotalEntryCount(context.segmentMetadata));
-
-        Assert.assertEquals("Unexpected number of candidate reads from the segment with copy-on-read enabled.",
-                expectedCopyOnReadCount, context.segment.getCopyOnReadCount());
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
- Enabling copy-on-read for all Segment Reads from the client.
- Enabling copy-on-read for all Segment Reads as a result of Table Segment Entry reads (TableBucketReader calls).

**Purpose of the change**  
Fixes #5155.

**What the code does**  
- Please see #5155 for a description of the bug being resolved that includes the scenario that can lead to it.
- PR #4841 has reduced the number of memory copies that were performed on the read path from a segment, however it has eliminated one too many such copies. 
- #5119 and #5120 have introduced a mechanism that tells the Read Index to return a pointer to a copy of the data in the cache instead of a direct view of the cache data. This would prevent the scenario described in #5155 from happening (i.e., a subsequent eviction of those blocks and reallocation may cause it to read the wrong data), however it has not been applied for all read paths.
- This PR enables this functionality for all Segment Reads. This includes:
    - Client reads
    - Table Segment Key/Entry reads.
- This ensures that the data returned is a single, immutable buffer that will not be modified by any background process.

**How to verify it**  
Unit tests updated to verify the flag is being set.
The actual scenario described in #5155 cannot be reliably tested directly via unit tests, but #5120  did add a new unit test to verify that the copy-on-read works as expected. 
