### PR TITLE
Issue 5470: Final check for KVTable deletion may cache incorrect value

### DIFF
--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -194,7 +194,7 @@ public class TableMetadataTasks implements AutoCloseable {
     }
 
     private CompletableFuture<Boolean> isDeleted(String scope, String kvtName, KVTOperationContext context) {
-        return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, false, context, executor),
+        return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, true, context, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, KVTableState.UNKNOWN)
                 .thenCompose(state -> {
                     if (state.equals(KVTableState.UNKNOWN)) {

--- a/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasks.java
@@ -193,7 +193,8 @@ public class TableMetadataTasks implements AutoCloseable {
                                                 false, delegationToken, requestId), executor));
     }
 
-    private CompletableFuture<Boolean> isDeleted(String scope, String kvtName, KVTOperationContext context) {
+    @VisibleForTesting
+    CompletableFuture<Boolean> isDeleted(String scope, String kvtName, KVTOperationContext context) {
         return Futures.exceptionallyExpecting(kvtMetadataStore.getState(scope, kvtName, true, context, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, KVTableState.UNKNOWN)
                 .thenCompose(state -> {

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -149,7 +149,7 @@ public abstract class TableMetadataTasksTest {
         assertTrue(Futures.await(processEvent((TableMetadataTasksTest.WriterMock) requestEventWriter)));
 
         assertEquals(Controller.DeleteKVTableStatus.Status.SUCCESS, future.get());
-
+        assertTrue(kvtMetadataTasks.isDeleted(SCOPE, kvtable1, null).join());
         assertFalse(kvtStore.checkTableExists(SCOPE, kvtable1).join());
     }
 


### PR DESCRIPTION
**Change log description**  
Ensure that final deletion check of KVTable deletion fetches information from store.

**Purpose of the change**  
Fixes #5470.

**What the code does**  
In some scenarios, we observed consistent failures on tests that create and subsequently delete a KVTable. The reason is that the final check for the deletion operation was relying exclusively on the already cached data in the Controller. In some situations, such data may be stale and the Controller is stuck retrying getting the stale state from the KVTable. We need to always enforce the final deletion check in `TableMetadataTasks:isDeleted` to fetch the state from the store to prevent this situation.

**How to verify it**  
Previously failing tests are now consistently passing (`io.pravega.cli.user.kvs.SecureKVTCommandsTest:testDeleteKVT` and `io.pravega.cli.user.kvs.KVTCommandsTest:testDeleteKVT`). Added test to check the correct result of `isDeleted()` method. All other tests should work as before.
