### PR TITLE
Issue 5281: Bookkeeper CLI tests failing to start up in some environments

### DIFF
--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -59,9 +59,9 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
 
     @Before
     public void setUp() throws Exception {
-	    baseConf.setAllowLoopback(true);
-	    baseConf.setEnableLocalTransport(true);
-	    baseConf.setAdvertisedAddress("localhost");
+        baseConf.setAllowLoopback(true);
+        baseConf.setEnableLocalTransport(true);
+        baseConf.setAdvertisedAddress("localhost");
         baseConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         baseClientConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         super.setUp();

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -34,7 +34,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,10 +59,17 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
 
     @Before
     public void setUp() throws Exception {
-        baseConf.setAdvertisedAddress(InetAddress.getByName("localhost").getHostAddress());
         baseConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         baseClientConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
-        super.setUp();
+        try {
+            super.setUp();
+        } catch (Exception e) {
+            // On some containerized environments, using lo interface does not allow to resolve the host name. As an
+            // alternative, we try with eth0 if available.
+            super.tearDown();
+            baseConf.setListeningInterface("eth0");
+            super.setUp();
+        }
 
         STATE.set(new AdminCommandState());
         Properties bkProperties = new Properties();

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -34,6 +34,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,9 +60,7 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
 
     @Before
     public void setUp() throws Exception {
-        baseConf.setAllowLoopback(true);
-        baseConf.setEnableLocalTransport(true);
-        baseConf.setAdvertisedAddress("127.0.0.1");
+        baseConf.setAdvertisedAddress(InetAddress.getByName("localhost").getHostAddress());
         baseConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         baseClientConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         super.setUp();

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -54,11 +54,14 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
     private final InputStream originalIn = System.in;
 
     public BookkeeperCommandsTest() {
-        super(3);
+        super(1);
     }
 
     @Before
     public void setUp() throws Exception {
+	    baseConf.setAllowLoopback(true);
+	    baseConf.setEnableLocalTransport(true);
+	    baseConf.setAdvertisedAddress("localhost");
         baseConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         baseClientConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         super.setUp();
@@ -69,6 +72,9 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
         bkProperties.setProperty("pravegaservice.zk.connect.uri", zkUtil.getZooKeeperConnectString());
         bkProperties.setProperty("bookkeeper.ledger.path", "/ledgers");
         bkProperties.setProperty("bookkeeper.zk.metadata.path", "ledgers");
+        bkProperties.setProperty("bookkeeper.ensemble.size", "1");
+        bkProperties.setProperty("bookkeeper.ack.quorum.size", "1");
+        bkProperties.setProperty("bookkeeper.write.quorum.size", "1");
         bkProperties.setProperty("pravegaservice.clusterName", "");
         STATE.get().getConfigBuilder().include(bkProperties);
 
@@ -185,7 +191,11 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
     }
 
     private void createLedgerInBookkeeperTestCluster(int logId) throws Exception {
-        BookKeeperConfig bookKeeperConfig = BookKeeperConfig.builder().with(BookKeeperConfig.ZK_METADATA_PATH, "ledgers")
+        BookKeeperConfig bookKeeperConfig = BookKeeperConfig.builder()
+                .with(BookKeeperConfig.BK_ENSEMBLE_SIZE, 1)
+                .with(BookKeeperConfig.BK_WRITE_QUORUM_SIZE, 1)
+                .with(BookKeeperConfig.BK_ACK_QUORUM_SIZE, 1)
+                .with(BookKeeperConfig.ZK_METADATA_PATH, "ledgers")
                 .with(BookKeeperConfig.BK_LEDGER_PATH, "/ledgers")
                 .with(BookKeeperConfig.ZK_ADDRESS, zkUtil.getZooKeeperConnectString()).build();
         @Cleanup

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -61,7 +61,7 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
     public void setUp() throws Exception {
         baseConf.setAllowLoopback(true);
         baseConf.setEnableLocalTransport(true);
-        baseConf.setAdvertisedAddress("localhost");
+        baseConf.setAdvertisedAddress("127.0.0.1");
         baseConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         baseClientConf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.FlatLedgerManagerFactory");
         super.setUp();


### PR DESCRIPTION
**Change log description**  
BookkeeperCommandsTest class now iterates over the available network interfaces to start the Bookkeeper test process if the default start up method fails.

**Purpose of the change**  
Fixes #5281.

**What the code does**  
After some investigation, we realized that the `BookkeeperTestClusterCase` class fails to initiate the Bookkeeper cluster in specific situations, concretely when it cannot find the local host on the selected network interface. For this reason, we added a new defensive mechanism to the `BookkeeperCommandsTest` class: if the default `startUp()` logic fails, we retry to execute it over the available network interfaces. By doing this, we have successfully executed the tests in environments where it was failing before.

Apart from that, we have set Bookkeeper CLI tests clusters to use 1 Bookie instead of 3, to make them more lightweight. 

**How to verify it**  
Bookkeeper CLI tests should pass in containerized environments as well.
