### PR TITLE
Issue 4193: Fixed ContainerKeyIndexTests.testRecoveryTimeout

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -816,7 +816,6 @@ class ContainerKeyIndex implements AutoCloseable {
 
             // Cleanup whenever the task is done.
             task.task.whenComplete((r, ex) -> {
-                sf.cancel(true);
                 synchronized (this) {
                     // Cleanup.
                     RecoveryTask removed = this.recoveryTasks.remove(task.segmentId);
@@ -825,6 +824,11 @@ class ContainerKeyIndex implements AutoCloseable {
                         this.recoveryTasks.put(task.segmentId, removed);
                     }
                 }
+
+                // It doesn't matter much if we attempt to cancel this ScheduledFuture before or after unregistering it.
+                // If it has already been completed (normally or exceptionally), this will have no effect. It is preferred
+                // to cancel it after being unregistered since that helps unit testing.
+                sf.cancel(true);
             });
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -29,6 +29,7 @@ import io.pravega.segmentstore.server.TableStoreMock;
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -41,13 +42,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -58,6 +62,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.Mockito;
 
 /**
  * Unit tests for the {@link ContainerKeyIndex} class.
@@ -69,7 +74,6 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
     private static final long SHORT_TIMEOUT_MILLIS = TIMEOUT.toMillis() / 3;
     private static final KeyHasher HASHER = KeyHashers.DEFAULT_HASHER;
     private static final int TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH = 128 * 1024;
-    private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(2);
     private static final Comparator<BufferView> KEY_COMPARATOR = BufferViewComparator.create()::compare;
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -547,9 +551,11 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testRecoveryTimeout() throws Exception {
-        val s = new EntrySerializer();
+        val spyExecutor = Mockito.spy(executorService());
         @Cleanup
         val context = new TestContext();
+        @Cleanup
+        val index = context.createIndex(spyExecutor);
 
         // Setup the segment with initial attributes.
         val iw = new IndexWriter(HASHER, executorService());
@@ -573,28 +579,54 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         // Update the index, but keep the LastIndexedOffset at 0.
         val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
         Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
-                                                        .map(e -> {
-                                                            val builder = BucketUpdate.forBucket(e.getValue());
-                                                            val ko = keysWithOffsets.get(e.getKey());
-                                                            builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
-                                                            return builder.build();
-                                                        })
-                                                        .collect(Collectors.toList());
+                .map(e -> {
+                    val builder = BucketUpdate.forBucket(e.getValue());
+                    val ko = keysWithOffsets.get(e.getKey());
+                    builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                    return builder.build();
+                })
+                .collect(Collectors.toList());
         iw.updateBuckets(context.segment, bucketUpdates, 0L, 0, keysWithOffsets.size(), TIMEOUT).join();
 
-        // Issue a request and verify it times out.
+        // Setup a mock Executor.schedule call that returns a future over which we have full control. This will save us
+        // from having to wait for the recovery timeout to actually expire.
+        val timeoutFuture = new AtomicReference<ScheduledFuture<?>>();
+        val timeoutCallback = new AtomicReference<Callable<?>>();
+        Mockito.doAnswer(arg -> {
+            timeoutCallback.set(arg.getArgument(0));
+            timeoutFuture.set((ScheduledFuture<?>) arg.callRealMethod());
+            return timeoutFuture.get();
+        }).when(spyExecutor)
+                .schedule(Mockito.<Callable<Boolean>>any(), Mockito.anyLong(), Mockito.any());
+
+        // Issue the first request. We intend to time it out.
+        val getBucketOffset1 = index.getBucketOffsets(context.segment, hashes, context.timer);
+        TestUtils.await(() -> timeoutFuture.get() != null, 5, TIMEOUT.toMillis());
+
+        // Time-out the call.
+        timeoutCallback.get().call();
         AssertExtensions.assertSuppliedFutureThrows(
                 "Request did not fail when recovery timed out.",
-                () -> context.index.getBucketOffsets(context.segment, hashes, context.timer),
+                () -> getBucketOffset1,
                 ex -> ex instanceof TimeoutException);
 
+        // Wait for the future to be unregistered before continuing.
+        TestUtils.await(timeoutFuture.get()::isDone, 5, TIMEOUT.toMillis());
+
         // Verify that a new operation will be unblocked if we notify that the recovery completed successfully.
-        val get1 = context.index.getBucketOffsets(context.segment, hashes, context.timer);
-        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), context.segment.getInfo().getLength());
-        val result1 = get1.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        timeoutFuture.set(null);
+        timeoutCallback.set(null);
+        val getBucketOffset2 = index.getBucketOffsets(context.segment, hashes, context.timer);
+
+        // Wait for the timeout future to be registered. We'll verify if it gets cancelled next.
+        TestUtils.await(() -> timeoutFuture.get() != null, 5, TIMEOUT.toMillis());
+        index.notifyIndexOffsetChanged(context.segment.getSegmentId(), context.segment.getInfo().getLength());
+        val result1 = getBucketOffset2.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         val expected1 = new HashMap<UUID, Long>();
         keysWithOffsets.forEach((k, o) -> expected1.put(k, o.offset));
         AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after a retry.", expected1, result1);
+        AssertExtensions.assertEventuallyEquals("Expected the internal timeout future to be cancelled after a successful recovery.",
+                true, timeoutFuture.get()::isCancelled, 5, TIMEOUT.toMillis());
     }
 
     /**
@@ -835,9 +867,13 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             this.sortedKeyStorage.createSegment(this.segment.getInfo().getName(), SegmentType.TABLE_SEGMENT_HASH, TIMEOUT).join();
             val ds = new SortedKeyIndexDataSource(this.sortedKeyStorage::put, this.sortedKeyStorage::remove, this.sortedKeyStorage::get);
             this.sortedKeyIndex = new ContainerSortedKeyIndex(ds, executorService());
-            this.index = new TestContainerKeyIndex(CONTAINER_ID, this.cacheManager, this.sortedKeyIndex, KeyHashers.DEFAULT_HASHER, executorService());
+            this.index = createIndex(executorService());
             this.timer = new TimeoutTimer(TIMEOUT);
             this.random = new Random(0);
+        }
+
+        TestContainerKeyIndex createIndex(ScheduledExecutorService executorService) {
+            return new TestContainerKeyIndex(CONTAINER_ID, this.cacheManager, this.sortedKeyIndex, KeyHashers.DEFAULT_HASHER, executorService);
         }
 
         @Override
@@ -856,11 +892,6 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             @Override
             protected long getMaxTailCachePreIndexLength() {
                 return TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH;
-            }
-
-            @Override
-            protected Duration getRecoveryTimeout() {
-                return ContainerKeyIndexTests.RECOVERY_TIMEOUT;
             }
         }
     }


### PR DESCRIPTION
**Change log description**  
Fixed flaky test ContainerKeyIndexTests.testRecoveryTimeout.

**Purpose of the change**  
Fixes #4193.

**What the code does**  
Rewrote the part of the test using Mockito to eliminate randomness due to thread scheduling.
Reordered some instructions in ContainerKeyIndex.setupRecoveryTask.lambda2 to cancel the timeout future after unregistering it. While this has no effect on the actual behavior of the code, it enables the test code to "hook into" those callbacks to it knows when it is safe to proceed (i.e., when its assumptions about the state of the index are true).

**How to verify it**  
Build shall pass.
