### PR TITLE
Issue 5597 : ExtendedS3ChunkStorage and ExtendedS3Storage should close S3Client.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
@@ -68,11 +68,7 @@ public class ExtendedS3ChunkStorage extends BaseChunkStorage {
     //endregion
 
     //region constructor
-    public ExtendedS3ChunkStorage(S3Client client, ExtendedS3StorageConfig config, Executor executor) {
-        this(client, config, executor, false);
-    }
-
-    ExtendedS3ChunkStorage(S3Client client, ExtendedS3StorageConfig config, Executor executor, boolean shouldClose) {
+    public ExtendedS3ChunkStorage(S3Client client, ExtendedS3StorageConfig config, Executor executor, boolean shouldClose) {
         super(executor);
         this.config = Preconditions.checkNotNull(config, "config");
         this.client = Preconditions.checkNotNull(client, "client");

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
@@ -62,16 +62,22 @@ public class ExtendedS3ChunkStorage extends BaseChunkStorage {
     //region members
     private final ExtendedS3StorageConfig config;
     private final S3Client client;
+    private final boolean shouldClose;
     private final AtomicBoolean closed;
 
     //endregion
 
     //region constructor
     public ExtendedS3ChunkStorage(S3Client client, ExtendedS3StorageConfig config, Executor executor) {
+        this(client, config, executor, false);
+    }
+
+    ExtendedS3ChunkStorage(S3Client client, ExtendedS3StorageConfig config, Executor executor, boolean shouldClose) {
         super(executor);
         this.config = Preconditions.checkNotNull(config, "config");
         this.client = Preconditions.checkNotNull(client, "client");
         this.closed = new AtomicBoolean(false);
+        this.shouldClose = shouldClose;
     }
     //endregion
 
@@ -302,7 +308,9 @@ public class ExtendedS3ChunkStorage extends BaseChunkStorage {
     public void close() {
         if (!this.closed.getAndSet(true)) {
             try {
-                this.client.destroy();
+                if (shouldClose) {
+                    this.client.destroy();
+                }
             } catch (Exception e) {
                 log.warn("Could not destroy the S3Client.", e);
             }

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
@@ -36,6 +36,7 @@ import io.pravega.segmentstore.storage.chunklayer.ChunkStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkStorageException;
 import io.pravega.segmentstore.storage.chunklayer.ConcatArgument;
 import io.pravega.segmentstore.storage.chunklayer.InvalidOffsetException;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.http.HttpStatus;
@@ -301,15 +302,10 @@ public class ExtendedS3ChunkStorage extends BaseChunkStorage {
     }
 
     @Override
+    @SneakyThrows
     public void close() {
-        if (!this.closed.getAndSet(true)) {
-            try {
-                if (shouldClose) {
-                    this.client.destroy();
-                }
-            } catch (Exception e) {
-                log.warn("Could not destroy the S3Client.", e);
-            }
+        if (shouldClose && !this.closed.getAndSet(true)) {
+            this.client.destroy();
         }
     }
 

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
@@ -41,7 +41,7 @@ public class ExtendedS3SimpleStorageFactory implements SimpleStorageFactory {
     @Override
     public Storage createStorageAdapter(int containerId, ChunkMetadataStore metadataStore) {
         ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(containerId,
-                new ExtendedS3ChunkStorage(createS3Client(), this.config, this.executor),
+                new ExtendedS3ChunkStorage(createS3Client(), this.config, this.executor, true),
                 metadataStore,
                 this.executor,
                 this.chunkedSegmentStorageConfig);

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -92,6 +92,7 @@ public class ExtendedS3Storage implements SyncStorage {
 
     private final ExtendedS3StorageConfig config;
     private final S3Client client;
+    private final boolean shouldClose;
     private final AtomicBoolean closed;
 
     //endregion
@@ -99,10 +100,14 @@ public class ExtendedS3Storage implements SyncStorage {
     //region constructor
 
     public ExtendedS3Storage(S3Client client, ExtendedS3StorageConfig config) {
+        this(client, config, false);
+    }
+
+    ExtendedS3Storage(S3Client client, ExtendedS3StorageConfig config, boolean shouldClose) {
         this.config = Preconditions.checkNotNull(config, "config");
         this.client = Preconditions.checkNotNull(client, "client");
         this.closed = new AtomicBoolean(false);
-
+        this.shouldClose = shouldClose;
     }
 
     //endregion
@@ -547,7 +552,9 @@ public class ExtendedS3Storage implements SyncStorage {
     public void close() {
         if (!this.closed.getAndSet(true)) {
             try {
-                this.client.destroy();
+                if (shouldClose) {
+                    this.client.destroy();
+                }
             } catch (Exception e) {
                 log.warn("Could not destroy the S3Client.", e);
             }

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -545,7 +545,13 @@ public class ExtendedS3Storage implements SyncStorage {
 
     @Override
     public void close() {
-        this.closed.set(true);
+        if (!this.closed.getAndSet(true)) {
+            try {
+                this.client.destroy();
+            } catch (Exception e) {
+                log.warn("Could not destroy the S3Client.", e);
+            }
+        }
     }
 
     //endregion

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -98,12 +98,7 @@ public class ExtendedS3Storage implements SyncStorage {
     //endregion
 
     //region constructor
-
-    public ExtendedS3Storage(S3Client client, ExtendedS3StorageConfig config) {
-        this(client, config, false);
-    }
-
-    ExtendedS3Storage(S3Client client, ExtendedS3StorageConfig config, boolean shouldClose) {
+    public ExtendedS3Storage(S3Client client, ExtendedS3StorageConfig config, boolean shouldClose) {
         this.config = Preconditions.checkNotNull(config, "config");
         this.client = Preconditions.checkNotNull(client, "client");
         this.closed = new AtomicBoolean(false);

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3Storage.java
@@ -544,15 +544,10 @@ public class ExtendedS3Storage implements SyncStorage {
     //region AutoClosable
 
     @Override
+    @SneakyThrows
     public void close() {
-        if (!this.closed.getAndSet(true)) {
-            try {
-                if (shouldClose) {
-                    this.client.destroy();
-                }
-            } catch (Exception e) {
-                log.warn("Could not destroy the S3Client.", e);
-            }
+        if (shouldClose && !this.closed.getAndSet(true)) {
+            this.client.destroy();
         }
     }
 

--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageFactory.java
@@ -43,6 +43,6 @@ public class ExtendedS3StorageFactory implements StorageFactory {
 
     private ExtendedS3Storage createS3Storage() {
         S3JerseyClient client = new S3JerseyClient(config.getS3Config());
-        return new ExtendedS3Storage(client, this.config);
+        return new ExtendedS3Storage(client, this.config, true);
     }
 }

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageTests.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageTests.java
@@ -43,7 +43,7 @@ public class ExtendedS3SimpleStorageTests extends SimpleStorageTests {
 
     @Override
     protected ChunkStorage getChunkStorage() {
-        return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService());
+        return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService(), false);
     }
 
     /**
@@ -66,7 +66,7 @@ public class ExtendedS3SimpleStorageTests extends SimpleStorageTests {
 
         @Override
         protected ChunkStorage getChunkStorage() {
-            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService());
+            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService(), false);
         }
     }
 
@@ -92,7 +92,7 @@ public class ExtendedS3SimpleStorageTests extends SimpleStorageTests {
 
         @Override
         protected ChunkStorage createChunkStorage() {
-            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService());
+            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService(), false);
         }
 
         /**
@@ -128,7 +128,7 @@ public class ExtendedS3SimpleStorageTests extends SimpleStorageTests {
 
         @Override
         protected ChunkStorage getChunkStorage() {
-            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService());
+            return new ExtendedS3ChunkStorage(testContext.client, testContext.adapterConfig, executorService(), false);
         }
     }
 }

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -268,7 +268,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
 
     private static Storage createStorage(S3Client client, ExtendedS3StorageConfig adapterConfig, Executor executor) {
         // We can't use the factory here because we're setting our own (mock) client.
-        ExtendedS3Storage storage = new ExtendedS3Storage(client, adapterConfig);
+        ExtendedS3Storage storage = new ExtendedS3Storage(client, adapterConfig, false);
         return new AsyncStorageWrapper(storage, executor);
     }
 
@@ -299,7 +299,7 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
 
         @Override
         protected Storage createStorage() {
-            ExtendedS3Storage storage = new ExtendedS3Storage(setup.client, setup.adapterConfig);
+            ExtendedS3Storage storage = new ExtendedS3Storage(setup.client, setup.adapterConfig, false);
             return wrap(storage);
         }
     }

--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -35,11 +35,6 @@ RUN set -x \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && cp -r bookkeeper-all-${BK_VERSION}/* /opt/bookkeeper/ \
     && rm -rf "bookkeeper-all-${BK_VERSION}" "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
-    # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
-    && python get-pip.py \
-    && pip install zk-shell \
-    && rm -rf get-pip.py \
     && yum clean all
 
 WORKDIR /opt/bookkeeper

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -106,7 +106,7 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
         }
 
         protected Storage getStorage(S3JerseyClient client) {
-            return new AsyncStorageWrapper(new RollingStorage(new ExtendedS3Storage(client, config)), this.storageExecutor);
+            return new AsyncStorageWrapper(new RollingStorage(new ExtendedS3Storage(client, config, false)), this.storageExecutor);
         }
     }
 
@@ -133,7 +133,7 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
 
             S3JerseyClient client = new S3ClientWrapper(s3Config, filesystemS3);
             return new ChunkedSegmentStorage(containerId,
-                    new ExtendedS3ChunkStorage(client, this.config, executorService()),
+                    new ExtendedS3ChunkStorage(client, this.config, executorService(), false),
                     metadataStore,
                     this.executor,
                     ChunkedSegmentStorageConfig.DEFAULT_CONFIG);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -645,6 +645,7 @@ public class ChunkedSegmentStorage implements Storage {
     public void close() {
         close("metadataStore", this.metadataStore);
         close("garbageCollector", this.garbageCollector);
+        close("chunkStorage", this.chunkStorage);
         this.closed.set(true);
     }
 


### PR DESCRIPTION
ExtendedS3ChunkStorage and ExtendedS3Storage should close S3Client

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
ExtendedS3ChunkStorage and ExtendedS3Storage should close S3Client

**Purpose of the change**  
Fixes #5597 

**What the code does**  
ChunkedSegmentStorage closes chunkStorage. 
ExtendedS3ChunkStorage and ExtendedS3Storage close S3Client.

**How to verify it**  
Build should pass.
