### PR TITLE
Issue 4998: Fix flaky testCheckpointAndRestore test.

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -140,7 +140,7 @@ public class CheckpointTest {
         assertFalse(read.isCheckpoint());
 
         clock.addAndGet(CLOCK_ADVANCE_INTERVAL);
-        readerGroup.resetReaderGroup(ReaderGroupConfig.builder().startFromCheckpoint(cpResult).build());
+        readerGroup.resetReaderGroup(ReaderGroupConfig.builder().startFromCheckpoint(cpResult).disableAutomaticCheckpoints().build());
         try {
             reader.readNextEvent(60000);
             fail();

--- a/test/integration/src/test/java/io/pravega/test/integration/ReadWithReadPermissionsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadWithReadPermissionsTest.java
@@ -202,7 +202,7 @@ public class ReadWithReadPermissionsTest {
         EventStreamReader<String> reader = readerClientFactory.createReader(
                 "readerId", "testRg",
                 new JavaSerializer<String>(), ReaderConfig.builder().initialAllocationDelay(0).build());
-        String readMessage = reader.readNextEvent(500).getEvent();
+        String readMessage = reader.readNextEvent(5000).getEvent();
 
         assertEquals("test message", readMessage);
     }


### PR DESCRIPTION
**Change log description**  
Fix flaky testCheckpointAndRestore test.

**Purpose of the change**  
Fix flaky testCheckpointAndRestore test. reported as part of #4998 

**What the code does**  
The test was flaky since an automatic checkpointing was enabled and the test never expected it.

**How to verify it**  
The test should continue to work.