### PR TITLE
Issue 5483, 5496, 5544: Flakey tests among controller unit tests

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -353,15 +353,18 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                                           if (e != null) {
                                               log.warn("Submission for truncation for stream {} failed. Will be retried in next iteration.",
                                                       streamName);
-                                          } else {
+                                          } else if (r) {
                                               log.debug("truncation for stream {} at streamcut {} submitted.", streamName, streamcut);
+                                          } else {
+                                              log.debug("truncation for stream {} at streamcut {} rejected.", streamName, streamcut);
                                           }
                                           return null;
                                       });
         } catch (Exception e) {
             // we will catch and log all exceptions and return a completed future so that the truncation is attempted in the
             // next iteration
-            log.warn("Encountered exception attempting to truncate stream. {}", Exceptions.unwrap(e).getMessage());
+            Throwable unwrap = Exceptions.unwrap(e);
+            log.warn("Encountered exception attempting to truncate stream {}. {}: {}", streamName, unwrap.getClass().getName(), unwrap.getMessage());
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
@@ -288,7 +288,7 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 10000)
-    public void testCancellation() {
+    public void testCancellation() throws Exception {
         final ConcurrentHashMap<String, List<Integer>> orderOfProcessing = new ConcurrentHashMap<>();
 
         SerializedRequestHandler<TestEvent> requestHandler = new SerializedRequestHandler<TestEvent>(executorService()) {
@@ -319,7 +319,9 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         CompletableFuture<Void> p3 = requestHandler.process(e3, stop::get);
 
         queue = requestHandler.getEventQueueForKey(getKeyForStream(scope, stream));
-        assertTrue(queue.size() >= 2);
+        // ensure that e1 is picked for processing
+        AssertExtensions.assertEventuallyEquals(2, () -> requestHandler.getEventQueueForKey(getKeyForStream(scope, stream)).size(),
+                10000L);
         assertTrue(queue.stream().noneMatch(x -> x.getRight().isDone()));
         List<Integer> collect = queue.stream().map(x -> x.getLeft().getNumber()).collect(Collectors.toList());
         assertTrue(collect.indexOf(2) < collect.indexOf(3));
@@ -329,7 +331,7 @@ public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
         
         // verify that until p1 completes nothing else will be processed. 
         queue = requestHandler.getEventQueueForKey(getKeyForStream(scope, stream));
-        assertTrue(queue.size() >= 2);
+        assertEquals(2, queue.size());
         assertTrue(queue.stream().noneMatch(x -> x.getRight().isDone()));
         
         // now complete processing for event 1. All subsequent events for the stream will be cancelled.


### PR DESCRIPTION
**Change log description**  
 - Issue 5496: Sporadic failure in SerializedRequestHandlerTest
 - Issue 5544: Sporadic failure in ControllerClusterListenerTest
 - Issue 5483: Sporadic failure in ControllerEventProcessors.testTruncate

**Purpose of the change**  
Fixes #5483, #5496, #5544

**What the code does**  
1. SerializedRequestHandlerTest.testCancellation: make sure that the first event is picked for processing before issuing a shutdown so that we wait for it to complete. 
2. Sporadic failure in ControllerClusterListenerTest: UnfinishedStubbingException comes if we modify the mock while it is being used by some component. If that happens then we could get the aforesaid error. So the fix is to move all the mocking to the initial part of the test and manage any transition via flags. 
3. Sporadic failure in ControllerEventProcessors.testTruncate: The core of the issue seems to be similar to previous one, but it manifests in different ways including mock invocation argument coming as empty being the most common. But we have seen other assertion related errors too. This test code has been modified to move all the mocking to the top. And also have better control mechanism over which calls are being made to reduce any chances of a race. 

**How to verify it**  
All tests should pass consistently.
These fixes have been run locally with success, but that is no guarantee that they fix the stubbing related exception. 