### PR TITLE
Issue 5478: Performance regression due to wrong logging on metrics

### DIFF
--- a/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/metrics/MetricProxy.java
@@ -79,9 +79,6 @@ abstract class MetricProxy<T extends Metric> implements AutoCloseable {
     }
 
     protected T getInstance() {
-        if (!closed.get()) {
-            log.warn("This MetricProxy ({}) has already been closed. Further updates to this Metric will not be seen by a MeterRegistry.", proxyName);
-        }
         return this.instance.get();
     }
 }


### PR DESCRIPTION
**Change log description**  
Removed logging message that was called upon an incorrect condition.

**Purpose of the change**  
Fixes #5478.

**What the code does**  
As described in #5478, PR #5422 introduced a logging message to warn about the use of a metric after being closed. The main problem is that the logic to write that log message is not correct, which makes the system to log many useless warnings.

While we could reverse the logic condition that logs that message, we propose to completely remove it given that it is called in the hot path (e.g., metrics for number of messages) in order to favor performance.

**How to verify it**  
Just removed a log message, no actual code changed. All tests should be passing as before. We have validated that performance now is similar to what it was in previous commits (e.g., commit 2703).