### PR TITLE
Issue 5207: (SegmentStore) Read Index Bug Fixes

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -224,7 +224,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
      * an appropriate message is sent back over the connection.
      */
     private void handleReadResult(ReadSegment request, ReadResult result) {
-        result.setCopyOnRead(true); // Get a copy of any data from the cache to avoid losing it due to cache eviction.
         String segment = request.getSegment();
         ArrayList<BufferView> cachedEntries = new ArrayList<>();
         ReadResultEntry nonCachedEntry = collectCachedEntries(request.getOffset(), result, cachedEntries);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -34,6 +34,7 @@ import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
 import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.segmentstore.server.mocks.SynchronousStreamSegmentStore;
 import io.pravega.segmentstore.server.reading.ReadResultEntryBase;
+import io.pravega.segmentstore.server.reading.StreamSegmentReadResult;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
@@ -60,7 +61,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Assert;
@@ -103,14 +105,16 @@ public class PravegaRequestProcessorTest {
 
     //region Stream Segments
 
-    @Data
-    private static class TestReadResult implements ReadResult {
-        final long streamSegmentStartOffset;
-        final int maxResultLength;
-        boolean closed = false;
+    @Getter
+    @Setter
+    private static class TestReadResult extends StreamSegmentReadResult implements ReadResult {
         final List<ReadResultEntry> results;
         long currentOffset = 0;
-        boolean copyOnRead = false;
+
+        TestReadResult(long streamSegmentStartOffset, int maxResultLength, List<ReadResultEntry> results) {
+            super(streamSegmentStartOffset, maxResultLength, (l, r, i) -> null, "");
+            this.results = results;
+        }
 
         @Override
         public boolean hasNext() {
@@ -119,20 +123,15 @@ public class PravegaRequestProcessorTest {
 
         @Override
         public ReadResultEntry next() {
-            Assert.assertTrue("Expected copy-on-read enabled for all segment reads.", this.copyOnRead);
+            Assert.assertTrue("Expected copy-on-read enabled for all segment reads.", isCopyOnRead());
             ReadResultEntry result = results.remove(0);
             currentOffset = result.getStreamSegmentOffset();
             return result;
         }
 
         @Override
-        public void close() {
-            closed = true;
-        }
-
-        @Override
         public int getConsumedLength() {
-            return (int) (currentOffset - streamSegmentStartOffset);
+            return (int) (currentOffset - getStreamSegmentStartOffset());
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/CompletableReadResultEntry.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 /**
  * Extends the ReadResultEntry interface by adding the ability to register a callback to be invoked upon completion.
  */
-interface CompletableReadResultEntry extends ReadResultEntry {
+public interface CompletableReadResultEntry extends ReadResultEntry {
     /**
      * Registers a CompletionConsumer that will be invoked when the content is retrieved, just before the Future is completed.
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -611,7 +611,6 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 if (existingEntry != null && existingEntry.getLastStreamSegmentOffset() >= segmentOffset) {
                     // First offset exists already. We need to skip over to the end of this entry.
                     overlapLength = existingEntry.getStreamSegmentOffset() + existingEntry.getLength() - segmentOffset;
-                    segmentOffset += overlapLength;
                 } else {
                     // First offset does not exist. Let's find out how much we can insert.
                     existingEntry = this.indexEntries.getCeiling(segmentOffset);
@@ -638,6 +637,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                 // Slice the remainder of the buffer, or set it to null if we processed everything.
                 assert overlapLength != 0 : "unable to make any progress";
                 data = overlapLength >= data.getLength() ? null : data.slice((int) overlapLength, data.getLength() - (int) overlapLength);
+                segmentOffset += overlapLength;
             }
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResult.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.contracts.ReadResult;
@@ -24,7 +25,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @ThreadSafe
-class StreamSegmentReadResult implements ReadResult {
+@VisibleForTesting
+public class StreamSegmentReadResult implements ReadResult {
     //region Members
 
     private final String traceObjectId;
@@ -53,10 +55,11 @@ class StreamSegmentReadResult implements ReadResult {
      * @param maxResultLength          The maximum number of bytes to read.
      * @param getNextItem              A Bi-Function that returns the next ReadResultEntry to consume. The first argument
      *                                 is startOffset (long) and the second is remainingLength (int).
+     * @param traceObjectId            Used for logging.
      * @throws NullPointerException     If getNextItem is null.
      * @throws IllegalArgumentException If any of the arguments are invalid.
      */
-    StreamSegmentReadResult(long streamSegmentStartOffset, int maxResultLength, @NonNull NextEntrySupplier getNextItem, String traceObjectId) {
+    public StreamSegmentReadResult(long streamSegmentStartOffset, int maxResultLength, @NonNull NextEntrySupplier getNextItem, String traceObjectId) {
         Exceptions.checkArgument(streamSegmentStartOffset >= 0, "streamSegmentStartOffset", "streamSegmentStartOffset must be a non-negative number.");
         Exceptions.checkArgument(maxResultLength >= 0, "maxResultLength", "maxResultLength must be a non-negative number.");
         this.traceObjectId = traceObjectId;
@@ -65,6 +68,11 @@ class StreamSegmentReadResult implements ReadResult {
         this.getNextItem = getNextItem;
         this.consumedLength = 0;
         this.canRead = true;
+
+        // By default, all cache reads are to be copied into heap buffers before being served to calling code. This is
+        // to avoid situations where there upstream code has pointers to evicted (and reallocated) cache blocks. If this
+        // is not desired, then the upstream code should disable this and document WHY it is safe to do so.
+        this.copyOnRead = true;
     }
 
     //endregion
@@ -221,7 +229,7 @@ class StreamSegmentReadResult implements ReadResult {
      * cached data, returns the next entry to be consumed (CompletableReadResultEntry).
      */
     @FunctionalInterface
-    interface NextEntrySupplier {
+    public interface NextEntrySupplier {
         CompletableReadResultEntry apply(Long startOffset, Integer remainingLength, Boolean makeCopy);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
@@ -121,7 +121,6 @@ abstract class TableBucketReader<ResultT> {
                     // Read the Key from the Segment. Copy it out of the Segment to avoid losing it or getting corrupted
                     // values back in case of a cache eviction. See {@link ReadResult#setCopyOnRead(boolean)}.
                     ReadResult readResult = segment.read(offset.get(), getMaxReadLength(), timer.getRemaining());
-                    readResult.setCopyOnRead(true);
                     val reader = getReader(null, offset.get(), timer);
                     AsyncReadResultProcessor.process(readResult, reader, this.executor);
                     return reader.getResult()
@@ -158,7 +157,6 @@ abstract class TableBucketReader<ResultT> {
                     // Read the Key from the Segment. Copy it out of the Segment to avoid losing it or getting corrupted
                     // values back in case of a cache eviction. See {@link ReadResult#setCopyOnRead(boolean)}.
                     ReadResult readResult = this.segment.read(offset.get(), maxReadLength, timer.getRemaining());
-                    readResult.setCopyOnRead(true);
                     val reader = getReader(soughtKey, offset.get(), timer);
                     AsyncReadResultProcessor.process(readResult, reader, this.executor);
                     return reader

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableCompactor.java
@@ -189,9 +189,6 @@ class TableCompactor {
      */
     private CompletableFuture<CompactionArgs> readCandidates(DirectSegmentAccess segment, long startOffset, int maxLength, TimeoutTimer timer) {
         ReadResult rr = segment.read(startOffset, maxLength, timer.getRemaining());
-        // Make a copy of all retrieved data since it may take a while until we are ready to write it back to the segment;
-        // we do not want the cache to be evicted from underneath us and thus invalidate our result.
-        rr.setCopyOnRead(true);
         return AsyncReadResultProcessor.processAll(rr, this.executor, timer.getRemaining())
                 .thenApply(inputData -> parseEntries(inputData, startOffset, maxLength));
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -757,7 +757,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     }
 
     private void testStorageReadsConcurrentWithOverwrite(int offsetDeltaBetweenReads) throws Exception {
-        testConcurrentStorageReads(offsetDeltaBetweenReads, 1,
+        testStorageReadsConcurrent(offsetDeltaBetweenReads, 1,
                 (context, metadata) -> {
                     // Do nothing.
                 },
@@ -800,7 +800,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
 
     private void testStorageReadsConcurrentNoOverwrite(int offsetDeltaBetweenReads) throws Exception {
         val appendedData = new AtomicReference<ByteArraySegment>();
-        testConcurrentStorageReads(offsetDeltaBetweenReads, 0,
+        testStorageReadsConcurrent(offsetDeltaBetweenReads, 0,
                 (context, metadata) -> {
                     // Now perform an append.
                     appendedData.set(getAppendData(metadata.getName(), metadata.getId(), 1, 1));
@@ -823,7 +823,7 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
                 });
     }
 
-    private void testConcurrentStorageReads(
+    private void testStorageReadsConcurrent(
             int offsetDeltaBetweenReads,
             int extraAllowedStorageReads,
             BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
@@ -923,6 +923,129 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         finalCheck.accept(context, metadata);
         Assert.assertEquals("Unexpected number of storage reads.", maxAllowedStorageReads, storageReadCount.get());
         Assert.assertEquals("Unexpected number of cache inserts.", 1, cacheInsertCount.get());
+    }
+
+    /**
+     * Tests a scenario where two concurrent Storage reads for overlapping ranges execute, with the smaller one
+     * completing first. This test validates that no data duplication occurs in the cache and that the index is properly
+     * updated in this case.
+     */
+    @Test
+    public void testStorageReadsConcurrentSmallLarge() throws Exception {
+        // Read 1 is wholly contained within Read 2.
+        testStorageReadsConcurrentSmallLarge(20000, 5000, 5000, 0, 20000);
+
+        // Read 1 and 2 overlap, but Read 2 begins before Read 1.
+        testStorageReadsConcurrentSmallLarge(20000, 5000, 5000, 3900, 16100);
+
+        // These are values from a real-world test, that lead to the discovery of the issue verified here.
+        testStorageReadsConcurrentSmallLarge(1011221, 397254, 8209, 0, 1011221);
+
+        // Read 1 and 2 overlap, but Read 2 begins before Read 1.
+        testStorageReadsConcurrentSmallLarge(1011221, 397254, 8209, 393149, 618072);
+    }
+
+    private void testStorageReadsConcurrentSmallLarge(int segmentLength, int read1Offset, int read1Length, int read2Offset, int read2Length) throws Exception {
+        // We only expect 2 Storage reads for this test.
+        val expectedStorageReadCount = 2;
+        val cachePolicy = new CachePolicy(100, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
+
+        val config = ReadIndexConfig
+                .builder()
+                .with(ReadIndexConfig.MEMORY_READ_MIN_LENGTH, DEFAULT_CONFIG.getMemoryReadMinLength())
+                .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, segmentLength)
+                .build();
+
+        @Cleanup
+        TestContext context = new TestContext(config, cachePolicy);
+
+        // Create the segment
+        val segmentId = createSegment(0, context);
+        val metadata = context.metadata.getStreamSegmentMetadata(segmentId);
+        context.storage.create(metadata.getName(), TIMEOUT).join();
+
+        // Write some data to the segment in Storage.
+        val rnd = new Random(0);
+        val segmentData = new ByteArraySegment(new byte[segmentLength]);
+        rnd.nextBytes(segmentData.array());
+        context.storage.openWrite(metadata.getName())
+                .thenCompose(handle -> context.storage.write(handle, 0, segmentData.getReader(), segmentData.getLength(), TIMEOUT))
+                .join();
+        metadata.setLength(segmentData.getLength());
+        metadata.setStorageLength(segmentData.getLength());
+
+        @Cleanup("release")
+        val firstReadBlocker = new ReusableLatch();
+        @Cleanup("release")
+        val firstRead = new ReusableLatch();
+        @Cleanup("release")
+        val secondReadBlocker = new ReusableLatch();
+        @Cleanup("release")
+        val secondRead = new ReusableLatch();
+        val cacheInsertCount = new AtomicInteger();
+        context.cacheStorage.insertCallback = address -> cacheInsertCount.incrementAndGet();
+
+        val storageReadCount = new AtomicInteger();
+        context.storage.setReadInterceptor((segment, wrappedStorage) -> {
+            int readCount = storageReadCount.incrementAndGet();
+            if (readCount == 1) {
+                firstRead.release();
+                Exceptions.handleInterrupted(firstReadBlocker::await);
+            } else if (readCount == 2) {
+                secondRead.release();
+                Exceptions.handleInterrupted(secondReadBlocker::await);
+            }
+        });
+
+        // Initiate the first Storage Read.
+        val read1Result = context.readIndex.read(segmentId, read1Offset, read1Length, TIMEOUT);
+        val read1Data = new byte[read1Length];
+        val read1Future = CompletableFuture.runAsync(() -> read1Result.readRemaining(read1Data, TIMEOUT), executorService());
+
+        // Wait for it to process.
+        firstRead.await();
+
+        // Initiate the second storage read.
+        val read2Result = context.readIndex.read(segmentId, read2Offset, read2Length, TIMEOUT);
+        val read2Data = new byte[read2Length];
+        val read2Future = CompletableFuture.runAsync(() -> read2Result.readRemaining(read2Data, TIMEOUT), executorService());
+
+        secondRead.await();
+
+        // Unblock the first Storage Read and wait for it to complete.
+        firstReadBlocker.release();
+        read1Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Unblock second Storage Read.
+        secondReadBlocker.release();
+        read2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Wait for the data from the second read to be fully added to the cache (background task).
+        TestUtils.await(
+                () -> {
+                    try {
+                        return context.readIndex.read(0, read2Offset, read2Length, TIMEOUT).next().getType() == ReadResultEntryType.Cache;
+                    } catch (StreamSegmentNotExistsException ex) {
+                        throw new CompletionException(ex);
+                    }
+                }, 10, TIMEOUT.toMillis());
+
+        // Verify that the initial read requests retrieved the data correctly.
+        Assert.assertEquals("Initial Read 1 (Storage)", segmentData.slice(read1Offset, read1Length), new ByteArraySegment(read1Data));
+        Assert.assertEquals("Initial Read 2 (Storage)", segmentData.slice(read2Offset, read2Length), new ByteArraySegment(read2Data));
+
+        // Re-issue the read requests for the exact same offsets. This time it should be from the cache.
+        val read1Data2 = new byte[read1Length];
+        context.readIndex.read(segmentId, read1Offset, read1Length, TIMEOUT).readRemaining(read1Data2, TIMEOUT);
+        Assert.assertArrayEquals("Reissued Read 1 (Cache)", read1Data, read1Data2);
+
+        val read2Data2 = new byte[read2Length];
+        context.readIndex.read(segmentId, read2Offset, read2Length, TIMEOUT).readRemaining(read2Data2, TIMEOUT);
+        Assert.assertArrayEquals("Reissued Read 2 (Cache)", read2Data, read2Data2);
+
+        // Verify that we did the expected number of Storage/Cache operations.
+        Assert.assertEquals("Unexpected number of storage reads.", expectedStorageReadCount, storageReadCount.get());
+        Assert.assertTrue("Unexpected number of cache inserts.", cacheInsertCount.get() == 3 || cacheInsertCount.get() == 1);
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -38,7 +38,7 @@ public class StreamSegmentReadResultTests {
      */
     @Test
     public void testCopyOnRead() {
-        AtomicBoolean expectedMakeCopy = new AtomicBoolean(false);
+        AtomicBoolean expectedMakeCopy = new AtomicBoolean(true);
         StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> {
             Assert.assertEquals(expectedMakeCopy.get(), makeCopy);
             return TestReadResultEntry.endOfSegment(offset, length);
@@ -49,8 +49,8 @@ public class StreamSegmentReadResultTests {
 
         @Cleanup
         StreamSegmentReadResult r2 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
-        r2.setCopyOnRead(true);
-        expectedMakeCopy.set(true);
+        r2.setCopyOnRead(false);
+        expectedMakeCopy.set(false);
         r2.next();
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/SegmentMock.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
@@ -63,21 +62,11 @@ class SegmentMock implements DirectSegmentAccess {
     private final ScheduledExecutorService executor;
     @GuardedBy("this")
     private BiConsumer<Long, Integer> appendCallback;
-    private final AtomicInteger readRequestCount = new AtomicInteger();
-    private final AtomicInteger copyOnReadCount = new AtomicInteger();
 
     SegmentMock(ScheduledExecutorService executor) {
         this(new StreamSegmentMetadata("Mock", 0, 0), executor);
         this.metadata.setLength(0);
         this.metadata.setStorageLength(0);
-    }
-
-    int getReadRequestCount() {
-        return this.readRequestCount.get();
-    }
-
-    int getCopyOnReadCount() {
-        return this.copyOnReadCount.get();
     }
 
     /**
@@ -297,15 +286,6 @@ class SegmentMock implements DirectSegmentAccess {
     private class TruncateableReadResultMock extends ReadResultMock {
         private TruncateableReadResultMock(long streamSegmentStartOffset, ArrayView data, int maxResultLength, int entryLength) {
             super(streamSegmentStartOffset, data, maxResultLength, entryLength);
-            readRequestCount.incrementAndGet();
-        }
-
-        @Override
-        public void setCopyOnRead(boolean copyOnRead) {
-            if (copyOnRead != isCopyOnRead()) {
-                copyOnReadCount.addAndGet(copyOnRead ? 1 : -1);
-            }
-            super.setCopyOnRead(copyOnRead);
         }
 
         @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableBucketReaderTests.java
@@ -77,7 +77,6 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
         val invalidKey = data.unlinkedEntry.getKey();
         val invalidResult = reader.find(invalidKey.getKey(), data.getBucketOffset(), new TimeoutTimer(TIMEOUT)).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Not expecting any result for key that does not exist.", invalidResult);
-        checkCopyOnRead(segment);
     }
 
     /**
@@ -105,7 +104,6 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
         val invalidKey = data.unlinkedEntry.getKey();
         val invalidResult = reader.find(invalidKey.getKey(), data.getBucketOffset(), new TimeoutTimer(TIMEOUT)).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Not expecting any result for key that does not exist.", invalidResult);
-        checkCopyOnRead(segment);
     }
 
     /**
@@ -134,7 +132,6 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
         val inexistentKey = entries.get(1).getKey();
         val inexistentResult = reader.find(inexistentKey.getKey(), 0L, new TimeoutTimer(TIMEOUT)).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Not expecting any result for key that was never present.", inexistentResult);
-        checkCopyOnRead(segment);
     }
 
     /**
@@ -181,7 +178,6 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
 
         AssertExtensions.assertContainsSameElements("Unexpected result from findAll().", expectedResult, result,
                 (i1, i2) -> areEqual.test(i1, i2) ? 0 : 1);
-        checkCopyOnRead(segment);
     }
 
     private TestData generateData() {
@@ -197,11 +193,6 @@ public class TableBucketReaderTests extends ThreadPooledTestSuite {
         }
 
         return new TestData(entries, serialization, backpointers, entries.get(0));
-    }
-
-    private void checkCopyOnRead(SegmentMock segment) {
-        AssertExtensions.assertGreaterThan("Expected at least one read request to be made.", 0, segment.getReadRequestCount());
-        Assert.assertEquals("Expected all reads to have copy-on-read set.", segment.getReadRequestCount(), segment.getCopyOnReadCount());
     }
 
     private List<TableEntry> generateEntries(EntrySerializer s) {

--- a/shared/controller-api/src/generated/.gitignore
+++ b/shared/controller-api/src/generated/.gitignore
@@ -1,0 +1,1 @@
+/grpc-java/

--- a/shared/controller-api/src/generated/.gitignore
+++ b/shared/controller-api/src/generated/.gitignore
@@ -1,1 +1,0 @@
-/grpc-java/


### PR DESCRIPTION
**Change log description**  
1. Setting `ReadResult.isCopyOnRead` to `true` by default. This will cause any upstream code reading from the cache to get a a copy of that data instead of a view. 
2. Fixed a bug in `StreamSegmentReadIndex.insertEntriesToCacheAndIndex` where it would incorrectly insert an entry if an existing entry that is a subset of the new one already exists.

**Purpose of the change**  
Fixes #5207.

**What the code does**  
- Copy-on-Read
   - Enable Copy-On-Read for any reads that end up getting data from the Cache. #5155 missed one case (in `WriterTableProcessor.readFromInMemorySegment`, which could lead to data corruption for Table Segments upon indexing).
    - By setting it to true by default, upstream code will have to explicitly opt-out (instead of opt-in), so any other cases (and future ones) should be covered.
    - The only exception to this rule is copying data to LTS. It uses a different API which provides a direct view of the underlying cache data, but that should be OK since by contract that data should not have been evicted in the first place.
- `StreamSegmentReadIndex.insertEntriesToCacheAndIndex`
    - This method was not incrementing the `segmentOffset` variable if it had to partially insert an entry due to another one that overlaps it exists. This caused the wrong slice of that new data to be inserted in that case.

**How to verify it**  
New unit test added for second bug.
Build must pass.
