### PR TITLE
Issue 5523: Enabling GithubActions and Disabling Travis CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,10 @@ env:
     gradle-m2-java-
     gradle-m2
   BUILD_CACHE_PATH: ./*
-  TEST_OUTPUT_CACHE_PATH: '**/build/test-results/** **/**/build/test-results/** **/**/build/test-results/**'
+  TEST_OUTPUT_CACHE_PATH: >
+    **/build/test-results
+    **/**/build/test-results
+    **/**/build/test-results
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -159,35 +159,6 @@ jobs:
           segmentstore:server:test
           segmentstore:storage:test
           segmentstore:server:host:test
-          --parallel ${{env.GRADLE_OPTS}}
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.15
-
-  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
-  unit_bindings:
-    name: Storage Bindings Unit Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Storage Bindings Unit tests
-        run: >
-          ./gradlew
           segmentstore:storage:impl:test
           bindings:test
           --parallel ${{env.GRADLE_OPTS}}
@@ -257,7 +228,7 @@ jobs:
   # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
   build_and_test_complete:
     name: CI Complete
-    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
+    needs: [build, integration, unit_other, unit_segment_store, unit_controller, unit_client]
     runs-on: ubuntu-20.04
     steps:
       - name: Check Build Status

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ env:
   BUILD_CACHE_PATH: ./*
   # We cache test execution (including history) and reports (code coverage) per test job. This helps speed up workflow re-runs.
   TEST_OUTPUT_CACHE_PATH: |
-    .gradle
+    .gradle/**/executionHistory
     **/build/test-results
     **/**/build/test-results
     **/**/build/test-results

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -158,9 +158,13 @@ jobs:
           ./gradlew
           segmentstore:server:test
           segmentstore:storage:test
-          segmentstore:server:host:test
           segmentstore:storage:impl:test
           bindings:test
+          --parallel ${{env.GRADLE_OPTS}}
+      - name: Segment Store Host Tests      # Run this separately since it conflicts with segmentstore:storage:impl:test.
+        run: >
+          ./gradlew
+          segmentstore:server:host:test
           --parallel ${{env.GRADLE_OPTS}}
       - name: Codecov
         uses: codecov/codecov-action@v1.0.15

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Unit tests
         run: ./gradlew client:test
       - name: Codecov
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Controller Unit tests
         run: ./gradlew controller:test
       - name: Codecov
@@ -135,7 +135,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Segment Store Unit tests
         run: >
           ./gradlew
@@ -167,7 +167,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Storage Bindings Unit tests
         run: >
           ./gradlew
@@ -197,7 +197,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Unit tests
         run: >
           ./gradlew test
@@ -233,7 +233,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.action}}
+          key: ${{github.run_id}}-${{github.job}}
       - name: Integration Tests
         run: ./gradlew test:integration:test
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,13 +34,16 @@ env:
   BUILD_CACHE_PATH: ./*
   # We cache test execution (including history) and reports (code coverage) per test job. This helps speed up workflow re-runs.
   TEST_OUTPUT_CACHE_PATH: |
-    .gradle/**/executionHistory
+    .gradle
     **/build/test-results
     **/**/build/test-results
-    **/**/build/test-results
-    **/build/reports/jacoco
-    **/**/build/reports/jacoco
-    **/**/**/build/reports/jacoco
+    **/**/**/build/test-results
+    **/build/jacoco
+    **/**/build/jacoco
+    **/**/**/build/jacoco
+    **/build/reports
+    **/**/build/reports
+    **/**/**/build/reports
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,14 +27,19 @@ env:
     ~/.gradle
     ~/.m2
   GLOBAL_CACHE_KEY: gradle-m2-java-11
-  GLOBAL_CACKE_RESTORE_KEYS: |
+  GLOBAL_CACHE_RESTORE_KEYS: |
     gradle-m2-java-
     gradle-m2
+  # We cache the source code, resources and build output. This is generated on the build job and reused in dependent jobs.
   BUILD_CACHE_PATH: ./*
+  # We cache test execution and reports (code coverage) per test job. This helps speed up workflow re-runs.
   TEST_OUTPUT_CACHE_PATH: >
     **/build/test-results
     **/**/build/test-results
     **/**/build/test-results
+    **/build/reports
+    **/**/build/reports
+    **/**/**/build/reports
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).
@@ -71,6 +76,8 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
+      - name: Build Information
+        run: echo Building a '${{ github.event_name }}' for target '${{ github.ref }}'.
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
@@ -91,6 +98,10 @@ jobs:
         run: ./gradlew client:test
       - name: Codecov
         uses: codecov/codecov-action@v1.0.15
+      - name: Debug
+        run: |
+          pwd
+          ls ${{env.TEST_OUTPUT_CACHE_PATH}}
 
   unit_controller:
     name: Controller Unit Tests
@@ -248,8 +259,6 @@ jobs:
     steps:
       - name: Check Build Status
         run: echo Build, static analysis, unit and integration tests successful.
-      - name: Debug # TODO remove
-        run: echo ${{ github.event_name }},${{ github.ref }}
 
   snapshot:
     name: Artifactory Snapshot
@@ -257,7 +266,7 @@ jobs:
     # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
     # TODO revert after validating this works correctly
     #if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/issue-5524-gha' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+    if: ${{ github.event_name == 'pull_request' && (github.ref == 'refs/pull/5563/merge' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Gradle & Maven Cache

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -95,188 +95,186 @@ jobs:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
           key: ${{github.run_id}}-${{github.job}}
       - name: Unit tests
-        run: ./gradlew client:test
+        run: ./gradlew client:test --info
       - name: Codecov
         uses: codecov/codecov-action@v1.0.15
-
-  unit_controller:
-    name: Controller Unit Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Controller Unit tests
-        run: ./gradlew controller:test
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.15
-
-  unit_segment_store:
-    name: Segment Store Unit Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Segment Store Unit tests
-        run: >
-          ./gradlew
-          segmentstore:server:test
-          segmentstore:storage:test
-          segmentstore:server:host:test
-          --parallel
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.15
-
-  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
-  unit_bindings:
-    name: Storage Bindings Unit Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Storage Bindings Unit tests
-        run: >
-          ./gradlew
-          segmentstore:storage:impl:test
-          bindings:test
-          --parallel
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.15
-
-  unit_other:
-    name: All Other Unit Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Unit tests
-        run: >
-          ./gradlew test
-          -x client:test
-          -x controller:test
-          -x test:integration:test
-          -x bindings:test
-          -x segmentstore:storage:impl:test
-          -x segmentstore:storage:test
-          -x segmentstore:server:host:test
-          -x segmentstore:server:test
-          --parallel
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.15
-
-  integration:
-    name: Integration Tests
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Test Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-          key: ${{github.run_id}}-${{github.job}}
-      - name: Integration Tests
-        run: ./gradlew test:integration:test
-
-  # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
-  build_and_test_complete:
-    name: CI Complete
-    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check Build Status
-        run: echo Build, static analysis, unit and integration tests successful.
-
-  snapshot:
-    name: Artifactory Snapshot
-    needs: [build_and_test_complete]
-    # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
-    # TODO revert after validating this works correctly
-    #if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
-    if: ${{ github.event_name == 'pull_request' && (github.ref == 'refs/pull/5563/merge' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-      - name: Build Output Cache
-        uses: actions/cache@v2.1.0
-        with:
-          path: ${{env.BUILD_CACHE_PATH}}
-          key: ${{github.run_id}}
-      - name: Assemble
-        run: ./gradlew assemble --parallel
-      - name: Publish Shapshot
-        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}}
+# TODO uncomment these.
+#  unit_controller:
+#    name: Controller Unit Tests
+#    needs: build
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Test Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+#          key: ${{github.run_id}}-${{github.job}}
+#      - name: Controller Unit tests
+#        run: ./gradlew controller:test
+#      - name: Codecov
+#        uses: codecov/codecov-action@v1.0.15
+#
+#  unit_segment_store:
+#    name: Segment Store Unit Tests
+#    needs: build
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Test Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+#          key: ${{github.run_id}}-${{github.job}}
+#      - name: Segment Store Unit tests
+#        run: >
+#          ./gradlew
+#          segmentstore:server:test
+#          segmentstore:storage:test
+#          segmentstore:server:host:test
+#          --parallel
+#      - name: Codecov
+#        uses: codecov/codecov-action@v1.0.15
+#
+#  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
+#  unit_bindings:
+#    name: Storage Bindings Unit Tests
+#    needs: build
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Test Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+#          key: ${{github.run_id}}-${{github.job}}
+#      - name: Storage Bindings Unit tests
+#        run: >
+#          ./gradlew
+#          segmentstore:storage:impl:test
+#          bindings:test
+#          --parallel
+#      - name: Codecov
+#        uses: codecov/codecov-action@v1.0.15
+#
+#  unit_other:
+#    name: All Other Unit Tests
+#    needs: build
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Test Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+#          key: ${{github.run_id}}-${{github.job}}
+#      - name: Unit tests
+#        run: >
+#          ./gradlew test
+#          -x client:test
+#          -x controller:test
+#          -x test:integration:test
+#          -x bindings:test
+#          -x segmentstore:storage:impl:test
+#          -x segmentstore:storage:test
+#          -x segmentstore:server:host:test
+#          -x segmentstore:server:test
+#          --parallel
+#      - name: Codecov
+#        uses: codecov/codecov-action@v1.0.15
+#
+#  integration:
+#    name: Integration Tests
+#    needs: build
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Test Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+#          key: ${{github.run_id}}-${{github.job}}
+#      - name: Integration Tests
+#        run: ./gradlew test:integration:test
+#
+#  # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
+#  build_and_test_complete:
+#    name: CI Complete
+#    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check Build Status
+#        run: echo Build, static analysis, unit and integration tests successful.
+#
+#  snapshot:
+#    name: Artifactory Snapshot
+#    needs: [build_and_test_complete]
+#    # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
+#    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Gradle & Maven Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.GLOBAL_CACHE_PATH}}
+#          key: ${{env.GLOBAL_CACHE_KEY}}
+#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+#      - name: Build Output Cache
+#        uses: actions/cache@v2.1.0
+#        with:
+#          path: ${{env.BUILD_CACHE_PATH}}
+#          key: ${{github.run_id}}
+#      - name: Assemble
+#        run: ./gradlew assemble --parallel
+#      - name: Publish Shapshot
+#        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - master                 # On every push to the master branch.
-      - 'r*.*'                 # On every push to a release branch.
+      - 'r[0-9]+.[0-9]+'       # On every push to a release branch.
   pull_request:                # On every pull request, regardless of source/target branch.
   release:
     types:
@@ -124,8 +124,32 @@ jobs:
         run: >
           ./gradlew
           segmentstore:server:test
-          segmentstore:server:host:test
           segmentstore:storage:test
+          segmentstore:server:host:test
+          --parallel
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
+  unit_bindings:
+    name: Storage Bindings Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Storage Bindings Unit tests
+        run: >
+          ./gradlew
           segmentstore:storage:impl:test
           bindings:test
           --parallel
@@ -185,7 +209,7 @@ jobs:
   # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
   build_and_test_complete:
     name: CI Complete
-    needs: [build, integration, unit_other, unit_segment_store, unit_controller, unit_client]
+    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
     runs-on: ubuntu-20.04
     steps:
       - name: Check Build Status

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,6 +44,9 @@ env:
     **/build/reports
     **/**/build/reports
     **/**/**/build/reports
+  # Set 'GRADLE_OPTS' to pass additional custom parameters to each ./gradlew invocation in this workflow.
+  # Example '--info' or '--debug'.
+  #GRADLE_OPTS: --info
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).
@@ -75,7 +78,7 @@ jobs:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
       - name: Compile & Static Analysis
-        run: ./gradlew jar compileTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel
+        run: ./gradlew jar compileTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel ${{env.GRADLE_OPTS}}
 
   unit_client:
     name: Client Unit Tests
@@ -99,186 +102,186 @@ jobs:
           path: ${{env.TEST_OUTPUT_CACHE_PATH}}
           key: ${{github.run_id}}-${{github.job}}
       - name: Unit tests
-        run: ./gradlew client:test --info
+        run: ./gradlew client:test ${{env.GRADLE_OPTS}}
       - name: Codecov
         uses: codecov/codecov-action@v1.0.15
-# TODO uncomment these.
-#  unit_controller:
-#    name: Controller Unit Tests
-#    needs: build
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Test Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-#          key: ${{github.run_id}}-${{github.job}}
-#      - name: Controller Unit tests
-#        run: ./gradlew controller:test
-#      - name: Codecov
-#        uses: codecov/codecov-action@v1.0.15
-#
-#  unit_segment_store:
-#    name: Segment Store Unit Tests
-#    needs: build
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Test Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-#          key: ${{github.run_id}}-${{github.job}}
-#      - name: Segment Store Unit tests
-#        run: >
-#          ./gradlew
-#          segmentstore:server:test
-#          segmentstore:storage:test
-#          segmentstore:server:host:test
-#          --parallel
-#      - name: Codecov
-#        uses: codecov/codecov-action@v1.0.15
-#
-#  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
-#  unit_bindings:
-#    name: Storage Bindings Unit Tests
-#    needs: build
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Test Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-#          key: ${{github.run_id}}-${{github.job}}
-#      - name: Storage Bindings Unit tests
-#        run: >
-#          ./gradlew
-#          segmentstore:storage:impl:test
-#          bindings:test
-#          --parallel
-#      - name: Codecov
-#        uses: codecov/codecov-action@v1.0.15
-#
-#  unit_other:
-#    name: All Other Unit Tests
-#    needs: build
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Test Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-#          key: ${{github.run_id}}-${{github.job}}
-#      - name: Unit tests
-#        run: >
-#          ./gradlew test
-#          -x client:test
-#          -x controller:test
-#          -x test:integration:test
-#          -x bindings:test
-#          -x segmentstore:storage:impl:test
-#          -x segmentstore:storage:test
-#          -x segmentstore:server:host:test
-#          -x segmentstore:server:test
-#          --parallel
-#      - name: Codecov
-#        uses: codecov/codecov-action@v1.0.15
-#
-#  integration:
-#    name: Integration Tests
-#    needs: build
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Test Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
-#          key: ${{github.run_id}}-${{github.job}}
-#      - name: Integration Tests
-#        run: ./gradlew test:integration:test
-#
-#  # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
-#  build_and_test_complete:
-#    name: CI Complete
-#    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check Build Status
-#        run: echo Build, static analysis, unit and integration tests successful.
-#
-#  snapshot:
-#    name: Artifactory Snapshot
-#    needs: [build_and_test_complete]
-#    # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
-#    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Gradle & Maven Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.GLOBAL_CACHE_PATH}}
-#          key: ${{env.GLOBAL_CACHE_KEY}}
-#          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
-#      - name: Build Output Cache
-#        uses: actions/cache@v2.1.0
-#        with:
-#          path: ${{env.BUILD_CACHE_PATH}}
-#          key: ${{github.run_id}}
-#      - name: Assemble
-#        run: ./gradlew assemble --parallel
-#      - name: Publish Shapshot
-#        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}}
+
+  unit_controller:
+    name: Controller Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.job}}
+      - name: Controller Unit tests
+        run: ./gradlew controller:test ${{env.GRADLE_OPTS}}
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  unit_segment_store:
+    name: Segment Store Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.job}}
+      - name: Segment Store Unit tests
+        run: >
+          ./gradlew
+          segmentstore:server:test
+          segmentstore:storage:test
+          segmentstore:server:host:test
+          --parallel ${{env.GRADLE_OPTS}}
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  # Bindings should be separate from segmentstore:server:host because of BK and ZK conflicts.
+  unit_bindings:
+    name: Storage Bindings Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.job}}
+      - name: Storage Bindings Unit tests
+        run: >
+          ./gradlew
+          segmentstore:storage:impl:test
+          bindings:test
+          --parallel ${{env.GRADLE_OPTS}}
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  unit_other:
+    name: All Other Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.job}}
+      - name: Unit tests
+        run: >
+          ./gradlew test
+          -x client:test
+          -x controller:test
+          -x test:integration:test
+          -x bindings:test
+          -x segmentstore:storage:impl:test
+          -x segmentstore:storage:test
+          -x segmentstore:server:host:test
+          -x segmentstore:server:test
+          --parallel ${{env.GRADLE_OPTS}}
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  integration:
+    name: Integration Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.job}}
+      - name: Integration Tests
+        run: ./gradlew test:integration:test ${{env.GRADLE_OPTS}}
+
+  # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
+  build_and_test_complete:
+    name: CI Complete
+    needs: [build, integration, unit_other, unit_segment_store, unit_bindings, unit_controller, unit_client]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Build Status
+        run: echo Build, static analysis, unit and integration tests successful.
+
+  snapshot:
+    name: Artifactory Snapshot
+    needs: [build_and_test_complete]
+    # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Assemble
+        run: ./gradlew assemble --parallel ${{env.GRADLE_OPTS}}
+      - name: Publish Shapshot
+        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}} ${{env.GRADLE_OPTS}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - master                 # On every push to the master branch.
-      - 'r*.*1'                # On every push to a release branch.
+      - 'r*.*'                 # On every push to a release branch.
   pull_request:                # On every pull request, regardless of source/target branch.
   release:
     types:
@@ -195,7 +195,9 @@ jobs:
     name: Artifactory Snapshot
     needs: [build_and_test_complete]
     # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
-    if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.'))}}
+    # TODO revert after validating this works correctly
+    #if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/issue-5524-gha' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Gradle & Maven Cache

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,13 +33,13 @@ env:
   # We cache the source code, resources and build output. This is generated on the build job and reused in dependent jobs.
   BUILD_CACHE_PATH: ./*
   # We cache test execution and reports (code coverage) per test job. This helps speed up workflow re-runs.
-  TEST_OUTPUT_CACHE_PATH: >
+  TEST_OUTPUT_CACHE_PATH: |
     **/build/test-results
     **/**/build/test-results
     **/**/build/test-results
-    **/build/reports
-    **/**/build/reports
-    **/**/**/build/reports
+    **/build/reports/jacoco
+    **/**/build/reports/jacoco
+    **/**/**/build/reports/jacoco
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).
@@ -55,6 +55,8 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
+      - name: Build Information
+        run: echo Building a '${{ github.event_name }}' for target '${{ github.ref }}'.
       - name: Checkout
         uses: actions/checkout@v1
       - name: Gradle & Maven Cache
@@ -76,8 +78,6 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
-      - name: Build Information
-        run: echo Building a '${{ github.event_name }}' for target '${{ github.ref }}'.
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
@@ -98,10 +98,6 @@ jobs:
         run: ./gradlew client:test
       - name: Codecov
         uses: codecov/codecov-action@v1.0.15
-      - name: Debug
-        run: |
-          pwd
-          ls ${{env.TEST_OUTPUT_CACHE_PATH}}
 
   unit_controller:
     name: Controller Unit Tests

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,68 +1,215 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
 name: build
 
+# Set up when this workflow will run.
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches:
+      - master                 # On every push to the master branch.
+      - 'r*.*1'                # On every push to a release branch.
+  pull_request:                # On every pull request, regardless of source/target branch.
+  release:
+    types:
+      - published              # On every published release.
 
+# Define a few constants that are shared across all the jobs.
+env:
+  GLOBAL_CACHE_PATH: |
+    .gradle
+    ~/.gradle
+    ~/.m2
+  GLOBAL_CACHE_KEY: gradle-m2-java-11
+  GLOBAL_CACKE_RESTORE_KEYS: |
+    gradle-m2-java-
+    gradle-m2
+  BUILD_CACHE_PATH: ./*
+
+# The workflow begins with a compilation and static analysis job that also caches the build output and source code,
+# followed by a number of parallel test jobs (which make use of that cached artifacts).
+#
+# Once the build job and all the test jobs complete successfully, a final (no-op) job ("build_and_test_complete") will
+# automatically complete. This job must NOT be renamed as the GitHub Pravega Repository gates merges into master on
+# this step passing.
+#
+# Finally, a "snapshot" job is triggered only for pushes (commits) to master and release branches, which publishes all
+# artifacts to a public repository.
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-20.04
-
-    name: Java 11
     steps:
-    - uses: actions/checkout@v1
-    - name: Restore local Gradle & Maven cache
-      uses: actions/cache@v2.1.0
-      with:
-        path: |
-          .gradle
-          ~/.gradle
-          ~/.m2
-        key: gradle-m2-java-11
-        restore-keys: |
-          gradle-m2-java-
-          gradle-m2
-#    - name: Set up JDK 11
-#      uses: actions/setup-java@v1
-#      with:
-#        java-version: 11
-    - name: Assemble with Gradle
-      run: ./gradlew assemble --parallel
-    - name: Rat, Checkstyle & Spotbugs with Gradle
-      run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Compile & Static Analysis
+        run: ./gradlew jar compileTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --parallel
 
-  test:
-
+  unit_client:
+    name: Client Unit Tests
     needs: build
     runs-on: ubuntu-20.04
-
-    name: Tests on Java 11
     steps:
-    - uses: actions/checkout@v1
-    - name: Restore local Gradle & Maven cache
-      uses: actions/cache@v2.1.0
-      with:
-        path: |
-          .gradle
-          ~/.gradle
-          ~/.m2
-        key: gradle-m2-java-11
-        restore-keys: |
-          gradle-m2-java-
-          gradle-m2
-#    - name: Set up JDK 11
-#      uses: actions/setup-java@v1
-#      with:
-#        java-version: 11
-    - name: Unit tests with Gradle
-      run: ./gradlew test --exclude-task test:integration:test
-    - name: Codecov
-      uses: codecov/codecov-action@v1.0.15
-    - name: Integration tests with Gradle
-      run: ./gradlew test:integration:test
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Unit tests
+        run: ./gradlew client:test
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  unit_controller:
+    name: Controller Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Controller Unit tests
+        run: ./gradlew controller:test
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  unit_segment_store:
+    name: Segment Store Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Segment Store Unit tests
+        run: >
+          ./gradlew
+          segmentstore:server:test
+          segmentstore:server:host:test
+          segmentstore:storage:test
+          segmentstore:storage:impl:test
+          bindings:test
+          --parallel
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  unit_other:
+    name: All Other Unit Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Unit tests
+        run: >
+          ./gradlew test
+          -x client:test
+          -x controller:test
+          -x test:integration:test
+          -x bindings:test
+          -x segmentstore:storage:impl:test
+          -x segmentstore:storage:test
+          -x segmentstore:server:host:test
+          -x segmentstore:server:test
+          --parallel
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.15
+
+  integration:
+    name: Integration Tests
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Integration Tests
+        run: ./gradlew test:integration:test
+
+  # DO NOT RENAME THIS JOB. Mergers to master branch are gated on this completing successfully.
+  build_and_test_complete:
+    name: CI Complete
+    needs: [build, integration, unit_other, unit_segment_store, unit_controller, unit_client]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Build Status
+        run: echo Build, static analysis, unit and integration tests successful.
+
+  snapshot:
+    name: Artifactory Snapshot
+    needs: [build_and_test_complete]
+    # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
+    if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.'))}}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+      - name: Build Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.BUILD_CACHE_PATH}}
+          key: ${{github.run_id}}
+      - name: Assemble
+        run: ./gradlew assemble --parallel
+      - name: Publish Shapshot
+        run: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,8 +32,9 @@ env:
     gradle-m2
   # We cache the source code, resources and build output. This is generated on the build job and reused in dependent jobs.
   BUILD_CACHE_PATH: ./*
-  # We cache test execution and reports (code coverage) per test job. This helps speed up workflow re-runs.
+  # We cache test execution (including history) and reports (code coverage) per test job. This helps speed up workflow re-runs.
   TEST_OUTPUT_CACHE_PATH: |
+    .gradle
     **/build/test-results
     **/**/build/test-results
     **/**/build/test-results

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,7 @@ env:
     gradle-m2-java-
     gradle-m2
   BUILD_CACHE_PATH: ./*
+  TEST_OUTPUT_CACHE_PATH: '**/build/test-results/** **/**/build/test-results/** **/**/build/test-results/**'
 
 # The workflow begins with a compilation and static analysis job that also caches the build output and source code,
 # followed by a number of parallel test jobs (which make use of that cached artifacts).
@@ -78,6 +79,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Unit tests
         run: ./gradlew client:test
       - name: Codecov
@@ -99,6 +105,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Controller Unit tests
         run: ./gradlew controller:test
       - name: Codecov
@@ -120,6 +131,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Segment Store Unit tests
         run: >
           ./gradlew
@@ -147,6 +163,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Storage Bindings Unit tests
         run: >
           ./gradlew
@@ -172,6 +193,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Unit tests
         run: >
           ./gradlew test
@@ -203,6 +229,11 @@ jobs:
         with:
           path: ${{env.BUILD_CACHE_PATH}}
           key: ${{github.run_id}}
+      - name: Test Output Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.TEST_OUTPUT_CACHE_PATH}}
+          key: ${{github.run_id}}-${{github.action}}
       - name: Integration Tests
         run: ./gradlew test:integration:test
 
@@ -214,6 +245,8 @@ jobs:
     steps:
       - name: Check Build Status
         run: echo Build, static analysis, unit and integration tests successful.
+      - name: Debug # TODO remove
+        run: echo ${{ github.event_name }},${{ github.ref }}
 
   snapshot:
     name: Artifactory Snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jobs:
     # Travis CI build has been deprecated in favor of GitHub Actions.
     - stage: build
       if: type IN (push, pull_request)
-      install: echo "Travis task disabled.
-      script: echo "Travis task disabled.
+      install: echo "Travis task disabled."
+      script: echo "Travis task disabled."
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,54 +20,11 @@ env:
 
 jobs:
   include:
-# the secure configurations in env: is for BINTRAY_USER=<USER> and BINTRAY_KEY=<KEY> properties
-# which will be used for publishing artifacts to snapshot repository
+    # Travis CI build has been deprecated in favor of GitHub Actions.
     - stage: build
       if: type IN (push, pull_request)
-      install: ./gradlew assemble
-      script: ./gradlew check
-      after_success:
-           - bash <(curl -s https://codecov.io/bash) -t ccceafaf-7c60-4a02-9165-480174b535a2
-
-    - stage: javadocs
-      install: echo "Building javadocs"
-      script: ./gradlew javadocs
-
-    - stage: snapshot
-      if: (branch = master OR branch =~ /^r[0-9]+\.[0-9]+/) AND NOT (type = pull_request)
-      env:
-         - secure: "EJGO5B4XxT6NpZ4+St4EG/Y3+UmQ2XNkbnJz/5vv7HZziC4OXFVFCigOsjqqRVjJaWmDmYf1a/U7QwJa+esgA9oBchg+DVWYeqkMOEbZkEJzBgHeA5Bmgp+3Q5/2ouOe6M2cUFhSNXN+lZaLri8xYis25ndK6E0Y6MIQ7CbCNyhA/edIIHSttJNHoGkaVxkfEDWNvIvdUbxt7MTTdAGIvT+Xj/EF8clT349N5UfZ8DdYy8Q6i4TKiy5557dj6nfegbD6qD0mGxWt8dqKBSIqmPMoiCjGsy+3LyfeMNhZiNji+7LRmwJtWD87fewlYeU5xkKZIaxXlCnd9JPrkIFH62FzXctn0wc18mDTD+c4mnc2efKHHrmvRcrvQrRD447iFt17lEMCROriHVZsB4m6igxrEg0i2paCBajMqhQG5LEwSqU7D8CQaW+ffC2+9agFR0a6uhW7n9GahU2AOVf9RhvLU7yFWtVJltOP2mBY0s8Oowxzy5OXSfqjxwSJeKKGgWVaTbBY14Y1Y2pCx9CuInLswz4oIO3LqHHfKJasKwHp9nHRSa6flh8JFR8+jGA7vo1MqGAPH3N4rrMQqpYs9DjYD50TPAh2h4asQj5gSjtYkKpvEu58dRRRzansjtSpiwo6TNfaVp9jhzYI3O3vnssyDyJvHjHjCnrvCB/KYrU="
-         - secure: "NdkraKeGWu2OLxxHEjxn09GdVaXeKxaSrpNuTMc38Bnq9O2msXgb2jiEBsq4Z23j8cxG6Y4JJ0ZAOQwhuB3Tfh6UwGxSf8CxAqplD9uy1VRrAT0gXneIjaAwlOITy5IQfP0bY0o+IwYSefLEKnR46YLxd4zHckgneq5SWD9bUZEByM7rcYZArpaHK/fBQ+0aM0SsYY0vHX/6ivA9f9oWIva2pnWgOXPABbgrN7Xah+a+XVAV3Qe2vBA0MAl0pA1S9PWWfZNbVAO+CSR6d4+Rdvn4tQsM5Si5p9hWjmBi22kkDMJtLAhKHUnutoHPVMH6ekQneakshhiVuhMzAJZoMI626P5GkiyN3OVkv+AlAGEUZdJnXlsx51veIAvQh1iZZhpJ5Cd5R8H7dQrgIFiios+fRLlD8VbCwv8NAL366khBkQjoW2RyF+Xl1Y1J7Yd9C7lsg/Ktm7PNIVNRsHjMu1msQHNNsn0VmVbH2IZo20u8giKhiUVcAznctj5kmleCBgszTlRj07pxMQggcLrK0d0y1gU9Gg/pOubcsHNzQ/pLWVjep1vuJ+wyW64BtgQuFvPK97eA95P5b3j3MpalhFUKPF+mVdqXNQjcJrYOwtRagq4CkPsg3fKr7+HMzUCHwo69eqJfgPCOR9NYLSMPzhKAl/YrdphH46wPuEiOopU="
-      install: skip
-      script: ./gradlew publish -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
-
-    - stage: system tests
-      if: repo != pravega/pravega
-      env:
-         - secure: xMd2acI6P4cIrVH1ha+CkwkHkomjjanKOWth8rqrLvLjSCA+K/zOqMp0VtDMyDFWSPLUnpa/D2oViGZD/q1rtLTs8O3aVQcQn9MiFL3VpwZKZ3PNEI9MhSgCMGh4oem4jIOu/A7xfTPFTOJsFyOFWi627MHW7EZmUsZOkzmMU04ms5i2Q63pboTd7W2ym9rzTWpGe3eb6IuqEbSyElWNDwKcVRT55YYvyahRL+lcOkObPXkiS2EcS098jfmofKDhkNFZ58m51ukOg7117pnQw0J8hXCtlcfJHfJC4+Mjao8IKeAzeoXkJL/lA1qSCAdkcg85+OeUjJ2HOTWsV+y+aS8VPe0bth2YMKn3/EfWVcrusbgVsbV1bUbje9C5OUOiBZ+0mgcBI2FMP9fk1lHOPJ/XXPfup6g1N67mB3kCK+YI3eTyhFaGnTaN+jz3qn86on8sXw9ionC3KJrUQP0C0JriPVMIAqRQoTBGP8BqtNvCHnEyhriJHuEeRB2XAOAjrge2qJ9MP7heaFmSlG/zqTUZDpHP4CVWX8OTc5jTVWKZ5mfB8XNXVLfVZjaVOXva4eQWJ1KGvoEMwBu+pCThyA6AKHikFSjPxUymdTscyIt7Ma+0YzTy0ejT1OHjdo2eLN2W5swSCA+SWM4oKkR5MAle6NHdHwnw6lPNfLyHzug=
-         - secure: hMyMR2tf9kNsWJ1+6aQWiW2X+vc6dF0mdB4sCXUk//wCqwZ81ri8AOndXdDWv+PZAE0ZCbNynRX5BtXyY1St0cY49+FFFy0ExvrD0Ydro/zoEw2vaAX6f5PSNISRwFXPZv13He516Ssj0733QHs+d0cSywd+6+KXJtaIbgxtzRcqI38pD6BXoT67x1LthkGDOdIt/+N6JQbuQVHsPchABRRr0eZcwU/SjdW0vXXoGZ5b0odHVtRnioFq2Q87zmcCr5rfvFmnerGrnhXywO4MzCA83K3j9vlkAoapV8WWMb9uTKwnxCj4XIKsH6nXDzWAsO2sNlwBu4QtkNXGfoS0H7vUSBZcjDaWSV2YZNl9YUVcjzgzHApoE63NAAm7XwESqAl7AE8GkZX8ZZIC7mH0nbQ3I312d6AzV69o6Npxr8q8sZjK94Qp9jUkgM7/GkMN0R6x8QbByTH5BY8KQaXO4XEF7/GaMkkklJARy66FjO8mOWk3z0cE1QG49zY6l+fatMJzKjDbPXDAoJNqiDqhtfXpHSq2CM+BHMRwp+SHMihl3kus0LzahFSPAqpdT6sJo5XYQi4Ygtkrxya/e15TZQeP4/uvEBwPcCf25LA8GhJ60L1poA2I9ptU1V79w7b72/rJeOWrVvqV+M9tviL1+j9VzSAeMXkBufa7J5W5uak=
-         - secure: hgu6ik1qGduzifEKVdzYyKNawyBmGClyDDw2SaNJqh/FVipT7nFPhi+O5v49OcyUuwXwW/BSYUNqlxjfSUWrZ7dN/kSnTUGFYYqs6RAjhY15NldoXYnmFZHqT3kS38ZQLyTMIeWd0OllR/nx0cQylkK1DNu42MmImH7MXHxjKw/FTN02tSba674ZaHVABxLGuqFtVVx2sORXkU64RCcwg4KSbSQlwUzUIInpkOyKkoI+RugcEHd8YItWiLrJUgvyBwU4IcBKvCgXDOWXlfii+/6eAZdw+2QiANtsWAkz0mxXejyyOAl4iUTMIuhuxjZ5eYcwyLoPXt14WXwuBh2wCZyzuU3h/sa6G+YR1gti4fMNjg2u1X+5uBD8TdHfCQ67D+1Pkx/7AzHYinrxEmx2o4XUs+6wkGcHGbzMUu/njeHSiVpedKAlIv+FuVeNJ73/CF1F2QCuEusUYnj7AXJFikYEWOK1FTI2ip3nQ5fAh/qFoHJNdWNHNhvF8XnRyCTdMK0GIUSXiHP7ciQtl8Sgl2N6Y0nvK9Hwk6T1nJBZr3rxdzPfwW0QBSFN4yyZkR6J4rq4mPi56xl72KV+zrcNsYWehcz8GWVspESn7EAXbwymHGdeJCel3JQ7Abxdf6mrDmTLP6POUtI3RjaIoQAulWBArNxe7e/wiVwWSPGRedE=
-      before_install:
-         - openssl aes-256-cbc -K $encrypted_7840d5b8aa7c_key -iv $encrypted_7840d5b8aa7c_iv -in aws-key-pair.pem.enc -out aws-key-pair.pem -d
-         - sudo wget https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip
-         - unzip terraform_0.11.3_linux_amd64.zip
-         - sudo mv terraform /usr/local/bin/
-         - chmod +x /usr/local/bin/terraform
-         - sudo terraform --version
-      install:
-         - echo "Executing system tests on AWS"
-      script:
-         - ./gradlew startSystemTestsWithDocker -DskipServiceInstallation=false
-               -Dlog.level=DEBUG -DexecType=DOCKER -PawsExecution=true -Paws_access_key="$AWS_ACCESS_KEY"
-               -Paws_secret_key="$AWS_SECRET_KEY" -Paws_region=us-east-2  -Paws_key_name=aws-key-pair
-               -Pconfig_path=/home/travis/build/pravega/pravega/test/system/aws -Pcred_path=/home/travis/build/pravega/pravega/aws-key-pair.pem
-               -Ppravega_org="$TRAVIS_REPO_SLUG" -Ppravega_branch="$TRAVIS_BRANCH"  -DimageVersion="$TRAVIS_BRANCH"
-               -DawsExec=true
-         - ./gradlew --info collectSystemTestLogsFromAws -Paws_access_key="$AWS_ACCESS_KEY" -Paws_secret_key="$AWS_SECRET_KEY"
-               -Paws_region=us-east-2 -Paws_key_name=aws-key-pair
-               -Pcred_path=/home/travis/build/pravega/pravega/aws-key-pair.pem -Pconfig_path=/home/travis/build/pravega/pravega/test/system/aws
-               -Ppravega_org="$TRAVIS_REPO_SLUG" -Ppravega_branch="$TRAVIS_BRANCH" -Ptravis_commit="$TRAVIS_COMMIT"
-
+      install: echo "Travis task disabled.
+      script: echo "Travis task disabled.
 
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-# Pravega [![Build Status](https://travis-ci.org/pravega/pravega.svg?branch=master)](https://travis-ci.org/pravega/pravega/builds) [![codecov](https://codecov.io/gh/pravega/pravega/branch/master/graph/badge.svg?token=6xOvaR0sIa)](https://codecov.io/gh/pravega/pravega) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![Version](https://img.shields.io/github/release/pravega/pravega.svg)](https://github.com/pravega/pravega/releases) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4178/badge)](https://bestpractices.coreinfrastructure.org/projects/4178)
+# Pravega [![Build Status](https://github.com/pravega/pravega/workflows/build/badge.svg?branch=master)](https://github.com/pravega/pravega/actions?query=branch%3Amaster) [![codecov](https://codecov.io/gh/pravega/pravega/branch/master/graph/badge.svg?token=6xOvaR0sIa)](https://codecov.io/gh/pravega/pravega) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![Version](https://img.shields.io/github/release/pravega/pravega.svg)](https://github.com/pravega/pravega/releases) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4178/badge)](https://bestpractices.coreinfrastructure.org/projects/4178)
 
 Pravega is an open source distributed storage service implementing **Streams**. It offers Stream as the main primitive for the foundation of reliable storage systems: a *high-performance, durable, elastic, and unlimited append-only byte stream with strict ordering and consistency*.
 


### PR DESCRIPTION
**Change log description**  
- Disabled .travis.yml as we will no longer be using Travis CI. This file will be deleted in a subsequent PR.
- Set up GitHub Actions workflow as follows:
   - Triggers on master branch and release branch pushes, on every pull request (regardless of branch) and release publish.
   - Has a compile and static analysis job, followed by a few parallel test jobs, then a check and a snapshot (only for master branch and release branches).
   - Check job is called `CI Complete`.
- Bonus features: 
    - Build output is cached after the `Build` step and reused for subsequent jobs. This speeds up the overall workflow run.
    - Test execution output, history and reports is cached on a per workflow-job basis. If a workflow is re-run for whatever reason (such as one job failing), the successful jobs will execute much faster (by skipping all tests that passed).

**Purpose of the change**  
Fixes #5523.
Fixes #5538.

**What the code does**  
See description.

**How to verify it**  
Please verify that this is functionally equivalent to the previous CI pipeline:
- It compiles the code.
- It performs static analysis.
- It executes all unit tests and all integration tests.
- It uploads code coverage correctly.
- For master and release branches, it publishes to JFrog artifactory.
- Triggers are correct and make sense.
