### PR TITLE
Issue 5192: Copying a segment

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -8,10 +8,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.segmentstore.server;
-import io.pravega.segmentstore.storage.Storage;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Defines debug segment container for stream segments.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -29,5 +29,12 @@ public interface DebugSegmentContainer extends SegmentContainer {
      */
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
 
-    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws ExecutionException, InterruptedException;
+    /**
+     * Creates a segment with target segment name and copies the contents of the source segment to the target segment.
+     * @param storage                   A storage instance to create the segment.
+     * @param sourceSegment             The name of the source segment to copy the contents from.
+     * @param targetSegment             The name of the segment to write the contents to.
+     * @throws Exception                In case of an exception occurred while execution.
+     */
+    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws Exception;
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.server;
 import io.pravega.segmentstore.storage.Storage;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Defines debug segment container for stream segments.
@@ -33,7 +34,9 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * @param storage                   A storage instance to create the segment.
      * @param sourceSegment             The name of the source segment to copy the contents from.
      * @param targetSegment             The name of the segment to write the contents to.
-     * @throws Exception                In case of an exception occurred while execution.
+     * @param executor                  An Executor for async operations.
+     * @return                          A CompletableFuture that, when completed normally, will indicate the operation
+     * completed. If the operation failed, the future will be failed with the causing exception.
      */
-    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws Exception;
+    CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -30,11 +30,11 @@ public interface DebugSegmentContainer extends SegmentContainer {
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
 
     /**
-     * Creates a segment with target segment name and copies the contents of the source segment to the target segment.
+     * Creates a target segment with the given name and copies the contents of the source segment to the target segment.
      * @param storage                   A storage instance to create the segment.
      * @param sourceSegment             The name of the source segment to copy the contents from.
      * @param targetSegment             The name of the segment to write the contents to.
-     * @param executor                  An Executor for async operations.
+     * @param executor                  A thread pool for execution.
      * @return                          A CompletableFuture that, when completed normally, will indicate the operation
      * completed. If the operation failed, the future will be failed with the causing exception.
      */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -11,7 +11,6 @@ package io.pravega.segmentstore.server;
 import io.pravega.segmentstore.storage.Storage;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Defines debug segment container for stream segments.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -8,7 +8,10 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.segmentstore.server;
+import io.pravega.segmentstore.storage.Storage;
+
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Defines debug segment container for stream segments.
@@ -25,4 +28,6 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * completed. If the operation failed, the future will be failed with the causing exception.
      */
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
+
+    void copySegment(Storage storage, String sourceSegment, String targetSegment) throws ExecutionException, InterruptedException;
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/DebugSegmentContainer.java
@@ -28,15 +28,4 @@ public interface DebugSegmentContainer extends SegmentContainer {
      * completed. If the operation failed, the future will be failed with the causing exception.
      */
     CompletableFuture<Void> registerSegment(String streamSegmentName, long length, boolean isSealed);
-
-    /**
-     * Creates a target segment with the given name and copies the contents of the source segment to the target segment.
-     * @param storage                   A storage instance to create the segment.
-     * @param sourceSegment             The name of the source segment to copy the contents from.
-     * @param targetSegment             The name of the segment to write the contents to.
-     * @param executor                  A thread pool for execution.
-     * @return                          A CompletableFuture that, when completed normally, will indicate the operation
-     * completed. If the operation failed, the future will be failed with the causing exception.
-     */
-    CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor);
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -257,9 +257,9 @@ public class ContainerRecoveryUtils {
      */
     protected static CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor) {
         byte[] buffer = new byte[BUFFER_SIZE];
-        return storage.create(targetSegment, TIMEOUT).thenCompose(targetHandle -> {
-            return storage.getStreamSegmentInfo(sourceSegment, TIMEOUT).thenCompose(info -> {
-                return storage.openRead(sourceSegment).thenCompose(sourceHandle -> {
+        return storage.create(targetSegment, TIMEOUT).thenComposeAsync(targetHandle -> {
+            return storage.getStreamSegmentInfo(sourceSegment, TIMEOUT).thenComposeAsync(info -> {
+                return storage.openRead(sourceSegment).thenComposeAsync(sourceHandle -> {
                     AtomicInteger offset = new AtomicInteger(0);
                     AtomicInteger bytesToRead = new AtomicInteger((int) info.getLength());
                     return Futures.loop(
@@ -274,8 +274,8 @@ public class ContainerRecoveryUtils {
                                             }, executor) : null;
                                         }, executor);
                             }, executor);
-                });
-            });
-        });
+                }, executor);
+            }, executor);
+        }, executor);
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -80,10 +80,10 @@ public class DebugStreamSegmentContainer extends StreamSegmentContainer implemen
                     return storage.read(sourceHandle, offset, buffer, 0, buffer.length, TIMEOUT)
                             .thenComposeAsync(size -> {
                                 bytesToRead -= size;
-                                return storage.write(targetHandle, offset, new ByteArrayInputStream(buffer, 0, size), size, TIMEOUT)
-                                        .thenAcceptAsync(r -> {
+                                return (size > 0) ? storage.write(targetHandle, offset, new ByteArrayInputStream(buffer, 0, size),
+                                        size, TIMEOUT).thenAcceptAsync(r -> {
                                             offset += size;
-                                        }, executor);
+                                        }, executor) : null;
                             }, executor);
                 },
                 executor

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -69,24 +69,26 @@ public class DebugStreamSegmentContainer extends StreamSegmentContainer implemen
 
     @Override
     public CompletableFuture<Void> copySegment(Storage storage, String sourceSegment, String targetSegment, ExecutorService executor) {
-        val targetHandle = storage.create(targetSegment, TIMEOUT).thenCompose(v -> storage.openWrite(targetSegment)).join();
-        bytesToRead = (int) storage.getStreamSegmentInfo(sourceSegment, TIMEOUT).join().getLength();
-        val sourceHandle = storage.openRead(sourceSegment).join();
-        offset = 0;
-        return Futures.loop(
-                () -> bytesToRead > 0,
-                () -> {
-                    byte[] buffer = new byte[Math.min(BUFFER_SIZE, bytesToRead)];
-                    return storage.read(sourceHandle, offset, buffer, 0, buffer.length, TIMEOUT)
-                            .thenComposeAsync(size -> {
-                                bytesToRead -= size;
-                                return (size > 0) ? storage.write(targetHandle, offset, new ByteArrayInputStream(buffer, 0, size),
-                                        size, TIMEOUT).thenAcceptAsync(r -> {
-                                            offset += size;
-                                        }, executor) : null;
-                            }, executor);
-                },
-                executor
-        );
+        return storage.create(targetSegment, TIMEOUT).thenCompose(targetHandle -> {
+            return storage.getStreamSegmentInfo(sourceSegment, TIMEOUT).thenCompose(info -> {
+                return storage.openRead(sourceSegment).thenCompose(sourceHandle -> {
+                    offset = 0;
+                    bytesToRead = (int) info.getLength();
+                    return Futures.loop(
+                            () -> bytesToRead > 0,
+                            () -> {
+                                byte[] buffer = new byte[Math.min(BUFFER_SIZE, bytesToRead)];
+                                return storage.read(sourceHandle, offset, buffer, 0, buffer.length, TIMEOUT)
+                                        .thenComposeAsync(size -> {
+                                            bytesToRead -= size;
+                                            return (size > 0) ? storage.write(targetHandle, offset, new
+                                                    ByteArrayInputStream(buffer, 0, size), size, TIMEOUT).thenAcceptAsync(r -> {
+                                                        offset += size;
+                                                        }, executor) : null;
+                                            }, executor);
+                                }, executor);
+                });
+            });
+        });
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -22,7 +22,6 @@ import io.pravega.segmentstore.storage.Storage;
 import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 
 import java.io.ByteArrayInputStream;
 import java.time.Duration;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -66,7 +66,7 @@ public class DebugStreamSegmentContainer extends StreamSegmentContainer implemen
 
     @Override
     public void copySegment(Storage storage, String sourceSegment, String targetSegment)
-            throws ExecutionException, InterruptedException {
+            throws Exception {
         storage.create(targetSegment, TIMEOUT);
         val info = storage.getStreamSegmentInfo(sourceSegment, TIMEOUT);
         int bytesToRead = (int) info.get().getLength();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainer.java
@@ -26,7 +26,6 @@ import lombok.val;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 @Slf4j

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -295,7 +295,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         // source segment should exist
         Assert.assertTrue("Unexpected result for existing segment (no files).", s.exists(sourceSegmentName, null).join());
         // target segment should exist
-        Assert.assertTrue("Unexpected result for missing segment (no files).", s.exists(targetSegmentName, null).join());
+        Assert.assertTrue("Unexpected result for existing segment (no files).", s.exists(targetSegmentName, null).join());
 
         // Do reading on target segment to verify if the copy was successful or not
         val readHandle = s.openRead(targetSegmentName).join();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -256,7 +256,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
      * contents from the first one.
      */
     @Test
-    public void testCopySegment() throws Exception {
+    public void testCopySegment() {
         int dataSize = 10 * 1024 * 1024;
         // Create a storage.
         @Cleanup

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -79,7 +79,6 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT = Duration.ofMillis(TEST_TIMEOUT_MILLIS);
     private static final Random RANDOM = new Random(1234);
     private static final int THREAD_POOL_COUNT = 30;
-    private static final int APPENDS_PER_SEGMENT = 10;
     private static final String APPEND_FORMAT = "Segment_%s_Append_%d";
     private static final ContainerConfig DEFAULT_CONFIG = ContainerConfig
             .builder()
@@ -258,6 +257,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testCopySegment() throws Exception {
+        int appendCount = 10;
         // Create a storage.
         @Cleanup
         val baseStorage =  new InMemoryStorage();
@@ -276,7 +276,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         // do some writing
         ByteArrayOutputStream writeStream = new ByteArrayOutputStream();
         long offset = 0;
-        for (int j = 0; j < APPENDS_PER_SEGMENT; j++) {
+        for (int j = 0; j < appendCount; j++) {
             byte[] writeData = populate(APPEND_FORMAT.length());
 
             val dataStream = new ByteArrayInputStream(writeData);
@@ -300,12 +300,12 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         // copy segment
         localContainer.copySegment(s, sourceSegmentName, targetSegmentName, executorService()).join();
 
-        // new segment should exist
+        // source segment should exist
         Assert.assertTrue("Unexpected result for existing segment (no files).", s.exists(sourceSegmentName, null).join());
-        // Old segment should exist
+        // target segment should exist
         Assert.assertTrue("Unexpected result for missing segment (no files).", s.exists(targetSegmentName, null).join());
 
-        // Do some reading.
+        // Do reading on target segment to verify if the copy was successful or not
         val readHandle = s.openRead(targetSegmentName).join();
         byte[] expectedData = writeStream.toByteArray();
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -256,7 +256,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
      * contents from the first one.
      */
     @Test
-    public void testCopySegment() throws Exception {
+    public void testCopySegment() {
         int dataSize = 10 * 1024 * 1024;
         // Create a storage.
         StorageFactory storageFactory = new InMemoryStorageFactory(executorService());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -63,7 +63,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static io.pravega.segmentstore.server.containers.ContainerRecoveryUtils.recoverAllSegments;
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -53,7 +53,6 @@ import org.junit.rules.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -52,7 +52,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -252,8 +252,9 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * The test creates a segment and then writes some data to it. The segment and its contents are then copied to a segment
-     * with different name. At the end, it is verified that the new segment has the accurate contents from the first one.
+     * The test creates a segment and then writes some data to it. The method under the test copies the contents of the
+     * segment to a segment with a different name. At the end, it is verified that the new segment has the accurate
+     * contents from the first one.
      */
     @Test
     public void testCopySegment() throws Exception {
@@ -297,7 +298,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         Services.startAsync(localContainer, executorService()).join();
 
         // copy segment
-        localContainer.copySegment(s, sourceSegmentName, targetSegmentName);
+        localContainer.copySegment(s, sourceSegmentName, targetSegmentName, executorService()).join();
 
         // new segment should exist
         Assert.assertTrue("Unexpected result for existing segment (no files).", s.exists(sourceSegmentName, null).join());


### PR DESCRIPTION
**Change log description**  
API to copy the contents of a segment to another segment.

**Purpose of the change**  
Fixes #5192 

**What the code does**  
A method which takes in the names of the `source` & `target` segment as parameters, creates the `target` segment using the `storage` API and then copies the contents of the `source` segment to the `target` segment. Copy is done by filling the buffer with bytes to be read and then writing it. Buffer size is 8MB.

**How to verify it**  
Build shall pass.