### PR TITLE
Issue 5498: Fix flaky unit test PravegaTablesStreamMetadataStoreTest.testReaderGroups

### DIFF
--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1971,14 +1971,17 @@ public abstract class StreamMetadataStoreTest {
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
         final RGOperationContext rgContext = store.createRGContext(scopeRGTest, rgName);
-        store.addReaderGroupToScope(scopeRGTest, rgName, rgConfig.getReaderGroupId());
+        store.addReaderGroupToScope(scopeRGTest, rgName, rgConfig.getReaderGroupId()).join();
         store.createReaderGroup(scopeRGTest, rgName, rgConfig, System.currentTimeMillis(), rgContext, executor).join();
+        UUID readerId = store.getReaderGroupId(scopeRGTest,rgName).get();
+        assertEquals(rgId, readerId);
         ReaderGroupConfigRecord cfgRecord = store.getReaderGroupConfigRecord(scopeRGTest, rgName, rgContext, executor).join().getObject();
         assertEquals(false, cfgRecord.isUpdating());
         assertEquals(rgConfig.getGeneration(), cfgRecord.getGeneration());
         assertEquals(rgConfig.getAutomaticCheckpointIntervalMillis(), cfgRecord.getAutomaticCheckpointIntervalMillis());
         assertEquals(rgConfig.getGroupRefreshTimeMillis(), cfgRecord.getGroupRefreshTimeMillis());
         assertEquals(rgConfig.getStartingStreamCuts().size(), cfgRecord.getStartingStreamCuts().size());
+        assertEquals(ReaderGroupState.ACTIVE, store.getReaderGroupState(scopeRGTest, rgName, true, rgContext, executor).get());
     }
     
     private void createAndScaleStream(StreamMetadataStore store, String scope, String stream, int times) {

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1981,7 +1981,8 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(rgConfig.getAutomaticCheckpointIntervalMillis(), cfgRecord.getAutomaticCheckpointIntervalMillis());
         assertEquals(rgConfig.getGroupRefreshTimeMillis(), cfgRecord.getGroupRefreshTimeMillis());
         assertEquals(rgConfig.getStartingStreamCuts().size(), cfgRecord.getStartingStreamCuts().size());
-        assertEquals(ReaderGroupState.ACTIVE, store.getReaderGroupState(scopeRGTest, rgName, true, rgContext, executor).get());
+        VersionedMetadata<ReaderGroupState> rgState = store.getVersionedReaderGroupState(scopeRGTest, rgName, true, rgContext, executor).get();
+        assertEquals(ReaderGroupState.CREATING, rgState.getObject());
     }
     
     private void createAndScaleStream(StreamMetadataStore store, String scope, String stream, int times) {

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1973,8 +1973,8 @@ public abstract class StreamMetadataStoreTest {
         final RGOperationContext rgContext = store.createRGContext(scopeRGTest, rgName);
         store.addReaderGroupToScope(scopeRGTest, rgName, rgConfig.getReaderGroupId()).join();
         store.createReaderGroup(scopeRGTest, rgName, rgConfig, System.currentTimeMillis(), rgContext, executor).join();
-        UUID readerId = store.getReaderGroupId(scopeRGTest,rgName).get();
-        assertEquals(rgId, readerId);
+        UUID readerGroupId = store.getReaderGroupId(scopeRGTest, rgName).get();
+        assertEquals(rgId, readerGroupId);
         ReaderGroupConfigRecord cfgRecord = store.getReaderGroupConfigRecord(scopeRGTest, rgName, rgContext, executor).join().getObject();
         assertEquals(false, cfgRecord.isUpdating());
         assertEquals(rgConfig.getGeneration(), cfgRecord.getGeneration());


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
The api call `store.addReaderGroupToScope(scopeRGTest, rgName, rgConfig.getReaderGroupId())` in the test was not followed by join() and hence this future did not complete prior to the following createReaderGroup() call in some cases. 
Hence the failure.

**Purpose of the change**  
Fixes #5498 

**What the code does**  
added join() after `store.addReaderGroupToScope(scopeRGTest, rgName, rgConfig.getReaderGroupId())`
Also added some more assertions to confirm the created completed successfully.

**How to verify it**  
All Unit and Integration tests should pass.
Test `PravegaTablesStreamMetadataStoreTest.testReaderGroups()` should always pass.
