### PR TITLE
Issue 5219: Reducing build log output

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/Main.java
+++ b/controller/src/main/java/io/pravega/controller/server/Main.java
@@ -26,12 +26,10 @@ import io.pravega.controller.timeout.TimeoutServiceConfig;
 import io.pravega.controller.util.Config;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.StatsProvider;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -137,9 +135,14 @@ public class Main {
     @VisibleForTesting
     static void onShutdown(ControllerServiceMain controllerServiceMain) {
         MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+        boolean previousVerbose = memoryMXBean.isVerbose();
         memoryMXBean.setVerbose(true);
-        log.info("Shutdown hook memory usage dump: Heap memory usage: {}, non heap memory usage {}", memoryMXBean.getHeapMemoryUsage(),
-                memoryMXBean.getNonHeapMemoryUsage());
+        try {
+            log.info("Shutdown hook memory usage dump: Heap memory usage: {}, non heap memory usage {}", memoryMXBean.getHeapMemoryUsage(),
+                    memoryMXBean.getNonHeapMemoryUsage());
+        } finally {
+            memoryMXBean.setVerbose(previousVerbose);
+        }
 
         log.info("Controller service shutting down");
         try {

--- a/standalone/src/test/resources/logback-test.xml
+++ b/standalone/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<!--
+  Copyright (c) Dell Inc., or its subsidiaries.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+-->
+<configuration>
+    <!-- This config is valid for all unit tests in this module. We are turning off all logging for unit tests -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="OFF">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Event.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Event.java
@@ -110,26 +110,26 @@ public class Event implements ProducerUpdate {
     @SneakyThrows(IOException.class)
     public Event(ArrayView source, int sourceOffset) {
         // Extract prefix and validate.
-        int prefix = BitConverter.readInt(source, sourceOffset);
+        int prefix = readInt(source, sourceOffset);
         sourceOffset += PREFIX_LENGTH;
         Preconditions.checkArgument(prefix == PREFIX, "Prefix mismatch.");
 
         // Extract ownerId.
-        this.ownerId = BitConverter.readInt(source, sourceOffset);
+        this.ownerId = readInt(source, sourceOffset);
         sourceOffset += OWNER_ID_LENGTH;
 
-        this.routingKey = BitConverter.readInt(source, sourceOffset);
+        this.routingKey = readInt(source, sourceOffset);
         sourceOffset += ROUTING_KEY_LENGTH;
 
-        this.sequence = BitConverter.readInt(source, sourceOffset);
+        this.sequence = readInt(source, sourceOffset);
         sourceOffset += SEQUENCE_LENGTH;
 
         // Extract start time.
-        this.startTime = BitConverter.readLong(source, sourceOffset);
+        this.startTime = readLong(source, sourceOffset);
         sourceOffset += START_TIME_LENGTH;
 
         // Extract length.
-        this.contentLength = BitConverter.readInt(source, sourceOffset);
+        this.contentLength = readInt(source, sourceOffset);
         sourceOffset += LENGTH_LENGTH;
         Preconditions.checkArgument(this.contentLength >= 0, "Payload length must be a positive integer.");
         Preconditions.checkElementIndex(sourceOffset + contentLength, source.getLength() + 1, "Insufficient data in given source.");
@@ -143,6 +143,26 @@ public class Event implements ProducerUpdate {
             this.serialization = source;
         }
         this.writeBuffer = Unpooled.wrappedBuffer(this.serialization.array(), this.serialization.arrayOffset(), this.serialization.getLength());
+    }
+
+    private int readInt(ArrayView truncateableArray, int offset) {
+        // TruncateableArray does not support a BufferView.Reader, so we need to read our own numbers.
+        return BitConverter.makeInt(truncateableArray.get(offset),
+                truncateableArray.get(offset + 1),
+                truncateableArray.get(offset + 2),
+                truncateableArray.get(offset + 3));
+    }
+
+    private long readLong(ArrayView truncateableArray, int offset) {
+        // TruncateableArray does not support a BufferView.Reader, so we need to read our own numbers.
+        return BitConverter.makeLong(truncateableArray.get(offset),
+                truncateableArray.get(offset + 1),
+                truncateableArray.get(offset + 2),
+                truncateableArray.get(offset + 3),
+                truncateableArray.get(offset + 4),
+                truncateableArray.get(offset + 5),
+                truncateableArray.get(offset + 6),
+                truncateableArray.get(offset + 7));
     }
 
     //endregion

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/Reporter.java
@@ -171,8 +171,8 @@ class Reporter extends AbstractScheduledService {
         }
     }
 
-    private void outputRow(Object opType, Object count, Object lAvg, Object l50, Object l75, Object l90, Object l99, Object l999, Object sum) {
-        TestLogger.log(LOG_ID, "%18s | %7s | %5s | %5s | %5s | %5s | %5s | %5s | %5s", opType, sum, count, lAvg, l50, l75, l90, l99, l999);
+    private void outputRow(Object opType, Object count, Object sum, Object lAvg, Object l50, Object l75, Object l90, Object l99, Object l999) {
+        TestLogger.log(LOG_ID, "%18s | %7s | %5s | %5s | %5s | %5s | %5s | %5s | %5s", opType, count, sum, lAvg, l50, l75, l90, l99, l999);
     }
 
     private double toMB(double bytes) {


### PR DESCRIPTION
**Change log description**  
1. Reducing the amount of output during each build:
- Controller: not outputting GC details
- Standalone: not outputting the entire log
2. Fixed a bug in SelfTester that prevented it from working properly with tail reads.

**Purpose of the change**  
Fixes #5219.

**What the code does**  
See "Change log description".

**How to verify it**  
Build must pass. Build must have less output than `master` build.
