### PR TITLE
Issue 5546:  Fix NPE in DynamicRestApiTest

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/DynamicRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/DynamicRestApiTest.java
@@ -73,13 +73,9 @@ public class DynamicRestApiTest extends AbstractSystemTest {
 
     /**
      * This is used to setup the various services required by the system test framework.
-     *
-     * @throws InterruptedException If interrupted
-     * @throws MarathonException    when error in setup
-     * @throws URISyntaxException   If URI is invalid
      */
     @Environment
-    public static void initialize() throws MarathonException {
+    public static void initialize() {
         URI zkUri = startZookeeperInstance();
         startBookkeeperInstances(zkUri);
         URI controllerUri = ensureControllerRunning(zkUri);
@@ -114,11 +110,7 @@ public class DynamicRestApiTest extends AbstractSystemTest {
         Client client = ClientBuilder.newClient();
         String responseAsString = null;
 
-        ClientConfig clientConfig = ClientConfig.builder()
-                .controllerURI(controllerGRPCUri)
-                .credentials(new DefaultCredentials(Utils.PRAVEGA_PROPERTIES.get("pravega.client.auth.username"),
-                        Utils.PRAVEGA_PROPERTIES.get("pravega.client.auth.username")))
-                .build();
+        ClientConfig clientConfig = Utils.buildClientConfig(controllerGRPCUri);
         // Create a scope.
         @Cleanup
         StreamManager streamManager = StreamManager.create(clientConfig);

--- a/test/system/src/test/java/io/pravega/test/system/DynamicRestApiTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/DynamicRestApiTest.java
@@ -14,7 +14,6 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.shared.security.auth.DefaultCredentials;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,7 +23,6 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.services.Service;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -38,7 +36,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-import mesosphere.marathon.client.MarathonException;
 
 import static org.junit.Assert.assertEquals;
 import static javax.ws.rs.core.Response.Status.OK;


### PR DESCRIPTION
**Change log description**  
Fix NPE in DynamicRestApiTest system test.

**Purpose of the change**  
Fixes #5546 

**What the code does**  
The constructor for `DefaultCredentaials ` follows the pattern ` public DefaultCredentials(@NonNull String password, @NonNull String userName)` 
and the current code 
- does not pass the password but username twice
- and the property is not set for a system test run without auth.
This has been fixed by using the helper method `Utils.buildClientConfig(..)`

**How to verify it**  
The system tests should pass.
