### PR TITLE
Issue 5169: Data Recovery - Copy the core attributes from old segment metadata to new segment metadata

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -29,5 +29,12 @@ public interface DebugSegmentContainer extends SegmentContainer {
      */
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
 
-    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws ExecutionException, InterruptedException;
+    /**
+     * Creates a segment with target segment name and copies the contents of the source segment to the target segment.
+     * @param storage                   A storage instance to create the segment.
+     * @param sourceSegment             The name of the source segment to copy the contents from.
+     * @param targetSegment             The name of the segment to write the contents to.
+     * @throws Exception                In case of an exception occurred while execution.
+     */
+    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws Exception;
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server;
 import io.pravega.segmentstore.storage.Storage;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Defines debug segment container for stream segments.
@@ -33,7 +34,9 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * @param storage                   A storage instance to create the segment.
      * @param sourceSegment             The name of the source segment to copy the contents from.
      * @param targetSegment             The name of the segment to write the contents to.
-     * @throws Exception                In case of an exception occurred while execution.
+     * @param executor                  An Executor for async operations.
+     * @return                          A CompletableFuture that, when completed normally, will indicate the operation
+     * completed. If the operation failed, the future will be failed with the causing exception.
      */
-    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws Exception;
+    CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -38,5 +38,5 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * @return                          A CompletableFuture that, when completed normally, will indicate the operation
      * completed. If the operation failed, the future will be failed with the causing exception.
      */
-    CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor);
+    //CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -11,7 +11,6 @@ package io.pravega.segmentstore.server;
 import io.pravega.segmentstore.storage.Storage;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Defines debug segment container for stream segments.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -8,7 +8,10 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.segmentstore.server;
+import io.pravega.segmentstore.storage.Storage;
+
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Defines debug segment container for stream segments.
@@ -25,4 +28,6 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * completed. If the operation failed, the future will be failed with the causing exception.
      */
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
+
+    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws ExecutionException, InterruptedException;
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.server.containers;
 
 import com.google.common.base.Preconditions;
-import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -139,12 +139,14 @@ public class ContainerRecoveryUtils {
      * @return                           CompletableFuture which when completed will have the segments' contents copied to another segments.
      */
     public static CompletableFuture<Void> backUpMetadataAndAttributeSegments(Storage storage, int containerId,
+                                                                             Map<Integer, DebugStreamSegmentContainer> containerMap,
                                                                              String backUpMetadataSegmentName,
                                                                              String backUpAttributeSegmentName,
-                                                                             ExecutorService executorService) {
+                                                                             ExecutorService executorService) throws Exception {
         Preconditions.checkNotNull(storage);
         String metadataSegmentName = NameUtils.getMetadataSegmentName(containerId);
         String attributeSegmentName = NameUtils.getAttributeSegmentName(metadataSegmentName);
+
         return Futures.exceptionallyExpecting(
                 copySegment(storage, metadataSegmentName, backUpMetadataSegmentName, executorService)
                         .thenAcceptAsync(x -> copySegment(storage, attributeSegmentName, backUpAttributeSegmentName,

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -80,10 +80,10 @@ public class DebugStreamSegmentContainer extends StreamSegmentContainer implemen
                     return storage.read(sourceHandle, offset, buffer, 0, buffer.length, TIMEOUT)
                             .thenComposeAsync(size -> {
                                 bytesToRead -= size;
-                                return storage.write(targetHandle, offset, new ByteArrayInputStream(buffer, 0, size), size, TIMEOUT)
-                                        .thenAcceptAsync(r -> {
+                                return (size > 0) ? storage.write(targetHandle, offset, new ByteArrayInputStream(buffer, 0, size),
+                                        size, TIMEOUT).thenAcceptAsync(r -> {
                                             offset += size;
-                                        }, executor);
+                                        }, executor) : null;
                             }, executor);
                 },
                 executor

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -66,7 +66,7 @@ public class DebugStreamSegmentContainer extends StreamSegmentContainer implemen
 
     @Override
     public void copySegment(Storage storage, String sourceSegment, String targetSegment)
-            throws ExecutionException, InterruptedException {
+            throws Exception {
         storage.create(targetSegment, TIMEOUT);
         val info = storage.getStreamSegmentInfo(sourceSegment, TIMEOUT);
         int bytesToRead = (int) info.get().getLength();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -26,7 +26,6 @@ import lombok.val;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 @Slf4j

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -724,13 +724,17 @@ public abstract class MetadataStore implements AutoCloseable {
                     .build());
         }
 
+        static SegmentInfo oldSegment(BufferView bufferView) {
+            return deserialize(bufferView);
+        }
+
         @SneakyThrows(IOException.class)
         static ArrayView serialize(SegmentInfo state) {
             return SERIALIZER.serialize(state);
         }
 
         @SneakyThrows(IOException.class)
-        static SegmentInfo deserialize(BufferView contents) {
+        static public SegmentInfo deserialize(BufferView contents) {
             try {
                 return SERIALIZER.deserialize(contents);
             } catch (EOFException | SerializationException ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -53,7 +53,6 @@ import org.junit.rules.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -252,8 +252,9 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * The test creates a segment and then writes some data to it. The segment and its contents are then copied to a segment
-     * with different name. At the end, it is verified that the new segment has the accurate contents from the first one.
+     * The test creates a segment and then writes some data to it. The method under the test copies the contents of the
+     * segment to a segment with a different name. At the end, it is verified that the new segment has the accurate
+     * contents from the first one.
      */
     @Test
     public void testCopySegment() throws Exception {
@@ -297,7 +298,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         Services.startAsync(localContainer, executorService()).join();
 
         // copy segment
-        localContainer.copySegment(s, sourceSegmentName, targetSegmentName);
+        localContainer.copySegment(s, sourceSegmentName, targetSegmentName, executorService()).join();
 
         // new segment should exist
         Assert.assertTrue("Unexpected result for existing segment (no files).", s.exists(sourceSegmentName, null).join());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -230,7 +230,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                 int containerId1 = segToConMapper.getContainerId(backUpAttributeSegment);
                 int containerId2 = segToConMapper.getContainerId(backUpAttributeSegment);
                 log.info("Original container Id: {}, new container Ids {}, {}", containerId, containerId1, containerId2);
-                ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, containerId, debugStreamSegmentContainerMap,
+                ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, containerId,
                         backUpMetadataSegment, backUpAttributeSegment, executorService())
                         .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                 ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerId)

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -230,7 +230,8 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
                 int containerId1 = segToConMapper.getContainerId(backUpAttributeSegment);
                 int containerId2 = segToConMapper.getContainerId(backUpAttributeSegment);
                 log.info("Original container Id: {}, new container Ids {}, {}", containerId, containerId1, containerId2);
-                ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, containerId, backUpMetadataSegment, backUpAttributeSegment, executorService())
+                ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, containerId, debugStreamSegmentContainerMap,
+                        backUpMetadataSegment, backUpAttributeSegment, executorService())
                         .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                 ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerId)
                         .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentStoreTestBase.java
@@ -95,7 +95,7 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
     private static final int APPENDS_PER_SEGMENT = 100;
     private static final int ATTRIBUTE_UPDATES_PER_SEGMENT = 100;
     private static final int MAX_INSTANCE_COUNT = 4;
-    private static final int CONTAINER_COUNT = 4;
+    private static final int CONTAINER_COUNT = 1;
     private static final long DEFAULT_EPOCH = 1;
     private static final List<UUID> ATTRIBUTES = Streams.concat(Stream.of(Attributes.EVENT_COUNT), IntStream.range(0, 10).mapToObj(i -> UUID.randomUUID())).collect(Collectors.toList());
     private static final int ATTRIBUTE_UPDATE_DELTA = APPENDS_PER_SEGMENT + ATTRIBUTE_UPDATES_PER_SEGMENT;
@@ -220,9 +220,6 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
             // Start a debug segment container corresponding to each container Id and put it in the Hashmap with the Id.
             Map<Integer, DebugStreamSegmentContainer> debugStreamSegmentContainerMap = new HashMap<>();
             for (int containerId = 0; containerId < CONTAINER_COUNT; containerId++) {
-                // Delete container metadata segment and attributes index segment corresponding to the container Id from the long term storage
-                ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerId).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-
                 DebugStreamSegmentContainerTests.MetadataCleanupContainer localContainer = new
                         DebugStreamSegmentContainerTests.MetadataCleanupContainer(containerId, CONTAINER_CONFIG, localDurableLogFactory,
                         context.readIndexFactory, context.attributeIndexFactory, context.writerFactory, context.storageFactory,
@@ -230,6 +227,12 @@ public abstract class StreamSegmentStoreTestBase extends ThreadPooledTestSuite {
 
                 Services.startAsync(localContainer, executorService()).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                 debugStreamSegmentContainerMap.put(containerId, localContainer);
+
+                // BackUp and delete container metadata segment and attributes index segment corresponding to the container Id from the long term storage
+                ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, localContainer, executorService())
+                        .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerId)
+                        .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             }
 
             // Restore all segments from the long term storage using debug segment container.

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -454,8 +454,11 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
                 containerCount, this.dataLogFactory, this.storageFactory);
 
         // Delete container metadata segment and attributes index segment corresponding to the container Id from the long term storage
-        for (int containerId = 0; containerId < containerCount; containerId++) {
-            ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerId).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        for (val containerEntry : debugStreamSegmentContainerMap.entrySet()) {
+            ContainerRecoveryUtils.backUpMetadataAndAttributeSegments(storage, containerEntry.getValue(), executorService())
+                    .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            ContainerRecoveryUtils.deleteMetadataAndAttributeSegments(storage, containerEntry.getKey())
+                    .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         }
 
         // List segments from storage and recover them using debug segment container instance.

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -93,6 +93,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.lang.Thread.sleep;
+
 /**
  * Integration test to verify data recovery.
  * Recovery scenario: when data written to Pravega is already flushed to the long term storage.
@@ -336,7 +338,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
      *  8. Reads all 600 events again.
      * @throws Exception    In case of an exception occurred while execution.
      */
-    @Test(timeout = 180000)
+    @Test(timeout = 880000)
     public void testDurableDataLogFailRecoverySingleContainer() throws Exception {
         testRecovery(1, 1, false);
     }
@@ -422,7 +424,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
 
         // Get names of all the segments created.
         ConcurrentHashMap<String, Boolean> allSegments = segmentStoreRunner.segmentsTracker.getSegments();
-        log.info("No. of segments created = {}", allSegments.size());
+        log.info("Number of segments created = {}", allSegments.size());
 
         // Get the long term storage from the running pravega instance
         @Cleanup
@@ -432,6 +434,8 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         // wait for all segments to be flushed to the long term storage.
         waitForSegmentsInStorage(allSegments.keySet(), segmentStoreRunner.segmentsTracker, storage)
                 .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        sleep(600000);
 
         segmentStoreRunner.close(); // Shutdown SegmentStore
         log.info("Segment Store Shutdown");

--- a/test/integration/src/test/resources/logback.xml
+++ b/test/integration/src/test/resources/logback.xml
@@ -16,7 +16,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
**Change log description**  
The `registerSegment` method is changed to included core attributes as one of the parameters while registering a segment which exists in LTS, but not in Durable data log.
The tests around the data recovery have also been updated with this.

**Purpose of the change**  
Fixes #5169 

**What the code does**  
Instead of using only sealed status, length and name for registering a segment, now we also include core attributes. 

**How to verify it**  
Build shall pass.