### PR TITLE
Issue 5294: Bookkeeper Client may cache old DNS entries for too long

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ServiceStarter.java
@@ -30,6 +30,8 @@ import io.pravega.segmentstore.storage.mocks.InMemoryDurableDataLogFactory;
 import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.StatsProvider;
+
+import java.security.Security;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
@@ -82,6 +84,8 @@ public final class ServiceStarter {
 
     public void start() throws Exception {
         Exceptions.checkNotClosed(this.closed, this);
+        // Make sure that the JVM is not caching DNS entries forever.
+        Security.setProperty("networkaddress.cache.ttl", "10");
 
         log.info("Initializing metrics provider ...");
         MetricsProvider.initialize(builderConfig.getConfig(MetricsConfig::builder));


### PR DESCRIPTION
**Change log description**  
(2-3 concise points about the changes in this PR. When committing this PR, the committer is expected to copy the content of this section to the merge description box)

**Purpose of the change**  
(_e.g._, Fixes #666, Closes #1234)

**What the code does**  
(Detailed description of the code changes)

**How to verify it**  
(Optional: steps to verify that the changes are effective)
