### PR TITLE
Issue 5416: Transaction commit order should take 'limit' elements from ordered list

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1957,7 +1957,7 @@ public abstract class PersistentStreamBase implements Stream {
                     case ABORTED:
                     case UNKNOWN:
                         // Aborting, aborted, unknown and committed 
-                        log.debug("stale txn {} with status. removing {}", txnId, txnRecord.getTxnStatus(), order);
+                        log.debug("stale txn {} with status {}. removing {}", txnId, txnRecord.getTxnStatus(), order);
                         toPurge.add(order);
                         break;
                 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1920,7 +1920,7 @@ public abstract class PersistentStreamBase implements Stream {
         int epoch = nextEpoch.getKey();
         List<Long> orders = new ArrayList<>();
         List<String> txnIds = new ArrayList<>();
-        nextEpoch.getValue().forEach(x -> {
+        nextEpoch.getValue().stream().sorted(Comparator.comparingLong(Map.Entry::getKey)).forEach(x -> {
             orders.add(x.getKey());
             txnIds.add(x.getValue());
         });
@@ -1931,8 +1931,9 @@ public abstract class PersistentStreamBase implements Stream {
                 () -> getTransactionRecords(epoch, txnIds.subList(from.get(), till.get())).thenAccept(txns -> {
             for (int i = 0; i < txns.size(); i++) {
                 ActiveTxnRecord txnRecord = txns.get(i);
-                UUID txnId = UUID.fromString(txnIds.get(i));
-                long order = orders.get(i);
+                int index = from.get() + i;
+                UUID txnId = UUID.fromString(txnIds.get(index));
+                long order = orders.get(index);
                 switch (txnRecord.getTxnStatus()) {
                     case COMMITTING:
                         if (txnRecord.getCommitOrder() == order) {

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1140,7 +1140,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(1, positions.size());
         assertEquals(positions.get(3L), tx02);
     }
-
+    
     @Test
     public void txnCommitBatchLimitTest() throws Exception {
         final String scope = "txnCommitBatch";
@@ -1204,6 +1204,44 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(tx02, ordered.get(0));
         
         // scale and create transaction on new epoch too. 
+    }
+    
+    @Test
+    public void txnCommitBatchLimitOrderTest() throws Exception {
+        final String scope = "txnCommitBatch2";
+        final String stream = "txnCommitBatch2";
+        final ScalingPolicy policy = ScalingPolicy.fixed(2);
+        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy).build();
+
+        long start = System.currentTimeMillis();
+        store.createScope(scope).get();
+
+        store.createStream(scope, stream, configuration, start, null, executor).get();
+        store.setState(scope, stream, State.ACTIVE, null, executor).get();
+        
+        // create 3 transactions on epoch 0 --> tx00, tx01, tx02 and mark them as committing.. 
+        List<UUID> txns = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            UUID tx = store.generateTransactionId(scope, stream, null, executor).join();
+            store.createTransaction(scope, stream, tx,
+                    100, 100, null, executor).join();
+            store.sealTransaction(scope, stream, tx, true, Optional.empty(),
+                    "", Long.MIN_VALUE, null, executor).join();
+            txns.add(tx);
+        }
+
+        PersistentStreamBase streamObj = (PersistentStreamBase) ((AbstractStreamMetadataStore) store).getStream(scope, stream, null);
+        
+        while (!txns.isEmpty()) {
+            int limit = 5;
+            List<Map.Entry<UUID, ActiveTxnRecord>> orderedRecords = streamObj.getOrderedCommittingTxnInLowestEpoch(limit).join();
+            List<UUID> ordered = orderedRecords.stream().map(Map.Entry::getKey).collect(Collectors.toList());
+            assertEquals(limit, ordered.size());
+            for (int i = 0; i < limit; i++) {
+                assertEquals(txns.remove(0), ordered.get(i));
+                ((AbstractStreamMetadataStore) store).commitTransaction(scope, stream, ordered.get(i), null, executor).join();
+            }
+        }
     }
 
     private void scale(String scope, String stream, long scaleTs, List<Map.Entry<Double, Double>> newSegments, List<Long> scale1SealedSegments) {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes transaction commit order regression introduced by #5197 where we took first n elements from an unsorted list whereby breaking the order. 

**Purpose of the change**  
Fixes #5416 

**What the code does**  
There were two regressions introduced by 5197. 
1. We took the "limit" number of elements from an unordered list which could break the order.
2. in subsequent iterations of the loop (if some elements were filtered out), we were reading from wrong index in the loop. 

**How to verify it**  
Unit test added