### PR TITLE
Issue 5360: Require permissions on the scope for creating key-value-tables

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -146,7 +146,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                 scope, kvt);
         log.info(requestTag.getRequestId(), "createKeyValueTable called for KVTable {}/{}.", scope, kvt);
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorizationAndCreateToken(
-                authorizationResource.ofKeyValueTableInScope(scope, kvt), AuthHandler.Permissions.READ_UPDATE),
+                authorizationResource.ofKeyValueTablesInScope(scope), AuthHandler.Permissions.READ_UPDATE),
                 delegationToken -> controllerService.createKeyValueTable(scope, kvt,
                         ModelHelper.encode(request),
                         System.currentTimeMillis()),

--- a/controller/src/main/java/io/pravega/controller/server/security/auth/AuthorizationResource.java
+++ b/controller/src/main/java/io/pravega/controller/server/security/auth/AuthorizationResource.java
@@ -91,6 +91,16 @@ public interface AuthorizationResource {
     String ofReaderGroupInScope(String scopeName, String readerGroupName);
 
     /**
+     * Creates a resource representation for use in authorization of actions pertaining to the collection of Key-Value
+     * tables within the specified scope.
+     *
+     * @param scopeName the name of the scope
+     * @throws NullPointerException if {@code scopeName} or {@code kvtName} are null
+     * @throws IllegalArgumentException if {@code scopeName} or {@code kvtName} are empty
+     */
+    String ofKeyValueTablesInScope(String scopeName);
+
+    /**
      * Creates a resource representation for use in authorization of actions pertaining to the specified KeyValueTable
      * within the specified scope.
      *

--- a/controller/src/main/java/io/pravega/controller/server/security/auth/AuthorizationResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/security/auth/AuthorizationResourceImpl.java
@@ -61,6 +61,11 @@ public class AuthorizationResourceImpl implements AuthorizationResource {
     }
 
     @Override
+    public String ofKeyValueTablesInScope(String scopeName) {
+        return ofScope(scopeName);
+    }
+
+    @Override
     public String ofKeyValueTableInScope(String scopeName, String keyValueTableName) {
         Exceptions.checkNotNullOrEmpty(scopeName, "scopeName");
         Exceptions.checkNotNullOrEmpty(keyValueTableName, "keyValueTableName");

--- a/controller/src/test/java/io/pravega/controller/server/security/auth/AuthorizationResourceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/security/auth/AuthorizationResourceImplTest.java
@@ -70,6 +70,11 @@ public class AuthorizationResourceImplTest {
     }
 
     @Test
+    public void testOfAKvtablesInScopeReturnsValidResourceStrWhenInputIsLegal() {
+        assertEquals("prn::/scope:testScopeName", objectUnderTest.ofKeyValueTablesInScope("testScopeName"));
+    }
+
+    @Test
     public void testOfAKvtableInScopeReturnsValidResourceStrWhenInputIsLegal() {
         assertEquals("prn::/scope:testScopeName/key-value-table:kvtName",
                 objectUnderTest.ofKeyValueTableInScope("testScopeName", "kvtName"));


### PR DESCRIPTION
**Change log description**  
Modify resource string used for authorizing Key-Value table creation operation from the resource to its parent resource. 

**Purpose of the change**  
Fixes #5360. 

**What the code does**  
Modifies the resource string used for creating Key-Value Tables from the resource itself (e.g., `prn::/scope:scope1/key-value-table:table1`) to its parent resource - the Scope (`prn::/scope:scope1`). 

**How to verify it**  
All unit, integration and system tests must pass. 
