### PR TITLE
Improvements to createReaderGroup and updateReaderGroup APIs

### DIFF
--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -99,7 +99,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.TxnStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfiguration;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupInfo;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
@@ -1571,8 +1571,8 @@ public class ControllerImpl implements Controller {
         final long requestId = requestIdGenerator.get();
         long traceId = LoggerHelpers.traceEnter(log, "updateReaderGroup", rgConfig, requestId);
 
-        final CompletableFuture<UpdateReaderGroupStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<UpdateReaderGroupStatus> callback = new RPCAsyncCallback<>(requestId, "updateReaderGroup", scope, rgName, rgConfig);
+        final CompletableFuture<UpdateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<UpdateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "updateReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "updateReaderGroup", scope, rgName)
                     .updateReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
             return callback.getFuture();
@@ -1863,7 +1863,7 @@ public class ControllerImpl implements Controller {
                     .deleteReaderGroup(readerGroupInfo, callback);
         }
 
-        void updateReaderGroup(ReaderGroupConfiguration rgConfig, RPCAsyncCallback<UpdateReaderGroupStatus> callback) {
+        void updateReaderGroup(ReaderGroupConfiguration rgConfig, RPCAsyncCallback<UpdateReaderGroupResponse> callback) {
             clientStub.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                     .updateReaderGroup(rgConfig, callback);
         }

--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -271,10 +271,10 @@ public final class ModelHelper {
                 .generation(rgConfig.getGeneration())
                 .readerGroupId(UUID.fromString(rgConfig.getReaderGroupId()))
                 .startingStreamCuts(rgConfig.getStartingStreamCutsList().stream()
-                .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
-                         streamCut.getStreamInfo().getStream()),
-                         streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
-                                 streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
+                                    .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
+                                    streamCut.getStreamInfo().getStream()),
+                                    streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
+                                    streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
                 .endingStreamCuts(rgConfig.getEndingStreamCutsList().stream()
                         .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
                                 streamCut.getStreamInfo().getStream()),

--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -271,10 +271,10 @@ public final class ModelHelper {
                 .generation(rgConfig.getGeneration())
                 .readerGroupId(UUID.fromString(rgConfig.getReaderGroupId()))
                 .startingStreamCuts(rgConfig.getStartingStreamCutsList().stream()
-                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
-                                streamCut.getStreamInfo().getStream()),
-                                streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream()),
-                                        getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
+                .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
+                         streamCut.getStreamInfo().getStream()),
+                         streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
+                                 streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
                 .endingStreamCuts(rgConfig.getEndingStreamCutsList().stream()
                         .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
                                 streamCut.getStreamInfo().getStream()),
@@ -283,7 +283,7 @@ public final class ModelHelper {
                 .build();
     }
 
-    private static Map<Segment, Long> getSegmentOffsetMap(String streamName, String scopeName, Map<Long, Long> streamCutMap) {
+    public static Map<Segment, Long> getSegmentOffsetMap(String scopeName, String streamName, Map<Long, Long> streamCutMap) {
         return streamCutMap.entrySet().stream()
                 .collect(Collectors.toMap(s -> new Segment(scopeName, streamName, s.getKey()), s -> s.getValue()));
     }
@@ -464,12 +464,12 @@ public final class ModelHelper {
         Preconditions.checkNotNull(groupName, "ReaderGroup name is null");
         Preconditions.checkNotNull(config, "ReaderGroupConfig is null");
 
-        List<StreamCut> startStreamCuts = config.getStartingStreamCuts().entrySet().stream()
+        List<Controller.StreamCut> startStreamCuts = config.getStartingStreamCuts().entrySet().stream()
                 .map(e -> Controller.StreamCut.newBuilder()
                 .setStreamInfo(createStreamInfo(e.getKey().getScope(), e.getKey().getStreamName()))
                 .putAllCut(getStreamCutMap(e.getValue())).build()).collect(Collectors.toList());
 
-        List<StreamCut> endStreamCuts = config.getEndingStreamCuts().entrySet().stream()
+        List<Controller.StreamCut> endStreamCuts = config.getEndingStreamCuts().entrySet().stream()
                 .map(e -> Controller.StreamCut.newBuilder()
                         .setStreamInfo(createStreamInfo(e.getKey().getScope(), e.getKey().getStreamName()))
                         .putAllCut(getStreamCutMap(e.getValue())).build()).collect(Collectors.toList());
@@ -488,7 +488,7 @@ public final class ModelHelper {
         return builder.build();
     }
 
-    private static Map<Long, Long> getStreamCutMap(io.pravega.client.stream.StreamCut streamCut) {
+    public static Map<Long, Long> getStreamCutMap(io.pravega.client.stream.StreamCut streamCut) {
         if (streamCut.equals(io.pravega.client.stream.StreamCut.UNBOUNDED)) {
             return Collections.emptyMap();
         }

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -82,7 +82,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatu
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscriberStreamCut;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupInfo;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
@@ -372,25 +372,25 @@ public class ControllerImplTest {
 
             @Override
             public void updateReaderGroup(ReaderGroupConfiguration request,
-                                          StreamObserver<UpdateReaderGroupStatus> responseObserver) {
+                                          StreamObserver<UpdateReaderGroupResponse> responseObserver) {
                 if (request.getReaderGroupName().equals("rg1")) {
-                    responseObserver.onNext(UpdateReaderGroupStatus.newBuilder()
-                            .setStatus(UpdateReaderGroupStatus.Status.SUCCESS)
+                    responseObserver.onNext(UpdateReaderGroupResponse.newBuilder()
+                            .setStatus(UpdateReaderGroupResponse.Status.SUCCESS)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg2")) {
-                    responseObserver.onNext(UpdateReaderGroupStatus.newBuilder()
-                            .setStatus(UpdateReaderGroupStatus.Status.FAILURE)
+                    responseObserver.onNext(UpdateReaderGroupResponse.newBuilder()
+                            .setStatus(UpdateReaderGroupResponse.Status.FAILURE)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg3")) {
-                    responseObserver.onNext(UpdateReaderGroupStatus.newBuilder()
-                            .setStatus(UpdateReaderGroupStatus.Status.RG_NOT_FOUND)
+                    responseObserver.onNext(UpdateReaderGroupResponse.newBuilder()
+                            .setStatus(UpdateReaderGroupResponse.Status.RG_NOT_FOUND)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg4")) {
-                    responseObserver.onNext(UpdateReaderGroupStatus.newBuilder()
-                            .setStatus(UpdateReaderGroupStatus.Status.INVALID_CONFIG)
+                    responseObserver.onNext(UpdateReaderGroupResponse.newBuilder()
+                            .setStatus(UpdateReaderGroupResponse.Status.INVALID_CONFIG)
                             .build());
                     responseObserver.onCompleted();
                 }

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -55,7 +55,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
 import io.pravega.controller.task.KeyValueTable.TableMetadataTasks;
@@ -188,16 +188,16 @@ public class ControllerService {
                 }, executor);
     }
 
-    public CompletableFuture<UpdateReaderGroupStatus> updateReaderGroup(String scope, String rgName,
+    public CompletableFuture<UpdateReaderGroupResponse> updateReaderGroup(String scope, String rgName,
                                                                         final ReaderGroupConfig rgConfig) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(rgConfig, "ReaderGroup config is null");
         Timer timer = new Timer();
         return streamMetadataTasks.updateReaderGroup(scope, rgName, rgConfig, null)
-                .thenApplyAsync(status -> {
-                    reportUpdateReaderGroupMetrics(scope, rgName, status, timer.getElapsed());
-                    return UpdateReaderGroupStatus.newBuilder().setStatus(status).build();
+                .thenApplyAsync(response -> {
+                            reportUpdateReaderGroupMetrics(scope, rgName, response.getStatus(), timer.getElapsed());
+                            return response;
                 }, executor);
     }
 
@@ -705,10 +705,10 @@ public class ControllerService {
         }
     }
 
-    private void reportUpdateReaderGroupMetrics(String scope, String streamName, UpdateReaderGroupStatus.Status status, Duration latency) {
-        if (status.equals(UpdateReaderGroupStatus.Status.SUCCESS)) {
+    private void reportUpdateReaderGroupMetrics(String scope, String streamName, UpdateReaderGroupResponse.Status status, Duration latency) {
+        if (status.equals(UpdateReaderGroupResponse.Status.SUCCESS)) {
             StreamMetrics.getInstance().updateReaderGroup(scope, streamName, latency);
-        } else if (status.equals(UpdateReaderGroupStatus.Status.FAILURE)) {
+        } else if (status.equals(UpdateReaderGroupResponse.Status.FAILURE)) {
             StreamMetrics.getInstance().updateReaderGroupFailed(scope, streamName);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -266,8 +266,10 @@ public class LocalController implements Controller {
                                  createTimestamp, 10)
                                  .thenCompose(createStatus -> {
                                  if (createStatus.equals(CreateStreamStatus.Status.STREAM_EXISTS) || createStatus.equals(CreateStreamStatus.Status.SUCCESS)) {
-                                    return streamMetadataStore.updateReaderGroupVersionedState(scope, rgName,
-                                                               ReaderGroupState.ACTIVE, state, context, localExecutor);
+                                    return streamMetadataStore.getVersionedReaderGroupState(scope, rgName, true, null, localExecutor)
+                                            .thenCompose(newstate -> streamMetadataStore.updateReaderGroupVersionedState(scope, rgName,
+                                                    ReaderGroupState.ACTIVE, newstate, context, localExecutor)
+                                                    .thenApply(v1 -> CreateReaderGroupStatus.Status.SUCCESS));
                                     }
                                     return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
                                                                             rgName, createStatus.toString())));

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -292,9 +292,9 @@ public class LocalController implements Controller {
                 case FAILURE:
                     throw new ControllerFailureException("Failed to create ReaderGroup: " + scopedRGName);
                 case INVALID_CONFIG:
-                    throw new IllegalArgumentException("Illegal ReaderGroup name: " + rgName);
+                    throw new IllegalArgumentException("Invalid Reader Group Config: " + scopedRGName);
                 case RG_NOT_FOUND:
-                    throw new IllegalArgumentException("Scope does not exist: " + scopeName);
+                    throw new IllegalArgumentException("Scope does not exist: " + scopedRGName);
                 case SUCCESS:
                     return true;
                 default:

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -37,8 +37,6 @@ import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.retryable.RetryableException;
-import io.pravega.controller.store.Version;
-import io.pravega.controller.store.VersionedMetadata;
 import io.pravega.controller.store.stream.RGOperationContext;
 import io.pravega.controller.store.stream.ReaderGroupState;
 import io.pravega.controller.store.stream.StreamMetadataStore;
@@ -222,7 +220,7 @@ public class LocalController implements Controller {
         });
     }
 
-    private CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName, ReaderGroupConfig config, final long createTimestamp) {
+    CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName, ReaderGroupConfig config, final long createTimestamp) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(config, "ReaderGroup config is null");

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -18,7 +18,6 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.control.impl.CancellableRequest;
 import io.pravega.client.control.impl.Controller;
@@ -34,13 +33,8 @@ import io.pravega.client.stream.impl.WriterPosition;
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.client.tables.impl.KeyValueTableSegments;
 import io.pravega.common.Exceptions;
-import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.concurrent.Futures;
-import io.pravega.controller.retryable.RetryableException;
-import io.pravega.controller.store.stream.RGOperationContext;
-import io.pravega.controller.store.stream.ReaderGroupState;
-import io.pravega.controller.store.stream.StreamMetadataStore;
-import io.pravega.controller.util.RetryHelper;
+import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.shared.NameUtils;
 import io.pravega.shared.security.auth.AccessOperation;
 import io.pravega.common.util.AsyncIterator;
@@ -50,8 +44,6 @@ import io.pravega.controller.server.security.auth.GrpcAuthHelper;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentRange;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateStreamStatus;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -63,7 +55,6 @@ import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -80,7 +71,6 @@ public class LocalController implements Controller {
     private ControllerService controller;
     private final String tokenSigningKey;
     private final boolean authorizationEnabled;
-    private final ScheduledExecutorService localExecutor = ExecutorServiceHelpers.newScheduledThreadPool(5, "controllerpool");
 
     public LocalController(ControllerService controller, boolean authorizationEnabled, String tokenSigningKey) {
         this.controller = controller;
@@ -201,7 +191,8 @@ public class LocalController implements Controller {
 
     @Override
     public CompletableFuture<Boolean> createReaderGroup(String scopeName, String rgName, ReaderGroupConfig config) {
-        return createReaderGroupInternal(scopeName, rgName, config, System.currentTimeMillis())
+        StreamMetadataTasks streamMetadataTasks = controller.getStreamMetadataTasks();
+        return streamMetadataTasks.createReaderGroupInternal(scopeName, rgName, config, System.currentTimeMillis())
                 .thenApply(x -> {
             final String scopedRGName = NameUtils.getScopedReaderGroupName(scopeName, rgName);
             switch (x) {
@@ -218,70 +209,6 @@ public class LocalController implements Controller {
                             + " " + x);
             }
         });
-    }
-
-    CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName, ReaderGroupConfig config, final long createTimestamp) {
-        Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
-        Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
-        Preconditions.checkNotNull(config, "ReaderGroup config is null");
-        Preconditions.checkArgument(createTimestamp >= 0);
-        try {
-            NameUtils.validateReaderGroupName(rgName);
-        } catch (IllegalArgumentException | NullPointerException e) {
-            log.warn("Create ReaderGroup failed due to invalid name {}", rgName);
-            return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.INVALID_RG_NAME);
-        }
-        StreamMetadataStore streamMetadataStore = controller.getStreamStore();
-        final RGOperationContext context = streamMetadataStore.createRGContext(scope, rgName);
-        return RetryHelper.withRetriesAsync(() -> {
-            // 1. check if scope with this name exists...
-            return streamMetadataStore.checkScopeExists(scope)
-                    .thenCompose(exists -> {
-                    if (!exists) {
-                            return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND);
-                    }
-                    //2. check state of the ReaderGroup
-                    return Futures.exceptionallyExpecting(streamMetadataStore.getReaderGroupState(scope, rgName, true, null, localExecutor),
-                           e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, ReaderGroupState.UNKNOWN)
-                           .thenCompose(state -> {
-                           if (state.equals(ReaderGroupState.UNKNOWN) || state.equals(ReaderGroupState.CREATING)) {
-                              return streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
-                              .thenCompose(v -> streamMetadataStore.createReaderGroup(scope, rgName, config, createTimestamp, context, localExecutor)
-                              .thenCompose(x -> {
-                                 if (!ReaderGroupConfig.StreamDataRetention.NONE.equals(config.getRetentionType())) {
-                                    String scopedRGName = NameUtils.getScopedReaderGroupName(scope, rgName);
-                                    // update Stream metadata tables, only if RG is a Subscriber
-                                    Iterator<String> streamIter = config.getStartingStreamCuts().keySet().stream().map(s -> s.getScopedName()).iterator();
-                                    return Futures.loop(() -> streamIter.hasNext(), () -> {
-                                    Stream stream = Stream.of(streamIter.next());
-                                                                    return streamMetadataStore.addSubscriber(stream.getScope(),
-                                                                            stream.getStreamName(), scopedRGName, config.getGeneration(), null, localExecutor);
-                                    }, localExecutor);
-                                 }
-                                 return CompletableFuture.completedFuture(null);
-                              }).thenCompose(x -> controller.getStreamMetadataTasks().createRGStream(scope, NameUtils.getStreamForReaderGroup(rgName),
-                                 StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
-                                 createTimestamp, 10)
-                                 .thenCompose(createStatus -> {
-                                 if (createStatus.equals(CreateStreamStatus.Status.STREAM_EXISTS) || createStatus.equals(CreateStreamStatus.Status.SUCCESS)) {
-                                    return streamMetadataStore.getVersionedReaderGroupState(scope, rgName, true, null, localExecutor)
-                                            .thenCompose(newstate -> streamMetadataStore.updateReaderGroupVersionedState(scope, rgName,
-                                                    ReaderGroupState.ACTIVE, newstate, context, localExecutor)
-                                                    .thenApply(v1 -> CreateReaderGroupStatus.Status.SUCCESS));
-                                    }
-                                    return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
-                                                                            rgName, createStatus.toString())));
-                                    })).exceptionally(ex -> {
-                                                            log.debug(ex.getMessage());
-                                                            Throwable cause = Exceptions.unwrap(ex);
-                                                            throw new CompletionException(cause);
-                                                        }))
-                                    .thenApply(y -> CreateReaderGroupStatus.Status.SUCCESS);
-                                    }
-                                    return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);
-                           });
-            });
-        }, e -> Exceptions.unwrap(e) instanceof RetryableException, 10, localExecutor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -11,16 +11,22 @@ package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import com.google.common.base.Preconditions;
 
+import io.pravega.client.control.impl.ModelHelper;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.common.Exceptions;
 
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.retryable.RetryableException;
+import io.pravega.controller.store.Version;
+import io.pravega.controller.store.VersionedMetadata;
 import io.pravega.controller.store.stream.RGOperationContext;
 import io.pravega.controller.store.stream.ReaderGroupState;
+import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 
 import io.pravega.controller.stream.api.grpc.v1.Controller;
@@ -29,10 +35,14 @@ import io.pravega.controller.util.RetryHelper;
 import io.pravega.shared.NameUtils;
 import io.pravega.shared.controller.event.CreateReaderGroupEvent;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.Iterator;
+import java.util.stream.Collectors;
 
 /**
  * Request handler for executing a create operation for a ReaderGroup.
@@ -57,48 +67,78 @@ public class CreateReaderGroupTask implements ReaderGroupTask<CreateReaderGroupE
 
     @Override
     public CompletableFuture<Void> execute(final CreateReaderGroupEvent request) {
-        String scope = request.getScopeName();
+        String scope = request.getScope();
         String readerGroup = request.getRgName();
-        long requestId = request.getRequestId();
+        UUID readerGroupId = request.getReaderGroupId();
         final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
-        return RetryHelper.withRetriesAsync(() -> streamMetadataStore.getVersionedReaderGroupState(scope, readerGroup,
-                true, context, executor)
-                .thenCompose(state -> {
-                    if (state.getObject().equals(ReaderGroupState.CREATING)) {
-                        String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);
-                        return streamMetadataStore.getReaderGroupConfigRecord(scope, readerGroup, context, executor)
-                               .thenCompose(configRecord -> {
-                               if (!ReaderGroupConfig.StreamDataRetention.values()[configRecord.getObject().getRetentionTypeOrdinal()]
-                                   .equals(ReaderGroupConfig.StreamDataRetention.NONE)) {
-                                   // update Stream metadata tables, only if RG is a Subscriber
-                                   Iterator<String> streamIter = configRecord.getObject().getStartingStreamCuts().keySet().iterator();
-                                   return Futures.loop(() -> streamIter.hasNext(), () -> {
-                                          Stream stream = Stream.of(streamIter.next());
-                                          return streamMetadataStore.addSubscriber(stream.getScope(),
-                                                       stream.getStreamName(), scopedRGName, configRecord.getObject().getGeneration(),
-                                                  null, executor);
-                                      }, executor);
-                                   }
-                               return CompletableFuture.completedFuture(null);
-                               }).thenCompose(v ->
-                                  streamMetadataTasks.createRGStream(scope, NameUtils.getStreamForReaderGroup(readerGroup),
-                                           StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
-                                          System.currentTimeMillis(), 10)
-                                 .thenCompose(status -> {
-                                     if (status.equals(Controller.CreateStreamStatus.Status.STREAM_EXISTS)
-                                     || status.equals(Controller.CreateStreamStatus.Status.SUCCESS)) {
-                                         return Futures.toVoid(streamMetadataStore.updateReaderGroupVersionedState(scope, readerGroup,
-                                                 ReaderGroupState.ACTIVE, state, context, executor));
-                                     }
-                               return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
-                                             readerGroup, status.toString())));
-                           })).exceptionally(ex -> {
-                                    log.debug(ex.getMessage());
-                                    Throwable cause = Exceptions.unwrap(ex);
-                                    throw new CompletionException(cause);
-                           });
+        return RetryHelper.withRetriesAsync(() -> streamMetadataStore.getReaderGroupId(scope, readerGroup, context, executor)
+                .thenCompose(rgId -> {
+                    if (!rgId.equals(readerGroupId)) {
+                        log.warn("Skipping processing of CreateReaderGroupEvent with invalid UUID.");
+                        return CompletableFuture.completedFuture(null);
                     }
-                    return CompletableFuture.completedFuture(null);
+                    ReaderGroupConfig config = getConfigFromEvent(request);
+                    return Futures.exceptionallyExpecting(streamMetadataStore.getVersionedReaderGroupState(scope, readerGroup, true, null, executor),
+                            e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, new VersionedMetadata<>(ReaderGroupState.UNKNOWN, new Version.IntVersion(0)))
+                            .thenCompose(state -> {
+                                if (state.getObject().equals(ReaderGroupState.UNKNOWN)
+                                        || state.getObject().equals(ReaderGroupState.CREATING)) {
+                                    return streamMetadataStore.createReaderGroup(scope, readerGroup, config, System.currentTimeMillis(), context, executor)
+                                            .thenCompose(v -> {
+                                             if (!ReaderGroupConfig.StreamDataRetention.NONE.equals(config.getRetentionType())) {
+                                                    String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);
+                                                    // update Stream metadata tables, only if RG is a Subscriber
+                                                    Iterator<String> streamIter = config.getStartingStreamCuts().keySet().stream()
+                                                            .map(s -> s.getScopedName()).iterator();
+                                                    return Futures.loop(() -> streamIter.hasNext(), () -> {
+                                                        Stream stream = Stream.of(streamIter.next());
+                                                        return streamMetadataStore.addSubscriber(stream.getScope(),
+                                                                stream.getStreamName(), scopedRGName, config.getGeneration(), null, executor);
+                                                    }, executor);
+                                                }
+                                                return CompletableFuture.completedFuture(null);
+                                            }).thenCompose(x -> streamMetadataTasks.createRGStream(scope, NameUtils.getStreamForReaderGroup(readerGroup),
+                                                    StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
+                                                    System.currentTimeMillis(), 10)
+                                                    .thenCompose(createStatus -> {
+                                                        if (createStatus.equals(Controller.CreateStreamStatus.Status.STREAM_EXISTS)
+                                                                || createStatus.equals(Controller.CreateStreamStatus.Status.SUCCESS)) {
+                                                            return Futures.toVoid(streamMetadataStore.updateReaderGroupVersionedState(scope, readerGroup,
+                                                                    ReaderGroupState.ACTIVE, state, context, executor));
+                                                        }
+                                                        return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
+                                                                readerGroup, createStatus.toString())));
+                                                    })).exceptionally(ex -> {
+                                                log.debug(ex.getMessage());
+                                                Throwable cause = Exceptions.unwrap(ex);
+                                                throw new CompletionException(cause);
+                                            });
+                                }
+                                return CompletableFuture.completedFuture(null);
+                            });
         }), e -> Exceptions.unwrap(e) instanceof RetryableException, Integer.MAX_VALUE, executor);
+    }
+
+    private ReaderGroupConfig getConfigFromEvent(CreateReaderGroupEvent request) {
+        Map<Stream, StreamCut> startStreamCut = request.getStartingStreamCuts().entrySet()
+                                                .stream().collect(Collectors.toMap(e -> Stream.of(e.getKey()),
+                                                e -> new StreamCutImpl(Stream.of(e.getKey()),
+                                                        ModelHelper.getSegmentOffsetMap(Stream.of(e.getKey()).getScope(),
+                                                                Stream.of(e.getKey()).getStreamName(),
+                                                                e.getValue().getStreamCut()))));
+        Map<Stream, StreamCut> endStreamCut = request.getEndingStreamCuts().entrySet()
+                .stream().collect(Collectors.toMap(e -> Stream.of(e.getKey()),
+                        e -> new StreamCutImpl(Stream.of(e.getKey()),
+                                ModelHelper.getSegmentOffsetMap(Stream.of(e.getKey()).getScope(),
+                                                                Stream.of(e.getKey()).getStreamName(),
+                                                                e.getValue().getStreamCut()))));
+        return ReaderGroupConfig.builder().readerGroupId(request.getReaderGroupId())
+                .groupRefreshTimeMillis(request.getGroupRefreshTimeMillis())
+                .automaticCheckpointIntervalMillis(request.getAutomaticCheckpointIntervalMillis())
+                .maxOutstandingCheckpointRequest(request.getMaxOutstandingCheckpointRequest())
+                .generation(request.getGeneration())
+                .retentionType(ReaderGroupConfig.StreamDataRetention.values()[request.getRetentionTypeOrdinal()])
+                .startingStreamCuts(startStreamCut)
+                .endingStreamCuts(endStreamCut).build();
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -60,14 +60,14 @@ public class CreateReaderGroupTask implements ReaderGroupTask<CreateReaderGroupE
         String scope = request.getScope();
         String readerGroup = request.getRgName();
         UUID readerGroupId = request.getReaderGroupId();
+        ReaderGroupConfig config = getConfigFromEvent(request);
         final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
         return RetryHelper.withRetriesAsync(() -> streamMetadataStore.getReaderGroupId(scope, readerGroup, context, executor)
                 .thenCompose(rgId -> {
                     if (!rgId.equals(readerGroupId)) {
-                        log.warn("Skipping processing of CreateReaderGroupEvent with invalid UUID.");
+                        log.warn("Skipping processing of CreateReaderGroupEvent with stale UUID.");
                         return CompletableFuture.completedFuture(null);
                     }
-                    ReaderGroupConfig config = getConfigFromEvent(request);
                     return streamMetadataTasks.isRGCreationComplete(scope, readerGroup)
                             .thenCompose(complete -> {
                                 if (!complete) {

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -22,8 +22,6 @@ import io.pravega.common.Exceptions;
 
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.retryable.RetryableException;
-import io.pravega.controller.store.Version;
-import io.pravega.controller.store.VersionedMetadata;
 import io.pravega.controller.store.stream.RGOperationContext;
 import io.pravega.controller.store.stream.ReaderGroupState;
 import io.pravega.controller.store.stream.StoreException;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -119,7 +119,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
 
     @Override
     public CompletableFuture<Void> processCreateReaderGroup(CreateReaderGroupEvent createRGEvent) {
-        log.info("Processing create request for ReaderGroup {}/{}",
+        log.info("Processing create request {} for ReaderGroup {}/{}", createRGEvent.getRequestId(),
                 createRGEvent.getScope(), createRGEvent.getRgName());
         return createRGTask.execute(createRGEvent);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -133,7 +133,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
 
     @Override
     public CompletableFuture<Void> processUpdateReaderGroup(UpdateReaderGroupEvent updateRGEvent) {
-        log.info("Processing delete request {} for ReaderGroup {}/{}",
+        log.info("Processing update request {} for ReaderGroup {}/{}",
                 updateRGEvent.getRequestId(), updateRGEvent.getScope(), updateRGEvent.getRgName());
         return updateRGTask.execute(updateRGEvent);
     }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -119,8 +119,8 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
 
     @Override
     public CompletableFuture<Void> processCreateReaderGroup(CreateReaderGroupEvent createRGEvent) {
-        log.info("Processing create request {} for ReaderGroup {}/{}",
-                createRGEvent.getRequestId(), createRGEvent.getScopeName(), createRGEvent.getRgName());
+        log.info("Processing create request for ReaderGroup {}/{}",
+                createRGEvent.getScope(), createRGEvent.getRgName());
         return createRGTask.execute(createRGEvent);
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -74,7 +74,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.StreamCut;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfiguration;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupInfo;
@@ -156,7 +156,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void updateReaderGroup(ReaderGroupConfiguration request, StreamObserver<UpdateReaderGroupStatus> responseObserver) {
+    public void updateReaderGroup(ReaderGroupConfiguration request, StreamObserver<UpdateReaderGroupResponse> responseObserver) {
         String scope = request.getScope();
         String rgName = request.getReaderGroupName();
         RequestTag requestTag = requestTracker.initializeAndTrackRequestTag(requestIdGenerator.get(), "updateReaderGroup",

--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
@@ -216,12 +216,9 @@ public class PravegaTablesScope implements Scope {
                 .thenCompose(tableName -> Futures.toVoid(storeHelper.removeEntry(tableName, kvt)));
     }
 
-    public CompletableFuture<Boolean> addReaderGroupToScope(String readerGroupName, UUID readerGroupId) {
+    public CompletableFuture<Void> addReaderGroupToScope(String readerGroupName, UUID readerGroupId) {
         return getReaderGroupsInScopeTableName()
-                .thenCompose(tableName ->
-                        Futures.exceptionallyExpecting(storeHelper.addNewEntry(tableName, readerGroupName, getIdInBytes(readerGroupId))
-                                        .thenApply(v -> Boolean.TRUE),
-                        e -> Exceptions.unwrap(e) instanceof StoreException.DataExistsException, Boolean.FALSE));
+                .thenCompose(tableName -> Futures.toVoid(storeHelper.addNewEntry(tableName, readerGroupName, getIdInBytes(readerGroupId))));
     }
 
     public CompletableFuture<Void> removeReaderGroupFromScope(String readerGroup) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractReaderGroup.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractReaderGroup.java
@@ -97,7 +97,6 @@ public abstract class AbstractReaderGroup implements ReaderGroup {
 
     @Override
     public CompletableFuture<ReaderGroupState> getState(boolean ignoreCached) {
-        log.debug("getState");
         return getStateData(ignoreCached)
                 .thenApply(x -> x.getObject().getState());
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -33,7 +33,11 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStreamMetadataStore.java
@@ -33,10 +33,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -210,6 +207,17 @@ public class InMemoryStreamMetadataStore extends AbstractStreamMetadataStore {
         }
     }
 
+    @Override
+    public CompletableFuture<Void> addReaderGroupToScope(String scopeName, String rgName, UUID readerGroupId) {
+        if (scopes.containsKey(scopeName)) {
+            scopes.get(scopeName).addReaderGroupToScope(rgName, readerGroupId);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return Futures.
+                    failedFuture(StoreException.create(StoreException.Type.DATA_NOT_FOUND, scopeName));
+        }
+    }
+
     // region ReaderGroup
     @Override
     public CompletableFuture<Void> createReaderGroup(final String scope,
@@ -219,17 +227,9 @@ public class InMemoryStreamMetadataStore extends AbstractStreamMetadataStore {
                                                      final RGOperationContext context,
                                                      final Executor executor) {
         if (scopes.containsKey(scope)) {
-            log.debug("Inside InMemoryStreamMetadataStore::createReaderGroup() is context null {}", context == null);
-            return scopes.get(scope).addReaderGroupToScope(name, configuration.getReaderGroupId())
-            .thenCompose(addedToScope -> {
-                if (addedToScope) {
-                    InMemoryReaderGroup readerGroup = (InMemoryReaderGroup) getReaderGroup(scope, name, context);
-                    log.debug("Inside InMemoryStreamMetadataStore created RG object 1");
-                    readerGroups.put(scopedStreamName(scope, name), readerGroup);
-                    return readerGroup.create(configuration, createTimestamp);
-                }
-                return CompletableFuture.completedFuture(null);
-            });
+           InMemoryReaderGroup readerGroup = (InMemoryReaderGroup) getReaderGroup(scope, name, context);
+           readerGroups.put(scopedStreamName(scope, name), readerGroup);
+           return readerGroup.create(configuration, createTimestamp);
         } else {
             return Futures.
                     failedFuture(StoreException.create(StoreException.Type.DATA_NOT_FOUND, scope));

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
@@ -307,6 +307,7 @@ public class PravegaTablesStreamMetadataStore extends AbstractStreamMetadataStor
                 () -> ((PravegaTablesScope) getScope(scope)).getReaderGroupsInScopeTableName(), executor);
     }
 
+    @Override
     public CompletableFuture<Void> addReaderGroupToScope(final String scope,
                                                          final String name, final UUID readerGroupId) {
         return Futures.completeOn(((PravegaTablesScope) getScope(scope)).addReaderGroupToScope(name, readerGroupId), executor);

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
@@ -12,7 +12,6 @@ package io.pravega.controller.store.stream;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.Unpooled;
-import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -37,10 +36,7 @@ import org.apache.curator.framework.CuratorFramework;
 import static io.pravega.shared.NameUtils.getQualifiedTableName;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -307,20 +303,9 @@ public class PravegaTablesStreamMetadataStore extends AbstractStreamMetadataStor
                 () -> ((PravegaTablesScope) getScope(scope)).getReaderGroupsInScopeTableName(), executor);
     }
 
-    @Override
-    public CompletableFuture<Void> createReaderGroup(final String scope,
-                                                                 final String name,
-                                                                 final ReaderGroupConfig configuration,
-                                                                 final long createTimestamp,
-                                                                 final RGOperationContext context,
-                                                                 final Executor executor) {
-        return Futures.completeOn(((PravegaTablesScope) getScope(scope)).addReaderGroupToScope(name, configuration.getReaderGroupId())
-                .thenCompose(rgAdded -> {
-                   if (rgAdded) {
-                       return super.createReaderGroup(scope, name, configuration, createTimestamp, context, executor);
-                   }
-                   return CompletableFuture.completedFuture(null);
-                }), executor);
+    public CompletableFuture<Void> addReaderGroupToScope(final String scope,
+                                                         final String name, final UUID readerGroupId) {
+        return Futures.completeOn(((PravegaTablesScope) getScope(scope)).addReaderGroupToScope(name, readerGroupId), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
@@ -36,7 +36,11 @@ import org.apache.curator.framework.CuratorFramework;
 import static io.pravega.shared.NameUtils.getQualifiedTableName;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -334,6 +334,18 @@ public interface StreamMetadataStore extends AutoCloseable {
     CompletableFuture<ReaderGroupState> getReaderGroupState(final String scope, final String name, final boolean ignoreCached, final RGOperationContext context, final Executor executor);
 
     /**
+     * Add ReaderGroup to scope.
+     *
+     * @param scopeName       scope name
+     * @param rgName          Reader Group name
+     * @param readerGroupId   Reader Group Identifier
+     * @return boolean indicating whether the stream was created
+     */
+    CompletableFuture<Void> addReaderGroupToScope(final String scopeName,
+                                              final String rgName,
+                                              final UUID readerGroupId);
+
+    /**
      * Creates a new stream with the given name and configuration.
      *
      * @param scopeName       scope name

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKStreamMetadataStore.java
@@ -171,6 +171,11 @@ public class ZKStreamMetadataStore extends AbstractStreamMetadataStore implement
     }
 
     @Override
+    public CompletableFuture<Void> addReaderGroupToScope(String scopeName, String rgName, UUID readerGroupId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public CompletableFuture<Boolean> checkReaderGroupExists(String scope, String rgName) {
         throw new UnsupportedOperationException();
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/ReaderGroupConfigRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/ReaderGroupConfigRecord.java
@@ -10,12 +10,13 @@
 package io.pravega.controller.store.stream.records;
 
 import com.google.common.collect.ImmutableMap;
+import io.pravega.client.control.impl.ModelHelper;
 import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.StreamCut;
 import io.pravega.common.ObjectBuilder;
 import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
+import io.pravega.shared.controller.event.RGStreamCutRecord;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -52,10 +53,10 @@ public class ReaderGroupConfigRecord {
     public static ReaderGroupConfigRecord update(ReaderGroupConfig rgConfig, long generation, boolean isUpdating) {
         Map<String, RGStreamCutRecord> startStreamCuts = rgConfig.getStartingStreamCuts().entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                        e -> new RGStreamCutRecord(getStreamCutMap(e.getValue()))));
+                        e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
         Map<String, RGStreamCutRecord> endStreamCuts = rgConfig.getEndingStreamCuts().entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                        e -> new RGStreamCutRecord(getStreamCutMap(e.getValue()))));
+                        e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
         return ReaderGroupConfigRecord.builder()
                 .generation(generation)
                 .groupRefreshTimeMillis(rgConfig.getGroupRefreshTimeMillis())
@@ -77,12 +78,6 @@ public class ReaderGroupConfigRecord {
                 .startingStreamCuts(rgConfigRecord.getStartingStreamCuts())
                 .endingStreamCuts(rgConfigRecord.getEndingStreamCuts())
                 .updating(false).build();
-    }
-
-    private static ImmutableMap<Long, Long> getStreamCutMap(StreamCut streamCut) {
-        ImmutableMap.Builder<Long, Long> mapBuilder = ImmutableMap.builder();
-        return mapBuilder.putAll(streamCut.asImpl().getPositions().entrySet()
-                .stream().collect(Collectors.toMap(x -> x.getKey().getSegmentId(), Map.Entry::getValue))).build();
     }
 
     @SneakyThrows(IOException.class)

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/StreamCutRecord.java
@@ -78,7 +78,7 @@ public class StreamCutRecord {
         return SERIALIZER.serialize(this).getCopy();
     }
 
-    private static class RetentionStreamCutRecordSerializer
+    public static class RetentionStreamCutRecordSerializer
             extends VersionedSerializer.WithBuilder<StreamCutRecord, StreamCutRecordBuilder> {
         @Override
         protected byte getWriteVersion() {

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -102,6 +102,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.CompletableFuture;
@@ -332,32 +333,111 @@ public class StreamMetadataTasks extends TaskBase {
                   return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND);
          }
          //2. check state of the ReaderGroup, if found
-         return Futures.exceptionallyExpecting(streamMetadataStore.getReaderGroupState(scope, rgName, true, null, executor),
-                e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, ReaderGroupState.UNKNOWN)
-                .thenCompose(state -> {
-                if (state.equals(ReaderGroupState.UNKNOWN) || state.equals(ReaderGroupState.CREATING)) {
-                    Map<String, RGStreamCutRecord> startStreamCuts = config.getStartingStreamCuts().entrySet().stream()
-                            .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                                    e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
-                    Map<String, RGStreamCutRecord> endStreamCuts = config.getEndingStreamCuts().entrySet().stream()
-                            .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                                    e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
-                   CreateReaderGroupEvent event = new CreateReaderGroupEvent(scope, rgName, config.getGroupRefreshTimeMillis(),
-                           config.getAutomaticCheckpointIntervalMillis(), config.getMaxOutstandingCheckpointRequest(),
-                           config.getRetentionType().ordinal(), config.getGeneration(), config.getReaderGroupId(),
-                           startStreamCuts, endStreamCuts);
+         return isRGCreationComplete(scope, rgName)
+                 .thenCompose(complete -> {
+                     if (!complete) {
+                         Map<String, RGStreamCutRecord> startStreamCuts = config.getStartingStreamCuts().entrySet().stream()
+                                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
+                                         e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
+                         Map<String, RGStreamCutRecord> endStreamCuts = config.getEndingStreamCuts().entrySet().stream()
+                                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
+                                         e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
+                         CreateReaderGroupEvent event = new CreateReaderGroupEvent(scope, rgName, config.getGroupRefreshTimeMillis(),
+                                 config.getAutomaticCheckpointIntervalMillis(), config.getMaxOutstandingCheckpointRequest(),
+                                 config.getRetentionType().ordinal(), config.getGeneration(), config.getReaderGroupId(),
+                                 startStreamCuts, endStreamCuts);
 
-                   //3. Create Reader Group Metadata and submit event
-                   return eventHelper.addIndexAndSubmitTask(event,
-                              () -> streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
-                              .thenCompose(x -> eventHelper.checkDone(() -> isRGCreated(scope, rgName, executor))
-                              .thenApply(done -> CreateReaderGroupStatus.Status.SUCCESS)));
-                }
-                // idempotent call
-                return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);
-             });
+                         //3. Create Reader Group Metadata and submit event
+                         return eventHelper.addIndexAndSubmitTask(event,
+                                 () -> streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
+                                         .thenCompose(x -> eventHelper.checkDone(() -> isRGCreated(scope, rgName, executor))
+                                                 .thenApply(done -> CreateReaderGroupStatus.Status.SUCCESS)));
+                     }
+                     return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);
+                 });
          });
         }, e -> Exceptions.unwrap(e) instanceof RetryableException, READER_GROUP_OPERATION_MAX_RETRIES, executor);
+    }
+
+    public CompletableFuture<Boolean> isRGCreationComplete(String scope, String rgName) {
+        return Futures.exceptionallyExpecting(streamMetadataStore.getReaderGroupState(scope, rgName, true, null, executor),
+        e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, ReaderGroupState.UNKNOWN)
+        .thenCompose(state -> {
+        if (state.equals(ReaderGroupState.UNKNOWN) || state.equals(ReaderGroupState.CREATING)) {
+            return CompletableFuture.completedFuture(Boolean.FALSE);
+        }
+        return CompletableFuture.completedFuture(Boolean.TRUE);
+        });
+    }
+
+    public CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupTasks(String scope, String readerGroup,
+                                                                             ReaderGroupConfig config, long createTimestamp) {
+        final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
+        return streamMetadataStore.createReaderGroup(scope, readerGroup, config, createTimestamp, context, executor)
+                .thenCompose(v -> {
+                    if (!ReaderGroupConfig.StreamDataRetention.NONE.equals(config.getRetentionType())) {
+                        String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);
+                        // update Stream metadata tables, only if RG is a Subscriber
+                        Iterator<String> streamIter = config.getStartingStreamCuts().keySet().stream()
+                                .map(s -> s.getScopedName()).iterator();
+                        return Futures.loop(() -> streamIter.hasNext(), () -> {
+                            Stream stream = Stream.of(streamIter.next());
+                            return streamMetadataStore.addSubscriber(stream.getScope(),
+                                    stream.getStreamName(), scopedRGName, config.getGeneration(), null, executor);
+                        }, executor);
+                    }
+                    return CompletableFuture.completedFuture(null);
+                }).thenCompose(x -> createRGStream(scope, NameUtils.getStreamForReaderGroup(readerGroup),
+                StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
+                System.currentTimeMillis(), 10)
+                .thenCompose(createStatus -> {
+                    if (createStatus.equals(Controller.CreateStreamStatus.Status.STREAM_EXISTS)
+                            || createStatus.equals(Controller.CreateStreamStatus.Status.SUCCESS)) {
+                        return streamMetadataStore.getVersionedReaderGroupState(scope, readerGroup, true, null, executor)
+                                .thenCompose(newstate -> streamMetadataStore.updateReaderGroupVersionedState(scope, readerGroup,
+                                        ReaderGroupState.ACTIVE, newstate, context, executor))
+                                .thenApply(v1 -> CreateReaderGroupStatus.Status.SUCCESS);
+                    }
+                    return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
+                            readerGroup, createStatus.toString())));
+                })).exceptionally(ex -> {
+            log.debug(ex.getMessage());
+            Throwable cause = Exceptions.unwrap(ex);
+            throw new CompletionException(cause);
+        });
+    }
+
+    public CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName, ReaderGroupConfig config, final long createTimestamp) {
+        Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
+        Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
+        Preconditions.checkNotNull(config, "ReaderGroup config is null");
+        Preconditions.checkArgument(createTimestamp >= 0);
+        try {
+            NameUtils.validateReaderGroupName(rgName);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.warn("Create ReaderGroup failed due to invalid name {}", rgName);
+            return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.INVALID_RG_NAME);
+        }
+
+        return RetryHelper.withRetriesAsync(() -> {
+            // 1. check if scope with this name exists...
+            return streamMetadataStore.checkScopeExists(scope)
+                    .thenCompose(exists -> {
+                        if (!exists) {
+                            return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND);
+                        }
+                        //2. check state of the ReaderGroup
+                        return isRGCreationComplete(scope, rgName)
+                                .thenCompose(complete -> {
+                                    if (!complete) {
+                                        return streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
+                                                .thenCompose(x -> createReaderGroupTasks(scope, rgName, config, System.currentTimeMillis()))
+                                                .thenApply(y -> CreateReaderGroupStatus.Status.SUCCESS);
+                                    }
+                                    return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);
+                                });
+                    });
+        }, e -> Exceptions.unwrap(e) instanceof RetryableException, 10, executor);
     }
 
     private CompletableFuture<Boolean> isRGCreated(String scope, String rgName, Executor executor) {
@@ -368,6 +448,7 @@ public class StreamMetadataTasks extends TaskBase {
                     return ReaderGroupState.ACTIVE.equals(state);
                 });
     }
+
 
     /**
      * Update Reader Group Configuration.

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -342,7 +342,7 @@ public class StreamMetadataTasks extends TaskBase {
                          Map<String, RGStreamCutRecord> endStreamCuts = config.getEndingStreamCuts().entrySet().stream()
                                  .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
                                          e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
-                         CreateReaderGroupEvent event = new CreateReaderGroupEvent(scope, rgName, config.getGroupRefreshTimeMillis(),
+                         CreateReaderGroupEvent event = new CreateReaderGroupEvent(requestId, scope, rgName, config.getGroupRefreshTimeMillis(),
                                  config.getAutomaticCheckpointIntervalMillis(), config.getMaxOutstandingCheckpointRequest(),
                                  config.getRetentionType().ordinal(), config.getGeneration(), config.getReaderGroupId(),
                                  startStreamCuts, endStreamCuts);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -329,7 +329,6 @@ public class StreamMetadataTasks extends TaskBase {
       // 1. check if scope with this name exists...
       return streamMetadataStore.checkScopeExists(scope)
          .thenCompose(exists -> {
-         log.debug("Checking if RG scope exists...");
          if (!exists) {
                   return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND);
          }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -421,7 +421,7 @@ public class StreamMetadataTasks extends TaskBase {
                                           .thenCompose(y -> streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, context, executor)
                                           .thenApply(configRecord -> {
                                               UpdateReaderGroupResponse response = UpdateReaderGroupResponse.newBuilder()
-                                                      .setStatus(UpdateReaderGroupResponse.Status.INVALID_CONFIG)
+                                                      .setStatus(UpdateReaderGroupResponse.Status.SUCCESS)
                                                       .setGeneration(configRecord.getObject().getGeneration()).build();
                                               return response;
                                           })));

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -329,6 +329,7 @@ public class StreamMetadataTasks extends TaskBase {
       // 1. check if scope with this name exists...
       return streamMetadataStore.checkScopeExists(scope)
          .thenCompose(exists -> {
+         log.debug("Checking if RG scope exists...");
          if (!exists) {
                   return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND);
          }
@@ -349,9 +350,9 @@ public class StreamMetadataTasks extends TaskBase {
 
                          //3. Create Reader Group Metadata and submit event
                          return eventHelper.addIndexAndSubmitTask(event,
-                                 () -> streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
+                                 () -> streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId()))
                                          .thenCompose(x -> eventHelper.checkDone(() -> isRGCreated(scope, rgName, executor))
-                                                 .thenApply(done -> CreateReaderGroupStatus.Status.SUCCESS)));
+                                                 .thenApply(done -> CreateReaderGroupStatus.Status.SUCCESS));
                      }
                      return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);
                  });
@@ -401,7 +402,7 @@ public class StreamMetadataTasks extends TaskBase {
                     return Futures.failedFuture(new IllegalStateException(String.format("Error creating StateSynchronizer Stream for Reader Group %s: %s",
                             readerGroup, createStatus.toString())));
                 })).exceptionally(ex -> {
-            log.debug(ex.getMessage());
+            log.debug("RG Stream Create failed with error: " + ex.getMessage());
             Throwable cause = Exceptions.unwrap(ex);
             throw new CompletionException(cause);
         });

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -261,59 +261,6 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
     }
 
     @Test
-    public void testCreateReaderGroup() throws ExecutionException, InterruptedException {
-        final Segment seg0 = new Segment("scope", "stream1", 0L);
-        final Segment seg1 = new Segment("scope", "stream1", 1L);
-        ImmutableMap<Segment, Long> startStreamCut = ImmutableMap.of(seg0, 10L, seg1, 10L);
-        Map<Stream, StreamCut> startSC = ImmutableMap.of(Stream.of("scope", "stream1"),
-                new StreamCutImpl(Stream.of("scope", "stream1"), startStreamCut));
-        ImmutableMap<Segment, Long> endStreamCut = ImmutableMap.of(seg0, 200L, seg1, 300L);
-        Map<Stream, StreamCut> endSC = ImmutableMap.of(Stream.of("scope", "stream1"),
-                new StreamCutImpl(Stream.of("scope", "stream1"), endStreamCut));
-        ReaderGroupConfig config = ReaderGroupConfig.builder()
-                .automaticCheckpointIntervalMillis(30000L)
-                .groupRefreshTimeMillis(20000L)
-                .maxOutstandingCheckpointRequest(2)
-                .retentionType(ReaderGroupConfig.StreamDataRetention.AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT)
-                .generation(0L)
-                .readerGroupId(UUID.randomUUID())
-                .startingStreamCuts(startSC)
-                .endingStreamCuts(endSC).build();
-        when(this.mockControllerService.createReaderGroup(anyString(), any(), any(), anyLong())).thenReturn(
-                CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.CreateReaderGroupStatus.Status.SUCCESS).build()));
-        Assert.assertTrue(this.testController.createReaderGroup("scope", "subscriber", config).join());
-
-        when(this.mockControllerService.createReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
-                CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.CreateReaderGroupStatus.Status.FAILURE).build()));
-        assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
-                ex -> ex instanceof ControllerFailureException);
-
-        when(this.mockControllerService.createReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
-                CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.CreateReaderGroupStatus.Status.INVALID_RG_NAME).build()));
-        assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
-                ex -> ex instanceof IllegalArgumentException);
-
-        when(this.mockControllerService.createReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
-                CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND).build()));
-        assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
-                ex -> ex instanceof IllegalArgumentException);
-
-        when(this.mockControllerService.createReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
-                CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatusValue(-1).build()));
-        assertThrows("Expected ControllerFailureException",
-                () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
-                ex -> ex instanceof ControllerFailureException);
-    }
-
-    @Test
     public void testGetReaderGroupConfig() throws ExecutionException, InterruptedException {
         final Segment seg0 = new Segment("scope", "stream1", 0L);
         final Segment seg1 = new Segment("scope", "stream1", 1L);
@@ -423,33 +370,33 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
-                CompletableFuture.completedFuture(Controller.UpdateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.UpdateReaderGroupStatus.Status.SUCCESS).build()));
+                CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
+                        .setStatus(Controller.UpdateReaderGroupResponse.Status.SUCCESS).setGeneration(1L).build()));
         Assert.assertTrue(this.testController.updateReaderGroup("scope", "subscriber", config).join());
 
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
-                CompletableFuture.completedFuture(Controller.UpdateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.UpdateReaderGroupStatus.Status.FAILURE).build()));
+                CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
+                        .setStatus(Controller.UpdateReaderGroupResponse.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.updateReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof ControllerFailureException);
 
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
-                CompletableFuture.completedFuture(Controller.UpdateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.UpdateReaderGroupStatus.Status.INVALID_CONFIG).build()));
+                CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
+                        .setStatus(Controller.UpdateReaderGroupResponse.Status.INVALID_CONFIG).build()));
         assertThrows("Expected IllegalArgumentException",
                 () -> this.testController.updateReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
-                CompletableFuture.completedFuture(Controller.UpdateReaderGroupStatus.newBuilder()
-                        .setStatus(Controller.UpdateReaderGroupStatus.Status.RG_NOT_FOUND).build()));
+                CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
+                        .setStatus(Controller.UpdateReaderGroupResponse.Status.RG_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
                 () -> this.testController.updateReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof IllegalArgumentException);
 
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
-                CompletableFuture.completedFuture(Controller.UpdateReaderGroupStatus.newBuilder()
+                CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.updateReaderGroup("scope", "subscriber", config).join(),

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
@@ -54,7 +54,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfiguration;
 import io.pravega.shared.NameUtils;
@@ -609,20 +609,21 @@ public abstract class ControllerServiceImplTest {
                 .readerGroupId(rgId)
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        ResultObserver<UpdateReaderGroupStatus> result = new ResultObserver<>();
+        ResultObserver<UpdateReaderGroupResponse> result = new ResultObserver<>();
         this.controllerService.updateReaderGroup(ModelHelper.decode(SCOPE1, rgName, newConfig), result);
-        UpdateReaderGroupStatus rgStatus = result.get();
-        assertEquals("Update Reader Group", UpdateReaderGroupStatus.Status.SUCCESS, rgStatus.getStatus());
+        UpdateReaderGroupResponse rgStatus = result.get();
+        assertEquals("Update Reader Group Status", UpdateReaderGroupResponse.Status.SUCCESS, rgStatus.getStatus());
+        assertEquals("Updated Generation", 1L, rgStatus.getGeneration());
 
-        ResultObserver<UpdateReaderGroupStatus> result1 = new ResultObserver<>();
+        ResultObserver<UpdateReaderGroupResponse> result1 = new ResultObserver<>();
         this.controllerService.updateReaderGroup(ModelHelper.decode(SCOPE1, rgName, newConfig), result1);
         rgStatus = result1.get();
-        assertEquals("Update Reader Group", UpdateReaderGroupStatus.Status.INVALID_CONFIG, rgStatus.getStatus());
+        assertEquals("Update Reader Group", UpdateReaderGroupResponse.Status.INVALID_CONFIG, rgStatus.getStatus());
 
-        ResultObserver<UpdateReaderGroupStatus> result2 = new ResultObserver<>();
+        ResultObserver<UpdateReaderGroupResponse> result2 = new ResultObserver<>();
         this.controllerService.updateReaderGroup(ModelHelper.decode(SCOPE1, "somerg", newConfig), result2);
         rgStatus = result2.get();
-        assertEquals("Update Reader Group", UpdateReaderGroupStatus.Status.RG_NOT_FOUND, rgStatus.getStatus());
+        assertEquals("Update Reader Group", UpdateReaderGroupResponse.Status.RG_NOT_FOUND, rgStatus.getStatus());
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
@@ -585,7 +585,7 @@ public abstract class ControllerServiceImplTest {
         assertEquals("Create Reader Group Scope not found", CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND, createRGStatus.getStatus());
     }
 
-    @Test
+    @Test(timeout = 50000)
     public void updateReaderGroupTests() {
         createScopeAndStream(SCOPE1, STREAM1, ScalingPolicy.fixed(2));
         String rgName = "rg1";

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
@@ -585,7 +585,7 @@ public abstract class ControllerServiceImplTest {
         assertEquals("Create Reader Group Scope not found", CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND, createRGStatus.getStatus());
     }
 
-    @Test(timeout = 50000)
+    @Test
     public void updateReaderGroupTests() {
         createScopeAndStream(SCOPE1, STREAM1, ScalingPolicy.fixed(2));
         String rgName = "rg1";

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1967,6 +1967,7 @@ public abstract class StreamMetadataStoreTest {
                 .readerGroupId(rgId)
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
+        store.addReaderGroupToScope(scope, rgName, rgConfig.getReaderGroupId());
         store.createReaderGroup(scope, rgName, rgConfig, System.currentTimeMillis(), null, executor).join();
         UUID readerGroupId = store.getReaderGroupId(scope, rgName, null, executor).get();
         assertEquals(rgId, readerGroupId);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -372,8 +372,7 @@ public abstract class StreamMetadataTasksTest {
         assertTrue(Futures.await(processEvent(requestEventWriter)));
         assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
 
-        createFuture = streamMetadataTasks.createReaderGroup(SCOPE, "rg3", rgConfig, System.currentTimeMillis());
-        assertTrue(Futures.await(processEvent(requestEventWriter)));
+        createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "rg3", rgConfig, System.currentTimeMillis());
         assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
 
         listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, null).get();

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -405,10 +405,12 @@ public abstract class StreamMetadataTasksTest {
                 .readerGroupId(rgConfig.getReaderGroupId())
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        CompletableFuture<Controller.UpdateReaderGroupStatus.Status> updateFuture =
+        CompletableFuture<Controller.UpdateReaderGroupResponse> updateResponse =
         streamMetadataTasks.updateReaderGroup(SCOPE, "rg2", newConfig, null);
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.UpdateReaderGroupStatus.Status.SUCCESS, updateFuture.join());
+        Controller.UpdateReaderGroupResponse updateResponseResult = updateResponse.join();
+        assertEquals(Controller.UpdateReaderGroupResponse.Status.SUCCESS, updateResponseResult.getStatus());
+        assertEquals(1L, updateResponseResult.getGeneration());
 
         response = streamMetadataTasks.getReaderGroupConfig(SCOPE, "rg2", null).get();
         assertEquals(ReaderGroupConfigResponse.Status.SUCCESS, response.getStatus());

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
@@ -9,16 +9,20 @@
  */
 package io.pravega.shared.controller.event;
 
+import com.google.common.collect.ImmutableMap;
 import io.pravega.common.ObjectBuilder;
 import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
+
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @Builder
@@ -26,13 +30,20 @@ import java.util.concurrent.CompletableFuture;
 @AllArgsConstructor
 public class CreateReaderGroupEvent implements ControllerEvent {
     private static final long serialVersionUID = 1L;
-    private final String scopeName;
+    private final String scope;
     private final String rgName;
-    private final long requestId;
+    private final long groupRefreshTimeMillis;
+    private final long automaticCheckpointIntervalMillis;
+    private final int maxOutstandingCheckpointRequest;
+    private final int retentionTypeOrdinal;
+    private final long generation;
+    private final UUID readerGroupId;
+    private final Map<String, RGStreamCutRecord> startingStreamCuts;
+    private final Map<String, RGStreamCutRecord> endingStreamCuts;
 
     @Override
     public String getKey() {
-        return String.format("%s/%s", scopeName, rgName);
+        return String.format("%s/%s", scope, rgName);
     }
 
     @Override
@@ -61,16 +72,36 @@ public class CreateReaderGroupEvent implements ControllerEvent {
         }
 
         private void write00(CreateReaderGroupEvent e, RevisionDataOutput target) throws IOException {
-            target.writeUTF(e.scopeName);
+            target.writeUTF(e.scope);
             target.writeUTF(e.rgName);
-            target.writeLong(e.requestId);
+            target.writeLong(e.groupRefreshTimeMillis);
+            target.writeLong(e.automaticCheckpointIntervalMillis);
+            target.writeInt(e.maxOutstandingCheckpointRequest);
+            target.writeCompactInt(e.retentionTypeOrdinal);
+            target.writeLong(e.generation);
+            target.writeUUID(e.readerGroupId);
+            target.writeMap(e.startingStreamCuts, DataOutput::writeUTF, RGStreamCutRecord.SERIALIZER::serialize);
+            target.writeMap(e.endingStreamCuts, DataOutput::writeUTF, RGStreamCutRecord.SERIALIZER::serialize);
         }
 
         private void read00(RevisionDataInput source, CreateReaderGroupEventBuilder eb) throws IOException {
-            eb.scopeName(source.readUTF());
+            eb.scope(source.readUTF());
             eb.rgName(source.readUTF());
-            eb.requestId(source.readLong());
+            eb.groupRefreshTimeMillis(source.readLong());
+            eb.automaticCheckpointIntervalMillis(source.readLong());
+            eb.maxOutstandingCheckpointRequest(source.readInt());
+            eb.retentionTypeOrdinal(source.readCompactInt());
+            eb.generation(source.readLong());
+            eb.readerGroupId(source.readUUID());
+            ImmutableMap.Builder<String, RGStreamCutRecord> startStreamCutBuilder = ImmutableMap.builder();
+            source.readMap(DataInput::readUTF, RGStreamCutRecord.SERIALIZER::deserialize, startStreamCutBuilder);
+            eb.startingStreamCuts(startStreamCutBuilder.build());
+            ImmutableMap.Builder<String, RGStreamCutRecord> endStreamCutBuilder = ImmutableMap.builder();
+            source.readMap(DataInput::readUTF, RGStreamCutRecord.SERIALIZER::deserialize, endStreamCutBuilder);
+            eb.endingStreamCuts(endStreamCutBuilder.build());
         }
     }
     //endregion
+
+
 }

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 @AllArgsConstructor
 public class CreateReaderGroupEvent implements ControllerEvent {
     private static final long serialVersionUID = 1L;
+    private final long requestId;
     private final String scope;
     private final String rgName;
     private final long groupRefreshTimeMillis;
@@ -72,6 +73,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
         }
 
         private void write00(CreateReaderGroupEvent e, RevisionDataOutput target) throws IOException {
+            target.writeLong(e.requestId);
             target.writeUTF(e.scope);
             target.writeUTF(e.rgName);
             target.writeLong(e.groupRefreshTimeMillis);
@@ -85,6 +87,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
         }
 
         private void read00(RevisionDataInput source, CreateReaderGroupEventBuilder eb) throws IOException {
+            eb.requestId(source.readLong());
             eb.scope(source.readUTF());
             eb.rgName(source.readUTF());
             eb.groupRefreshTimeMillis(source.readLong());

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/RGStreamCutRecord.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/RGStreamCutRecord.java
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.pravega.controller.store.stream.records;
+package io.pravega.shared.controller.event;
 
 import com.google.common.collect.ImmutableMap;
 import io.pravega.common.ObjectBuilder;
@@ -61,7 +61,7 @@ public class RGStreamCutRecord {
         return SERIALIZER.serialize(this).getCopy();
     }
 
-    static class RGStreamCutRecordSerializer
+    public static class RGStreamCutRecordSerializer
             extends VersionedSerializer.WithBuilder<RGStreamCutRecord, RGStreamCutRecordBuilder> {
         @Override
         protected byte getWriteVersion() {

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -58,7 +58,7 @@ service ControllerService {
     rpc createReaderGroup(ReaderGroupConfiguration) returns (CreateReaderGroupStatus);
     rpc getReaderGroupConfig(ReaderGroupInfo) returns (ReaderGroupConfigResponse);
     rpc deleteReaderGroup(ReaderGroupInfo) returns (DeleteReaderGroupStatus);
-    rpc updateReaderGroup(ReaderGroupConfiguration) returns (UpdateReaderGroupStatus);
+    rpc updateReaderGroup(ReaderGroupConfiguration) returns (UpdateReaderGroupResponse);
 }
 
 message ServerRequest {
@@ -122,7 +122,7 @@ message DeleteReaderGroupStatus {
     Status status = 1;
 }
 
-message UpdateReaderGroupStatus {
+message UpdateReaderGroupResponse {
     enum Status {
         SUCCESS = 0;
         FAILURE = 1;
@@ -130,6 +130,7 @@ message UpdateReaderGroupStatus {
         INVALID_CONFIG = 3;
     }
     Status status = 1;
+    int64 generation = 2;
 }
 
 message CreateKeyValueTableStatus {

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -90,7 +90,7 @@ public class ControllerEventSerializerTests {
     public void testCreateReaderGroupEvent() {
         Map<String, RGStreamCutRecord> testMap = new HashMap<String, RGStreamCutRecord>(1);
         testClass(() ->
-                new CreateReaderGroupEvent(SCOPE, READER_GROUP,
+                new CreateReaderGroupEvent(111L, SCOPE, READER_GROUP,
                         123L, 456L, 10,
                         1, 0L, UUID.randomUUID(), testMap, testMap));
     }

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import java.util.function.Supplier;
 import com.google.common.collect.ImmutableSet;
@@ -86,7 +87,11 @@ public class ControllerEventSerializerTests {
 
     @Test
     public void testCreateReaderGroupEvent() {
-        testClass(() -> new CreateReaderGroupEvent(SCOPE, READER_GROUP, 123L));
+        Map<String, RGStreamCutRecord> testMap = Map.of();
+        testClass(() ->
+                new CreateReaderGroupEvent(SCOPE, READER_GROUP,
+                        123L, 456L, 10,
+                        1, 0L, UUID.randomUUID(), testMap, testMap));
     }
 
     @Test

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.HashMap;
 
 import java.util.function.Supplier;
 import com.google.common.collect.ImmutableSet;
@@ -87,7 +88,7 @@ public class ControllerEventSerializerTests {
 
     @Test
     public void testCreateReaderGroupEvent() {
-        Map<String, RGStreamCutRecord> testMap = Map.of();
+        Map<String, RGStreamCutRecord> testMap = new HashMap<String, RGStreamCutRecord>(1);
         testClass(() ->
                 new CreateReaderGroupEvent(SCOPE, READER_GROUP,
                         123L, 456L, 10,

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -135,8 +135,7 @@ public class ControllerServiceTest {
         assertFalse(controller.createStream(scope, stream, streamConfiguration).join());
     }
     
-    
-    @Test(timeout = 80000)
+    @Test(timeout = 30000)
     public void testControllerService() throws Exception {
         final String scope1 = "scope1";
         final String scope2 = "scope2";


### PR DESCRIPTION
**Change log description**  
This PR has the following changes:
1. createReaderGroup() method in streamMetadataTasks has been changed to do only 1 metadata operation instead of multiple. The the rest of the create operations have been moved to the CreateReaderGroupTask.
2. createReaderGroup() for internal reader groups created by ControllerEventProcessor should not use events as it leads to cyclic dependency, so changed LocalController::createReaderGroup() to invoke a createReaderGroupInternal() method on StreamMetadataTasks for creating a reader group without using events.
3. Changed updateReaderGroup API to return updated generation of the ReaderGroup in addition to update operation status.

**Purpose of the change**  
Fixes #5447

**What the code does**  


**How to verify it**  
All Unit and Integration tests should pass.
