### PR TITLE
Issue 5507: Fix the atTail check in integration test testReceivingReadCall 

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadTest.java
@@ -167,14 +167,11 @@ public class ReadTest extends LeakDetectorTestSuite {
             actual.writeBytes(result.getData());
             if (actual.writerIndex() < actual.capacity()) {
                 assertFalse(result.isAtTail());
-            } else {
-                assertTrue(result.isAtTail());
-            }
-
-            if (actual.writerIndex() < actual.capacity()) {
                 // Prevent entering a tight loop by giving the store a bit of time to process al the appends internally
                 // before trying again.
                 Thread.sleep(10);
+            } else {
+                assertTrue(result.isAtTail());
             }
         }
 


### PR DESCRIPTION
**Change log description**  
Fix incorrect atTail assertion  in the test ReadTest > testReceivingReadCall

**Purpose of the change**  
Fixes #5507 

**What the code does**  
Fix incorrect atTail assertion  in the test ReadTest > testReceivingReadCall

**How to verify it**  
The test should cease being flaky.
