### PR TITLE
Issue 5584 - r0.9 Cherry Pick

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/stat/SegmentStatsRecorderImpl.java
@@ -176,7 +176,9 @@ class SegmentStatsRecorderImpl implements SegmentStatsRecorder {
     public void createSegment(String streamSegmentName, byte type, int targetRate, Duration elapsed) {
         this.createStreamSegment.reportSuccessEvent(elapsed);
         SegmentAggregates sa = SegmentAggregates.forPolicy(ScaleType.fromValue(type), targetRate);
-        cache.put(streamSegmentName, new SegmentWriteContext(streamSegmentName, sa));
+        if (!NameUtils.isTransactionSegment(streamSegmentName)) {
+            cache.put(streamSegmentName, new SegmentWriteContext(streamSegmentName, sa));
+        }
         if (sa.isScalingEnabled()) {
             reporter.notifyCreated(streamSegmentName);
         }


### PR DESCRIPTION
Avoids prematurely closing SEGMENT_WRITE_BYTE metrics on segments due to eviction of transaction segment SimpleCache entries (multiple entries reference the same MetricProxy).

Signed-off-by: co-jo <colin.hryniowski@dell.com>

**Change log description**  

* See above.

**Purpose of the change**  

* Cherry-pick in #5584 

**What the code does**  

* See above.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
