### PR TITLE
Issue 5271: Fix credentials and ACL parsing in Pravega CLI

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileCreatorCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileCreatorCommand.java
@@ -51,22 +51,14 @@ public class PasswordFileCreatorCommand extends AdminCommand {
     private String getUserDetails(List<String> userInput) {
         String userDetails = userInput.get(1);
 
-        // A sample object value comprises of  "userName:password:acl". We don't want the splits at the
-        // access control entries (like "prn::/scope:testScope") in the ACL, so we restrict the splits to 3.
-        if ((userDetails.split(":", 3)).length == 3) {
-            return userDetails;
-        } else {
-            throw new IllegalArgumentException("The user detail entered is not of the format uname:pwd:acl");
-        }
+        // An exception is thrown if the structure is invalid
+        PasswordFileEntryParser.parse(userDetails, true);
+        return userDetails;
     }
 
     private void createPassword(String userDetails) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String[] lists = parseUserDetails(userDetails);
+        String[] lists = PasswordFileEntryParser.parse(userDetails);
         toWrite = generatePassword(lists);
-    }
-
-    private String[] parseUserDetails(String userDetails) {
-        return userDetails.split(":");
     }
 
     private String generatePassword(String[] lists) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileEntryParser.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/password/PasswordFileEntryParser.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.cli.admin.password;
+
+import lombok.NonNull;
+
+public class PasswordFileEntryParser {
+
+    /**
+     * Parses the specified credentials and ACL entry into an array containing a maximum of three elements.
+     *
+     * @param entry the credentials and ACL entry to be parsed
+     * @return an array containing the parsed elements, typically a username, plaintext or hashed password and an ACL.
+     */
+    public static String[] parse(@NonNull String entry) {
+        return parse(entry, true);
+    }
+
+    /**
+     * Parses the specified credentials and ACL entry into an array containing a maximum of three elements.
+     *
+     * @param entry the credentials and ACL entry to be parsed
+     * @param validateHasThreeElements whether to validate that the entry has exactly three elements. If this flag is
+     *                                 true, and the entry does not contain three elements, this method will throw an
+     *                                 an IllegalArgumentException.
+     * @return an array containing the parsed elements, typically a username, plaintext or hashed password and an ACL.
+     */
+    public static String[] parse(@NonNull String entry, boolean validateHasThreeElements) {
+        // A sample object value comprises of  "userName:password:acl". We don't want the splits at the
+        // access control entries (like "prn::/scope:testScope") in the ACL, so we restrict the splits to 3.
+        String[] result = entry.split(":", 3);
+
+        if (validateHasThreeElements && result.length != 3) {
+            throw new IllegalArgumentException(
+                    "Entry does not contain exactly three elements of the form username:pwd:acl");
+        }
+        return result;
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileEntryParserTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileEntryParserTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.cli.admin.password;
+
+import io.pravega.test.common.AssertExtensions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PasswordFileEntryParserTest {
+
+    @Test
+    public void parseThrowsExceptionForInvalidInput() {
+        AssertExtensions.assertThrows(NullPointerException.class, () -> PasswordFileEntryParser.parse(null));
+        AssertExtensions.assertThrows(IllegalArgumentException.class,
+                () -> PasswordFileEntryParser.parse("username:hashedPassword"));
+    }
+
+    @Test
+    public void parsesExpectedInput() {
+        assertTrue(PasswordFileEntryParser.parse("username:hashedpassword:prn::*,READ_UPDATE").length == 3);
+        assertTrue(PasswordFileEntryParser.parse("username:hashedpassword:prn::/,READ_UPDATE;prn::/scope,READ_UPDATE").length == 3);
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileEntryParserTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/password/PasswordFileEntryParserTest.java
@@ -19,6 +19,7 @@ public class PasswordFileEntryParserTest {
     @Test
     public void parseThrowsExceptionForInvalidInput() {
         AssertExtensions.assertThrows(NullPointerException.class, () -> PasswordFileEntryParser.parse(null));
+        AssertExtensions.assertThrows(NullPointerException.class, () -> PasswordFileEntryParser.parse(null, true));
         AssertExtensions.assertThrows(IllegalArgumentException.class,
                 () -> PasswordFileEntryParser.parse("username:hashedPassword"));
     }
@@ -26,6 +27,7 @@ public class PasswordFileEntryParserTest {
     @Test
     public void parsesExpectedInput() {
         assertTrue(PasswordFileEntryParser.parse("username:hashedpassword:prn::*,READ_UPDATE").length == 3);
+        assertTrue(PasswordFileEntryParser.parse("username:hashedpassword", false).length == 2);
         assertTrue(PasswordFileEntryParser.parse("username:hashedpassword:prn::/,READ_UPDATE;prn::/scope,READ_UPDATE").length == 3);
     }
 }


### PR DESCRIPTION
**Change log description**  
Modify Credentials and ACL handling code in CLI to parse ACLs in new format. 

**Purpose of the change**  
Fixes #5271. 

**What the code does**  

* Fixes the bug. 
* Extracts out parsing logic to a utility class and reuses the same everywhere in the CLI code. 

**How to verify it**  

All unit and integration tests should pass. 

Also, here's a test I ran manually: 

```bash
./gradlew distTar
cd build/distributions/
tar -xzvf pravega-0.9.0-2668.410b69b-SNAPSHOT.tgz
cd pravega-0.9.0-2668.410b69b-SNAPSHOT
./bin/pravega-admin password create-password-file /home/<uname>/temp/passwd "super-admin:1111_aaaa:prn::*,READ_UPDATE"
```

Now inspect the file /home/<uname>/temp/passwd. It should contain an entry  that looks like below:

```
super-admin:35...:prn::*,READ_UPDATE;
```
