### PR TITLE
Issue: 5467 updateReaderGroup hangs when changing configuration from subscriber to non-subscriber

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
@@ -57,6 +57,7 @@ public class UpdateReaderGroupTask implements ReaderGroupTask<UpdateReaderGroupE
         long requestId = request.getRequestId();
         long generation = request.getGeneration();
         UUID readerGroupId = request.getReaderGroupId();
+        boolean isTransition = request.isTransitionToFromSubscriber();
         ImmutableSet<String> streamsToBeUnsubscribed = request.getRemoveStreams();
         final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
 
@@ -68,30 +69,39 @@ public class UpdateReaderGroupTask implements ReaderGroupTask<UpdateReaderGroupE
                 }
                 return streamMetadataStore.getReaderGroupConfigRecord(scope, readerGroup, context, executor)
                        .thenCompose(rgConfigRecord -> {
-                       if (rgConfigRecord.getObject().getGeneration() != generation) {
-                           log.warn("Skipping processing of Reader Group update request {} as generation did not match.", requestId);
-                           return CompletableFuture.completedFuture(null);
-                       }
-                       if (rgConfigRecord.getObject().isUpdating() &&
-                          (!ReaderGroupConfig.StreamDataRetention.values()[rgConfigRecord.getObject().getRetentionTypeOrdinal()]
-                            .equals(ReaderGroupConfig.StreamDataRetention.NONE))) {
-                            // update Stream metadata tables, only if RG is a Subscriber
-                            Iterator<String> streamIter = rgConfigRecord.getObject().getStartingStreamCuts().keySet().iterator();
-                            String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);
-                            Iterator<String> removeStreamsIter = streamsToBeUnsubscribed.stream().iterator();
-                            return Futures.loop(() -> streamIter.hasNext(), () -> {
-                                          Stream stream = Stream.of(streamIter.next());
-                                          return streamMetadataStore.addSubscriber(stream.getScope(),
-                                                       stream.getStreamName(), scopedRGName, rgConfigRecord.getObject().getGeneration(),
-                                                  null, executor);
-                                      }, executor)
-                                    .thenCompose(v -> Futures.loop(() -> removeStreamsIter.hasNext(), () -> {
-                                        Stream stream = Stream.of(removeStreamsIter.next());
-                                        return streamMetadataStore.deleteSubscriber(stream.getScope(),
-                                                stream.getStreamName(), scopedRGName, rgConfigRecord.getObject().getGeneration(), null, executor);
-                                    }, executor))
-                                    .thenCompose(v -> streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor));
-                            }
+                           if (rgConfigRecord.getObject().getGeneration() != generation) {
+                               log.warn("Skipping processing of Reader Group update request {} as generation did not match.", requestId);
+                               return CompletableFuture.completedFuture(null);
+                           }
+                           if (rgConfigRecord.getObject().isUpdating()) {
+                               if (isTransition) {
+                                   // update Stream metadata tables, only if RG is a Subscriber
+                                   Iterator<String> streamIter = rgConfigRecord.getObject().getStartingStreamCuts().keySet().iterator();
+                                   String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);
+                                   Iterator<String> removeStreamsIter = streamsToBeUnsubscribed.stream().iterator();
+                                   return Futures.loop(() -> removeStreamsIter.hasNext(), () -> {
+                                       Stream stream = Stream.of(removeStreamsIter.next());
+                                       return streamMetadataStore.deleteSubscriber(stream.getScope(),
+                                               stream.getStreamName(), scopedRGName, rgConfigRecord.getObject().getGeneration(), null, executor);
+                                   }, executor)
+                                   .thenCompose(v -> {
+                                       // updated config suggests this is a subscriber RG so addSubscriber
+                                       if (!ReaderGroupConfig.StreamDataRetention.NONE
+                                           .equals(ReaderGroupConfig.StreamDataRetention.values()
+                                                  [rgConfigRecord.getObject().getRetentionTypeOrdinal()])) {
+                                           return Futures.loop(() -> streamIter.hasNext(), () -> {
+                                                  Stream stream = Stream.of(streamIter.next());
+                                                  return streamMetadataStore.addSubscriber(stream.getScope(),
+                                                         stream.getStreamName(), scopedRGName, rgConfigRecord.getObject().getGeneration(),
+                                                         null, executor);
+                                           }, executor);
+                                       }
+                                       return CompletableFuture.completedFuture(null);
+                                   })
+                                   .thenCompose(v -> streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor));
+                               }
+                               return streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor);
+                           }
                            return CompletableFuture.completedFuture(null);
                        });
         }), e -> Exceptions.unwrap(e) instanceof RetryableException, Integer.MAX_VALUE, executor);

--- a/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/InMemoryStream.java
@@ -116,9 +116,6 @@ public class InMemoryStream extends PersistentStreamBase {
     @GuardedBy("subscribersLock")
     private final List<VersionedMetadata<StreamSubscriber>> streamSubscribers = new ArrayList<>();
 
-    @GuardedBy("subscribersLock")
-    private final Set<String> subscribersSet = new HashSet<String>();
-
     InMemoryStream(String scope, String name) {
         this(scope, name, Duration.ofHours(Config.COMPLETED_TRANSACTION_TTL_IN_HOURS).toMillis());
     }
@@ -843,11 +840,18 @@ public class InMemoryStream extends PersistentStreamBase {
     @Override
     public CompletableFuture<Void> addSubscriber(String subscriber, long generation) {
         synchronized (subscribersLock) {
-            if (!subscribersSet.contains(subscriber)) {
-                subscribersSet.add(subscriber);
-            }
-            streamSubscribers.add(new VersionedMetadata<>(new StreamSubscriber(subscriber, generation, ImmutableMap.of(),
+            Optional<VersionedMetadata<StreamSubscriber>> foundSubscriber = streamSubscribers.stream()
+                    .filter(sub -> sub.getObject().getSubscriber().equals(subscriber)).findAny();
+            if (foundSubscriber.isEmpty()) {
+                streamSubscribers.add(new VersionedMetadata<>(new StreamSubscriber(subscriber, generation, ImmutableMap.of(),
                         System.currentTimeMillis()), new Version.IntVersion(0)));
+            } else {
+                if (foundSubscriber.get().getObject().getGeneration() < generation) {
+                    setSubscriberData(new VersionedMetadata<>(new StreamSubscriber(subscriber, generation,
+                            foundSubscriber.get().getObject().getTruncationStreamCut(),
+                            System.currentTimeMillis()), foundSubscriber.get().getVersion()));
+                }
+            }
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -855,9 +859,9 @@ public class InMemoryStream extends PersistentStreamBase {
     @Override
     public CompletableFuture<Void> deleteSubscriber(final String subscriber, final long generation) {
         synchronized (subscribersLock) {
-            Optional<StreamSubscriber> foundSubscriber = streamSubscribers.stream()
-                    .map(s -> s.getObject()).filter(sub -> sub.getSubscriber().equals(subscriber)).findAny();
-            if (foundSubscriber.isPresent() && foundSubscriber.get().getGeneration() >= generation) {
+            Optional<VersionedMetadata<StreamSubscriber>> foundSubscriber = streamSubscribers.stream()
+                    .filter(sub -> sub.getObject().getSubscriber().equals(subscriber)).findAny();
+            if (foundSubscriber.isPresent() && generation >= foundSubscriber.get().getObject().getGeneration()) {
                 streamSubscribers.remove(foundSubscriber.get());
             }
         }

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStream.java
@@ -360,9 +360,7 @@ class PravegaTablesStream extends PersistentStreamBase {
                     .thenCompose(v -> getSubscriberSetRecord(true)
                             .thenCompose(subscriberSetRecord -> {
                                 if (subscriberSetRecord.getObject().getSubscribers().contains(subscriber)) {
-                                    log.info("Inside deleteSubscriber. deleting subscriber from subscriber setRecord.");
                                     Subscribers subSet = Subscribers.remove(subscriberSetRecord.getObject(), subscriber);
-                                    log.info("Inside deleteSubscriber. New set size {}", subSet.getSubscribers().size());
                                     return storeHelper.updateEntry(table, SUBSCRIBER_SET_KEY, subSet.toBytes(), subscriberSetRecord.getVersion())
                                             .thenAccept(x -> storeHelper.invalidateCache(table, SUBSCRIBER_SET_KEY));
                                 }

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -575,7 +575,7 @@ public class StreamMetadataTasks extends TaskBase {
     private CompletableFuture<Boolean> isRGUpdated(String scope, String rgName, Executor executor) {
             return streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, null, executor)
                     .thenCompose(rgConfigRecord -> {
-                        log.debug("ReaderGroup Config is {}", rgConfigRecord.getObject().isUpdating());
+                        log.debug("Is ReaderGroup Config update complete ? {}", rgConfigRecord.getObject().isUpdating());
                         return CompletableFuture.completedFuture(!rgConfigRecord.getObject().isUpdating());
                    });
     }

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/UpdateReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/UpdateReaderGroupEvent.java
@@ -34,6 +34,7 @@ public class UpdateReaderGroupEvent implements ControllerEvent {
     private final long requestId;
     private UUID readerGroupId;
     private long generation;
+    private boolean isTransitionToFromSubscriber;
     private ImmutableSet<String> removeStreams;
 
     @Override
@@ -72,6 +73,7 @@ public class UpdateReaderGroupEvent implements ControllerEvent {
             target.writeLong(e.requestId);
             target.writeUUID(e.readerGroupId);
             target.writeLong(e.generation);
+            target.writeBoolean(e.isTransitionToFromSubscriber);
             target.writeCollection(e.removeStreams, DataOutput::writeUTF);
         }
 
@@ -81,6 +83,7 @@ public class UpdateReaderGroupEvent implements ControllerEvent {
             eb.requestId(source.readLong());
             eb.readerGroupId(source.readUUID());
             eb.generation(source.readLong());
+            eb.isTransitionToFromSubscriber(source.readBoolean());
             ImmutableSet.Builder<String> builder = ImmutableSet.builder();
             source.readCollection(DataInput::readUTF, builder);
             eb.removeStreams(builder.build());

--- a/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
+++ b/shared/controller-api/src/test/java/io/pravega/shared/controller/event/ControllerEventSerializerTests.java
@@ -102,7 +102,7 @@ public class ControllerEventSerializerTests {
 
     @Test
     public void testUpdateReaderGroupEvent() {
-        testClass(() -> new UpdateReaderGroupEvent(SCOPE, READER_GROUP, 123L, UUID.randomUUID(), 0L, ImmutableSet.of()));
+        testClass(() -> new UpdateReaderGroupEvent(SCOPE, READER_GROUP, 123L, UUID.randomUUID(), 0L, false, ImmutableSet.of()));
     }
 
     private <T extends ControllerEvent> void testClass(Supplier<T> generateInstance) {

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -414,7 +414,7 @@ public class ControllerServiceTest {
         assertEquals(0, subscribers.size());
 
         // Update ReaderGroup from Non-Subscriber to Subscriber
-        ReaderGroupConfig subscriberConfig = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+        ReaderGroupConfig subscriberConfig = ReaderGroupConfig.builder()
                 .stream(scopedStreamName).retentionType(ReaderGroupConfig.StreamDataRetention.AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT)
                 .generation(updatedConfig.getGeneration()).readerGroupId(updatedConfig.getReaderGroupId())
                 .build();

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -390,6 +390,17 @@ public class ControllerServiceTest {
         assertEquals(newRGConfig.getEndingStreamCuts().keySet().size(), updatedConfig.getEndingStreamCuts().keySet().size());
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream3)));
         assertTrue(updatedConfig.getStartingStreamCuts().keySet().contains(Stream.of(scope, stream2)));
+
+        // Create a ReaderGroup
+        String scopedStreamName = NameUtils.getScopedStreamName(scope, stream1);
+        ReaderGroupConfig rgconfig = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream(scopedStreamName).retentionType(ReaderGroupConfig.StreamDataRetention.MANUAL_RELEASE_AT_USER_STREAMCUT)
+                .build();
+        ReaderGroupConfig rgconfig2 = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream(scopedStreamName).readerGroupId(rgconfig.getReaderGroupId()).generation(rgconfig.getGeneration())
+                .build();
+        controller.createReaderGroup(scope, "group", rgconfig).join();
+        controller.updateReaderGroup(scope, "group", rgconfig2).join();
     }
 
     private static void updateSubscriberStreamCutTest(Controller controller, final String scope, final String stream) throws InterruptedException, ExecutionException {


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
updateReaderGroup() API requires handling stream subscriptions when a ReaderGroup Configuration has stream changes and/or when the Config changes Retention.Type from a non-subscriber or a subscriber or vice-versa. 
These multiple combinations were not handled correctly leading to the 'updating' flag in ReaderGroupConfigRecord staying "true" and never changing to "false" when a ReaderGroup config is changed from subscriber to non-subscriber.

**Purpose of the change**  
Fixes #5467

**What the code does**  
1. Added code to check for transition from subscriber or non-subscriber or vice versa and handle stream subscriptions accordingly in StreamMetadataTasks.updateReaderGroup and updateReaderGroupTask.execute()
2. If the old and new config both have RetentionType=NONE (non-subscriber RG) then there is no need to make any changes with subscriber metadata in StreamMetadata. 
3. In all other cases we need to add the ReaderGroup as a subscriber to Streams in the new config and deleteSubscriber() from Streams present in old config but not in new config.

**How to verify it**  
Added additional unit and integration tests to verify all possible config update scenarios from Subscriber to NonSubscriber and vice versa, changes in Stream without change to RetentionType, etc..
All unit and integration tests should pass.
