### PR TITLE
Issue #5186: CherryPick #5170 into r0.8

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -321,7 +321,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
                 }
             } catch (ObjectClosedException ex) {
                 // This object was closed but it was not unregistered. Do it now.
-                log.warn("{} Detected closed client {}.", TRACE_OBJECT_ID, c);
+                log.info("{} Detected closed client {}.", TRACE_OBJECT_ID, c);
                 toUnregister.add(c);
                 continue;
             }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
@@ -93,9 +93,11 @@ class ReadIndexSummary {
      * @return The value of the current generation.
      */
     synchronized int touchOne(int generation) {
+        if (generation == this.currentGeneration) {
+            return this.currentGeneration;
+        }
         removeOne(generation);
-        addOne();
-        return this.currentGeneration;
+        return addOne();
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -580,8 +580,8 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             synchronized (this.lock) {
                 ReadIndexEntry previous = this.indexEntries.put(newEntry);
                 assert previous == null;
+                newEntry.setGeneration(this.summary.addOne());
             }
-            newEntry.setGeneration(this.summary.addOne());
         } catch (Throwable ex) {
             if (!Exceptions.mustRethrow(ex)) {
                 // Clean up the data we inserted if we were unable to add it to the index.
@@ -655,8 +655,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 this.summary.addOne(entry.getGeneration());
             } else {
                 // Update the Stats with the entry's length, and set the entry's generation as well.
-                int generation = this.summary.addOne();
-                entry.setGeneration(generation);
+                entry.setGeneration(this.summary.addOne());
             }
         }
 
@@ -1113,8 +1112,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
         if (updateStats) {
             // Update its generation before returning it.
-            int generation = this.summary.touchOne(entry.getGeneration());
-            entry.setGeneration(generation);
+            entry.setGeneration(this.summary.touchOne(entry.getGeneration()));
         }
 
         data = data.slice(entryOffset, length);


### PR DESCRIPTION
**Change log description**  
CherryPick #5170.
Issue 5154: (SegmentStore) Fixed a stats concurrency bug in the Read Index (#5170)

Fixed a concurrency bug in StreamSegmentReadIndex which could allow index summaries to get out of sync, thus causing the Cache Manager to evict more than needed.


**Purpose of the change**  
Fixes #5186.

**What the code does**  
CherryPick #5170.

**How to verify it**  
Build must pass.
