### PR TITLE
Issue 5435: Allow DefaultCredentials to be assigned to both new and legacy Credentials interface

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/DefaultCredentials.java
@@ -13,12 +13,12 @@ import io.pravega.auth.AuthConstants;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import io.pravega.shared.security.auth.Credentials;
 import lombok.EqualsAndHashCode;
 
 /**
  * Username/password credentials for basic authentication.
  */
+@SuppressWarnings("deprecation")
 @EqualsAndHashCode
 public class DefaultCredentials implements Credentials {
     

--- a/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
+++ b/client/src/test/java/io/pravega/client/CredentialsExtractorTest.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.client;
 
+import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.shared.security.auth.Credentials;
 import java.util.HashMap;
 import java.util.Map;
@@ -234,6 +235,12 @@ public class CredentialsExtractorTest {
         assertNotNull(LegacyCredentials2.class.getName(), credentials.getClass());
         assertEquals("Expected a different authentication type",
                 LegacyCredentials2.AUTHENTICATION_METHOD, credentials.getAuthenticationType());
+    }
+
+    @Test
+    public void defaultCredentialsIsAssignableToEitherCredsInterface() {
+        Credentials credentials1 = new DefaultCredentials("pwd", "username");
+        io.pravega.client.stream.impl.Credentials credentials2 = new DefaultCredentials("pwd", "username");
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Make `DefaultCredentials` implement the legacy `io.pravega.client.stream.impl.Credentials` interface instead of `io.pravega.shared.security.auth.Credentials`. Since, the legacy interface, in turn, extends the new interface, `DefaultCredentials` may be assigned to both those interfaces, improving its backward compatibility. 

**Purpose of the change**  
Resolves #5435. 

**What the code does**  
* Changes the interface that `DefaultCredentials` implements from `io.pravega.shared.security.auth.Credentials` to `io.pravega.client.stream.impl.Credentials`. 

**How to verify it**  
All unit and integration tests must pass. 
