### PR TITLE
Issue 5578: Cherry pick PR 5577 into r0.9

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -242,7 +242,7 @@ jobs:
     name: Artifactory Snapshot
     needs: [build_and_test_complete]
     # Only run this on PUSH (no pull requests) and only on the master branch and release branches.
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/head/r0.') || startsWith(github.ref, 'refs/head/r1.')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Gradle & Maven Cache


### PR DESCRIPTION
**Change log description**  
Fix a typo causing snapshot publish step to be skipped for release branches.

**Purpose of the change**  
Fixes #5578

**What the code does**  
Allows snapshots to publish for r0.* and r1.* branches.

**How to verify it**  
Merge this PR and confirm r0.9 publishes a snapshot.
