### PR TITLE
Issue 5375: (SegmentStore) Logging the exception in StreamSegmentReadIndex.queueStorageRead

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -1172,7 +1172,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                     insert(offset, data);
                 }
             } catch (Exception ex) {
-                log.error("{}: Unable to process Storage Read callback. Offset={}, Result=[{}].", this.traceObjectId, offset, result);
+                log.error("{}: Unable to process Storage Read callback. Offset={}, Result=[{}].", this.traceObjectId, offset, result, ex);
             }
         };
 


### PR DESCRIPTION
**Change log description**  
- Fixed the error logging in `StreamSegmentReadIndex.queueStorageRead` to log the exception, not just the message.

**Purpose of the change**  
Fixes #5375.

**What the code does**  
Added the exception as an argument to the error log.

**How to verify it**  
Build must pass.
