### PR TITLE
Issue 5240: (SegmentStore) Fixed a possible infinite loop in SegmentAggregator

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -1304,7 +1304,8 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
             // Initialize the Aggregator and add the DeleteSegmentOperation.
             a.initialize(TIMEOUT).join();
             if (a == withMergers) {
-                // Add a merged segment to this one.
+                // Add a merged segment to this one, but not before adding an arbitrary operation.
+                withMergers.add(generateAppendAndUpdateMetadata(1, withMergers.getMetadata().getId(), context));
                 a.add(generateMergeTransactionAndUpdateMetadata(withMergers.getMetadata().getId(), withMergerSource.getMetadata().getId(), context));
             }
 


### PR DESCRIPTION
**Change log description**  
Fixed a bug in `SegmentAggregator.deleteUnmergedSourceSegments` where it may enter an infinite loop if the outstanding operation list contains at least one non-`MergeSegmentOperation` in it.

**Purpose of the change**  
Fixes #5240.

**What the code does**  
Reworked the `deleteUnmergedSourceSegments` to :
- Simply iterate through the entire list and pick the operations it cares about. 
- Do not try to alter this list. It will be cleared immediately after this method exits.

Context:
- `deleteUnmergedSourceSegments` is invoked when a Segment is deleted in order to delete any (transaction) segments that have recently been merged into it but whose merger has not yet been applied to LTS. 
- Not deleting this would leave a lot of garbage around in LTS in situations where transactions were merged and then the target segment is immediately deleted.

**How to verify it**  
Unit tests updated with this case. All tests must pass.
