### PR TITLE
Issue 5587: BookKeeper Docker Image build failure.

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
     && cp -r bookkeeper-all-${BK_VERSION}/* /opt/bookkeeper/ \
     && rm -rf "bookkeeper-all-${BK_VERSION}" "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
     # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
     && python get-pip.py \
     && pip install zk-shell \
     && rm -rf get-pip.py \

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -35,11 +35,6 @@ RUN set -x \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && cp -r bookkeeper-all-${BK_VERSION}/* /opt/bookkeeper/ \
     && rm -rf "bookkeeper-all-${BK_VERSION}" "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
-    # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
-    && python get-pip.py \
-    && pip install zk-shell \
-    && rm -rf get-pip.py \
     && yum clean all
 
 WORKDIR /opt/bookkeeper


### PR DESCRIPTION
**Change log description**  
 [BookKeeper Dockerfile](https://github.com/pravega/pravega/blob/master/docker/bookkeeper/Dockerfile) uses  `apache/bookkeeper:4.11.1` as a base image. The Dockerfile downloads [pip bootstrap script](https://github.com/pravega/pravega/blob/master/docker/bookkeeper/Dockerfile#L40) whose installation is failing since it uses newer, Python 3 syntax. Thus, BookKeeper image build fails as well.
`pip` is installed in order to install `zk-shell` into the image, however, `zk-shell` is already available within base image `apache/bookkeeper:4.11.1`, thus both pip and zk-shell installations could be removed from the Dockerfile.

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/5587

**What the code does** 
Removes `pip` and `zk-shell` references from [BookKeeper Dockerfile](https://github.com/pravega/pravega/blob/master/docker/bookkeeper/Dockerfile).

**How to verify it**  
Build BookKeeper docker image.

Signed-off-by: Andrey Koltsov <a99920641@gmail.com>