### PR TITLE
Issue 5254: Update credentials and ACL handling tools to work with the new resource format

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileCreatorCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileCreatorCommand.java
@@ -50,7 +50,10 @@ public class PasswordFileCreatorCommand extends AdminCommand {
 
     private String getUserDetails(List<String> userInput) {
         String userDetails = userInput.get(1);
-        if ((userDetails.split(":")).length == 3) {
+
+        // A sample object value comprises of  "userName:password:acl". We don't want the splits at the
+        // access control entries (like "prn::/scope:testScope") in the ACL, so we restrict the splits to 3.
+        if ((userDetails.split(":", 3)).length == 3) {
             return userDetails;
         } else {
             throw new IllegalArgumentException("The user detail entered is not of the format uname:pwd:acl");

--- a/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileCreatorCommandTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileCreatorCommandTest.java
@@ -30,4 +30,14 @@ public class PasswordFileCreatorCommandTest {
         // Remove generated file by command.
         Files.delete(Paths.get(fileName));
     }
+
+    @Test
+    public void testPasswordFileCreatorCommandParsesAuthFormat() throws Exception {
+        final String fileName = "passwordFileTest";
+        TestUtils.executeCommand("password create-password-file " + fileName + " user:password:prn::/scope:scope1,READ_UPDATE,", new AdminCommandState());
+        Assert.assertTrue(Files.exists(Paths.get(fileName)));
+
+        // Remove generated file by command.
+        Files.delete(Paths.get(fileName));
+    }
 }

--- a/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileCreatorCommandTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileCreatorCommandTest.java
@@ -33,11 +33,9 @@ public class PasswordFileCreatorCommandTest {
 
     @Test
     public void testPasswordFileCreatorCommandParsesAuthFormat() throws Exception {
-        final String fileName = "passwordFileTest";
+        final String fileName = "fileWithAuthFormat";
         TestUtils.executeCommand("password create-password-file " + fileName + " user:password:prn::/scope:scope1,READ_UPDATE,", new AdminCommandState());
         Assert.assertTrue(Files.exists(Paths.get(fileName)));
-
-        // Remove generated file by command.
         Files.delete(Paths.get(fileName));
     }
 }

--- a/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java
+++ b/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java
@@ -30,7 +30,7 @@ public class PasswordFileCreatorTool {
                 if (Strings.isNullOrEmpty(s)) {
                     break;
                 }
-                String[] lists = s.split(":");
+                String[] lists = s.split(":", 3);
                 String toWrite = lists[0] + ":" + passwordEncryptor.encryptPassword(lists[1])
                         + ":" + lists[2];
                 writer.write(toWrite + "\n");


### PR DESCRIPTION
**Change log description**  
Modifies the credentials and ACL handling code to look for only three splits based on character `:`. 

**Purpose of the change**  
Fixes #5254. 

**What the code does**  
Modifies the logic to look for only three splits based on character `:`, so that the same character used in ACLs don't end up generating additional splits. 

**How to verify it**  
All unit, integration and system tests must pass. 

Note: A new unit test was added for the change in `PasswordFileCreatorCommand.java` file. 

In addition, the change was also manually verified via the `PasswordFileCreatorTool` like this: 

1. Run the tool using Intellij. Pass a file path as a program argument. 
2. On the command line, input a line containing ACLs in the new format. For example, `admin:supersecretpassword:prn::*,READ_UPDATE`
3. Inspect the file and check if the credentials and ACLs are in the expected format. 
