### PR TITLE
Issue 5222: Update target Pravega version from 0.8.0 to 0.8.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ k8ClientVersion=8.0.0
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.8.0
+pravegaVersion=0.8.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Ravi Sharda <ravi.sharda@emc.com>

**Change log description**  
As part of the release process post-release activity and in preparation of the next version in this release line, this PR updates release branch from `0.8.0` to `0.8.1-SNAPSHOT`.

**Purpose of the change**  
Resolves #5222.  

**What the code does**  
Modifies the target version in `gradle.properties`. 

**How to verify it**  

