### PR TITLE
Issue 5576: fix typo 'refs/head'->'refs/heads' in snapshot build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -242,7 +242,7 @@ jobs:
     name: Artifactory Snapshot
     needs: [build_and_test_complete]
     # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Gradle & Maven Cache


### PR DESCRIPTION
**Change log description**  
Fix typo preventing release branches from publishing snapshot builds.

**Purpose of the change**  
Fixes #5576

**What the code does**  
Fixes typo in "refs/head/r0." and "refs/head/r1.". Git branches live at "refs/heads".

**How to verify it**  
v0.9 release branch should publish a snapshot on next attempt.
