### PR TITLE
Issue 5606: BoundedInputStream::markSupported() should always return false.

### DIFF
--- a/common/src/main/java/io/pravega/common/io/BoundedInputStream.java
+++ b/common/src/main/java/io/pravega/common/io/BoundedInputStream.java
@@ -99,6 +99,11 @@ public class BoundedInputStream extends FilterInputStream {
         return Math.min(this.in.available(), this.remaining);
     }
 
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
     /**
      * Creates a new BoundedInputStream wrapping the same InputStream as this one, starting at the current position, with
      * the given bound.

--- a/common/src/test/java/io/pravega/common/io/BoundedInputStreamTests.java
+++ b/common/src/test/java/io/pravega/common/io/BoundedInputStreamTests.java
@@ -141,6 +141,13 @@ public class BoundedInputStreamTests {
         }
     }
 
+    @Test
+    public void testMarkSupported() throws Exception {
+        @Cleanup
+        val input = new BoundedInputStream(new ByteArrayInputStream(construct(1)), 1);
+        Assert.assertFalse("BoundedInputStream should not support mark", input.markSupported());
+    }
+
     private byte[] construct(int length) {
         byte[] result = new byte[length];
         for (int i = 0; i < length; i++) {


### PR DESCRIPTION
Issue 5606: BoundedInputStream::markSupported() should always return false.

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
BoundedInputStream::markSupported() should always return false.

**Purpose of the change**  
Fixes #5606 

**What the code does**  
Issue 5606: BoundedInputStream::markSupported() should always return false.

**How to verify it**  
Tests should pass
