### PR TITLE
Issue 5630: Missing required information from pom file during publish task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1191,7 +1191,6 @@ task publishAllJars() {
     dependsOn ':shared:security'
     dependsOn ':shared:protocol:publish'
     dependsOn ':segmentstore:contracts:publish'
-    dependsOn ':segmentstore:storage:testJar'
     dependsOn ':segmentstore:storage:publish'
     dependsOn ':segmentstore:storage:impl:publish'
     dependsOn ':segmentstore:server:publish'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -9,15 +9,6 @@
  *
  */
 plugins.withId('maven') {
-    task sourcesJar(type: Jar, dependsOn: classes) {
-         classifier = 'sources'
-         from sourceSets.main.allSource
-    }
-    artifacts{
-        archives sourcesJar
-        archives javadocJar
-        archives testJar
-    }
     uploadArchives {
         repositories {
             mavenDeployer {
@@ -69,32 +60,6 @@ plugins.withId('maven') {
                             id 'fpj'
                             name 'Flavio Junqueira'
                         }
-                    }
-                }
-
-                addFilter(':') {artifact, file ->
-                    artifact.name.indexOf("tests") == -1
-                }
-                pom(':', {
-                    artifactId = "pravega" + project.path.replace(':', '-')
-                    version getProjectVersion()
-                })
-
-                addFilter('tests') {artifact, file ->
-                    artifact.name.indexOf("segmentstore") != -1 &&
-                    artifact.name.indexOf("tests") != -1
-                }
-
-                pom('tests', {
-                    artifactId = "pravega" + project.path.replace(':', '-') + "-tests"
-                    version getProjectVersion()
-                }).withXml {
-                    def dependencies  = asNode().appendNode("dependencies")
-                    configurations.compile.allDependencies.each {  dep ->
-                        def depNode  = dependencies.appendNode("dependency")
-                        depNode.appendNode("groupId", dep.group)
-                        depNode.appendNode("artifactId", dep.name)
-                        depNode.appendNode("version", dep.version)
                     }
                 }
 


### PR DESCRIPTION
project pom files generated during the gradle publish task are missing information that is required for successful publishing of artifacts to mavenCentral.

This causes validation failure on sonatype.

`failureMessage Invalid POM: /io/pravega/pravega-cli-admin/0.9.0/pravega-cli-admin-0.9.0.pom: Project name missing, Project description missing, Project URL missing, License information missing, SCM URL missing, Developer information missing`

It seems like following commit introduced the problem 0c98b91cd1be4ffd0d0fdc45da9a3e0c1da626ee.

This reverts commit 0c98b91cd1be4ffd0d0fdc45da9a3e0c1da626ee.


Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
This reverts commit 0c98b91cd1be4ffd0d0fdc45da9a3e0c1da626ee.

**Purpose of the change**  
Fixes #5630

**What the code does**  
This reverts commit 0c98b91cd1be4ffd0d0fdc45da9a3e0c1da626ee.

**How to verify it**  
Build should pass.
