### PR TITLE
Issue 5154: (SegmentStore) Fixed a stats concurrency bug in the Read Index

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -321,7 +321,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
                 }
             } catch (ObjectClosedException ex) {
                 // This object was closed but it was not unregistered. Do it now.
-                log.warn("{} Detected closed client {}.", TRACE_OBJECT_ID, c);
+                log.info("{} Detected closed client {}.", TRACE_OBJECT_ID, c);
                 toUnregister.add(c);
                 continue;
             }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
@@ -93,9 +93,11 @@ class ReadIndexSummary {
      * @return The value of the current generation.
      */
     synchronized int touchOne(int generation) {
+        if (generation == this.currentGeneration) {
+            return this.currentGeneration;
+        }
         removeOne(generation);
-        addOne();
-        return this.currentGeneration;
+        return addOne();
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -580,8 +580,8 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             synchronized (this.lock) {
                 ReadIndexEntry previous = this.indexEntries.put(newEntry);
                 assert previous == null;
+                newEntry.setGeneration(this.summary.addOne());
             }
-            newEntry.setGeneration(this.summary.addOne());
         } catch (Throwable ex) {
             if (!Exceptions.mustRethrow(ex)) {
                 // Clean up the data we inserted if we were unable to add it to the index.
@@ -655,8 +655,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 this.summary.addOne(entry.getGeneration());
             } else {
                 // Update the Stats with the entry's length, and set the entry's generation as well.
-                int generation = this.summary.addOne();
-                entry.setGeneration(generation);
+                entry.setGeneration(this.summary.addOne());
             }
         }
 
@@ -1113,8 +1112,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
         if (updateStats) {
             // Update its generation before returning it.
-            int generation = this.summary.touchOne(entry.getGeneration());
-            entry.setGeneration(generation);
+            entry.setGeneration(this.summary.touchOne(entry.getGeneration()));
         }
 
         data = data.slice(entryOffset, length);


### PR DESCRIPTION
**Change log description**  
Fixed a concurrency bug in StreamSegmentReadIndex which could allow index summaries to get out of sync, thus causing the Cache Manager to evict more than needed.

**Purpose of the change**  
Fixes #5154.

**What the code does**  
The Cache Manager relies on accurate data from its clients to determine whether to advance its "Oldest Generation" (i.e., tell clients to evict data) or not. If the reported Oldest Generation from the clients does not change as a result of this process, it will  keep advancing it in subsequent iterations until it can no longer do it (equals Current Generation). If Oldest Generation == Current Generation, then cache entries will not live too long in the cache, thus rendering it mostly useless.

The StreamSegmentReadIndex keeps a parallel statistic of how many entries it has per generation (this is because it can have tens, if not hundreds of thousands of entries - and querying them every time the Cache Manager needs it would be too time consuming). This statistic should be updated in lockstep with the rest of the index (upon inserts, removals, appends and retrievals). For consistency, all these updates (except evictions) should be done while holding the read index lock as they may end up changing the Generation of the entry (i.e., it was touched). It seems that one code path was not doing it under the lock, which meant that a "touch" could alter the stats of the wrong generation (should a concurrent touch/update execute).

This change moves the problematic stats update under the read index lock, which ensures that no other update on that entry may produce adverse side effects.

NOTE: there may be more efficient ways of operating on the Read Index, probably with finer grained locks. However this has not posed a problem so far and hasn't gotten in our way. The goal of this PR is to fix a bug, and not improve theoretical performance.

**How to verify it**  
All tests must pass. Unfortunately the nature of this change means it cannot be tested via unit tests.
