### PR TITLE
Issue 5433: Remove redundant read request sent by the BatchClient reader.

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -45,8 +45,7 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
         this.deserializer = deserializer;
         this.startingOffset = startingOffset;
         this.endingOffset = endingOffset;
-        input = factory.createEventReaderForSegment(segment);
-        input.setOffset(startingOffset);        
+        input = factory.createEventReaderForSegment(segment, startingOffset, endingOffset);
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamFactory.java
@@ -59,6 +59,20 @@ public interface SegmentInputStreamFactory {
     EventSegmentReader createEventReaderForSegment(Segment segment);
 
     /**
+     * Opens an existing segment for reading events. This operation will fail if the
+     * segment does not exist.
+     * This operation may be called multiple times on the same segment from the
+     * same client (i.e., there can be concurrent Event Readers in the same
+     * process space).
+     *
+     * @param segment The segment to create an input for.
+     * @param startOffset the start offset of the segment.
+     * @param endOffset The end offset of the segment.
+     * @return New instance of EventSegmentReader for reading.
+     */
+    EventSegmentReader createEventReaderForSegment(Segment segment, long startOffset, long endOffset);
+
+    /**
      * Open an existing segment for reading up to the provided end offset. This operation will fail if the segment
      * does not exist.
      *

--- a/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Pinger.java
@@ -108,7 +108,7 @@ public class Pinger implements AutoCloseable {
                                       Throwable unwrap = Exceptions.unwrap(e);
                                       if (unwrap instanceof StatusRuntimeException && 
                                               ((StatusRuntimeException) unwrap).getStatus().equals(Status.NOT_FOUND)) {
-                                          log.info("Ping Transaction for txn ID:{} did not find the transaction");
+                                          log.info("Ping Transaction for txn ID:{} did not find the transaction", uuid);
                                           completedTxns.add(uuid);
                                       }
                                       log.warn("Ping Transaction for txn ID:{} failed", uuid, unwrap(e));

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -129,7 +129,7 @@ public class SegmentIteratorTest {
         int endOffset = 10;
         SegmentInputStreamFactory factory = mock(SegmentInputStreamFactory.class);
         EventSegmentReader input = mock(EventSegmentReader.class);
-        when(factory.createEventReaderForSegment(segment)).thenReturn(input);
+        when(factory.createEventReaderForSegment(segment, 0, endOffset)).thenReturn(input);
         when(input.read()).thenReturn(null).thenReturn(stringSerializer.serialize("s"));
         @Cleanup
         SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, endOffset);

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
@@ -71,6 +71,11 @@ public class MockSegmentStreamFactory implements SegmentInputStreamFactory, Segm
     }
 
     @Override
+    public EventSegmentReader createEventReaderForSegment(Segment segment, long startOffset, long endOffset) {
+        return getMockStream(segment);
+    }
+
+    @Override
     public EventSegmentReader createEventReaderForSegment(Segment segment, int bufferSize, Semaphore hasData, long endOffset) {
         MockSegmentIoStreams streams = new MockSegmentIoStreams(segment, hasData);
         segments.putIfAbsent(segment, streams);

--- a/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockSegmentStreamFactory.java
@@ -21,6 +21,8 @@ import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
 import io.pravega.client.segment.impl.SegmentOutputStream;
 import io.pravega.client.segment.impl.SegmentOutputStreamFactory;
 import io.pravega.client.stream.EventWriterConfig;
+import lombok.val;
+
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,7 +74,9 @@ public class MockSegmentStreamFactory implements SegmentInputStreamFactory, Segm
 
     @Override
     public EventSegmentReader createEventReaderForSegment(Segment segment, long startOffset, long endOffset) {
-        return getMockStream(segment);
+        val reader =  getMockStream(segment);
+        reader.setOffset(startOffset);
+        return reader;
     }
 
     @Override


### PR DESCRIPTION
**Change log description**  
Remove redundant read request sent by the BatchClient reader.

**Purpose of the change**  
Fixes #5433 

**What the code does**  
Remove redundant read request sent by the BatchClient reader.

**How to verify it**  
All the existing tests should continue to pass.
