### PR TITLE
Issue 5229: Ensure references to SegmentTransaction are cleared post a transaction commit/abort.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -127,6 +127,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
             for (SegmentTransaction<Type> tx : inner.values()) {
                 tx.close();
             }
+            inner.clear(); // clear all references to SegmentTransaction to enable garbage collection.
             Futures.getThrowingException(controller.commitTransaction(stream, writerId, timestamp, txId));
             pinger.stopPing(txId);
             closed.set(true);
@@ -144,6 +145,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
                         log.debug("Got exception while writing to transaction on abort: {}", e.getMessage());
                     }
                 }
+                inner.clear(); // clear all references to SegmentTransaction to enable garbage collection.
                 Futures.getThrowingException(controller.abortTransaction(stream, txId));
                 closed.set(true);
             }

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -337,7 +337,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         }
 
         // verify if segments are flushed and closed.
-        Mockito.verify(outputStream, Mockito.times(2)).close();
+        Mockito.verify(outputStream, Mockito.times(1)).close();
         Mockito.verify(controller, Mockito.times(2)).commitTransaction(eq(stream), anyString(), isNull(), eq(txid));
         assertTrue(bad.unacked.isEmpty());
         assertTrue(outputStream.unacked.isEmpty());


### PR DESCRIPTION
**Change log description**  
Clear SegmentTransaction  references from TransactionImpl

**Purpose of the change**  
Fixes #5229 

**What the code does**  
Clear SegmentTransaction  references from TransactionImpl.

**How to verify it**  
All the existing tests should pass.
