### PR TITLE
Issue 5408: Remove 'snapshot' from version in preparation of releasing r0.8.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ k8ClientVersion=8.0.0
 jjwtVersion=0.9.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.8.1-SNAPSHOT
+pravegaVersion=0.8.1
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: rsharda <ravi.sharda@emc.com>

**Change log description**  
Changed version to `0.8.1` in `gradle.properties`.

**Purpose of the change**  
Fixes #5408. 

**What the code does**  
Changed version to `0.8.1` in `gradle.properties`.

**How to verify it**  
Inspect the change. 
