### PR TITLE
Issue 5519: (SegmentStore) SegmentAttributeIndex bug fixes.

### DIFF
--- a/common_server/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
+++ b/common_server/src/test/java/io/pravega/common/util/btree/BTreeIndexTests.java
@@ -286,6 +286,14 @@ public class BTreeIndexTests extends ThreadPooledTestSuite {
         val recoveredIndex = defaultBuilder(ds).build();
         recoveredIndex.initialize(TIMEOUT).join();
         check("after recovery", recoveredIndex, entries, 0);
+
+        // Now verify how it would behave if we had no root pointer. An exception should be thrown.
+        ds.rootPointer.set(-1L);
+        val corruptedIndex = defaultBuilder(ds).build();
+        AssertExtensions.assertSuppliedFutureThrows(
+                "Expected corrupted index to fail initialization.",
+                () -> corruptedIndex.initialize(TIMEOUT),
+                ex -> ex instanceof IllegalArgumentException); // Captures IllegalDataFormatException as well.
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -232,6 +232,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
             this.writer.close();
             this.durableLog.close();
             this.readIndex.close();
+            this.attributeIndex.close();
             this.storage.close();
             this.metrics.close();
             log.info("{}: Closed.", this.traceObjectId);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
@@ -243,6 +243,13 @@ class AttributeAggregator implements WriterSegmentProcessor, AutoCloseable {
     }
 
     private void queueRootPointerUpdate(long newRootPointer, long lastSeqNo) {
+        // TODO: remove this method and all associated code (including Attributes#ATTRIBUTE_SEGMENT_ROOT_POINTER) once
+        // ChunkedSegmentStorage is the only supported Storage (and RollingStorage is retired).
+        if (newRootPointer < 0) {
+            log.trace("{}: Not updating Root Pointer.", this.traceObjectId);
+            return;
+        }
+
         if (this.lastRootPointer.getAndSet(new RootPointerInfo(newRootPointer, lastSeqNo)) == null) {
             // There was nothing else executing now.
             // Initiate an async loop that will execute as long as we have a new value.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
@@ -243,13 +243,6 @@ class AttributeAggregator implements WriterSegmentProcessor, AutoCloseable {
     }
 
     private void queueRootPointerUpdate(long newRootPointer, long lastSeqNo) {
-        // TODO: remove this method and all associated code (including Attributes#ATTRIBUTE_SEGMENT_ROOT_POINTER) once
-        // ChunkedSegmentStorage is the only supported Storage (and RollingStorage is retired).
-        if (newRootPointer < 0) {
-            log.trace("{}: Not updating Root Pointer.", this.traceObjectId);
-            return;
-        }
-
         if (this.lastRootPointer.getAndSet(new RootPointerInfo(newRootPointer, lastSeqNo)) == null) {
             // There was nothing else executing now.
             // Initiate an async loop that will execute as long as we have a new value.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
@@ -200,6 +200,11 @@ public class TestStorage implements Storage {
     }
 
     @Override
+    public boolean supportsAtomicWrites() {
+        return this.wrappedStorage.supportsAtomicWrites();
+    }
+
+    @Override
     public Iterator<SegmentProperties> listSegments() {
         return null;
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
@@ -907,7 +907,7 @@ public class AttributeIndexTests extends ThreadPooledTestSuite {
             expectedValues.put(attributeId, value);
             val updateBatch = Collections.singletonMap(attributeId, value);
 
-            // Inject a callback to knwo when we finished truncating, as it is an async task.
+            // Inject a callback to know when we finished truncating, as it is an async task.
             @Cleanup("release")
             val truncated = new ReusableLatch();
             context.storage.truncateCallback = (s, o) -> truncated.release();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -122,6 +122,12 @@ public class AsyncStorageWrapper implements Storage {
     }
 
     @Override
+    public boolean supportsAtomicWrites() {
+        // RollingStorage (non-Chunked Storage) does not support atomic writes if the underlying Storage implementation does not.
+        return false;
+    }
+
+    @Override
     public CompletableFuture<SegmentHandle> openRead(String streamSegmentName) {
         return supplyAsync(() -> this.syncStorage.openRead(streamSegmentName), streamSegmentName);
     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -10,7 +10,6 @@
 package io.pravega.segmentstore.storage;
 
 import io.pravega.segmentstore.contracts.SegmentProperties;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -173,7 +172,20 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
     boolean supportsTruncation();
 
     /**
+     * Determines whether this Storage implementation supports atomic writes. Supporting atomic writes means that calls
+     * to {@link #write} will either make all the payload available for reading (via {@link #getStreamSegmentInfo} and
+     * {@link #read}) or none, regardless of whether the underlying Storage binding supports that (i.e., FileSystem does not).
+     *
+     * If this returns true, then even a system crash or other failure will guarantee that, upon a recovery, the payload
+     * will either be visible in its entirety or none at all.
+     *
+     * @return True if atomic writes are supported, false otherwise.
+     */
+    boolean supportsAtomicWrites();
+
+    /**
      * Lists all the segments stored on the storage device.
+     *
      * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
      * @throws IOException if exception occurred while listing segments.
      */

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -174,7 +174,7 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
     /**
      * Determines whether this Storage implementation supports atomic writes. Supporting atomic writes means that calls
      * to {@link #write} will either make all the payload available for reading (via {@link #getStreamSegmentInfo} and
-     * {@link #read}) or none, regardless of whether the underlying Storage binding supports that (i.e., FileSystem does not).
+     * {@link #read}) or none, regardless of whether the underlying Storage binding supports that (e.g., FileSystem does not).
      *
      * If this returns true, then even a system crash or other failure will guarantee that, upon a recovery, the payload
      * will either be visible in its entirety or none at all.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheFullException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/cache/CacheFullException.java
@@ -9,13 +9,15 @@
  */
 package io.pravega.segmentstore.storage.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.segmentstore.storage.CacheException;
 
 /**
  * {@link CacheException} thrown whenever the {@link CacheStorage} is full and cannot accept any extra data.
  */
 public class CacheFullException extends CacheException {
-    CacheFullException(String message) {
+    @VisibleForTesting
+    public CacheFullException(String message) {
         super(message);
     }
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -538,6 +538,13 @@ public class ChunkedSegmentStorage implements Storage {
     }
 
     @Override
+    public boolean supportsAtomicWrites() {
+        // Regardless of the actual Storage implementation, ChunkedSegmentStorage guarantees that all calls to #write(...)
+        // are atomic.
+        return true;
+    }
+
+    @Override
     public Iterator<SegmentProperties> listSegments() {
         throw new UnsupportedOperationException("listSegments is not yet supported");
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/AsyncStorageWrapperTests.java
@@ -355,6 +355,14 @@ public class AsyncStorageWrapperTests extends ThreadPooledTestSuite {
 
     }
 
+    @Test
+    public void testSupportsAtomicWrites() {
+        val innerStorage = new TestStorage((operation, segment) -> null);
+        @Cleanup
+        val s = new AsyncStorageWrapper(innerStorage, executorService());
+        Assert.assertFalse(s.supportsAtomicWrites());
+    }
+
     private CompletableFuture<Void> allOf(Collection<CompletableFuture<?>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -97,9 +97,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * Test capabilities.
-     *
-     * @throws Exception
+     * Test {@link ChunkedSegmentStorage#supportsTruncation()}.
      */
     @Test
     public void testSupportsTruncate() throws Exception {
@@ -110,6 +108,20 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
         @Cleanup
         val chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
         Assert.assertTrue(chunkedSegmentStorage.supportsTruncation());
+    }
+
+    /**
+     * Tests {@link ChunkedSegmentStorage#supportsAtomicWrites()}
+     */
+    @Test
+    public void testSupportsAtomicWrites() throws Exception {
+        @Cleanup
+        val chunkStorage = createChunkStorage();
+        @Cleanup
+        val metadataStore = createMetadataStore();
+        @Cleanup
+        val chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        Assert.assertTrue(chunkedSegmentStorage.supportsAtomicWrites());
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
- Updated SegmentAttributeBTreeIndex to recover a BTreeIndex using solely the information encoded in the index file if the LTS adapter used supports atomic writes.
- Fixed a bug in SegmentAttributeBTreeIndex where it would corrupt in-memory state (and require a process restart) if unable to store entries in the cache after an update.
- Improved SegmentAttributeBTreeIndex to handle cache insertion exceptions (do not bubble up and log accordingly).
- Fixed a bug in StreamSegmentContainer where it would not be closing the Attribute Indices upon shutdown.

**Purpose of the change**  
Fixes #5519.
Fixes #5575.

**What the code does**  
- Root Pointers
    - The Segment Attribute Index (in the format of a BTreeIndex) is highly sensitive to the format of the data written within. Every write to LTS that it makes must be executed atomically by the underlying LTS implementation; partially written data (in the event of a crash) will result in index corruption. #4451 introduced a work-around for then-default `RollingStorage` which did not guarantee atomic writes (especially for FileSystem implementations). 
    - However, as described by #5519, that approach has a major flaw, which can cause more harm than good in certain failure situations. 
    - This PR makes use of the SLTS (`ChunkedSegmentStorage`) guarantees that all writes are atomic, regardless of the capabilities of the underlying storage adapter. It adds a flag (`supportsAtomicWrites`) which is false for `RollingStorage`/`AsyncStorageWrapper` and true for `ChunkedSegmentStorage`. If the flag is indeed set, it will begin recovery in the traditional way, by reading the "footer" as the last 12 bytes of the index file. If the flag is false, then it will execute as before.
    - This fix does not address the problem if `RollingStorage` is the default LTS implementation (as we are aiming to deprecate and ultimately retire that one). It fixes it only for SLTS.
- SegmentAttributeBTreeIndex (other bugs):
    - The state of the index includes the current length of the attribute segment, which is used for length-conditional writes. This state is only updated after successful writes.
    - However, it is possible that an LTS write + truncation occurred, but the rest of the update operation failed due to an inability to store data in the cache. This would leave the state in an inconsistent state.
    - The state would eventually be refreshed/reinitialized upon a new update. However, if the cache is full (which is likely the root cause of the above exceptions), any update would require a read, which would likely try to read from truncated offsets, hence corrupted in-memory state.
    - The fix for this is to handle exceptions coming from `storeInCache` and log them appropriately and perform any necessary index cleanup. It is OK if we can't cache data, as we can always read it later from LTS.

**How to verify it**  
Build shall pass.