### PR TITLE
Issue 5325: DR integration test does not work with FileSystem storage

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -141,7 +141,7 @@ public class ContainerRecoveryUtils {
      *                                          satisfy the above two criteria.
      */
     private static void validateContainerIds(Map<Integer, DebugStreamSegmentContainer> debugStreamSegmentContainersMap,
-                                             int containerCount) throws IllegalArgumentException {
+                                          int containerCount) throws IllegalArgumentException {
         Set<Integer> containerIdsSet = new HashSet<>();
         for (val containerId : debugStreamSegmentContainersMap.keySet()) {
             if (containerId < 0 || containerId >= containerCount) {
@@ -288,8 +288,8 @@ public class ContainerRecoveryUtils {
         String metadataSegmentName = NameUtils.getMetadataSegmentName(containerId);
         String attributeSegmentName = NameUtils.getAttributeSegmentName(metadataSegmentName);
         return copySegment(storage, metadataSegmentName, backUpMetadataSegmentName, executorService, timeout)
-                .thenAcceptAsync(x -> copySegment(storage, attributeSegmentName, backUpAttributeSegmentName,
-                        executorService, timeout));
+                        .thenAcceptAsync(x -> copySegment(storage, attributeSegmentName, backUpAttributeSegmentName,
+                                executorService, timeout));
     }
 
     /**
@@ -397,7 +397,7 @@ public class ContainerRecoveryUtils {
                                                     .thenAcceptAsync(r -> {
                                                         bytesToRead.addAndGet(-size);
                                                         offset.addAndGet(size);
-                                                    }, executor) : null;
+                                            }, executor) : null;
                                         }, executor);
                             }, executor);
                 }, executor);
@@ -421,7 +421,7 @@ public class ContainerRecoveryUtils {
      * @throws ExecutionException       When execution of the opreations encountered an error.
      */
     public static Map<Integer, String> createBackUpMetadataSegments(Storage storage, int containerCount, ExecutorService executorService,
-                                                                    Duration timeout)
+                                                                 Duration timeout)
             throws InterruptedException, ExecutionException, TimeoutException {
         String fileSuffix = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
         Map<Integer, String> backUpMetadataSegments = new HashMap<>();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -103,12 +103,9 @@ public class ContainerRecoveryUtils {
         while (segmentIterator.hasNext()) {
             val currentSegment = segmentIterator.next();
             int containerId = segToConMapper.getContainerId(currentSegment.getName());
-            String metadataSegment = getMetadataSegmentName(containerId);
-            String attributeSegment = NameUtils.getAttributeSegmentName(metadataSegment);
             String currentSegmentName = currentSegment.getName();
-            // skip recovery if the segment is an attribute segment.
-            if (NameUtils.isAttributeSegment(currentSegmentName) || metadataSegment.equals(currentSegmentName) ||
-                    attributeSegment.equals(currentSegmentName)) {
+            // skip recovery if the segment is an attribute segment or metadata segment.
+            if (NameUtils.isAttributeSegment(currentSegmentName) || getMetadataSegmentName(containerId).equals(currentSegmentName)) {
                 continue;
             }
 
@@ -141,7 +138,7 @@ public class ContainerRecoveryUtils {
      *                                          satisfy the above two criteria.
      */
     private static void validateContainerIds(Map<Integer, DebugStreamSegmentContainer> debugStreamSegmentContainersMap,
-                                          int containerCount) throws IllegalArgumentException {
+                                             int containerCount) throws IllegalArgumentException {
         Set<Integer> containerIdsSet = new HashSet<>();
         for (val containerId : debugStreamSegmentContainersMap.keySet()) {
             if (containerId < 0 || containerId >= containerCount) {
@@ -288,8 +285,8 @@ public class ContainerRecoveryUtils {
         String metadataSegmentName = NameUtils.getMetadataSegmentName(containerId);
         String attributeSegmentName = NameUtils.getAttributeSegmentName(metadataSegmentName);
         return copySegment(storage, metadataSegmentName, backUpMetadataSegmentName, executorService, timeout)
-                        .thenAcceptAsync(x -> copySegment(storage, attributeSegmentName, backUpAttributeSegmentName,
-                                executorService, timeout));
+                .thenAcceptAsync(x -> copySegment(storage, attributeSegmentName, backUpAttributeSegmentName,
+                        executorService, timeout));
     }
 
     /**
@@ -397,12 +394,12 @@ public class ContainerRecoveryUtils {
                                                     .thenAcceptAsync(r -> {
                                                         bytesToRead.addAndGet(-size);
                                                         offset.addAndGet(size);
-                                            }, executor) : null;
-                                        }, executor);
-                            }, executor);
+                                                        }, executor) : null;
+                                            }, executor);
+                                }, executor);
+                    }, executor);
                 }, executor);
             }, executor);
-        }, executor);
     }
 
     /**

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -82,7 +82,6 @@ import lombok.val;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -166,15 +166,11 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
 
     private StorageFactory storageFactory;
     private BookKeeperLogFactory dataLogFactory;
-    private MiniDFSCluster hdfsCluster = null;
 
     @After
     public void tearDown() throws Exception {
         if (this.dataLogFactory != null) {
             this.dataLogFactory.close();
-        }
-        if (hdfsCluster != null) {
-            hdfsCluster.shutdown();
         }
         timer.set(0);
     }
@@ -392,7 +388,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
      *  8. Reads all 600 events again.
      * @throws Exception    In case of an exception occurred while execution.
      */
-    @Test(timeout = 600000)
+    @Test(timeout = 180000)
     public void testDurableDataLogFailRecoverySingleContainer() throws Exception {
         testRecovery(1, 1, false);
     }
@@ -484,6 +480,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         @Cleanup
         Storage storage = new AsyncStorageWrapper(new RollingStorage(this.storageFactory.createSyncStorage(),
                 new SegmentRollingPolicy(DEFAULT_ROLLING_SIZE)), executorService());
+
         Map<Integer, String> backUpMetadataSegments = ContainerRecoveryUtils.createBackUpMetadataSegments(storage, containerCount,
                 executorService(), TIMEOUT);
 
@@ -591,7 +588,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
      *  9. Starts segment store and controller.
      *  10. Let readers read rest of the 300-N number of events.
      * @throws Exception    In case of an exception occurred while execution.
-     */
+    */
     @Test(timeout = 180000)
     public void testDurableDataLogFailRecoveryReadersPaused() throws Exception {
         int instanceId = 0;
@@ -735,7 +732,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
      *  8. Starts segment store and controller.
      *  9. Read all events and verify that all events are below the bounds.
      * @throws Exception    In case of an exception occurred while execution.
-     */
+    */
     @Test(timeout = 180000)
     public void testDurableDataLogFailRecoveryWatermarking() throws Exception {
         int instanceId = 0;
@@ -919,7 +916,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
      * Adds water marks to the watermarks queue.
      */
     private CompletableFuture<Void> fetchWatermarks(RevisionedStreamClient<Watermark> watermarkReader, LinkedBlockingQueue<Watermark> watermarks,
-                                                    AtomicBoolean stop) {
+                                 AtomicBoolean stop) {
         AtomicReference<Revision> revision = new AtomicReference<>(watermarkReader.fetchOldestRevision());
         return Futures.loop(() -> !stop.get(), () -> Futures.delayedTask(() -> {
             if (stop.get()) {


### PR DESCRIPTION
**Change log description**
Avoiding newly created container metadata segment to be flushed to the Long Term Storage while recovery is in progress.

**Purpose of the change**  
Fixes #5325 

**What the code does**  
Using config parameters which doesn't allow truncations from DurabeLog, and very infrequent flushing to the Long Term Storage. 

**How to verify it**  
Build shall pass.