### PR TITLE
Issue 5476: ReaderGroupConfiguration to ReaderGroupConfig conversion support for UNBOUNDED StreamCuts

### DIFF
--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -271,26 +271,19 @@ public final class ModelHelper {
                 .generation(rgConfig.getGeneration())
                 .readerGroupId(UUID.fromString(rgConfig.getReaderGroupId()))
                 .startingStreamCuts(rgConfig.getStartingStreamCutsList().stream()
-                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
-                                streamCut.getStreamInfo().getStream()),
-                                streamCut -> {
-                                    if (streamCut.getCutMap().isEmpty()) {
-                                        return io.pravega.client.stream.StreamCut.UNBOUNDED;
-                                    }
-                                    return new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
-                                            streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()));
-                                })))
+                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream()),
+                                streamCut -> generateStreamCut(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()))))
                 .endingStreamCuts(rgConfig.getEndingStreamCutsList().stream()
-                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
-                                streamCut.getStreamInfo().getStream()),
-                                streamCut -> {
-                                    if (streamCut.getCutMap().isEmpty()) {
-                                        return io.pravega.client.stream.StreamCut.UNBOUNDED;
-                                    }
-                                    return new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
-                                            streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()));
-                                })))
+                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream()),
+                                streamCut -> generateStreamCut(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()))))
                 .build();
+    }
+
+    public static io.pravega.client.stream.StreamCut generateStreamCut(String scope, String stream, Map<Long, Long> cutMap) {
+        if (cutMap.isEmpty()) {
+            return io.pravega.client.stream.StreamCut.UNBOUNDED;
+        }
+        return new StreamCutImpl(Stream.of(scope, stream), getSegmentOffsetMap(scope, stream, cutMap));
     }
 
     public static Map<Segment, Long> getSegmentOffsetMap(String scopeName, String streamName, Map<Long, Long> streamCutMap) {

--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -271,15 +271,25 @@ public final class ModelHelper {
                 .generation(rgConfig.getGeneration())
                 .readerGroupId(UUID.fromString(rgConfig.getReaderGroupId()))
                 .startingStreamCuts(rgConfig.getStartingStreamCutsList().stream()
-                                    .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
-                                    streamCut.getStreamInfo().getStream()),
-                                    streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
-                                    streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
+                        .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
+                                streamCut.getStreamInfo().getStream()),
+                                streamCut -> {
+                                    if (streamCut.getCutMap().isEmpty()) {
+                                        return io.pravega.client.stream.StreamCut.UNBOUNDED;
+                                    }
+                                    return new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
+                                            streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()));
+                                })))
                 .endingStreamCuts(rgConfig.getEndingStreamCutsList().stream()
                         .collect(Collectors.toMap(streamCut -> Stream.of(streamCut.getStreamInfo().getScope(),
                                 streamCut.getStreamInfo().getStream()),
-                                streamCut -> new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream()),
-                                        getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap())))))
+                                streamCut -> {
+                                    if (streamCut.getCutMap().isEmpty()) {
+                                        return io.pravega.client.stream.StreamCut.UNBOUNDED;
+                                    }
+                                    return new StreamCutImpl(Stream.of(streamCut.getStreamInfo().getScope(),
+                                            streamCut.getStreamInfo().getStream()), getSegmentOffsetMap(streamCut.getStreamInfo().getScope(), streamCut.getStreamInfo().getStream(), streamCut.getCutMap()));
+                                })))
                 .build();
     }
 

--- a/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
@@ -11,7 +11,12 @@ package io.pravega.client.control.impl;
 
 import com.google.common.collect.ImmutableMap;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.*;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.RetentionPolicy;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.client.tables.KeyValueTableConfiguration;

--- a/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
@@ -9,11 +9,11 @@
  */
 package io.pravega.client.control.impl;
 
+import com.google.common.collect.ImmutableMap;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.stream.RetentionPolicy;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.*;
 import io.pravega.client.stream.impl.SegmentWithRange;
+import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentId;
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import static io.pravega.shared.NameUtils.getScopedStreamName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -274,6 +275,18 @@ public class ModelHelperTest {
                 ModelHelper.createStreamInfo("testScope", "testStream", AccessOperation.WRITE).getAccessOperation());
         assertEquals(Controller.StreamInfo.AccessOperation.READ_WRITE,
                 ModelHelper.createStreamInfo("testScope", "testStream", AccessOperation.READ_WRITE).getAccessOperation());
+    }
+
+    @Test
+    public void testReaderGroupConfig() {
+        String scope = "test";
+        String stream = "test";
+        ImmutableMap<Segment, Long> positions = ImmutableMap.<Segment, Long>builder().put(new Segment(scope, stream, 0), 90L).build();
+        StreamCut sc = new StreamCutImpl(Stream.of(scope, stream), positions);
+        ReaderGroupConfig config = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream(getScopedStreamName(scope, stream), StreamCut.UNBOUNDED, sc).build();
+        Controller.ReaderGroupConfiguration decodedConfig = ModelHelper.decode(scope, "group", config);
+        assertEquals(config, ModelHelper.encode(decodedConfig));
     }
 
     private Controller.SegmentRange createSegmentRange(double minKey, double maxKey) {

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -62,7 +62,6 @@ public class CreateReaderGroupTask implements ReaderGroupTask<CreateReaderGroupE
         String scope = request.getScope();
         String readerGroup = request.getRgName();
         UUID readerGroupId = request.getReaderGroupId();
-        log.debug("");
         ReaderGroupConfig config = getConfigFromEvent(request);
         final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
         return RetryHelper.withRetriesAsync(() -> streamMetadataStore.getReaderGroupId(scope, readerGroup, context, executor)

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CreateReaderGroupTask.java
@@ -10,19 +10,15 @@
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import com.google.common.base.Preconditions;
-
 import io.pravega.client.control.impl.ModelHelper;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.common.Exceptions;
-
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.retryable.RetryableException;
 import io.pravega.controller.store.stream.RGOperationContext;
 import io.pravega.controller.store.stream.StreamMetadataStore;
-
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.util.RetryHelper;
 import io.pravega.shared.controller.event.CreateReaderGroupEvent;
@@ -33,8 +29,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
-
-import static io.pravega.client.stream.StreamCut.UNBOUNDED;
 
 /**
  * Request handler for executing a create operation for a ReaderGroup.
@@ -83,27 +77,15 @@ public class CreateReaderGroupTask implements ReaderGroupTask<CreateReaderGroupE
 
     private ReaderGroupConfig getConfigFromEvent(CreateReaderGroupEvent request) {
         Map<Stream, StreamCut> startStreamCut = request.getStartingStreamCuts().entrySet()
-                                                .stream().collect(Collectors.toMap(e -> Stream.of(e.getKey()),
-                                                e -> {
-                                                    if (e.getValue().getStreamCut().isEmpty()) {
-                                                        return UNBOUNDED;
-                                                    }
-                                                    return new StreamCutImpl(Stream.of(e.getKey()),
-                                                            ModelHelper.getSegmentOffsetMap(Stream.of(e.getKey()).getScope(),
-                                                                    Stream.of(e.getKey()).getStreamName(),
-                                                                    e.getValue().getStreamCut()));
-                                                }));
+                .stream().collect(Collectors.toMap(e -> Stream.of(e.getKey()),
+                        e -> ModelHelper.generateStreamCut(Stream.of(e.getKey()).getScope(),
+                                Stream.of(e.getKey()).getStreamName(),
+                                e.getValue().getStreamCut())));
         Map<Stream, StreamCut> endStreamCut = request.getEndingStreamCuts().entrySet()
                 .stream().collect(Collectors.toMap(e -> Stream.of(e.getKey()),
-                        e -> {
-                            if (e.getValue().getStreamCut().isEmpty()) {
-                                return UNBOUNDED;
-                            }
-                            return new StreamCutImpl(Stream.of(e.getKey()),
-                                    ModelHelper.getSegmentOffsetMap(Stream.of(e.getKey()).getScope(),
-                                            Stream.of(e.getKey()).getStreamName(),
-                                            e.getValue().getStreamCut()));
-                        }));
+                        e -> ModelHelper.generateStreamCut(Stream.of(e.getKey()).getScope(),
+                                Stream.of(e.getKey()).getStreamName(),
+                                e.getValue().getStreamCut())));
         return ReaderGroupConfig.builder().readerGroupId(request.getReaderGroupId())
                 .groupRefreshTimeMillis(request.getGroupRefreshTimeMillis())
                 .automaticCheckpointIntervalMillis(request.getAutomaticCheckpointIntervalMillis())


### PR DESCRIPTION
**Change log description**  
Added a check to identify `StreamCut.UNBOUNDED` cases and deal with them separately.

**Purpose of the change**  
Fixes #5476 

**What the code does**  
Currently when a `ReaderGroupConfig` is converted into a controller side `ReaderGroupConfiguration`, the UNBOUNDED cases are stored as empty lists.
In both the `ModelHelper` and `CreateReaderGroupTask`, when an empty stream-cut list is found, we store it as an `UNBOUNDED` instead.

**How to verify it**  
All tests should pass.
