### PR TITLE
Issue 5300: Add ConditionalAppendRawBytes

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -106,6 +106,8 @@ public enum WireCommandType {
     TABLE_ENTRIES_DELTA_READ(87, WireCommands.TableEntriesDeltaRead::readFrom),
     READ_TABLE_ENTRIES_DELTA(88, WireCommands.ReadTableEntriesDelta::readFrom),
 
+    CONDITIONAL_APPEND_RAW_BYTES(89, WireCommands.ConditionalAppendRawBytes::readFrom),
+
     KEEP_ALIVE(100, WireCommands.KeepAlive::readFrom);
 
     private final int code;

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -940,6 +940,17 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
         assertEquals(0, buffer.refCnt());
     }
 
+    @Test
+    public void testConditionalAppendRawBytes() throws IOException {
+        testCommand(new WireCommands.ConditionalAppendRawBytes(uuid, l, l, buf, l));
+
+        // Test that it correctly implements ReleasableCommand.
+        testReleasableCommand(
+                () -> new WireCommands.ConditionalAppend(uuid, l, l, new Event(buf), -1),
+                WireCommands.ConditionalAppend::readFrom,
+                ce -> ce.getEvent().getData().refCnt());
+    }
+
     private void testCommand(WireCommand command) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         command.writeFields(new DataOutputStream(bout));


### PR DESCRIPTION
**Change log description**  
Adds a new conditional append wirecommand that has raw bytes as playload.

**Purpose of the change**  
Fix #5300 

**What the code does**  
Add a new wirecommand

**How to verify it**  
Unit test should pass. Also Rust client test using this build should pass its tests.
