### PR TITLE
Issue : Fix EventProcessor integration test.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -537,6 +537,9 @@ project('test:integration') {
         jvmArgs = ["-server", "-Xmx2g", "-XX:+HeapDumpOnOutOfMemoryError",
                    "-Dlog.dir=PRAVEGA_APP_HOME/logs",
                    "-Dlog.name=selftest"]
+        beforeTest { descriptor ->
+            logger.lifecycle("\nRunning test: " + descriptor.getClassName() + " > " + descriptor.getDisplayName());
+        }
     }
 
     dependencies {

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/EventProcessorTest.java
@@ -208,6 +208,7 @@ public class EventProcessorTest {
         server.close();
         zkTestServer.stop();
         executor.shutdownNow();
+        serviceBuilder.close();
     }
     
     @Test(timeout = 60000)


### PR DESCRIPTION
**Change log description**  
Ensure `serviceBuilder` is closed by the EventProcessortest integration test.

**Purpose of the change**  
TBD

**What the code does**  
- Ensure `serviceBuilder` is closed by the EventProcessortest integration test.
- Logs the integration test that is being executed.

**How to verify it**  
No Changes to functionality. All the tests should continue to pass.
