### PR TITLE
Issue 5465 Re-creating Reader Group with same name fails

### DIFF
--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -10,6 +10,7 @@
 package io.pravega.client.control.impl;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.pravega.client.segment.impl.Segment;
@@ -488,12 +489,15 @@ public final class ModelHelper {
         return builder.build();
     }
 
-    public static Map<Long, Long> getStreamCutMap(io.pravega.client.stream.StreamCut streamCut) {
+    public static ImmutableMap<Long, Long> getStreamCutMap(io.pravega.client.stream.StreamCut streamCut) {
         if (streamCut.equals(io.pravega.client.stream.StreamCut.UNBOUNDED)) {
-            return Collections.emptyMap();
+            return ImmutableMap.of();
         }
-        return streamCut.asImpl().getPositions().entrySet()
-                .stream().collect(Collectors.toMap(x -> x.getKey().getSegmentId(), Map.Entry::getValue));
+        ImmutableMap.Builder<Long, Long> mapBuilder = ImmutableMap.builder();
+        streamCut.asImpl().getPositions().entrySet()
+                .stream().forEach(entry -> mapBuilder.put(entry.getKey().getSegmentId(), entry.getValue()));
+        return mapBuilder.build();
+
     }
 
     public static final Controller.ScopeInfo createScopeInfo(final String scope) {

--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
-import java.util.Collections;
 import java.util.stream.Collectors;
 
 /**

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -10,7 +10,6 @@
 package io.pravega.controller.server.eventProcessor;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import io.pravega.client.admin.KeyValueTableInfo;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.PingFailedException;
@@ -287,7 +286,8 @@ public class LocalController implements Controller {
     @Override
     public CompletableFuture<Boolean> updateSubscriberStreamCut(final String scope, final String streamName, final String subscriber,
                                                                 final UUID readerGroupId, final long generation, final StreamCut streamCut) {
-        return this.controller.updateSubscriberStreamCut(scope, streamName, subscriber, readerGroupId.toString(), generation, getStreamCutAsImmutableMap(streamCut)).thenApply(x -> {
+        return this.controller.updateSubscriberStreamCut(scope, streamName, subscriber, readerGroupId.toString(), generation,
+                ModelHelper.getStreamCutMap(streamCut)).thenApply(x -> {
             switch (x.getStatus()) {
                 case FAILURE:
                     throw new ControllerFailureException("Failed to update streamcut: " + scope + "/" + streamName);
@@ -579,11 +579,6 @@ public class LocalController implements Controller {
         }
         return streamCut.asImpl().getPositions().entrySet()
                 .stream().collect(Collectors.toMap(x -> x.getKey().getSegmentId(), Map.Entry::getValue));
-    }
-
-    private ImmutableMap<Long, Long> getStreamCutAsImmutableMap(StreamCut streamCut) {
-        return ImmutableMap.copyOf(streamCut.asImpl().getPositions().entrySet()
-                .stream().collect(Collectors.toMap(x -> x.getKey().getSegmentId(), Map.Entry::getValue)));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -72,7 +72,7 @@ public class CreateReaderGroupTask implements ReaderGroupTask<CreateReaderGroupE
                             .thenCompose(complete -> {
                                 if (!complete) {
                                     return Futures.toVoid(streamMetadataTasks.createReaderGroupTasks(scope, readerGroup,
-                                            config, System.currentTimeMillis()));
+                                            config, request.getCreateTimeStamp()));
                                 }
                                 return CompletableFuture.completedFuture(null);
                             });

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesReaderGroup.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesReaderGroup.java
@@ -158,7 +158,7 @@ class PravegaTablesReaderGroup extends AbstractReaderGroup {
     public CompletableFuture<Void> delete() {
         return getId().thenCompose(id -> storeHelper.deleteTable(getMetadataTableName(id), false)
         .thenCompose(v -> {
-            this.idRef = new AtomicReference<>(null);
+            this.idRef.set(null);
             return CompletableFuture.completedFuture(null);
         }));
     }
@@ -176,5 +176,6 @@ class PravegaTablesReaderGroup extends AbstractReaderGroup {
 
     @Override
     public void refresh() {
+        idRef.set(null);
     }
 }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesReaderGroup.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesReaderGroup.java
@@ -48,7 +48,7 @@ class PravegaTablesReaderGroup extends AbstractReaderGroup {
 
     private final PravegaTablesStoreHelper storeHelper;
     private final Supplier<CompletableFuture<String>> readerGroupsInScopeTableNameSupplier;
-    private final AtomicReference<String> idRef;
+    private AtomicReference<String> idRef;
     private final ScheduledExecutorService executor;
 
     @VisibleForTesting
@@ -68,8 +68,8 @@ class PravegaTablesReaderGroup extends AbstractReaderGroup {
             return CompletableFuture.completedFuture(id);
         } else {
             return readerGroupsInScopeTableNameSupplier.get()
-                    .thenCompose(streamsInScopeTable ->
-                            storeHelper.getEntry(streamsInScopeTable, getName(),
+                    .thenCompose(readerGroupsInScopeTable ->
+                            storeHelper.getEntry(readerGroupsInScopeTable, getName(),
                                     x -> BitConverter.readUUID(x, 0)))
                     .thenComposeAsync(data -> {
                         idRef.compareAndSet(null, data.getObject().toString());
@@ -156,7 +156,11 @@ class PravegaTablesReaderGroup extends AbstractReaderGroup {
 
     @Override
     public CompletableFuture<Void> delete() {
-        return getId().thenCompose(id -> Futures.toVoid(storeHelper.deleteTable(getMetadataTableName(id), false)));
+        return getId().thenCompose(id -> storeHelper.deleteTable(getMetadataTableName(id), false)
+        .thenCompose(v -> {
+            this.idRef = new AtomicReference<>(null);
+            return CompletableFuture.completedFuture(null);
+        }));
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -362,7 +362,7 @@ class PravegaTablesStream extends PersistentStreamBase {
                                     return storeHelper.updateEntry(table, SUBSCRIBER_SET_KEY, subSet.toBytes(), subscriberSetRecord.getVersion())
                                             .thenAccept(x -> storeHelper.invalidateCache(table, SUBSCRIBER_SET_KEY));
                                 }
-                                return null;
+                                return CompletableFuture.completedFuture(null);
                             })));
         });
     }

--- a/controller/src/main/java/io/pravega/controller/store/stream/records/ReaderGroupConfigRecord.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/records/ReaderGroupConfigRecord.java
@@ -53,10 +53,10 @@ public class ReaderGroupConfigRecord {
     public static ReaderGroupConfigRecord update(ReaderGroupConfig rgConfig, long generation, boolean isUpdating) {
         Map<String, RGStreamCutRecord> startStreamCuts = rgConfig.getStartingStreamCuts().entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                        e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
+                        e -> new RGStreamCutRecord(ModelHelper.getStreamCutMap(e.getValue()))));
         Map<String, RGStreamCutRecord> endStreamCuts = rgConfig.getEndingStreamCuts().entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().getScopedName(),
-                        e -> new RGStreamCutRecord(ImmutableMap.copyOf(ModelHelper.getStreamCutMap(e.getValue())))));
+                        e -> new RGStreamCutRecord(ModelHelper.getStreamCutMap(e.getValue()))));
         return ReaderGroupConfigRecord.builder()
                 .generation(generation)
                 .groupRefreshTimeMillis(rgConfig.getGroupRefreshTimeMillis())

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -407,7 +407,8 @@ public class StreamMetadataTasks extends TaskBase {
         });
     }
 
-    public CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName, ReaderGroupConfig config, final long createTimestamp) {
+    public CompletableFuture<CreateReaderGroupStatus.Status> createReaderGroupInternal(String scope, String rgName,
+                                                                                       ReaderGroupConfig config, final long createTimestamp) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(config, "ReaderGroup config is null");
@@ -418,7 +419,6 @@ public class StreamMetadataTasks extends TaskBase {
             log.warn("Create ReaderGroup failed due to invalid name {}", rgName);
             return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.INVALID_RG_NAME);
         }
-
         return RetryHelper.withRetriesAsync(() -> {
             // 1. check if scope with this name exists...
             return streamMetadataStore.checkScopeExists(scope)
@@ -431,7 +431,7 @@ public class StreamMetadataTasks extends TaskBase {
                                 .thenCompose(complete -> {
                                     if (!complete) {
                                         return streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
-                                                .thenCompose(x -> createReaderGroupTasks(scope, rgName, config, System.currentTimeMillis()))
+                                                .thenCompose(x -> createReaderGroupTasks(scope, rgName, config, createTimestamp))
                                                 .thenApply(y -> CreateReaderGroupStatus.Status.SUCCESS);
                                     }
                                     return CompletableFuture.completedFuture(CreateReaderGroupStatus.Status.SUCCESS);

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -345,7 +345,7 @@ public class StreamMetadataTasks extends TaskBase {
                          CreateReaderGroupEvent event = new CreateReaderGroupEvent(requestId, scope, rgName, config.getGroupRefreshTimeMillis(),
                                  config.getAutomaticCheckpointIntervalMillis(), config.getMaxOutstandingCheckpointRequest(),
                                  config.getRetentionType().ordinal(), config.getGeneration(), config.getReaderGroupId(),
-                                 startStreamCuts, endStreamCuts);
+                                 startStreamCuts, endStreamCuts, createTimestamp);
 
                          //3. Create Reader Group Metadata and submit event
                          return eventHelper.addIndexAndSubmitTask(event,

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
@@ -41,6 +41,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
     private final UUID readerGroupId;
     private final Map<String, RGStreamCutRecord> startingStreamCuts;
     private final Map<String, RGStreamCutRecord> endingStreamCuts;
+    private final long createTimeStamp;
 
     @Override
     public String getKey() {
@@ -76,6 +77,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
             target.writeLong(e.requestId);
             target.writeUTF(e.scope);
             target.writeUTF(e.rgName);
+            target.writeLong(e.createTimeStamp);
             target.writeLong(e.groupRefreshTimeMillis);
             target.writeLong(e.automaticCheckpointIntervalMillis);
             target.writeInt(e.maxOutstandingCheckpointRequest);
@@ -90,6 +92,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
             eb.requestId(source.readLong());
             eb.scope(source.readUTF());
             eb.rgName(source.readUTF());
+            eb.createTimeStamp(source.readLong());
             eb.groupRefreshTimeMillis(source.readLong());
             eb.automaticCheckpointIntervalMillis(source.readLong());
             eb.maxOutstandingCheckpointRequest(source.readInt());
@@ -102,6 +105,7 @@ public class CreateReaderGroupEvent implements ControllerEvent {
             ImmutableMap.Builder<String, RGStreamCutRecord> endStreamCutBuilder = ImmutableMap.builder();
             source.readMap(DataInput::readUTF, RGStreamCutRecord.SERIALIZER::deserialize, endStreamCutBuilder);
             eb.endingStreamCuts(endStreamCutBuilder.build());
+
         }
     }
     //endregion

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/CreateReaderGroupEvent.java
@@ -105,6 +105,4 @@ public class CreateReaderGroupEvent implements ControllerEvent {
         }
     }
     //endregion
-
-
 }

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -92,7 +92,7 @@ public class ControllerEventSerializerTests {
         testClass(() ->
                 new CreateReaderGroupEvent(111L, SCOPE, READER_GROUP,
                         123L, 456L, 10,
-                        1, 0L, UUID.randomUUID(), testMap, testMap));
+                        1, 0L, UUID.randomUUID(), testMap, testMap, System.currentTimeMillis()));
     }
 
     @Test

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -163,7 +163,7 @@ public class ControllerServiceTest {
         //Different name in same scope
         createAStream(scope1, streamName2, controller, config3);
         createAStream(scope1, streamName3, controller, config3);
-
+        /*
         final String kvtName1 = "kvtable1";
         final String kvtName2 = "kvtable2";
         final String kvtZero = "kvtableZero";
@@ -220,7 +220,7 @@ public class ControllerServiceTest {
         getSegmentsBeforeCreation(controller, scope1, streamName1);
 
         getSegmentsAfterCreation(controller, scope1, streamName1);
-
+        */
         readerGroupsTest(controller, scope1, streamName1, streamName2, streamName3);
 
         updateSubscriberStreamCutTest(controller, scope2, streamName1);
@@ -398,7 +398,6 @@ public class ControllerServiceTest {
                 .generation(0L)
                 .readerGroupId(UUID.randomUUID())
                 .startingStreamCuts(startSC)
-                .readerGroupId(UUID.randomUUID())
                 .endingStreamCuts(endSC).build();
         assertTrue(controller.createReaderGroup(scope, "rg2", rgConfig1).get());
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -135,7 +135,7 @@ public class ControllerServiceTest {
         assertFalse(controller.createStream(scope, stream, streamConfiguration).join());
     }
     
-    @Test(timeout = 30000)
+    @Test(timeout = 80000)
     public void testControllerService() throws Exception {
         final String scope1 = "scope1";
         final String scope2 = "scope2";
@@ -179,7 +179,7 @@ public class ControllerServiceTest {
         createAKeyValueTable(scope2, kvtName2, controller, kvtConfig1);
         //KVTable with 0 partitions should fail
         createAKeyValueTableZeroPC(scope2, kvtZero, controller, kvtConfigZeroPC);
-        
+
         final String scopeSeal = "scopeSeal";
         final String streamNameSeal = "streamSeal";
         sealAStream(controllerWrapper, controller, scalingPolicy, scopeSeal, streamNameSeal);
@@ -341,8 +341,7 @@ public class ControllerServiceTest {
         CompletableFuture<Boolean> createRG = controller.createReaderGroup(scope, "rg1", rgConfig);
         assertTrue(createRG.get());
 
-        createRG = controller.createReaderGroup(scope, "rg2", rgConfig);
-        assertTrue(createRG.get());
+        assertTrue(controller.createReaderGroup(scope, "rg2", rgConfig).get());
 
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup(scope, "bad_rg_name", rgConfig).get());
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup("badscope", "rg3", rgConfig).get());
@@ -391,8 +390,17 @@ public class ControllerServiceTest {
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream3)));
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream2)));
 
-        createRG = controller.createReaderGroup(scope, "rg2", rgConfig);
-        assertTrue(createRG.get());
+        final ReaderGroupConfig rgConfig1 = ReaderGroupConfig.builder()
+                .automaticCheckpointIntervalMillis(30000L)
+                .groupRefreshTimeMillis(20000L)
+                .maxOutstandingCheckpointRequest(2)
+                .retentionType(ReaderGroupConfig.StreamDataRetention.AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT)
+                .generation(0L)
+                .readerGroupId(UUID.randomUUID())
+                .startingStreamCuts(startSC)
+                .readerGroupId(UUID.randomUUID())
+                .endingStreamCuts(endSC).build();
+        assertTrue(controller.createReaderGroup(scope, "rg2", rgConfig1).get());
     }
 
     private static void updateSubscriberStreamCutTest(Controller controller, final String scope, final String stream) throws InterruptedException, ExecutionException {

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -391,6 +391,9 @@ public class ControllerServiceTest {
         assertEquals(newRGConfig.getEndingStreamCuts().keySet().size(), updatedConfig.getEndingStreamCuts().keySet().size());
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream3)));
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream2)));
+
+        createRG = controller.createReaderGroup(scope, "rg2", rgConfig);
+        assertTrue(createRG.get());
     }
 
     private static void updateSubscriberStreamCutTest(Controller controller, final String scope, final String stream) throws InterruptedException, ExecutionException {

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -163,7 +163,7 @@ public class ControllerServiceTest {
         //Different name in same scope
         createAStream(scope1, streamName2, controller, config3);
         createAStream(scope1, streamName3, controller, config3);
-        /*
+
         final String kvtName1 = "kvtable1";
         final String kvtName2 = "kvtable2";
         final String kvtZero = "kvtableZero";
@@ -220,7 +220,7 @@ public class ControllerServiceTest {
         getSegmentsBeforeCreation(controller, scope1, streamName1);
 
         getSegmentsAfterCreation(controller, scope1, streamName1);
-        */
+
         readerGroupsTest(controller, scope1, streamName1, streamName2, streamName3);
 
         updateSubscriberStreamCutTest(controller, scope2, streamName1);


### PR DESCRIPTION
**Change log description**  

This PR fixes the following:
1. If a Reader Group is created on Controller and then deleted and then recreated again with same scope/name the new create fails with an exception.
2. Fix minor review comments in PR 5462

**Purpose of the change**  
Fixes #5465

**What the code does**  
The issue occurs because deleteReaderGroup API did not clean the Reader group cache after the ReaderGroup was deleted hence the old ReaderGroupId from cache was used for creating table for the new ReaderGroup cause conflict on Segment Store.

**How to verify it**  
All Unit and Integration tests should pass.
Added a new test to verify ReaderGroup recreation works post delete as long as it is recreated with a new UUID.
