### PR TITLE
Issue 5392: Adapt Gradle script to accommodate specific Bookkeeper images in system tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1001,6 +1001,7 @@ project('test:system') {
         environment "helmRepository",System.getProperty("helmRepository", "pravega")
         // To update config map with desired pravega version
         environment "desiredPravegaCMVersion",System.getProperty("desiredPravegaCMVersion", "0.9.0")
+        environment "desiredBookkeeperCMVersion",System.getProperty("desiredBookkeeperCMVersion", "0.9.0")
         environment "tlsEnabled", System.getProperty("tlsEnabled", "false")
 
         commandLine './kubernetes/setupTestPod.sh'
@@ -1035,6 +1036,7 @@ project('test:system') {
         systemProperty "bookkeeperOperatorVersion",System.getProperty("bookkeeperOperatorVersion", "latest")
         systemProperty "zookeeperOperatorVersion",System.getProperty("zookeeperOperatorVersion", "latest")
         systemProperty "desiredPravegaCMVersion",System.getProperty("desiredPravegaCMVersion", "0.9.0")
+        systemProperty "desiredBookkeeperCMVersion",System.getProperty("desiredBookkeeperCMVersion", "0.9.0")
         systemProperty "publishedChartName",System.getProperty("publishedChartName", "pravega")
         systemProperty "helmRepository",System.getProperty("helmRepository", "pravega")
 

--- a/test/system/kubernetes/setupTestPod.sh
+++ b/test/system/kubernetes/setupTestPod.sh
@@ -88,7 +88,7 @@ if [ "$readyValueZk" != "1/1" ];then
 
 #Step 7: Creating BK-OP
 echo "Creating BK Operator"
-helm install bkop $publishedChartName/bookkeeper-operator --version=$bookkeeperOperatorVersion --set testmode.enabled=true
+helm install bkop $publishedChartName/bookkeeper-operator --version=$bookkeeperOperatorVersion --set testmode.enabled=true --set testmode.version=$desiredBookkeeperCMVersion --wait
 
 bkOpName="$(kubectl get pod | grep "bookkeeper-operator" | awk '{print $1}')"
 #kubectl wait --timeout=1m --for=condition=Ready pod/$bkOpName

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -221,6 +221,11 @@ public abstract class AbstractService implements Service {
         return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions"};
     }
 
+    private String[] getBookkeeperMemoryOptions() {
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions"};
+    }
+
+
     private Map<String, Object> getPersistentVolumeClaimSpec(String size, String storageClass) {
         return ImmutableMap.<String, Object>builder()
                 .put("accessModes", singletonList("ReadWriteOnce"))
@@ -330,6 +335,9 @@ public abstract class AbstractService implements Service {
                 .put("autoRecovery", true)
                 .put("options", ImmutableMap.builder()  .put("journalDirectories", JOURNALDIRECTORIES)
                         .put("ledgerDirectories", LEDGERDIRECTORIES)
+                        .build())
+                .put("jvmOptions", ImmutableMap.builder()
+                        .put("memoryOpts", getBookkeeperMemoryOptions())
                         .build())
                 .build();
 


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

**Change log description**  
Added one more param in build.gradle to accept bookkeeper  version, so that it can be added in operator configmap.

**Purpose of the change**  
 Fixes #5392

**What the code does**  
Added one param that accepts the desired bookkeeper version to be installed and update the bookkeeper-operator configmap

**How to verify it**  
System tests should pass with the changes.
